### PR TITLE
feat: Milestone 2 — migration step-through, merge provenance, preset hosting coverage, tree legibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   datasource lookups, preset HTTP clients) are swapped for browser-safe shims
   by a Vite `resolveId` plugin. The logger shim doubles as the trace
   collector. Preset fetching uses plain `fetch()` against the CORS-enabled
-  GitHub/npm APIs.
+  GitHub / GitLab / Gitea / Forgejo / npm APIs (see the support matrix below).
 - `packages/app` is a React SPA rendering the trace: config editor with
   Renovate's JSON schema, stage timeline, per-stage diffs, validation
   messages and the effective config.
@@ -24,8 +24,38 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   graph, and must produce byte-identical results.
 
 Configs never leave the browser except for the preset fetches they themselves
-declare. The optional GitHub token (for rate limits) is stored in
-`localStorage` only.
+declare. Optional per-host tokens (for rate limits / private repos) are stored
+in `localStorage` only.
+
+## Preset hosting support
+
+Every fetcher runs in the page, so each host must serve CORS headers. The
+public default endpoints below verifiably do; self-hosted endpoints usually do
+not, so their presets fall back to manual injection.
+
+| Prefix                                                       | Status               | Notes                                                       |
+| ------------------------------------------------------------ | -------------------- | ----------------------------------------------------------- |
+| `github>`                                                    | fetched in browser   | `api.github.com` (custom endpoint supported)                |
+| `gitlab>`                                                    | fetched in browser   | `gitlab.com` API v4 (custom endpoint supported)             |
+| `gitea>`                                                     | fetched in browser   | `gitea.com` API v1 (custom endpoint supported)              |
+| `forgejo>`                                                   | fetched in browser   | `codeberg.org` API v1 (custom endpoint supported)           |
+| `npm>`                                                       | fetched in browser   | `registry.npmjs.org` (deprecated upstream)                  |
+| bare `owner/repo`, `local>`                                  | via platform context | resolves against the toolbar platform + endpoint you select |
+| `http(s)://…`                                                | manual only          | arbitrary endpoints rarely serve CORS                       |
+| azure / bitbucket / bitbucket-server / gerrit (via `local>`) | not supported        | reachable only via a real Renovate run                      |
+| codecommit / scm-manager (via `local>`)                      | not supported        | Renovate itself does not serve local presets there          |
+
+**Platform context** — `local>` (and a bare `owner/repo` reference) is not a
+host of its own; it resolves against the repository's platform + endpoint. Pick
+these in the toolbar's _Platform context_ control (default `github` /
+`https://api.github.com`); the trace records which platform each `local>` node
+resolved against.
+
+**Manual preset injection** — any preset a fetcher cannot reach (self-hosted /
+air-gapped hosts, or a hypothetical preset) can be supplied by hand: select the
+failed node in the resolution tree and paste its JSON into "Provide preset
+content manually". The pipeline re-runs using it and the node is flagged
+`user-supplied`.
 
 Note: Renovate's config code is not a public API, so the `renovate` dependency
 is pinned exactly and every Renovate release PR runs the full CI (golden tests

--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   GitHub / GitLab / Gitea / Forgejo / npm APIs (see the support matrix below).
 - `packages/app` is a React SPA rendering the trace: config editor with
   Renovate's JSON schema, stage timeline, per-stage diffs, validation
-  messages and the effective config.
+  messages and the effective config. The preset resolution tree stays legible
+  even when `extends: ["config:recommended"]` explodes to ~1,100 presets — a
+  summary header shows the honest cost (a handful of presets actually change
+  top-level options; the rest just contribute grouping packageRules), with
+  windowed rendering, contribution roll-ups, search, a flat-table view and a
+  "hide zero-contribution routers" toggle.
 - **Golden tests** prove the shims don't alter behavior: the same fixtures run
   once against untouched Renovate modules and once through the browser module
   graph, and must produce byte-identical results.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "dev": "pnpm --filter @renovate-config-visualizer/app dev",
     "lint": "oxlint",
     "format": "oxfmt",
     "format:check": "oxfmt --check",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -16,11 +16,54 @@ const DEFAULT_CONFIG = `{
 `;
 
 const TOKEN_KEY = "rcv.githubToken";
+const GITLAB_TOKEN_KEY = "rcv.gitlabToken";
+const GITEA_TOKEN_KEY = "rcv.giteaToken";
+const FORGEJO_TOKEN_KEY = "rcv.forgejoToken";
+const PLATFORM_KEY = "rcv.platform";
+const ENDPOINT_KEY = "rcv.endpoint";
+
+/** Platforms that resolve `local>` in the browser, with their default endpoint. */
+const PLATFORM_ENDPOINTS: Record<string, string> = {
+  github: "https://api.github.com",
+  gitlab: "https://gitlab.com/api/v4",
+  gitea: "https://gitea.com",
+  forgejo: "https://codeberg.org",
+  azure: "",
+  bitbucket: "",
+  "bitbucket-server": "",
+  gerrit: "",
+  codecommit: "",
+  "scm-manager": "",
+};
+
+const PLATFORMS = Object.keys(PLATFORM_ENDPOINTS);
+
+type InjectionMap = Record<string, Record<string, unknown>>;
+
+function readStored(key: string, fallback: string): string {
+  return localStorage.getItem(key) ?? fallback;
+}
+
+function persist(key: string, value: string): void {
+  if (value) {
+    localStorage.setItem(key, value);
+  } else {
+    localStorage.removeItem(key);
+  }
+}
 
 export function App() {
   const [content, setContent] = useState(DEFAULT_CONFIG);
   const [fileName, setFileName] = useState<"renovate.json" | "renovate.json5">("renovate.json");
-  const [token, setToken] = useState(() => localStorage.getItem(TOKEN_KEY) ?? "");
+  const [token, setToken] = useState(() => readStored(TOKEN_KEY, ""));
+  const [gitlabToken, setGitlabToken] = useState(() => readStored(GITLAB_TOKEN_KEY, ""));
+  const [giteaToken, setGiteaToken] = useState(() => readStored(GITEA_TOKEN_KEY, ""));
+  const [forgejoToken, setForgejoToken] = useState(() => readStored(FORGEJO_TOKEN_KEY, ""));
+  const [platform, setPlatform] = useState(() => readStored(PLATFORM_KEY, "github"));
+  const [endpoint, setEndpoint] = useState(() =>
+    readStored(ENDPOINT_KEY, "https://api.github.com"),
+  );
+  const [injected, setInjected] = useState<InjectionMap>({});
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<TraceResult | null>(null);
   const [selectedStage, setSelectedStage] = useState<StageId>("preset");
@@ -31,11 +74,12 @@ export function App() {
   const [fatal, setFatal] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState<OptionIndex | null>(null);
 
-  async function onRun() {
+  async function onRun(overrideInjected?: InjectionMap) {
+    const injectedPresets = overrideInjected ?? injected;
     setRunning(true);
     setFatal(null);
     try {
-      const traceResult = await run({ fileName, content });
+      const traceResult = await run({ fileName, content, platform, endpoint, injectedPresets });
       setResult(traceResult);
       const firstError = (Object.entries(traceResult.stageStatus) as [StageId, string][]).find(
         ([, status]) => status === "error",
@@ -50,14 +94,35 @@ export function App() {
     }
   }
 
-  function onTokenChange(value: string) {
-    setToken(value);
-    if (value) {
-      localStorage.setItem(TOKEN_KEY, value);
-    } else {
-      localStorage.removeItem(TOKEN_KEY);
-    }
+  function makeTokenHandler(key: string, setter: (v: string) => void) {
+    return (value: string) => {
+      setter(value);
+      persist(key, value);
+    };
   }
+  const onTokenChange = makeTokenHandler(TOKEN_KEY, setToken);
+
+  function onPlatformChange(value: string) {
+    setPlatform(value);
+    persist(PLATFORM_KEY, value);
+    // Snap the endpoint to the new platform's default; the user can still edit.
+    const next = PLATFORM_ENDPOINTS[value] ?? "";
+    setEndpoint(next);
+    persist(ENDPOINT_KEY, next);
+  }
+
+  function onEndpointChange(value: string) {
+    setEndpoint(value);
+    persist(ENDPOINT_KEY, value);
+  }
+
+  function onInject(key: string, contentObj: Record<string, unknown>) {
+    const next = { ...injected, [key]: contentObj };
+    setInjected(next);
+    void onRun(next);
+  }
+
+  const usesLocal = platform !== "github";
 
   return (
     <OptionDocsProvider index={optionIndex}>
@@ -87,10 +152,82 @@ export function App() {
             value={token}
             onChange={(e) => onTokenChange(e.target.value)}
           />
-          <button type="button" className="primary" onClick={onRun} disabled={running}>
+          <button type="button" className="primary" onClick={() => onRun()} disabled={running}>
             {running ? "Running…" : "Run pipeline"}
           </button>
         </div>
+
+        <details className="advanced-settings">
+          <summary>
+            Platform context &amp; per-host tokens
+            <span className="advanced-hint">
+              {" "}
+              — defines `local&gt;` and bare `owner/repo` presets
+            </span>
+          </summary>
+          <div className="advanced-body">
+            <div className="advanced-row">
+              <label>
+                Platform
+                <select value={platform} onChange={(e) => onPlatformChange(e.target.value)}>
+                  {PLATFORMS.map((p) => (
+                    <option key={p} value={p}>
+                      {p}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="grow">
+                Endpoint
+                <input
+                  type="text"
+                  placeholder={PLATFORM_ENDPOINTS[platform] || "not fetched in the browser"}
+                  value={endpoint}
+                  onChange={(e) => onEndpointChange(e.target.value)}
+                />
+              </label>
+            </div>
+            {usesLocal && !(platform in PLATFORM_ENDPOINTS && PLATFORM_ENDPOINTS[platform]) ? (
+              <p className="advanced-note">
+                <code>{platform}</code> presets are not fetched in the browser — a real Renovate run
+                reaches them. You can still provide their content manually from a failed node below.
+              </p>
+            ) : null}
+            <div className="advanced-row">
+              <label className="grow">
+                GitLab token (PRIVATE-TOKEN)
+                <input
+                  type="password"
+                  placeholder="optional — stays in your browser"
+                  value={gitlabToken}
+                  onChange={(e) =>
+                    makeTokenHandler(GITLAB_TOKEN_KEY, setGitlabToken)(e.target.value)
+                  }
+                />
+              </label>
+              <label className="grow">
+                Gitea token
+                <input
+                  type="password"
+                  placeholder="optional — stays in your browser"
+                  value={giteaToken}
+                  onChange={(e) => makeTokenHandler(GITEA_TOKEN_KEY, setGiteaToken)(e.target.value)}
+                />
+              </label>
+              <label className="grow">
+                Forgejo token
+                <input
+                  type="password"
+                  placeholder="optional — stays in your browser"
+                  value={forgejoToken}
+                  onChange={(e) =>
+                    makeTokenHandler(FORGEJO_TOKEN_KEY, setForgejoToken)(e.target.value)
+                  }
+                />
+              </label>
+            </div>
+          </div>
+        </details>
 
         {fatal ? <p style={{ color: "var(--error)" }}>{fatal}</p> : null}
 
@@ -107,7 +244,7 @@ export function App() {
               <StageDiff result={result} stage={deferredStage} />
             </div>
             <MessagesPanel result={result} />
-            <PresetTree result={result} />
+            <PresetTree result={result} onInject={onInject} />
             <EffectiveConfig result={result} />
           </>
         ) : null}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,8 +1,9 @@
-import { useDeferredValue, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import type { OptionIndex, StageId, TraceResult } from "@renovate-config-visualizer/engine";
 import { ConfigEditor } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
 import { MessagesPanel } from "./components/MessagesPanel";
+import { MigrationSteps } from "./components/MigrationSteps";
 import { PresetTree } from "./components/PresetTree";
 import { StageDiff } from "./components/StageDiff";
 import { StageTimeline } from "./components/StageTimeline";
@@ -124,6 +125,19 @@ export function App() {
 
   const usesLocal = platform !== "github";
 
+  // Granular migrate-stage steps (004); the migrate stage shows the stepper
+  // when any exist, otherwise falls back to the whole-stage blob diff.
+  const migrateSteps = useMemo(
+    () =>
+      result?.events.filter((e) => e.stage === "migrate" && e.kind === "migration-applied") ?? [],
+    [result],
+  );
+  const finalMigrated = useMemo(
+    () =>
+      result?.events.findLast((e) => e.stage === "migrate" && e.kind === "stage-complete")?.after,
+    [result],
+  );
+
   return (
     <OptionDocsProvider index={optionIndex}>
       <main>
@@ -241,7 +255,11 @@ export function App() {
                   <span className="rendering-note"> rendering…</span>
                 ) : null}
               </div>
-              <StageDiff result={result} stage={deferredStage} />
+              {deferredStage === "migrate" && migrateSteps.length > 0 ? (
+                <MigrationSteps steps={migrateSteps} finalConfig={finalMigrated} />
+              ) : (
+                <StageDiff result={result} stage={deferredStage} />
+              )}
             </div>
             <MessagesPanel result={result} />
             <PresetTree result={result} onInject={onInject} />

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useMemo, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { OptionIndex, StageId, TraceResult } from "@renovate-config-visualizer/engine";
 import { ConfigEditor } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
@@ -74,6 +74,12 @@ export function App() {
   const deferredStage = useDeferredValue(selectedStage);
   const [fatal, setFatal] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState<OptionIndex | null>(null);
+  // Preset-tree selection is owned here so a provenance chain (005) can select
+  // a preset node in the tree. Node ids restart every run, so reset on result.
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  useEffect(() => {
+    setSelectedNodeId(null);
+  }, [result]);
 
   async function onRun(overrideInjected?: InjectionMap) {
     const injectedPresets = overrideInjected ?? injected;
@@ -262,8 +268,13 @@ export function App() {
               )}
             </div>
             <MessagesPanel result={result} />
-            <PresetTree result={result} onInject={onInject} />
-            <EffectiveConfig result={result} />
+            <PresetTree
+              result={result}
+              onInject={onInject}
+              selectedId={selectedNodeId}
+              onSelectNode={setSelectedNodeId}
+            />
+            <EffectiveConfig result={result} onSelectPreset={setSelectedNodeId} />
           </>
         ) : null}
       </main>

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -1,53 +1,379 @@
-import { useMemo, useState } from "react";
-import type { TraceResult } from "@renovate-config-visualizer/engine";
+import { useEffect, useMemo, useState } from "react";
+import type {
+  KeyProvenance,
+  ProvenanceStep,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
+import { OptionKey } from "../option-docs";
 import { ConfigJson } from "./ConfigJson";
 
 /**
- * Shows the effective config. By default hides keys whose value is identical
- * to the untouched Renovate default, so users see what their config actually
- * changes; a toggle reveals the fully hydrated config.
+ * Roadmap 005: the effective config as a provenance view. Every top-level key
+ * carries a colour-coded badge for its winning source layer (default / a
+ * preset / the repo config) and expands to the full override chain — who set
+ * it, who overrode it, and the losing values. Provenance is computed post-hoc
+ * from the trace via the engine's `computeProvenance`, loaded through the same
+ * dynamic import that keeps the renovate chunk out of the initial bundle.
  */
-export function EffectiveConfig({ result }: { result: TraceResult }) {
-  const [showDefaults, setShowDefaults] = useState(false);
 
-  const display = useMemo(() => {
-    if (!result.finalConfig) {
-      return undefined;
+type Provenance = Map<string, KeyProvenance>;
+
+/** Loads + computes provenance for a result once the engine chunk is present. */
+function useProvenance(result: TraceResult): Provenance | null | undefined {
+  // undefined = loading, null = unavailable (e.g. preset resolution failed)
+  const [state, setState] = useState<Provenance | null | undefined>(undefined);
+  useEffect(() => {
+    let live = true;
+    setState(undefined);
+    void import("@renovate-config-visualizer/engine").then((engine) => {
+      if (live) {
+        setState(engine.computeProvenance(result) ?? null);
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, [result]);
+  return state;
+}
+
+type LayerId = string;
+
+/** Stable id for a layer, used by the dropdown filter + winning-badge classes. */
+function layerId(layer: ProvenanceStep["layer"]): LayerId {
+  return layer.kind === "preset" ? `preset:${layer.name}` : layer.kind;
+}
+
+function layerLabel(layer: ProvenanceStep["layer"]): string {
+  if (layer.kind === "defaults") {
+    return "default";
+  }
+  if (layer.kind === "repo") {
+    return "repo config";
+  }
+  return layer.name;
+}
+
+function layerClass(layer: ProvenanceStep["layer"]): string {
+  return `prov-${layer.kind}`;
+}
+
+const VERBS: Record<ProvenanceStep["action"], string> = {
+  set: "sets",
+  overwrite: "overwrites with",
+  concat: "appends",
+  "shallow-merge": "shallow-merges",
+  "deep-merge": "deep-merges",
+  forced: "forces",
+};
+
+/** The step whose value survives into the final config (skips no-op steps). */
+function winningStep(entry: KeyProvenance): ProvenanceStep {
+  return entry.chain.findLast((s) => !s.noop) ?? entry.chain[entry.chain.length - 1]!;
+}
+
+/** Non-no-op layers that contributed to a key, for the layer filter. */
+function contributingLayerIds(entry: KeyProvenance): Set<LayerId> {
+  const ids = new Set<LayerId>();
+  for (const step of entry.chain) {
+    if (!step.noop) {
+      ids.add(layerId(step.layer));
     }
-    if (showDefaults) {
-      return result.finalConfig;
-    }
-    const merge = result.events.findLast((e) => e.stage === "merge" && e.kind === "stage-complete");
-    const defaults = (merge?.before ?? {}) as Record<string, unknown>;
-    const trimmed: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(result.finalConfig)) {
-      if (JSON.stringify(defaults[key]) !== JSON.stringify(value)) {
-        trimmed[key] = value;
+  }
+  return ids;
+}
+
+function isOverridden(entry: KeyProvenance): boolean {
+  const contributors = entry.chain.filter((s) => !s.noop && s.layer.kind !== "defaults");
+  return (
+    contributors.length >= 2 ||
+    entry.chain.some((s) => s.action === "overwrite" || s.action === "forced")
+  );
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function preview(value: unknown): string {
+  if (value === null) {
+    return "null";
+  }
+  if (Array.isArray(value)) {
+    return value.length ? `[ ${value.length} item${value.length === 1 ? "" : "s"} ]` : "[]";
+  }
+  if (typeof value === "object") {
+    const n = Object.keys(value).length;
+    return n ? `{ ${n} key${n === 1 ? "" : "s"} }` : "{}";
+  }
+  return truncate(JSON.stringify(value) ?? String(value), 80);
+}
+
+function LayerBadge({
+  layer,
+  onSelectPreset,
+}: {
+  layer: ProvenanceStep["layer"];
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const clickable = layer.kind === "preset" && onSelectPreset;
+  const className = `badge prov-layer ${layerClass(layer)}`;
+  if (clickable) {
+    return (
+      <button
+        type="button"
+        className={className}
+        title="Show this preset in the resolution tree"
+        onClick={() => onSelectPreset(layer.nodeId)}
+      >
+        {layerLabel(layer)}
+      </button>
+    );
+  }
+  return <span className={className}>{layerLabel(layer)}</span>;
+}
+
+function Step({
+  step,
+  onSelectPreset,
+}: {
+  step: ProvenanceStep;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const showBefore =
+    (step.action === "overwrite" || step.action === "forced") && step.before !== undefined;
+  return (
+    <div className={`prov-step action-${step.action}`}>
+      <div className="prov-step-head">
+        <LayerBadge layer={step.layer} onSelectPreset={onSelectPreset} />
+        <span className="prov-step-verb">{VERBS[step.action]}</span>
+        {step.expandedNested ? (
+          <span
+            className="badge nested"
+            title="Renovate further expanded nested extends inside this value"
+          >
+            + nested extends
+          </span>
+        ) : null}
+      </div>
+      {showBefore ? (
+        <pre className="config-view prov-value prov-before">
+          <ConfigJson value={step.before} />
+        </pre>
+      ) : null}
+      <pre className="config-view prov-value">
+        <ConfigJson value={step.after} />
+      </pre>
+    </div>
+  );
+}
+
+function KeyRow({
+  entry,
+  expanded,
+  onToggle,
+  onSelectPreset,
+}: {
+  entry: KeyProvenance;
+  expanded: boolean;
+  onToggle: () => void;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const winner = winningStep(entry);
+  const visibleSteps = entry.chain.filter((s) => !s.noop);
+  return (
+    <div className={`prov-row${expanded ? " expanded" : ""}`}>
+      <button type="button" className="prov-row-head" onClick={onToggle} aria-expanded={expanded}>
+        <span className="caret">{expanded ? "▾" : "▸"}</span>
+        <span className="prov-key-name">
+          <OptionKey name={entry.key} flagUnknown />
+        </span>
+        <span className="prov-key-preview">{preview(entry.finalValue)}</span>
+        {isOverridden(entry) ? (
+          <span className="badge prov-overridden" title="Set more than once, or overwritten/forced">
+            overridden
+          </span>
+        ) : null}
+        <LayerBadge layer={winner.layer} onSelectPreset={onSelectPreset} />
+      </button>
+      {expanded ? (
+        <div className="prov-detail">
+          <div className="prov-final">
+            <div className="prov-final-title">Final value</div>
+            <pre className="config-view prov-value">
+              <ConfigJson value={entry.finalValue} />
+            </pre>
+          </div>
+          <div className="prov-chain-title">
+            Override chain ({visibleSteps.length} step{visibleSteps.length === 1 ? "" : "s"})
+          </div>
+          {visibleSteps.map((step, i) => (
+            <Step key={i} step={step} onSelectPreset={onSelectPreset} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function EffectiveConfig({
+  result,
+  onSelectPreset,
+}: {
+  result: TraceResult;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const provenance = useProvenance(result);
+  const [query, setQuery] = useState("");
+  const [layerFilter, setLayerFilter] = useState<LayerId | "all">("all");
+  const [onlyOverridden, setOnlyOverridden] = useState(false);
+  const [showDefaults, setShowDefaults] = useState(false);
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+
+  // node ids and keys are per-run, so drop any stale expansion/filter state
+  useEffect(() => {
+    setExpanded(new Set());
+    setQuery("");
+    setLayerFilter("all");
+    setOnlyOverridden(false);
+    setShowDefaults(false);
+  }, [provenance]);
+
+  const entries = useMemo(() => (provenance ? [...provenance.values()] : []), [provenance]);
+
+  // dropdown options: every layer that non-trivially contributed to some key
+  const layerOptions = useMemo(() => {
+    const seen = new Map<LayerId, string>();
+    for (const entry of entries) {
+      for (const step of entry.chain) {
+        if (!step.noop) {
+          seen.set(layerId(step.layer), layerLabel(step.layer));
+        }
       }
     }
-    return trimmed;
-  }, [result, showDefaults]);
+    return [...seen.entries()];
+  }, [entries]);
 
-  if (!display) {
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return entries.filter((entry) => {
+      if (!showDefaults && entry.isDefaultOnly) {
+        return false;
+      }
+      if (q && !entry.key.toLowerCase().includes(q)) {
+        return false;
+      }
+      if (onlyOverridden && !isOverridden(entry)) {
+        return false;
+      }
+      if (layerFilter !== "all" && !contributingLayerIds(entry).has(layerFilter)) {
+        return false;
+      }
+      return true;
+    });
+  }, [entries, query, showDefaults, onlyOverridden, layerFilter]);
+
+  if (!result.finalConfig) {
     return null;
   }
 
+  // Fallback: provenance needs a completed preset resolution. When it is
+  // unavailable, still show the effective config as plain JSON.
+  if (provenance === null) {
+    return (
+      <div className="card">
+        <div className="card-title">Effective config</div>
+        <p className="empty-note">
+          Per-key provenance is unavailable because preset resolution did not complete. Showing the
+          effective config Renovate produced from the defaults.
+        </p>
+        <pre className="config-view">
+          <ConfigJson value={result.finalConfig} />
+        </pre>
+      </div>
+    );
+  }
+
+  const hiddenDefaults = entries.filter((e) => e.isDefaultOnly).length;
+
   return (
     <div className="card">
-      <div className="card-title">
-        Effective config{" "}
-        <label style={{ fontWeight: "normal" }}>
-          <input
-            type="checkbox"
-            checked={showDefaults}
-            onChange={(e) => setShowDefaults(e.target.checked)}
-          />{" "}
-          include untouched defaults
-        </label>
-      </div>
-      <pre className="config-view">
-        <ConfigJson value={display} />
-      </pre>
+      <div className="card-title">Effective config — per-key provenance</div>
+      {provenance === undefined ? (
+        <p className="empty-note">Computing provenance…</p>
+      ) : (
+        <>
+          <div className="prov-filters">
+            <input
+              type="text"
+              className="prov-filter-input"
+              placeholder="Filter keys…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+            <select value={layerFilter} onChange={(e) => setLayerFilter(e.target.value)}>
+              <option value="all">All layers</option>
+              {layerOptions.map(([id, label]) => (
+                <option key={id} value={id}>
+                  only set by {label}
+                </option>
+              ))}
+            </select>
+            <label className="prov-check">
+              <input
+                type="checkbox"
+                checked={onlyOverridden}
+                onChange={(e) => setOnlyOverridden(e.target.checked)}
+              />{" "}
+              only overridden
+            </label>
+            <label className="prov-check">
+              <input
+                type="checkbox"
+                checked={showDefaults}
+                onChange={(e) => setShowDefaults(e.target.checked)}
+              />{" "}
+              show default-only ({hiddenDefaults})
+            </label>
+          </div>
+          <div className="prov-list">
+            {filtered.length === 0 ? (
+              <p className="empty-note">
+                No keys match.{" "}
+                {!showDefaults && hiddenDefaults > 0
+                  ? `${hiddenDefaults} default-only option${hiddenDefaults === 1 ? "" : "s"} hidden — enable "show default-only" to reveal the fully hydrated config.`
+                  : null}
+              </p>
+            ) : (
+              filtered.map((entry) => (
+                <KeyRow
+                  key={entry.key}
+                  entry={entry}
+                  expanded={expanded.has(entry.key)}
+                  onToggle={() =>
+                    setExpanded((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(entry.key)) {
+                        next.delete(entry.key);
+                      } else {
+                        next.add(entry.key);
+                      }
+                      return next;
+                    })
+                  }
+                  onSelectPreset={onSelectPreset}
+                />
+              ))
+            )}
+          </div>
+          {!showDefaults && hiddenDefaults > 0 && filtered.length > 0 ? (
+            <p className="empty-note">
+              {hiddenDefaults} default-only option{hiddenDefaults === 1 ? "" : "s"} hidden — enable
+              “show default-only” above for the fully hydrated config.
+            </p>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/packages/app/src/components/MigrationSteps.tsx
+++ b/packages/app/src/components/MigrationSteps.tsx
@@ -1,0 +1,113 @@
+import { memo, useEffect, useState } from "react";
+import type { TraceEvent } from "@renovate-config-visualizer/engine";
+import { JsonDiff } from "./JsonDiff";
+
+interface Props {
+  /** Granular `migration-applied` events, in the order Renovate applied them. */
+  steps: TraceEvent[];
+  /**
+   * Authoritative final config for the "Copy migrated config" button. Falls
+   * back to the last step's `after` when omitted.
+   */
+  finalConfig?: unknown;
+  /** Tighter layout for the preset detail panel. */
+  compact?: boolean;
+}
+
+/**
+ * Roadmap 004: steps through the migrations Renovate applied one at a time.
+ * Each step names the migration, explains why the old form is deprecated, and
+ * shows its diff. Steps carry full-document before/after snapshots, so both the
+ * per-step diff (small) and the cumulative diff (stage start → current step)
+ * come straight from the event stream.
+ */
+export const MigrationSteps = memo(function MigrationSteps({ steps, finalConfig, compact }: Props) {
+  const [index, setIndex] = useState(0);
+  const [cumulative, setCumulative] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // A re-run replaces the event list; reset to the first step.
+  useEffect(() => {
+    setIndex(0);
+    setCopied(false);
+  }, [steps]);
+
+  if (steps.length === 0) {
+    return null;
+  }
+
+  const clamped = Math.min(index, steps.length - 1);
+  const step = steps[clamped];
+  if (!step) {
+    return null;
+  }
+  const migration = step.migration;
+  const stageStart = steps[0]?.before;
+  const before = cumulative ? stageStart : step.before;
+  const finalAfter = finalConfig ?? steps[steps.length - 1]?.after;
+
+  function copy() {
+    void navigator.clipboard.writeText(`${JSON.stringify(finalAfter, null, 2)}\n`).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <div className={`migration-steps${compact ? " compact" : ""}`}>
+      <div className="migration-step-head">
+        <span className="migration-step-counter">
+          Step {clamped + 1} of {steps.length}
+        </span>
+        <span className="migration-step-name">{migration?.name ?? step.title}</span>
+        {migration?.key ? <code className="migration-step-key">{migration.key}</code> : null}
+        {migration?.pass && migration.pass > 1 ? (
+          <span className="badge count" title="Renovate re-runs migrations until stable">
+            pass {migration.pass}
+          </span>
+        ) : null}
+      </div>
+      {migration?.explanation ? (
+        <p className="migration-explanation">{migration.explanation}</p>
+      ) : null}
+
+      <JsonDiff
+        key={`${clamped}-${cumulative ? "cumulative" : "single"}`}
+        before={before}
+        after={step.after}
+        names={cumulative ? ["stage start", "after this step"] : ["before", "after"]}
+      />
+
+      <div className="migration-nav">
+        <button type="button" onClick={() => setIndex(clamped - 1)} disabled={clamped === 0}>
+          ‹ Prev
+        </button>
+        <button
+          type="button"
+          onClick={() => setIndex(clamped + 1)}
+          disabled={clamped >= steps.length - 1}
+        >
+          Next ›
+        </button>
+        <button
+          type="button"
+          onClick={() => setIndex(steps.length - 1)}
+          disabled={clamped >= steps.length - 1}
+        >
+          Jump to end
+        </button>
+        <label className="migration-cumulative">
+          <input
+            type="checkbox"
+            checked={cumulative}
+            onChange={(e) => setCumulative(e.target.checked)}
+          />
+          Cumulative
+        </label>
+        <button type="button" className="migration-copy" onClick={copy}>
+          {copied ? "Copied!" : "Copy migrated config"}
+        </button>
+      </div>
+    </div>
+  );
+});

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -111,9 +111,14 @@ function useEngineHelpers() {
 export const PresetTree = memo(function PresetTree({
   result,
   onInject,
+  selectedId,
+  onSelectNode,
 }: {
   result: TraceResult;
   onInject: (key: string, content: Record<string, unknown>) => void;
+  /** Controlled selection, so provenance chains (005) can select a preset node. */
+  selectedId: string | null;
+  onSelectNode: (id: string | null) => void;
 }) {
   const root = result.presetTree;
   const helpers = useEngineHelpers();
@@ -137,13 +142,12 @@ export const PresetTree = memo(function PresetTree({
     return map;
   }, [result.events]);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
-  const [selectedId, setSelectedId] = useState<string | null>(null);
 
   // node ids restart at p1 for every run, so state from a previous result
-  // would silently map onto unrelated nodes of the new tree
+  // would silently map onto unrelated nodes of the new tree (selection is
+  // owned by App, which resets it on a new run)
   useEffect(() => {
     setExpanded(new Set());
-    setSelectedId(null);
   }, [root]);
 
   const parents = useMemo(
@@ -193,7 +197,7 @@ export const PresetTree = memo(function PresetTree({
               expanded={expanded}
               selectedId={selectedId}
               onToggle={toggle}
-              onSelect={setSelectedId}
+              onSelect={onSelectNode}
               injectionKey={injectionKey}
               usedInjections={usedInjections}
             />
@@ -203,7 +207,7 @@ export const PresetTree = memo(function PresetTree({
           <PresetDetail
             node={selected}
             parent={parents.get(selected.id)}
-            onClose={() => setSelectedId(null)}
+            onClose={() => onSelectNode(null)}
             injectionKey={injectionKey}
             parse={helpers?.parse ?? null}
             usedInjections={usedInjections}

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -1,7 +1,13 @@
 import { memo, useEffect, useMemo, useState } from "react";
-import type { PresetNode, PresetSourceRef, TraceResult } from "@renovate-config-visualizer/engine";
+import type {
+  PresetNode,
+  PresetSourceRef,
+  TraceEvent,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
 import { ConfigJson } from "./ConfigJson";
 import { JsonDiff } from "./JsonDiff";
+import { MigrationSteps } from "./MigrationSteps";
 
 type InjectionKeyFn = (id: {
   presetSource: string;
@@ -116,6 +122,20 @@ export const PresetTree = memo(function PresetTree({
     () => new Set(result.usedInjections ?? []),
     [result.usedInjections],
   );
+  // Migration steps Renovate applied while fetching each preset (004), grouped
+  // by the preset they belong to so the detail panel can show them per node.
+  const migrationStepsByPreset = useMemo(() => {
+    const map = new Map<string, TraceEvent[]>();
+    for (const event of result.events) {
+      const presetName = event.migration?.presetName;
+      if (event.kind === "migration-applied" && presetName) {
+        const list = map.get(presetName) ?? [];
+        list.push(event);
+        map.set(presetName, list);
+      }
+    }
+    return map;
+  }, [result.events]);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -188,6 +208,7 @@ export const PresetTree = memo(function PresetTree({
             parse={helpers?.parse ?? null}
             usedInjections={usedInjections}
             onInject={onInject}
+            migrationSteps={migrationStepsByPreset.get(selected.name) ?? []}
           />
         ) : (
           <div className="preset-panel-hint">Select a preset to inspect it.</div>
@@ -427,6 +448,7 @@ function PresetDetail({
   parse,
   usedInjections,
   onInject,
+  migrationSteps,
 }: {
   node: PresetNode;
   parent: PresetNode | undefined;
@@ -435,6 +457,7 @@ function PresetDetail({
   parse: ParseFn | null;
   usedInjections: ReadonlySet<string>;
   onInject: (key: string, content: Record<string, unknown>) => void;
+  migrationSteps: TraceEvent[];
 }) {
   const contribution = useContribution(node, parent);
   const stateLabel = STATE_LABELS[node.state];
@@ -488,6 +511,15 @@ function PresetDetail({
             after={node.input}
             names={["fetched", "migrated"]}
           />
+          {migrationSteps.length > 0 ? (
+            <div className="preset-migration-steps">
+              <div className="preset-migration-steps-title">
+                Step through the {migrationSteps.length} migration
+                {migrationSteps.length === 1 ? "" : "s"}
+              </div>
+              <MigrationSteps key={`${node.id}-steps`} steps={migrationSteps} compact />
+            </div>
+          ) : null}
         </details>
       ) : null}
       {node.resolved !== undefined &&

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -1,7 +1,33 @@
 import { memo, useEffect, useMemo, useState } from "react";
-import type { PresetNode, TraceResult } from "@renovate-config-visualizer/engine";
+import type { PresetNode, PresetSourceRef, TraceResult } from "@renovate-config-visualizer/engine";
 import { ConfigJson } from "./ConfigJson";
 import { JsonDiff } from "./JsonDiff";
+
+type InjectionKeyFn = (id: {
+  presetSource: string;
+  repo?: string;
+  presetPath?: string;
+  presetName?: string;
+  tag?: string;
+}) => string;
+type ParseFn = (text: string) => Record<string, unknown>;
+
+/** Injection key for a node, or null when its source could not be parsed. */
+function nodeInjectionKey(
+  source: PresetSourceRef | undefined,
+  keyFn: InjectionKeyFn | null,
+): string | null {
+  if (!source?.presetSource || !keyFn) {
+    return null;
+  }
+  return keyFn({
+    presetSource: source.presetSource,
+    repo: source.repo,
+    presetPath: source.presetPath,
+    presetName: source.presetName,
+    tag: source.tag,
+  });
+}
 
 /**
  * Roadmap 002: interactive tree of the recursive `extends` expansion. One
@@ -49,8 +75,47 @@ function buildParents(root: PresetNode): Map<string, PresetNode> {
   return parents;
 }
 
-export const PresetTree = memo(function PresetTree({ result }: { result: TraceResult }) {
+/** Loads the engine helpers the tree needs (merge + injection key/parse). */
+function useEngineHelpers() {
+  const [helpers, setHelpers] = useState<{
+    merge: MergeFn;
+    injectionKey: InjectionKeyFn;
+    parse: ParseFn;
+  } | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    void import("@renovate-config-visualizer/engine").then((engine) => {
+      if (live) {
+        setHelpers({
+          merge: engine.mergeChildConfig as MergeFn,
+          injectionKey: engine.presetInjectionKey as InjectionKeyFn,
+          parse: engine.parseInjectedPreset as ParseFn,
+        });
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  return helpers;
+}
+
+export const PresetTree = memo(function PresetTree({
+  result,
+  onInject,
+}: {
+  result: TraceResult;
+  onInject: (key: string, content: Record<string, unknown>) => void;
+}) {
   const root = result.presetTree;
+  const helpers = useEngineHelpers();
+  const injectionKey = helpers?.injectionKey ?? null;
+  const usedInjections = useMemo(
+    () => new Set(result.usedInjections ?? []),
+    [result.usedInjections],
+  );
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -109,6 +174,8 @@ export const PresetTree = memo(function PresetTree({ result }: { result: TraceRe
               selectedId={selectedId}
               onToggle={toggle}
               onSelect={setSelectedId}
+              injectionKey={injectionKey}
+              usedInjections={usedInjections}
             />
           ))}
         </div>
@@ -117,6 +184,10 @@ export const PresetTree = memo(function PresetTree({ result }: { result: TraceRe
             node={selected}
             parent={parents.get(selected.id)}
             onClose={() => setSelectedId(null)}
+            injectionKey={injectionKey}
+            parse={helpers?.parse ?? null}
+            usedInjections={usedInjections}
+            onInject={onInject}
           />
         ) : (
           <div className="preset-panel-hint">Select a preset to inspect it.</div>
@@ -132,16 +203,22 @@ function TreeNode({
   selectedId,
   onToggle,
   onSelect,
+  injectionKey,
+  usedInjections,
 }: {
   node: PresetNode;
   expanded: ReadonlySet<string>;
   selectedId: string | null;
   onToggle: (id: string) => void;
   onSelect: (id: string) => void;
+  injectionKey: InjectionKeyFn | null;
+  usedInjections: ReadonlySet<string>;
 }) {
   const hasChildren = node.children.length > 0;
   const isExpanded = expanded.has(node.id);
   const stateLabel = STATE_LABELS[node.state];
+  const key = nodeInjectionKey(node.source, injectionKey);
+  const userSupplied = key !== null && usedInjections.has(key);
 
   return (
     <div
@@ -167,6 +244,19 @@ function TreeNode({
         {node.source?.presetSource ? (
           <span className={`badge src src-${node.source.presetSource}`}>
             {node.source.presetSource}
+          </span>
+        ) : null}
+        {node.source?.platform ? (
+          <span
+            className="badge via"
+            title={`local> resolved against ${node.source.platform} @ ${node.source.endpoint ?? "default endpoint"}`}
+          >
+            via {node.source.platform}
+          </span>
+        ) : null}
+        {userSupplied ? (
+          <span className="badge user-supplied" title="Resolved from manually provided content">
+            user-supplied
           </span>
         ) : null}
         {hasChildren && !isExpanded ? (
@@ -205,6 +295,8 @@ function TreeNode({
               selectedId={selectedId}
               onToggle={onToggle}
               onSelect={onSelect}
+              injectionKey={injectionKey}
+              usedInjections={usedInjections}
             />
           ))}
         </div>
@@ -220,19 +312,7 @@ function TreeNode({
  * out of the app's initial bundle) resolves instantly.
  */
 function useContribution(node: PresetNode, parent: PresetNode | undefined) {
-  const [merge, setMerge] = useState<MergeFn | null>(null);
-
-  useEffect(() => {
-    let live = true;
-    void import("@renovate-config-visualizer/engine").then((engine) => {
-      if (live) {
-        setMerge(() => engine.mergeChildConfig as MergeFn);
-      }
-    });
-    return () => {
-      live = false;
-    };
-  }, []);
+  const merge = useEngineHelpers()?.merge ?? null;
 
   return useMemo(() => {
     if (!merge || !parent || node.nested || node.state !== "resolved" || !node.resolved) {
@@ -266,6 +346,8 @@ function SourceDetails({ node }: { node: PresetNode }) {
     ["Preset", source.presetName],
     ["Tag", source.tag],
     ["Parameters", source.params?.join(", ")],
+    ["Platform", source.platform],
+    ["Endpoint", source.endpoint],
   ];
   return (
     <dl className="preset-source">
@@ -281,17 +363,83 @@ function SourceDetails({ node }: { node: PresetNode }) {
   );
 }
 
+function PresetInjector({
+  node,
+  injectionKey,
+  parse,
+  onInject,
+}: {
+  node: PresetNode;
+  injectionKey: InjectionKeyFn | null;
+  parse: ParseFn | null;
+  onInject: (key: string, content: Record<string, unknown>) => void;
+}) {
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const key = nodeInjectionKey(node.source, injectionKey);
+  if (!key || !parse) {
+    return null;
+  }
+
+  function submit() {
+    setError(null);
+    try {
+      const parsed = parse!(text);
+      onInject(key!, parsed);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  return (
+    <details className="preset-inject" open>
+      <summary>Provide preset content manually</summary>
+      <p className="empty-note">
+        Paste this preset&apos;s JSON (JSON5 accepted). It is stored in memory and the pipeline
+        re-runs using it, so unreachable / self-hosted presets can still be explored.
+      </p>
+      <textarea
+        className="preset-inject-input"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder={'{\n  "labels": ["from-manual-preset"]\n}'}
+        rows={6}
+        spellCheck={false}
+      />
+      {error ? <p className="preset-node-error">{error}</p> : null}
+      <button
+        type="button"
+        className="preset-inject-button"
+        onClick={submit}
+        disabled={text.trim().length === 0}
+      >
+        Use this content &amp; re-run
+      </button>
+    </details>
+  );
+}
+
 function PresetDetail({
   node,
   parent,
   onClose,
+  injectionKey,
+  parse,
+  usedInjections,
+  onInject,
 }: {
   node: PresetNode;
   parent: PresetNode | undefined;
   onClose: () => void;
+  injectionKey: InjectionKeyFn | null;
+  parse: ParseFn | null;
+  usedInjections: ReadonlySet<string>;
+  onInject: (key: string, content: Record<string, unknown>) => void;
 }) {
   const contribution = useContribution(node, parent);
   const stateLabel = STATE_LABELS[node.state];
+  const key = nodeInjectionKey(node.source, injectionKey);
+  const userSupplied = key !== null && usedInjections.has(key);
   const migrationChanged =
     node.fetched !== undefined &&
     node.input !== undefined &&
@@ -306,8 +454,16 @@ function PresetDetail({
         </button>
       </div>
       <SourceDetails node={node} />
+      {userSupplied ? (
+        <p className="empty-note">
+          Resolved from preset content you supplied manually rather than a fetch.
+        </p>
+      ) : null}
       {node.error ? <p className="preset-node-error">{node.error.message}</p> : null}
       {stateLabel && !node.error ? <p className="empty-note">{stateLabel}</p> : null}
+      {node.state === "error" ? (
+        <PresetInjector node={node} injectionKey={injectionKey} parse={parse} onInject={onInject} />
+      ) : null}
       {node.duplicate ? (
         <p className="empty-note">
           This preset also appears elsewhere in the tree; its content was resolved once and served

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, useEffect, useMemo, useState, type CSSProperties } from "react";
 import type {
   PresetNode,
   PresetSourceRef,
@@ -36,11 +36,17 @@ function nodeInjectionKey(
 }
 
 /**
- * Roadmap 002: interactive tree of the recursive `extends` expansion. One
- * node per preset in resolution order; clicking a node opens a panel with the
- * fetched/migrated/resolved content and this preset's contribution to the
- * merged config. Subtrees are collapsed by default so config:recommended's
- * ~1000 nodes never hit the DOM at once.
+ * Roadmap 002 + 011: interactive tree of the recursive `extends` expansion,
+ * made legible at `config:recommended` scale (~1,100 nodes). The tree is
+ * conceptually a flat array of visible rows; only the rows intersecting the
+ * scroll viewport are mounted (windowed render with top/bottom spacers), so a
+ * thousand-node expansion never puts a thousand components in the DOM. Every
+ * node carries contribution badges (own options / packageRules) and, when
+ * collapsed, a subtree roll-up. A search box, a "hide zero-contribution
+ * routers" toggle, a flat-table view and a summary header turn the raw tree
+ * into an instrument for "what did all of that do?" and "where did this come
+ * from?". All per-node/per-subtree aggregates are computed once per result in
+ * a single walk (`computeTreeStats`), never per render.
  */
 
 type MergeFn = (
@@ -56,29 +62,413 @@ const STATE_LABELS: Record<PresetNode["state"], string | null> = {
   aborted: "not resolved — run aborted by an earlier error",
 };
 
-/** Unique resolved presets (duplicates via multiple paths count once). */
-function countResolvedPresets(root: PresetNode): number {
-  const names = new Set<string>();
-  const walk = (node: PresetNode) => {
-    if (node !== root && node.state === "resolved") {
-      names.add(node.name);
-    }
-    node.children.forEach(walk);
-  };
-  walk(root);
-  return names.size;
+/** Fixed row height keeps the windowing math trivial; rows never wrap. */
+const ROW_HEIGHT = 26;
+const INDENT = 14;
+const OVERSCAN = 8;
+
+const nf = new Intl.NumberFormat();
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function buildParents(root: PresetNode): Map<string, PresetNode> {
+/** packageRules keys whose string contents feed the search index. */
+const RULE_MATCH_KEYS = [
+  "matchPackageNames",
+  "matchDepNames",
+  "matchPackagePatterns",
+  "matchPackagePrefixes",
+];
+
+/** Per-node contribution + search facts, all derived from the node's `input`. */
+interface NodeStats {
+  /** Top-level option keys this preset sets (excludes extends/ignorePresets/packageRules). */
+  ownOptions: number;
+  optionKeys: string[];
+  /** packageRules entries this preset contributes itself. */
+  ownRules: number;
+  /** Sets no top-level option and no packageRules of its own — a pure `extends` router. */
+  zero: boolean;
+  /** Lowercased name/source/option-key/package-string haystack for the filter box. */
+  search: string;
+  depth: number;
+  /** Stable structural identity (name-path from root) for expansion persistence. */
+  identity: string;
+  /** Descendants (excluding self). */
+  descResolved: number;
+  descRules: number;
+  /** Descendants that are contributing or non-resolved — i.e. would render something. */
+  descContrib: number;
+}
+
+interface TreeStats {
+  statsById: Map<string, NodeStats>;
+  nodesById: Map<string, PresetNode>;
+  parents: Map<string, PresetNode>;
+  identityById: Map<string, string>;
+  idByIdentity: Map<string, string>;
+  /** All occurrences of each preset name, in pre-order, for dedup cycling. */
+  occurrencesByName: Map<string, PresetNode[]>;
+  summary: TreeSummary;
+}
+
+interface TreeSummary {
+  resolved: number;
+  fetched: number;
+  internal: number;
+  options: number;
+  rules: number;
+  maxDepth: number;
+  duplicates: number;
+  errors: number;
+}
+
+function ownContribution(node: PresetNode): {
+  ownOptions: number;
+  optionKeys: string[];
+  ownRules: number;
+  search: string;
+} {
+  const parts: string[] = [node.name];
+  const src = node.source;
+  if (src) {
+    for (const v of [src.presetSource, src.repo, src.presetPath, src.presetName, src.tag]) {
+      if (v) {
+        parts.push(v);
+      }
+    }
+    if (src.params) {
+      parts.push(...src.params);
+    }
+  }
+  let ownOptions = 0;
+  let ownRules = 0;
+  const optionKeys: string[] = [];
+  const input = node.input;
+  if (isPlainObject(input)) {
+    for (const key of Object.keys(input)) {
+      if (key === "extends" || key === "ignorePresets" || key === "packageRules") {
+        continue;
+      }
+      ownOptions++;
+      optionKeys.push(key);
+      parts.push(key);
+    }
+    const rules = input.packageRules;
+    if (Array.isArray(rules)) {
+      ownRules = rules.length;
+      for (const rule of rules) {
+        if (!isPlainObject(rule)) {
+          continue;
+        }
+        for (const mk of RULE_MATCH_KEYS) {
+          const arr = rule[mk];
+          if (Array.isArray(arr)) {
+            for (const s of arr) {
+              if (typeof s === "string") {
+                parts.push(s);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return { ownOptions, optionKeys, ownRules, search: parts.join(" ").toLowerCase() };
+}
+
+/** Single walk: per-node/per-subtree stats, identities, occurrences and totals. */
+function computeTreeStats(root: PresetNode): TreeStats {
+  const statsById = new Map<string, NodeStats>();
+  const nodesById = new Map<string, PresetNode>();
   const parents = new Map<string, PresetNode>();
-  const walk = (node: PresetNode) => {
+  const identityById = new Map<string, string>();
+  const idByIdentity = new Map<string, string>();
+  const occurrencesByName = new Map<string, PresetNode[]>();
+  let maxDepth = 0;
+
+  // Returns subtree aggregates INCLUDING self so the parent can roll them up.
+  const visit = (
+    node: PresetNode,
+    identity: string,
+    depth: number,
+  ): { resolved: number; rules: number; contrib: number } => {
+    nodesById.set(node.id, node);
+    identityById.set(node.id, identity);
+    if (!idByIdentity.has(identity)) {
+      idByIdentity.set(identity, node.id);
+    }
+    if (node !== root) {
+      const list = occurrencesByName.get(node.name);
+      if (list) {
+        list.push(node);
+      } else {
+        occurrencesByName.set(node.name, [node]);
+      }
+    }
+    maxDepth = Math.max(maxDepth, depth);
+
+    const { ownOptions, optionKeys, ownRules, search } = ownContribution(node);
+    const zero = ownOptions === 0 && ownRules === 0;
+    const selfResolved = node.state === "resolved" ? 1 : 0;
+    const selfContrib = node.state !== "resolved" || !zero ? 1 : 0;
+
+    let aggResolved = selfResolved;
+    let aggRules = ownRules;
+    let aggContrib = selfContrib;
+
+    // Disambiguate identical-named siblings by occurrence index.
+    const nameCounts = new Map<string, number>();
     for (const child of node.children) {
+      const seen = nameCounts.get(child.name) ?? 0;
+      nameCounts.set(child.name, seen + 1);
+      const childIdentity = `${identity}>${child.name}${seen > 0 ? `#${seen}` : ""}`;
       parents.set(child.id, node);
-      walk(child);
+      const sub = visit(child, childIdentity, depth + 1);
+      aggResolved += sub.resolved;
+      aggRules += sub.rules;
+      aggContrib += sub.contrib;
+    }
+
+    statsById.set(node.id, {
+      ownOptions,
+      optionKeys,
+      ownRules,
+      zero,
+      search,
+      depth,
+      identity,
+      descResolved: aggResolved - selfResolved,
+      descRules: aggRules - ownRules,
+      descContrib: aggContrib - selfContrib,
+    });
+
+    return { resolved: aggResolved, rules: aggRules, contrib: aggContrib };
+  };
+
+  visit(root, "", 0);
+
+  // Totals attributed per UNIQUE resolved preset name (duplicates served from
+  // cache do not re-contribute), so the header reads as the honest cost.
+  const seen = new Set<string>();
+  const optionUnion = new Set<string>();
+  let fetched = 0;
+  let internal = 0;
+  let rules = 0;
+  let duplicates = 0;
+  let errors = 0;
+  for (const node of nodesById.values()) {
+    if (node === root) {
+      continue;
+    }
+    if (node.duplicate) {
+      duplicates++;
+    }
+    if (node.state === "error") {
+      errors++;
+    }
+    if (node.state !== "resolved" || seen.has(node.name)) {
+      continue;
+    }
+    seen.add(node.name);
+    const st = statsById.get(node.id);
+    if (!st) {
+      continue;
+    }
+    const kind = node.source?.presetSource ?? "internal";
+    if (kind === "internal") {
+      internal++;
+    } else {
+      fetched++;
+    }
+    rules += st.ownRules;
+    for (const k of st.optionKeys) {
+      optionUnion.add(k);
+    }
+  }
+
+  return {
+    statsById,
+    nodesById,
+    parents,
+    identityById,
+    idByIdentity,
+    occurrencesByName,
+    summary: {
+      resolved: seen.size,
+      fetched,
+      internal,
+      options: optionUnion.size,
+      rules,
+      maxDepth,
+      duplicates,
+      errors,
+    },
+  };
+}
+
+/** Node ids whose subtree (self or any descendant) matches the query. */
+function computeSubtreeMatch(
+  root: PresetNode,
+  statsById: Map<string, NodeStats>,
+  q: string,
+): Set<string> {
+  const set = new Set<string>();
+  const visit = (node: PresetNode): boolean => {
+    let any = statsById.get(node.id)?.search.includes(q) ?? false;
+    for (const child of node.children) {
+      if (visit(child)) {
+        any = true;
+      }
+    }
+    if (any) {
+      set.add(node.id);
+    }
+    return any;
+  };
+  for (const child of root.children) {
+    visit(child);
+  }
+  return set;
+}
+
+interface Row {
+  node: PresetNode;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+  /** Kept only for orientation while filtering (rendered dimmed). */
+  dimmed: boolean;
+  /** Routers shortcut by the hide-zero toggle between the shown parent and this node. */
+  elidedChain: PresetNode[] | null;
+  stats: NodeStats;
+}
+
+interface FlattenArgs {
+  root: PresetNode;
+  stats: TreeStats;
+  expandedIdentities: ReadonlySet<string>;
+  hideZero: boolean;
+  query: string;
+}
+
+/** The tree collapsed to the ordered list of currently-visible rows. */
+function flattenTree({ root, stats, expandedIdentities, hideZero, query }: FlattenArgs): Row[] {
+  const { statsById, identityById } = stats;
+  const q = query.trim().toLowerCase();
+  const searching = q.length > 0;
+  const subtreeMatch = searching ? computeSubtreeMatch(root, statsById, q) : null;
+  const rows: Row[] = [];
+
+  const emit = (node: PresetNode, depth: number, elided: PresetNode[]): void => {
+    if (subtreeMatch && !subtreeMatch.has(node.id)) {
+      return;
+    }
+    const st = statsById.get(node.id);
+    if (!st) {
+      return;
+    }
+    const isResolved = node.state === "resolved";
+    const selfMatch = searching ? st.search.includes(q) : false;
+
+    // Hide-zero: pure resolved routers are shortcut, promoting their
+    // contributing descendants into this level with an elided-path chip.
+    if (hideZero && isResolved && st.zero && !selfMatch) {
+      if (node.children.length > 0) {
+        for (const child of node.children) {
+          emit(child, depth, [...elided, node]);
+        }
+      }
+      return; // zero leaves simply vanish while the toggle is on (recoverable)
+    }
+
+    let hasChildren: boolean;
+    if (searching) {
+      hasChildren = node.children.some((c) => subtreeMatch?.has(c.id));
+    } else if (hideZero) {
+      hasChildren = st.descContrib > 0;
+    } else {
+      hasChildren = node.children.length > 0;
+    }
+
+    const expanded =
+      hasChildren && (searching || expandedIdentities.has(identityById.get(node.id) ?? ""));
+
+    rows.push({
+      node,
+      depth,
+      hasChildren,
+      expanded,
+      dimmed: searching ? !selfMatch : false,
+      elidedChain: elided.length > 0 ? elided : null,
+      stats: st,
+    });
+
+    if (expanded) {
+      for (const child of node.children) {
+        emit(child, depth + 1, []);
+      }
     }
   };
-  walk(root);
-  return parents;
+
+  for (const child of root.children) {
+    emit(child, 0, []);
+  }
+  return rows;
+}
+
+interface TableRow {
+  node: PresetNode;
+  name: string;
+  sourceKind: string;
+  opts: number;
+  rules: number;
+  count: number;
+  search: string;
+}
+
+type SortColumn = "name" | "source" | "opts" | "rules" | "count";
+
+/** One row per unique resolved preset name for the flat table view. */
+function buildTableRows(stats: TreeStats): TableRow[] {
+  const rows: TableRow[] = [];
+  for (const [name, occurrences] of stats.occurrencesByName) {
+    const first = occurrences.find((n) => n.state === "resolved");
+    if (!first) {
+      continue;
+    }
+    const st = stats.statsById.get(first.id);
+    if (!st) {
+      continue;
+    }
+    rows.push({
+      node: first,
+      name,
+      sourceKind: first.source?.presetSource ?? "internal",
+      opts: st.ownOptions,
+      rules: st.ownRules,
+      count: occurrences.length,
+      search: st.search,
+    });
+  }
+  return rows;
+}
+
+function sortTableRows(rows: TableRow[], column: SortColumn, dir: 1 | -1): TableRow[] {
+  const sorted = [...rows];
+  sorted.sort((a, b) => {
+    let cmp: number;
+    if (column === "name") {
+      cmp = a.name.localeCompare(b.name);
+    } else if (column === "source") {
+      cmp = a.sourceKind.localeCompare(b.sourceKind) || a.name.localeCompare(b.name);
+    } else {
+      cmp = a[column] - b[column] || a.name.localeCompare(b.name);
+    }
+    return cmp * dir;
+  });
+  return sorted;
 }
 
 /** Loads the engine helpers the tree needs (merge + injection key/parse). */
@@ -106,6 +496,217 @@ function useEngineHelpers() {
   }, []);
 
   return helpers;
+}
+
+/**
+ * Windowing state for a scroll container: which slice of rows to mount. The
+ * container is captured through a callback ref held in state, so the scroll
+ * listener re-attaches whenever the element (re)mounts, not just on first run.
+ */
+function useWindow(count: number) {
+  const [el, setEl] = useState<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewport, setViewport] = useState(400);
+
+  useEffect(() => {
+    if (!el) {
+      return;
+    }
+    const update = () => {
+      setScrollTop(el.scrollTop);
+      setViewport(el.clientHeight);
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => {
+      el.removeEventListener("scroll", update);
+      ro.disconnect();
+    };
+  }, [el]);
+
+  const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const end = Math.min(count, Math.ceil((scrollTop + viewport) / ROW_HEIGHT) + OVERSCAN);
+  return {
+    ref: setEl,
+    el,
+    start,
+    end,
+    padTop: start * ROW_HEIGHT,
+    padBottom: Math.max(0, (count - end) * ROW_HEIGHT),
+  };
+}
+
+function SummaryHeader({ summary }: { summary: TreeSummary }) {
+  const bits: { label: string; value: number; title: string }[] = [
+    { label: "presets", value: summary.resolved, title: "Unique presets resolved" },
+    { label: "fetched", value: summary.fetched, title: "Unique presets fetched from a host" },
+    { label: "internal", value: summary.internal, title: "Unique built-in presets" },
+    {
+      label: "options set",
+      value: summary.options,
+      title: "Distinct top-level options the presets set",
+    },
+    { label: "rules", value: summary.rules, title: "packageRules contributed by presets" },
+    { label: "depth", value: summary.maxDepth, title: "Deepest extends chain" },
+    {
+      label: "duplicates",
+      value: summary.duplicates,
+      title: "Repeat occurrences served from cache",
+    },
+    { label: "errors", value: summary.errors, title: "Presets that failed to resolve" },
+  ];
+  return (
+    <div className="preset-summary">
+      {bits.map((b) => (
+        <span key={b.label} className="preset-summary-stat" title={b.title}>
+          <strong>{nf.format(b.value)}</strong> {b.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed: boolean }) {
+  return (
+    <>
+      {stats.ownOptions > 0 ? (
+        <span className="badge contrib opts" title="Top-level options this preset sets">
+          {stats.ownOptions} opt{stats.ownOptions === 1 ? "" : "s"}
+        </span>
+      ) : null}
+      {stats.ownRules > 0 ? (
+        <span className="badge contrib rules" title="packageRules this preset contributes">
+          {stats.ownRules} rule{stats.ownRules === 1 ? "" : "s"}
+        </span>
+      ) : null}
+      {collapsed && (stats.descResolved > 0 || stats.descRules > 0) ? (
+        <span className="badge rollup" title="Totals hidden inside this collapsed subtree">
+          {stats.descResolved > 0 ? `· ${nf.format(stats.descResolved)} presets ` : ""}
+          {stats.descRules > 0 ? `· ${nf.format(stats.descRules)} rules` : ""}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function TreeRow({
+  row,
+  selectedId,
+  onToggle,
+  onSelect,
+  onCycleDup,
+  injectionKey,
+  usedInjections,
+  dupCount,
+}: {
+  row: Row;
+  selectedId: string | null;
+  onToggle: (identity: string) => void;
+  onSelect: (id: string) => void;
+  onCycleDup: (node: PresetNode) => void;
+  injectionKey: InjectionKeyFn | null;
+  usedInjections: ReadonlySet<string>;
+  dupCount: number;
+}) {
+  const { node, stats } = row;
+  const stateLabel = STATE_LABELS[node.state];
+  const key = nodeInjectionKey(node.source, injectionKey);
+  const userSupplied = key !== null && usedInjections.has(key);
+  const style: CSSProperties = {
+    height: ROW_HEIGHT,
+    paddingLeft: row.depth * INDENT,
+  };
+  const chain = row.elidedChain;
+
+  return (
+    <div
+      className={`preset-row state-${node.state}${stats.zero ? " zero" : ""}${row.dimmed ? " dimmed" : ""}`}
+      role="treeitem"
+      aria-expanded={row.hasChildren ? row.expanded : undefined}
+      style={style}
+    >
+      {row.hasChildren ? (
+        <button
+          type="button"
+          className="caret"
+          onClick={() => onToggle(stats.identity)}
+          aria-label={row.expanded ? "Collapse" : "Expand"}
+        >
+          {row.expanded ? "▾" : "▸"}
+        </button>
+      ) : (
+        <span className="caret-spacer" />
+      )}
+      {chain ? (
+        <button
+          type="button"
+          className="badge elided"
+          title={`Routers skipped: ${chain.map((n) => n.name).join(" › ")} (click to select)`}
+          onClick={() => {
+            const last = chain[chain.length - 1];
+            if (last) {
+              onSelect(last.id);
+            }
+          }}
+        >
+          {chain[0]?.name}
+          {chain.length > 1 ? " › … " : " "}›
+        </button>
+      ) : null}
+      <button
+        type="button"
+        className={`preset-name${node.id === selectedId ? " selected" : ""}`}
+        onClick={() => onSelect(node.id)}
+      >
+        {node.name}
+      </button>
+      {node.source?.presetSource ? (
+        <span className={`badge src src-${node.source.presetSource}`}>
+          {node.source.presetSource}
+        </span>
+      ) : null}
+      {node.source?.platform ? (
+        <span
+          className="badge via"
+          title={`local> resolved against ${node.source.platform} @ ${node.source.endpoint ?? "default endpoint"}`}
+        >
+          via {node.source.platform}
+        </span>
+      ) : null}
+      {userSupplied ? (
+        <span className="badge user-supplied" title="Resolved from manually provided content">
+          user-supplied
+        </span>
+      ) : null}
+      <ContributionBadges stats={stats} collapsed={row.hasChildren && !row.expanded} />
+      {node.duplicate ? (
+        <button
+          type="button"
+          className="badge dup"
+          title={`Appears ${dupCount}× in this tree — click to cycle to the next occurrence`}
+          onClick={() => onCycleDup(node)}
+        >
+          duplicate ×{dupCount}
+        </button>
+      ) : null}
+      {node.nested ? (
+        <span
+          className="badge nested"
+          title="Found while resolving a nested value (e.g. packageRules[n].extends), not this parent's own extends"
+        >
+          nested
+        </span>
+      ) : null}
+      {stateLabel ? <span className={`badge state state-${node.state}`}>{stateLabel}</span> : null}
+      {node.state === "error" && node.error ? (
+        <span className="preset-row-error" title={node.error.message}>
+          {node.error.message}
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 export const PresetTree = memo(function PresetTree({
@@ -141,72 +742,269 @@ export const PresetTree = memo(function PresetTree({
     }
     return map;
   }, [result.events]);
+
+  const stats = useMemo(() => (root ? computeTreeStats(root) : null), [root]);
+
+  const [view, setView] = useState<"tree" | "table">("tree");
+  const [hideZero, setHideZero] = useState(false);
+  const [rawQuery, setRawQuery] = useState("");
+  const [query, setQuery] = useState("");
+  const [sortColumn, setSortColumn] = useState<SortColumn>("count");
+  const [sortDir, setSortDir] = useState<1 | -1>(-1);
+  // Expansion keyed by stable structural identity (name-path from root), so it
+  // survives re-runs of the same config even though node ids restart at p1.
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
 
-  // node ids restart at p1 for every run, so state from a previous result
-  // would silently map onto unrelated nodes of the new tree (selection is
-  // owned by App, which resets it on a new run)
+  // Debounce the filter box; the match pass is a full walk, so avoid running it
+  // on every keystroke.
   useEffect(() => {
-    setExpanded(new Set());
-  }, [root]);
+    const id = setTimeout(() => setQuery(rawQuery), 150);
+    return () => clearTimeout(id);
+  }, [rawQuery]);
 
-  const parents = useMemo(
-    () => (root ? buildParents(root) : new Map<string, PresetNode>()),
-    [root],
-  );
-  const nodesById = useMemo(() => {
-    const map = new Map<string, PresetNode>();
-    const walk = (node: PresetNode) => {
-      map.set(node.id, node);
-      node.children.forEach(walk);
-    };
-    if (root) {
-      walk(root);
+  // On a new result, translate stored identities to the new tree: keep the ones
+  // that still exist, drop the rest. Selection is reset by App separately.
+  useEffect(() => {
+    if (!stats) {
+      return;
     }
-    return map;
-  }, [root]);
+    setExpanded((prev) => {
+      const valid = new Set<string>();
+      for (const id of prev) {
+        if (stats.idByIdentity.has(id)) {
+          valid.add(id);
+        }
+      }
+      return valid.size === prev.size ? prev : valid;
+    });
+  }, [stats]);
 
-  if (!root || root.children.length === 0) {
-    return null;
-  }
-  const selected = selectedId ? nodesById.get(selectedId) : undefined;
+  const flatRows = useMemo(
+    () =>
+      root && stats
+        ? flattenTree({ root, stats, expandedIdentities: expanded, hideZero, query })
+        : [],
+    [root, stats, expanded, hideZero, query],
+  );
 
-  function toggle(id: string) {
+  const tableRows = useMemo(() => {
+    if (!stats) {
+      return [];
+    }
+    const q = query.trim().toLowerCase();
+    const base = buildTableRows(stats);
+    const filtered = q ? base.filter((r) => r.search.includes(q)) : base;
+    return sortTableRows(filtered, sortColumn, sortDir);
+  }, [stats, query, sortColumn, sortDir]);
+
+  const activeCount = view === "tree" ? flatRows.length : tableRows.length;
+  const win = useWindow(activeCount);
+
+  // Reverse lookup (005) + dedup cycling: when selection changes, open every
+  // ancestor of the selected node so the row exists in the flattened list.
+  useEffect(() => {
+    if (!selectedId || !stats) {
+      return;
+    }
+    const additions: string[] = [];
+    let node: PresetNode | undefined = stats.nodesById.get(selectedId);
+    while (node) {
+      const parent = stats.parents.get(node.id);
+      if (!parent) {
+        break;
+      }
+      additions.push(stats.identityById.get(parent.id) ?? "");
+      node = parent;
+    }
+    if (additions.length === 0) {
+      return;
+    }
     setExpanded((prev) => {
       const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
+      let changed = false;
+      for (const id of additions) {
+        if (!next.has(id)) {
+          next.add(id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [selectedId, stats]);
+
+  // …then scroll the selected row into view once it is in the flattened list.
+  useEffect(() => {
+    if (!selectedId || view !== "tree") {
+      return;
+    }
+    const idx = flatRows.findIndex((r) => r.node.id === selectedId);
+    const el = win.el;
+    if (idx < 0 || !el) {
+      return;
+    }
+    const top = idx * ROW_HEIGHT;
+    const bottom = top + ROW_HEIGHT;
+    if (top < el.scrollTop) {
+      el.scrollTop = top;
+    } else if (bottom > el.scrollTop + el.clientHeight) {
+      el.scrollTop = bottom - el.clientHeight;
+    }
+  }, [selectedId, flatRows, view, win.el]);
+
+  if (!root || root.children.length === 0 || !stats) {
+    return null;
+  }
+  const selected = selectedId ? stats.nodesById.get(selectedId) : undefined;
+
+  function toggle(identity: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(identity)) {
+        next.delete(identity);
       } else {
-        next.add(id);
+        next.add(identity);
       }
       return next;
     });
   }
 
+  function cycleDup(node: PresetNode) {
+    const list = stats?.occurrencesByName.get(node.name);
+    if (!list || list.length < 2) {
+      return;
+    }
+    const i = list.findIndex((n) => n.id === node.id);
+    const next = list[(i + 1) % list.length];
+    if (next) {
+      onSelectNode(next.id);
+    }
+  }
+
+  function toggleSort(column: SortColumn) {
+    if (column === sortColumn) {
+      setSortDir((d) => (d === 1 ? -1 : 1));
+    } else {
+      setSortColumn(column);
+      setSortDir(column === "name" || column === "source" ? 1 : -1);
+    }
+  }
+
+  const treeSlice = flatRows.slice(win.start, win.end);
+  const tableSlice = tableRows.slice(win.start, win.end);
+
+  const columns: { key: SortColumn; label: string }[] = [
+    { key: "name", label: "preset" },
+    { key: "source", label: "source" },
+    { key: "opts", label: "opts" },
+    { key: "rules", label: "rules" },
+    { key: "count", label: "count" },
+  ];
+
   return (
     <div className="card">
       <div className="card-title">
-        Preset resolution tree ({countResolvedPresets(root)} resolved)
+        Preset resolution tree ({nf.format(stats.summary.resolved)} resolved)
+      </div>
+      <SummaryHeader summary={stats.summary} />
+      <div className="preset-controls">
+        <input
+          type="text"
+          className="preset-search"
+          placeholder="Filter by preset, option key, or package name…"
+          value={rawQuery}
+          onChange={(e) => setRawQuery(e.target.value)}
+        />
+        <label
+          className="preset-check"
+          title="Shortcut pure extends routers to the presets that actually changed something"
+        >
+          <input
+            type="checkbox"
+            checked={hideZero}
+            onChange={(e) => setHideZero(e.target.checked)}
+          />{" "}
+          hide zero-contribution
+        </label>
+        <div className="preset-view-toggle" role="group" aria-label="View">
+          <button
+            type="button"
+            className={view === "tree" ? "active" : ""}
+            onClick={() => setView("tree")}
+          >
+            tree
+          </button>
+          <button
+            type="button"
+            className={view === "table" ? "active" : ""}
+            onClick={() => setView("table")}
+          >
+            table
+          </button>
+        </div>
       </div>
       <div className={`preset-tree-layout${selected ? " with-panel" : ""}`}>
-        <div className="preset-tree" role="tree">
-          {root.children.map((child) => (
-            <TreeNode
-              key={child.id}
-              node={child}
-              expanded={expanded}
-              selectedId={selectedId}
-              onToggle={toggle}
-              onSelect={onSelectNode}
-              injectionKey={injectionKey}
-              usedInjections={usedInjections}
-            />
-          ))}
+        <div>
+          {view === "table" ? (
+            <div className="preset-table-head" role="row">
+              {columns.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  className={`preset-th col-${c.key}${sortColumn === c.key ? " sorted" : ""}`}
+                  onClick={() => toggleSort(c.key)}
+                >
+                  {c.label}
+                  {sortColumn === c.key ? (sortDir === 1 ? " ▲" : " ▼") : ""}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <div className="preset-tree" role={view === "tree" ? "tree" : "table"} ref={win.ref}>
+            {activeCount === 0 ? (
+              <p className="empty-note">No presets match the filter.</p>
+            ) : (
+              <>
+                <div style={{ height: win.padTop }} />
+                {view === "tree"
+                  ? treeSlice.map((row) => (
+                      <TreeRow
+                        key={row.node.id}
+                        row={row}
+                        selectedId={selectedId}
+                        onToggle={toggle}
+                        onSelect={onSelectNode}
+                        onCycleDup={cycleDup}
+                        injectionKey={injectionKey}
+                        usedInjections={usedInjections}
+                        dupCount={stats.occurrencesByName.get(row.node.name)?.length ?? 1}
+                      />
+                    ))
+                  : tableSlice.map((r) => (
+                      <button
+                        type="button"
+                        key={r.node.id}
+                        className={`preset-table-row${r.node.id === selectedId ? " selected" : ""}`}
+                        style={{ height: ROW_HEIGHT }}
+                        onClick={() => onSelectNode(r.node.id)}
+                      >
+                        <span className="col-name">{r.name}</span>
+                        <span className="col-source">
+                          <span className={`badge src src-${r.sourceKind}`}>{r.sourceKind}</span>
+                        </span>
+                        <span className="col-opts">{r.opts || ""}</span>
+                        <span className="col-rules">{r.rules || ""}</span>
+                        <span className="col-count">{r.count > 1 ? `×${r.count}` : ""}</span>
+                      </button>
+                    ))}
+                <div style={{ height: win.padBottom }} />
+              </>
+            )}
+          </div>
         </div>
         {selected ? (
           <PresetDetail
             node={selected}
-            parent={parents.get(selected.id)}
+            parent={stats.parents.get(selected.id)}
             onClose={() => onSelectNode(null)}
             injectionKey={injectionKey}
             parse={helpers?.parse ?? null}
@@ -221,114 +1019,6 @@ export const PresetTree = memo(function PresetTree({
     </div>
   );
 });
-
-function TreeNode({
-  node,
-  expanded,
-  selectedId,
-  onToggle,
-  onSelect,
-  injectionKey,
-  usedInjections,
-}: {
-  node: PresetNode;
-  expanded: ReadonlySet<string>;
-  selectedId: string | null;
-  onToggle: (id: string) => void;
-  onSelect: (id: string) => void;
-  injectionKey: InjectionKeyFn | null;
-  usedInjections: ReadonlySet<string>;
-}) {
-  const hasChildren = node.children.length > 0;
-  const isExpanded = expanded.has(node.id);
-  const stateLabel = STATE_LABELS[node.state];
-  const key = nodeInjectionKey(node.source, injectionKey);
-  const userSupplied = key !== null && usedInjections.has(key);
-
-  return (
-    <div
-      className="preset-node"
-      role="treeitem"
-      aria-expanded={hasChildren ? isExpanded : undefined}
-    >
-      <div className={`preset-row state-${node.state}`}>
-        {hasChildren ? (
-          <button type="button" className="caret" onClick={() => onToggle(node.id)}>
-            {isExpanded ? "▾" : "▸"}
-          </button>
-        ) : (
-          <span className="caret-spacer" />
-        )}
-        <button
-          type="button"
-          className={`preset-name${node.id === selectedId ? " selected" : ""}`}
-          onClick={() => onSelect(node.id)}
-        >
-          {node.name}
-        </button>
-        {node.source?.presetSource ? (
-          <span className={`badge src src-${node.source.presetSource}`}>
-            {node.source.presetSource}
-          </span>
-        ) : null}
-        {node.source?.platform ? (
-          <span
-            className="badge via"
-            title={`local> resolved against ${node.source.platform} @ ${node.source.endpoint ?? "default endpoint"}`}
-          >
-            via {node.source.platform}
-          </span>
-        ) : null}
-        {userSupplied ? (
-          <span className="badge user-supplied" title="Resolved from manually provided content">
-            user-supplied
-          </span>
-        ) : null}
-        {hasChildren && !isExpanded ? (
-          <span className="badge count">{node.children.length}</span>
-        ) : null}
-        {node.duplicate ? (
-          <span
-            className="badge dup"
-            title="The same preset is also resolved elsewhere in this tree"
-          >
-            duplicate
-          </span>
-        ) : null}
-        {node.nested ? (
-          <span
-            className="badge nested"
-            title="Found while resolving a nested value (e.g. packageRules[n].extends), not this parent's own extends"
-          >
-            nested
-          </span>
-        ) : null}
-        {stateLabel ? (
-          <span className={`badge state state-${node.state}`}>{stateLabel}</span>
-        ) : null}
-      </div>
-      {node.state === "error" && node.error ? (
-        <div className="preset-node-error">{node.error.message}</div>
-      ) : null}
-      {hasChildren && isExpanded ? (
-        <div className="preset-children" role="group">
-          {node.children.map((child) => (
-            <TreeNode
-              key={child.id}
-              node={child}
-              expanded={expanded}
-              selectedId={selectedId}
-              onToggle={onToggle}
-              onSelect={onSelect}
-              injectionKey={injectionKey}
-              usedInjections={usedInjections}
-            />
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
-}
 
 /**
  * Replays the parent's merge loop with renovate's real mergeChildConfig to

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -315,6 +315,110 @@ pre.config-view {
   color: var(--error);
 }
 
+.badge.via {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.badge.user-supplied {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
+/* ---------- platform context / per-host tokens (010) ---------- */
+
+.advanced-settings {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.advanced-settings > summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.advanced-hint {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.6rem;
+}
+
+.advanced-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.advanced-row label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.78rem;
+  gap: 0.2rem;
+}
+
+.advanced-row label.grow {
+  flex: 1;
+  min-width: 12rem;
+}
+
+.advanced-row select,
+.advanced-row input {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.6rem;
+}
+
+.advanced-note {
+  color: var(--muted);
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.preset-inject {
+  border-top: 1px solid var(--border);
+  padding: 0.4rem 0;
+}
+
+.preset-inject-input {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font-family: ui-monospace, monospace;
+  font-size: 0.8rem;
+  margin: 0.3rem 0;
+  padding: 0.4rem 0.6rem;
+  resize: vertical;
+  width: 100%;
+}
+
+.preset-inject-button {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.35rem 0.7rem;
+}
+
+.preset-inject-button:disabled {
+  opacity: 0.6;
+}
+
 .preset-node-error {
   color: var(--error);
   font-size: 0.8rem;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -722,3 +722,171 @@ pre.config-view {
     color: var(--muted);
   }
 }
+
+/* ---------- merge provenance view (005) ---------- */
+
+.prov-filters {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.prov-filters input.prov-filter-input,
+.prov-filters select {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.5rem;
+}
+
+.prov-filters input.prov-filter-input {
+  flex: 1;
+  min-width: 10rem;
+}
+
+.prov-check {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.prov-list {
+  max-height: 40rem;
+  overflow: auto;
+}
+
+.prov-row {
+  border-bottom: 1px solid var(--border);
+}
+
+.prov-row:last-child {
+  border-bottom: none;
+}
+
+.prov-row-head {
+  align-items: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  gap: 0.5rem;
+  padding: 0.4rem 0.75rem;
+  text-align: left;
+  width: 100%;
+}
+
+.prov-row-head:hover {
+  background: var(--surface);
+}
+
+.prov-row-head .caret {
+  color: var(--muted);
+  flex: none;
+  font-size: 0.75rem;
+  width: 0.9rem;
+}
+
+.prov-key-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+}
+
+.prov-key-preview {
+  color: var(--muted);
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge.prov-layer {
+  cursor: default;
+  flex: none;
+}
+
+button.badge.prov-layer {
+  background: transparent;
+  cursor: pointer;
+}
+
+.badge.prov-defaults {
+  border-color: var(--border);
+  color: var(--muted);
+}
+
+.badge.prov-repo {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.badge.prov-preset {
+  border-color: #8250df;
+  color: #8250df;
+}
+
+.badge.prov-overridden {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
+.prov-detail {
+  padding: 0 0.75rem 0.75rem 1.65rem;
+}
+
+.prov-final-title,
+.prov-chain-title {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0.5rem 0 0.3rem;
+  text-transform: uppercase;
+}
+
+.prov-step {
+  border-left: 2px solid var(--border);
+  margin: 0.4rem 0;
+  padding-left: 0.6rem;
+}
+
+.prov-step.action-overwrite,
+.prov-step.action-forced {
+  border-left-color: var(--warn);
+}
+
+.prov-step-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.25rem;
+}
+
+.prov-step-verb {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.prov-step.action-forced .prov-step-verb {
+  color: var(--warn);
+  font-weight: 600;
+}
+
+pre.config-view.prov-value {
+  border-radius: 6px;
+  max-height: 16rem;
+}
+
+pre.config-view.prov-before {
+  opacity: 0.65;
+  text-decoration: line-through;
+  text-decoration-color: var(--error);
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -218,9 +218,19 @@ pre.config-view {
 .preset-row {
   align-items: center;
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 0.35rem;
-  padding: 0.1rem 0;
+  overflow: hidden;
+  padding: 0 0.1rem;
+  white-space: nowrap;
+}
+
+.preset-row.dimmed {
+  opacity: 0.5;
+}
+
+.preset-row.zero .preset-name {
+  color: var(--muted);
 }
 
 .preset-row .caret,
@@ -246,7 +256,7 @@ pre.config-view {
   font-size: 0.85rem;
   padding: 0.05rem 0.3rem;
   text-align: left;
-  word-break: break-all;
+  white-space: nowrap;
 }
 
 .preset-row .preset-name:hover {
@@ -323,6 +333,191 @@ pre.config-view {
 .badge.user-supplied {
   border-color: var(--warn);
   color: var(--warn);
+}
+
+/* ---------- preset tree legibility at scale (011) ---------- */
+
+.preset-summary {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.9rem;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.preset-summary-stat strong {
+  color: light-dark(#1f2328, #f0f6fc);
+  font-variant-numeric: tabular-nums;
+}
+
+.preset-controls {
+  align-items: center;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.preset-search {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  flex: 1;
+  font-size: 0.85rem;
+  min-width: 12rem;
+  padding: 0.3rem 0.5rem;
+}
+
+.preset-check {
+  color: var(--muted);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.preset-view-toggle {
+  display: inline-flex;
+}
+
+.preset-view-toggle button {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.7rem;
+}
+
+.preset-view-toggle button:first-child {
+  border-radius: 6px 0 0 6px;
+}
+
+.preset-view-toggle button:last-child {
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+}
+
+.preset-view-toggle button.active {
+  background: var(--surface);
+  color: inherit;
+}
+
+/* contribution + roll-up badges */
+.badge.contrib.opts {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.badge.contrib.rules {
+  border-color: #8250df;
+  color: #8250df;
+}
+
+.badge.rollup {
+  border: none;
+  color: var(--muted);
+  padding: 0;
+}
+
+.badge.elided {
+  background: transparent;
+  border: 1px dashed var(--border);
+  color: var(--muted);
+  cursor: pointer;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+button.badge.dup {
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.preset-row-error {
+  color: var(--error);
+  font-size: 0.78rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* flat table view */
+.preset-table-head,
+.preset-table-row {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(8rem, 1fr) 7rem 3.5rem 3.5rem 3.5rem;
+  padding: 0 0.75rem;
+}
+
+.preset-table-head {
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+}
+
+.preset-th {
+  background: var(--surface);
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0;
+  text-align: left;
+  text-transform: uppercase;
+}
+
+.preset-th.col-opts,
+.preset-th.col-rules,
+.preset-th.col-count {
+  text-align: right;
+}
+
+.preset-th.sorted {
+  color: var(--accent);
+}
+
+.preset-table-row {
+  align-items: center;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.82rem;
+  overflow: hidden;
+  text-align: left;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.preset-table-row:hover {
+  background: var(--surface);
+}
+
+.preset-table-row.selected {
+  outline: 1px solid var(--accent);
+  outline-offset: -1px;
+}
+
+.preset-table-row .col-name {
+  font-family: ui-monospace, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preset-table-row .col-opts,
+.preset-table-row .col-rules,
+.preset-table-row .col-count {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }
 
 /* ---------- platform context / per-host tokens (010) ---------- */

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -604,6 +604,95 @@ pre.config-view {
   white-space: nowrap;
 }
 
+/* 004 migration step-through */
+.migration-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.migration-step-head {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.migration-step-counter {
+  color: var(--muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.migration-step-name {
+  font-weight: 600;
+}
+
+.migration-step-key {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  font-size: 0.8rem;
+  padding: 0.05rem 0.35rem;
+}
+
+.migration-explanation {
+  color: var(--muted);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.migration-nav {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.migration-nav button {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.7rem;
+}
+
+.migration-nav button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.migration-cumulative {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 0.85rem;
+  gap: 0.3rem;
+}
+
+.migration-copy {
+  margin-left: auto;
+}
+
+.migration-steps.compact .migration-nav button {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+}
+
+.preset-migration-steps {
+  border-top: 1px dashed var(--border);
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+}
+
+.preset-migration-steps-title {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+}
+
 /* react-diff-view ships light-theme colors only; keep text readable in dark */
 @media (prefers-color-scheme: dark) {
   .diff {

--- a/packages/app/src/run.ts
+++ b/packages/app/src/run.ts
@@ -1,13 +1,24 @@
 import type { OptionIndex, PipelineInput, TraceResult } from "@renovate-config-visualizer/engine";
 
+const TOKEN_KEYS = {
+  githubToken: "rcv.githubToken",
+  gitlabToken: "rcv.gitlabToken",
+  giteaToken: "rcv.giteaToken",
+  forgejoToken: "rcv.forgejoToken",
+} as const;
+
 /**
  * Dynamic import keeps the heavy renovate chunk out of the initial page load;
  * Vite code-splits it automatically behind this call.
  */
 export async function run(input: PipelineInput): Promise<TraceResult> {
   const engine = await import("@renovate-config-visualizer/engine");
-  const token = localStorage.getItem("rcv.githubToken");
-  engine.setPresetAuth({ githubToken: token ?? undefined });
+  engine.setPresetAuth({
+    githubToken: localStorage.getItem(TOKEN_KEYS.githubToken) ?? undefined,
+    gitlabToken: localStorage.getItem(TOKEN_KEYS.gitlabToken) ?? undefined,
+    giteaToken: localStorage.getItem(TOKEN_KEYS.giteaToken) ?? undefined,
+    forgejoToken: localStorage.getItem(TOKEN_KEYS.forgejoToken) ?? undefined,
+  });
   return engine.runPipeline(input);
 }
 

--- a/packages/engine/src/auth.ts
+++ b/packages/engine/src/auth.ts
@@ -1,6 +1,18 @@
+/**
+ * Per-host credentials for the browser preset fetchers (roadmap 010). Each
+ * fetcher reads the token for its own host to lift rate limits / reach private
+ * repos. Optional fields keep this backward compatible with the original
+ * `githubToken`-only shape.
+ */
 export interface PresetAuth {
-  /** GitHub token used by the browser preset fetcher to lift rate limits. */
+  /** GitHub token — sent as `Authorization: Bearer <t>`. */
   githubToken?: string;
+  /** GitLab token — sent as `PRIVATE-TOKEN: <t>`. */
+  gitlabToken?: string;
+  /** Gitea token — sent as `Authorization: token <t>`. */
+  giteaToken?: string;
+  /** Forgejo token — sent as `Authorization: token <t>`. */
+  forgejoToken?: string;
 }
 
 let auth: PresetAuth = {};

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./shims/presets/injection";
 export type {
   LogLevel,
+  MigrationStepInfo,
   PipelineInput,
   PlatformContext,
   PresetNode,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -4,6 +4,13 @@ export { renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
 export {
+  computeProvenance,
+  type KeyProvenance,
+  type ProvenanceAction,
+  type ProvenanceLayer,
+  type ProvenanceStep,
+} from "./trace/provenance";
+export {
   parseInjectedPreset,
   type PresetIdentity,
   presetInjectionKey,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,9 +3,15 @@ export { setPresetAuth, type PresetAuth } from "./auth";
 export { renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
+export {
+  parseInjectedPreset,
+  type PresetIdentity,
+  presetInjectionKey,
+} from "./shims/presets/injection";
 export type {
   LogLevel,
   PipelineInput,
+  PlatformContext,
   PresetNode,
   PresetNodeState,
   PresetSource,

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -120,17 +120,12 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
     collector.enterStage("migrate");
     collector.emit({ kind: "stage-start", title: "Migrate deprecated options" });
     const before = snapshot(config);
+    // migrateConfig (shimmed to src/shims/migration.ts) emits one granular
+    // `migration-applied` event per migration/post-processing block that
+    // changed something, during this call. The stage-complete event below
+    // still carries the whole-stage before/after as the fallback blob view.
     const { isMigrated, migratedConfig } = migrateConfig(config);
     config = migratedConfig;
-    if (isMigrated) {
-      collector.emit({
-        kind: "migration-applied",
-        title: "Config contained deprecated options and was migrated",
-        before,
-        after: snapshot(config),
-        delta: computeDelta(before, config),
-      });
-    }
     stageStatus.migrate = "ok";
     collector.emit({
       kind: "stage-complete",

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -10,16 +10,44 @@ import {
   resolveConfigPresets,
   validateConfig,
 } from "./renovate-adapter";
+import {
+  getUsedInjectionKeys,
+  resetInjectedPresets,
+  setInjectedPresets,
+} from "./shims/presets/injection";
 import { setCurrentCollector, TraceCollector } from "./trace/collector";
 import { computeDelta, snapshot } from "./trace/delta";
 import type {
   PipelineInput,
+  PlatformContext,
   StageId,
   StageStatus,
   TraceResult,
   ValidationMessage,
 } from "./trace/model";
 import { renovateVersion } from "./version";
+
+/** Default browser endpoint per platform, for display + when none is given. */
+const ENDPOINT_DEFAULTS: Record<string, string> = {
+  github: "https://api.github.com/",
+  gitlab: "https://gitlab.com/api/v4/",
+  gitea: "https://gitea.com/",
+  forgejo: "https://codeberg.org/",
+};
+
+function resolvePlatformContext(input: PipelineInput): PlatformContext {
+  const globalConfig = input.globalConfig ?? {};
+  const platform =
+    (typeof globalConfig.platform === "string" ? globalConfig.platform : undefined) ??
+    input.platform ??
+    "github";
+  const endpoint =
+    (typeof globalConfig.endpoint === "string" ? globalConfig.endpoint : undefined) ??
+    input.endpoint ??
+    ENDPOINT_DEFAULTS[platform] ??
+    "";
+  return { platform, endpoint };
+}
 
 // Renovate's config modules hold module-level state (GlobalConfig, memCache,
 // the active trace collector), so runs must never overlap.
@@ -32,7 +60,8 @@ export function runPipeline(input: PipelineInput): Promise<TraceResult> {
 }
 
 async function execute(input: PipelineInput): Promise<TraceResult> {
-  const collector = new TraceCollector(parsePreset);
+  const platformContext = resolvePlatformContext(input);
+  const collector = new TraceCollector(parsePreset, platformContext);
   setCurrentCollector(collector);
 
   const stageStatus: Record<StageId, StageStatus> = {
@@ -57,11 +86,20 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
     stageStatus,
     visitedPresets,
     presetTree: collector.finalizePresetTree(),
+    platformContext,
+    usedInjections: getUsedInjectionKeys(),
   });
 
   try {
     memCache.init();
-    GlobalConfig.set({ ...input.globalConfig });
+    setInjectedPresets(input.injectedPresets);
+    // Platform context defines `local>`; the pasted global config (008) still
+    // wins over the explicit options, matching how a real run is configured.
+    GlobalConfig.set({
+      platform: platformContext.platform,
+      endpoint: platformContext.endpoint,
+      ...input.globalConfig,
+    } as Parameters<typeof GlobalConfig.set>[0]);
 
     // parse
     collector.enterStage("parse");
@@ -186,6 +224,7 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
   } finally {
     GlobalConfig.reset();
     memCache.reset();
+    resetInjectedPresets();
     setCurrentCollector(null);
   }
 }

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -5,6 +5,10 @@
  */
 export { parseFileConfig } from "renovate/dist/config/parse.js";
 export { migrateConfig } from "renovate/dist/config/migration.js";
+export {
+  type Migration,
+  MigrationsService,
+} from "renovate/dist/config/migrations/migrations-service.js";
 export { massageConfig } from "renovate/dist/config/massage.js";
 export { validateConfig } from "renovate/dist/config/validation.js";
 export { resolveConfigPresets } from "renovate/dist/config/presets/index.js";

--- a/packages/engine/src/shims/migration.ts
+++ b/packages/engine/src/shims/migration.ts
@@ -1,0 +1,377 @@
+/**
+ * Instrumented fork of renovate/dist/config/migration.js (`migrateConfig`).
+ *
+ * The vite shim plugin maps `config/migration.js` here so the browser bundle
+ * and the shimmed Vitest project run this file in place of Renovate's own. The
+ * CONTROL FLOW is copied line-for-line from upstream and its RETURN VALUE is
+ * byte-identical — the shimmed-vs-golden `finalConfig` assertion is the
+ * fidelity net, so this must never diverge. The only additions are:
+ *   - `runMigrations` replaces the single `MigrationsService.run(...)` call
+ *     with a per-key instrumented version that uses Renovate's REAL
+ *     `getMigrations` / `getMigration` (never re-listing the registry) and
+ *     emits one step per migration that actually changed something.
+ *   - synthetic named steps around each non-class post-processing block.
+ * Every step carries a full-document before/after snapshot (a shared
+ * {root, path} context is threaded through the recursion), so the stepper's
+ * diffs stay small.
+ *
+ * When Renovate bumps, re-diff this against the upstream source — the golden
+ * drift tripwire test hashes it and will fail until re-checked.
+ */
+import { getOptions } from "renovate/dist/config/options/index.js";
+import { MigrationsService } from "renovate/dist/config/migrations/migrations-service.js";
+import { mergeChildConfig } from "renovate/dist/config/utils.js";
+import { clone } from "renovate/dist/util/clone.js";
+import { regEx } from "renovate/dist/util/regex.js";
+import { emitMigrationStep } from "../trace/collector";
+import {
+  dequal,
+  isArray,
+  isBoolean,
+  isNonEmptyArray,
+  isNonEmptyObject,
+  isObject,
+  isString,
+} from "./renovate-deps";
+
+// Loosely typed to mirror upstream's JS; the return value fidelity is enforced
+// by the golden snapshots, not by these internal types.
+type AnyConfig = Record<string, any>;
+
+const options = getOptions();
+
+export function fixShortHours(input: string): string {
+  return input.replace(regEx(/( \d?\d)((a|p)m)/g), "$1:00$2");
+}
+
+/** Shared, mutable full-document context threaded through the recursion. */
+interface MigCtx {
+  /** Outermost migratedConfig of the current fixed-point pass. */
+  root: AnyConfig | undefined;
+  /** Position of the current subtree within `root`. */
+  path: (string | number)[];
+  /** Fixed-point pass number (1 = first pass). */
+  pass: number;
+}
+
+/** Full-document snapshot: `root` cloned with `subtree` spliced in at `path`. */
+function fullDoc(ctx: MigCtx, subtree: unknown): unknown {
+  if (ctx.path.length === 0 || ctx.root === undefined) {
+    return clone(subtree);
+  }
+  const doc = clone(ctx.root) as AnyConfig;
+  let cursor: unknown = doc;
+  for (let i = 0; i < ctx.path.length - 1; i++) {
+    if (cursor === null || typeof cursor !== "object") {
+      return clone(subtree);
+    }
+    cursor = (cursor as AnyConfig)[String(ctx.path[i])];
+  }
+  if (cursor === null || typeof cursor !== "object") {
+    return clone(subtree);
+  }
+  (cursor as AnyConfig)[String(ctx.path[ctx.path.length - 1])] = clone(subtree);
+  return doc;
+}
+
+/** Apply the key-level diff between two migratedConfig snapshots to `work`. */
+function applyKeyDiff(work: AnyConfig, before: AnyConfig, after: AnyConfig): void {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  for (const key of keys) {
+    if (dequal(before[key], after[key])) {
+      continue;
+    }
+    if (key in after) {
+      work[key] = clone(after[key]);
+    } else {
+      delete work[key];
+    }
+  }
+}
+
+/**
+ * Faithful re-implementation of `MigrationsService.run` (each migration mutates
+ * a shared `migratedConfig`), instrumented to emit one step per migration whose
+ * `run` + deprecated-delete actually changed the shared object. `work` mirrors
+ * the eventual full subtree so each step's before/after are complete documents.
+ */
+function runMigrations(
+  originalConfig: AnyConfig,
+  parentKey: string | undefined,
+  ctx: MigCtx,
+): AnyConfig {
+  const migratedConfig: AnyConfig = {};
+  const migrations = MigrationsService.getMigrations(originalConfig, migratedConfig);
+  const work: AnyConfig = clone(originalConfig);
+  for (const [key, value] of Object.entries(originalConfig)) {
+    migratedConfig[key] ??= value;
+    const migration = MigrationsService.getMigration(migrations, key);
+    if (migration) {
+      const before = clone(migratedConfig);
+      migration.run(value, key, parentKey);
+      if (migration.deprecated) {
+        delete migratedConfig[key];
+      }
+      const after = clone(migratedConfig);
+      if (!dequal(before, after)) {
+        const workBefore = clone(work);
+        applyKeyDiff(work, before, after);
+        emitMigrationStep({
+          className: migration.constructor.name,
+          key,
+          newKey:
+            typeof migration.newPropertyName === "string" ? migration.newPropertyName : undefined,
+          parentKey,
+          pass: ctx.pass,
+          before: fullDoc(ctx, workBefore),
+          after: fullDoc(ctx, work),
+        });
+      }
+    }
+  }
+  return migratedConfig;
+}
+
+/** Emit a synthetic post-processing step if the block changed the subtree. */
+function emitPostStep(
+  ctx: MigCtx,
+  className: string,
+  before: AnyConfig,
+  after: AnyConfig,
+  parentKey: string | undefined,
+): void {
+  if (dequal(before, after)) {
+    return;
+  }
+  emitMigrationStep({
+    className,
+    parentKey,
+    pass: ctx.pass,
+    before: fullDoc(ctx, before),
+    after: fullDoc(ctx, after),
+  });
+}
+
+let optionTypes: Record<string, string> | undefined;
+
+interface MigrationResult {
+  isMigrated: boolean;
+  migratedConfig: AnyConfig;
+}
+
+export function migrateConfig(
+  config: AnyConfig,
+  parentKey?: string,
+  ctx?: MigCtx,
+): MigrationResult {
+  if (!optionTypes) {
+    optionTypes = {};
+    options.forEach((option) => {
+      optionTypes![option.name] = option.type;
+    });
+  }
+  const activeCtx: MigCtx = ctx ?? { root: undefined, path: [], pass: 1 };
+  const newConfig = runMigrations(config, parentKey, activeCtx);
+  const migratedConfig = clone(newConfig);
+  // For nested calls `root` is the ancestor's top-level object; at the top of
+  // a pass it is this call's own migratedConfig (path is []).
+  const root = activeCtx.root ?? migratedConfig;
+  const basePath = activeCtx.path;
+  for (const [key, val] of Object.entries(newConfig)) {
+    // Per-key value normalization (template rewrites + optionType coercions).
+    // Recursion into arrays/objects is threaded (it emits its own steps), so
+    // only the non-recursive branches produce a synthetic per-key step.
+    const keyBefore = clone(migratedConfig[key]);
+    let stepClass: string | undefined;
+    let recursed = false;
+    if (isString(val) && val.includes("{{baseDir}}")) {
+      migratedConfig[key] = val.replace(regEx(/{{baseDir}}/g), "{{packageFileDir}}");
+      stepClass = "TemplateRewrite";
+    } else if (isString(val) && val.includes("{{lookupName}}")) {
+      migratedConfig[key] = val.replace(regEx(/{{lookupName}}/g), "{{packageName}}");
+      stepClass = "TemplateRewrite";
+    } else if (isString(val) && val.includes("{{depNameShort}}")) {
+      migratedConfig[key] = val.replace(regEx(/{{depNameShort}}/g), "{{depName}}");
+      stepClass = "TemplateRewrite";
+    } else if (isString(val) && val.startsWith("{{semanticPrefix}}")) {
+      migratedConfig[key] = val.replace(
+        "{{semanticPrefix}}",
+        "{{#if semanticCommitType}}{{semanticCommitType}}{{#if semanticCommitScope}}({{semanticCommitScope}}){{/if}}: {{/if}}",
+      );
+      stepClass = "TemplateRewrite";
+    } else if (optionTypes[key] === "object" && isBoolean(val)) {
+      migratedConfig[key] = { enabled: val };
+      stepClass = "OptionTypeCoercion";
+    } else if (optionTypes[key] === "boolean") {
+      if (val === "true") {
+        migratedConfig[key] = true;
+        stepClass = "OptionTypeCoercion";
+      } else if (val === "false") {
+        migratedConfig[key] = false;
+        stepClass = "OptionTypeCoercion";
+      }
+    } else if (optionTypes[key] === "string" && isArray(val) && val.length === 1) {
+      migratedConfig[key] = String(val[0]);
+      stepClass = "OptionTypeCoercion";
+    } else if (isArray(val)) {
+      // v8 ignore else -- upstream parity
+      if (isArray(migratedConfig?.[key])) {
+        const newArray = [];
+        let index = 0;
+        for (const item of migratedConfig[key]) {
+          if (isObject(item) && !isArray(item)) {
+            const arrMigrate = migrateConfig(item, undefined, {
+              root,
+              path: [...basePath, key, index],
+              pass: activeCtx.pass,
+            });
+            newArray.push(arrMigrate.migratedConfig);
+          } else {
+            newArray.push(item);
+          }
+          index++;
+        }
+        migratedConfig[key] = newArray;
+        recursed = true;
+      }
+    } else if (isObject(val)) {
+      const subMigrate = migrateConfig(migratedConfig[key], key, {
+        root,
+        path: [...basePath, key],
+        pass: activeCtx.pass,
+      });
+      if (subMigrate.isMigrated) {
+        migratedConfig[key] = subMigrate.migratedConfig;
+      }
+      recursed = true;
+    }
+    const migratedTemplates: Record<string, string> = {
+      fromVersion: "currentVersion",
+      newValueMajor: "newMajor",
+      newValueMinor: "newMinor",
+      newVersionMajor: "newMajor",
+      newVersionMinor: "newMinor",
+      toVersion: "newVersion",
+    };
+    if (isString(migratedConfig[key])) {
+      for (const [from, to] of Object.entries(migratedTemplates)) {
+        migratedConfig[key] = migratedConfig[key].replace(regEx(from, "g"), to);
+      }
+    }
+    if (!recursed && !dequal(keyBefore, migratedConfig[key])) {
+      emitMigrationStep({
+        className: stepClass ?? "TemplateRewrite",
+        key,
+        parentKey,
+        pass: activeCtx.pass,
+        before: fullDoc(activeCtx, cloneWithKey(migratedConfig, key, keyBefore)),
+        after: fullDoc(activeCtx, clone(migratedConfig)),
+      });
+    }
+  }
+  const languageBefore = clone(migratedConfig);
+  for (const language of [
+    "docker",
+    "dotnet",
+    "golang",
+    "java",
+    "js",
+    "node",
+    "php",
+    "python",
+    "ruby",
+    "rust",
+  ]) {
+    if (isNonEmptyObject(migratedConfig[language])) {
+      migratedConfig.packageRules ??= [];
+      const currentContent = migratedConfig[language];
+      const packageRule = { matchCategories: [language], ...currentContent };
+      migratedConfig.packageRules.unshift(packageRule);
+      delete migratedConfig[language];
+    }
+  }
+  emitPostStep(activeCtx, "LanguagePackageRules", languageBefore, migratedConfig, parentKey);
+
+  const flattenBefore = clone(migratedConfig);
+  if (isNonEmptyArray(migratedConfig.packageRules)) {
+    const existingRules = migratedConfig.packageRules;
+    migratedConfig.packageRules = [];
+    for (const packageRule of existingRules) {
+      if (isArray(packageRule.packageRules)) {
+        for (const subrule of packageRule.packageRules) {
+          const combinedRule = mergeChildConfig(packageRule, subrule);
+          delete combinedRule.packageRules;
+          migratedConfig.packageRules.push(combinedRule);
+        }
+      } else {
+        migratedConfig.packageRules.push(packageRule);
+      }
+    }
+  }
+  emitPostStep(activeCtx, "FlattenNestedPackageRules", flattenBefore, migratedConfig, parentKey);
+
+  const pipBefore = clone(migratedConfig);
+  if (
+    isNonEmptyObject(migratedConfig["pip-compile"]) &&
+    isNonEmptyArray(migratedConfig["pip-compile"].managerFilePatterns)
+  ) {
+    migratedConfig["pip-compile"].managerFilePatterns = migratedConfig[
+      "pip-compile"
+    ].managerFilePatterns.map((filePattern: string) => {
+      const pattern = filePattern;
+      if (pattern.endsWith(".in")) {
+        return pattern.replace(/\.in$/, ".txt");
+      }
+      if (pattern.endsWith(".in/")) {
+        return pattern.replace(/\.in\/$/, ".txt/");
+      }
+      return pattern.replace(/\.in\$\/$/, ".txt$/");
+    });
+  }
+  emitPostStep(activeCtx, "PipCompileFilePatterns", pipBefore, migratedConfig, parentKey);
+
+  const gradleManagersBefore = clone(migratedConfig);
+  if (
+    isNonEmptyArray(migratedConfig.matchManagers) &&
+    migratedConfig.matchManagers.includes("gradle-lite")
+  ) {
+    // v8 ignore else -- upstream parity
+    if (!migratedConfig.matchManagers.includes("gradle")) {
+      migratedConfig.matchManagers.push("gradle");
+    }
+    migratedConfig.matchManagers = migratedConfig.matchManagers.filter(
+      (manager: string) => manager !== "gradle-lite",
+    );
+  }
+  emitPostStep(activeCtx, "GradleLiteManager", gradleManagersBefore, migratedConfig, parentKey);
+
+  const gradleBefore = clone(migratedConfig);
+  if (isNonEmptyObject(migratedConfig["gradle-lite"])) {
+    migratedConfig.gradle = mergeChildConfig(
+      migratedConfig.gradle ?? {},
+      migratedConfig["gradle-lite"],
+    );
+  }
+  delete migratedConfig["gradle-lite"];
+  emitPostStep(activeCtx, "GradleLiteMerge", gradleBefore, migratedConfig, parentKey);
+
+  const isMigrated = !dequal(config, migratedConfig);
+  if (isMigrated) {
+    return {
+      isMigrated,
+      migratedConfig: migrateConfig(migratedConfig, undefined, {
+        root: undefined,
+        path: [],
+        pass: activeCtx.pass + 1,
+      }).migratedConfig,
+    };
+  }
+  return { isMigrated, migratedConfig };
+}
+
+/** Clone of `config` with one key replaced by `value` (for per-key before). */
+function cloneWithKey(config: AnyConfig, key: string, value: unknown): AnyConfig {
+  const copy = clone(config);
+  copy[key] = clone(value);
+  return copy;
+}

--- a/packages/engine/src/shims/presets/forgejo.ts
+++ b/packages/engine/src/shims/presets/forgejo.ts
@@ -1,3 +1,16 @@
-import { makeUnsupportedGetPreset } from "./unsupported";
+/**
+ * Browser shim for renovate/dist/config/presets/forgejo/index.js.
+ * Upstream defaults to code.forgejo.org, but that host does not send CORS
+ * headers to the page; codeberg.org (a public Forgejo instance) does and its
+ * API v1 is verified reachable, so it is the browser default here. Self-hosted
+ * Forgejo endpoints can be pointed at via the platform-context endpoint field
+ * (falling back to manual injection when they lack CORS).
+ */
+import { makeGiteaLikeResolver } from "./gitea-forgejo";
 
-export const getPreset = makeUnsupportedGetPreset("forgejo");
+const { Endpoint, fetchJSONFile, getPresetFromEndpoint, getPreset } = makeGiteaLikeResolver(
+  "forgejo",
+  "https://codeberg.org/",
+);
+
+export { Endpoint, fetchJSONFile, getPreset, getPresetFromEndpoint };

--- a/packages/engine/src/shims/presets/gitea-forgejo.ts
+++ b/packages/engine/src/shims/presets/gitea-forgejo.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared browser transport for the Gitea and Forgejo preset fetchers — they
+ * hit the same `/api/v1/repos/:repo/contents/:file` endpoint and return the
+ * file as base64-encoded JSON. Mirrors Renovate's gitea/forgejo helpers
+ * (getRepoContents), decoding base64 in-browser (no Node Buffer) and reusing
+ * Renovate's fetchPreset for the file-candidate / sub-preset logic.
+ */
+import {
+  fetchPreset,
+  parsePreset,
+  PRESET_DEP_NOT_FOUND,
+  PRESET_INVALID,
+} from "renovate/dist/config/presets/util.js";
+import { ExternalHostError } from "renovate/dist/types/errors/external-host-error.js";
+import { getPresetAuth } from "../../auth";
+import { getInjectedPreset } from "./injection";
+
+type Source = "gitea" | "forgejo";
+
+interface ContentsResponse {
+  type?: string;
+  content?: string;
+  encoding?: string;
+}
+
+/** Decode base64 → UTF-8 string using browser-native primitives. */
+function decodeBase64(input: string): string {
+  const bin = atob(input.replace(/\s/g, ""));
+  const bytes = Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function tokenFor(source: Source): string | undefined {
+  const auth = getPresetAuth();
+  return source === "gitea" ? auth.giteaToken : auth.forgejoToken;
+}
+
+function makeFetchJSONFile(source: Source) {
+  return async function fetchJSONFile(
+    repo: string,
+    fileName: string,
+    endpoint: string,
+    tag?: string,
+  ): Promise<Record<string, unknown> | null> {
+    const ref = tag ? `?ref=${encodeURIComponent(tag)}` : "";
+    const url = `${endpoint}api/v1/repos/${repo}/contents/${encodeURIComponent(fileName)}${ref}`;
+    const headers: Record<string, string> = { accept: "application/json" };
+    const token = tokenFor(source);
+    if (token) {
+      headers.authorization = `token ${token}`;
+    }
+    let res: Response;
+    try {
+      res = await fetch(url, { headers });
+    } catch (err) {
+      throw new ExternalHostError(
+        new Error(
+          `Could not reach the ${source} endpoint ${endpoint} from the browser — ` +
+            `likely missing CORS headers or a network block (${err instanceof Error ? err.message : String(err)})`,
+        ),
+        source,
+      );
+    }
+    if (res.status === 401 || res.status === 403 || res.status === 429) {
+      throw new ExternalHostError(
+        new Error(
+          `${source} API rejected the request (HTTP ${res.status}) — rate limit or missing token`,
+        ),
+        source,
+      );
+    }
+    if (!res.ok) {
+      throw new Error(PRESET_DEP_NOT_FOUND);
+    }
+    const body = (await res.json()) as ContentsResponse;
+    // Forgejo's resolver rejects anything that is not a plain file.
+    if (source === "forgejo" && body.type && body.type !== "file") {
+      throw new Error(PRESET_INVALID);
+    }
+    const contentString = body.content ? decodeBase64(body.content) : "";
+    return parsePreset(contentString, fileName);
+  };
+}
+
+export function makeGiteaLikeResolver(source: Source, defaultEndpoint: string) {
+  const fetchJSONFile = makeFetchJSONFile(source);
+
+  function getPresetFromEndpoint(
+    repo: string,
+    filePreset: string,
+    presetPath?: string,
+    endpoint: string = defaultEndpoint,
+    tag?: string,
+  ): Promise<Record<string, unknown> | null> {
+    return fetchPreset({ repo, filePreset, presetPath, endpoint, tag, fetch: fetchJSONFile });
+  }
+
+  function getPreset(config: {
+    repo: string;
+    presetName?: string;
+    presetPath?: string;
+    tag?: string;
+  }): Promise<Record<string, unknown> | null> {
+    const { repo, presetName = "default", presetPath, tag } = config;
+    const injected = getInjectedPreset({ presetSource: source, repo, presetPath, presetName, tag });
+    if (injected) {
+      return Promise.resolve(injected);
+    }
+    return getPresetFromEndpoint(repo, presetName, presetPath, defaultEndpoint, tag);
+  }
+
+  return { Endpoint: defaultEndpoint, fetchJSONFile, getPresetFromEndpoint, getPreset };
+}

--- a/packages/engine/src/shims/presets/gitea.ts
+++ b/packages/engine/src/shims/presets/gitea.ts
@@ -1,3 +1,12 @@
-import { makeUnsupportedGetPreset } from "./unsupported";
+/**
+ * Browser shim for renovate/dist/config/presets/gitea/index.js.
+ * Default endpoint is gitea.com (upstream), whose API v1 serves CORS headers.
+ */
+import { makeGiteaLikeResolver } from "./gitea-forgejo";
 
-export const getPreset = makeUnsupportedGetPreset("gitea");
+const { Endpoint, fetchJSONFile, getPresetFromEndpoint, getPreset } = makeGiteaLikeResolver(
+  "gitea",
+  "https://gitea.com/",
+);
+
+export { Endpoint, fetchJSONFile, getPreset, getPresetFromEndpoint };

--- a/packages/engine/src/shims/presets/github.ts
+++ b/packages/engine/src/shims/presets/github.ts
@@ -11,6 +11,7 @@ import {
 } from "renovate/dist/config/presets/util.js";
 import { ExternalHostError } from "renovate/dist/types/errors/external-host-error.js";
 import { getPresetAuth } from "../../auth";
+import { getInjectedPreset } from "./injection";
 
 export const Endpoint = "https://api.github.com/";
 
@@ -34,8 +35,15 @@ export async function fetchJSONFile(
   try {
     res = await fetch(url, { headers });
   } catch (err) {
-    // network failure or CORS rejection
-    throw new ExternalHostError(err instanceof Error ? err : new Error(String(err)), "github");
+    // fetch() rejects on network failure or a CORS block — the endpoint could
+    // not be reached from the browser at all (distinct from a 404 not-found).
+    throw new ExternalHostError(
+      new Error(
+        `Could not reach the GitHub endpoint ${endpoint} from the browser — ` +
+          `likely missing CORS headers or a network block (${err instanceof Error ? err.message : String(err)})`,
+      ),
+      "github",
+    );
   }
   if (res.status === 401 || res.status === 403 || res.status === 429) {
     throw new ExternalHostError(
@@ -68,5 +76,9 @@ export function getPreset(config: {
   tag?: string;
 }): Promise<Record<string, unknown> | null> {
   const { repo, presetName = "default", presetPath, tag } = config;
+  const injected = getInjectedPreset({ presetSource: "github", repo, presetPath, presetName, tag });
+  if (injected) {
+    return Promise.resolve(injected);
+  }
   return getPresetFromEndpoint(repo, presetName, presetPath, Endpoint, tag);
 }

--- a/packages/engine/src/shims/presets/gitlab.ts
+++ b/packages/engine/src/shims/presets/gitlab.ts
@@ -1,3 +1,98 @@
-import { makeUnsupportedGetPreset } from "./unsupported";
+/**
+ * Browser shim for renovate/dist/config/presets/gitlab/index.js.
+ * Reuses Renovate's fetchPreset/parsePreset (file-name candidates, sub-preset
+ * lookup, renovate.json fallback); only the HTTP transport is replaced with a
+ * browser fetch() against the CORS-enabled GitLab REST API v4. Like upstream,
+ * a missing tag resolves the project's default branch first.
+ */
+import {
+  fetchPreset,
+  parsePreset,
+  PRESET_DEP_NOT_FOUND,
+} from "renovate/dist/config/presets/util.js";
+import { ExternalHostError } from "renovate/dist/types/errors/external-host-error.js";
+import { getPresetAuth } from "../../auth";
+import { getInjectedPreset } from "./injection";
 
-export const getPreset = makeUnsupportedGetPreset("gitlab");
+export const Endpoint = "https://gitlab.com/api/v4/";
+
+function authHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { accept: "application/json" };
+  const { gitlabToken } = getPresetAuth();
+  if (gitlabToken) {
+    headers["PRIVATE-TOKEN"] = gitlabToken;
+  }
+  return headers;
+}
+
+async function gitlabRequest(url: string): Promise<Response> {
+  let res: Response;
+  try {
+    res = await fetch(url, { headers: authHeaders() });
+  } catch (err) {
+    throw new ExternalHostError(
+      new Error(
+        `Could not reach the GitLab endpoint ${url} from the browser — ` +
+          `likely missing CORS headers or a network block (${err instanceof Error ? err.message : String(err)})`,
+      ),
+      "gitlab",
+    );
+  }
+  if (res.status === 401 || res.status === 403 || res.status === 429) {
+    throw new ExternalHostError(
+      new Error(
+        `GitLab API rejected the request (HTTP ${res.status}) — rate limit or missing token`,
+      ),
+      "gitlab",
+    );
+  }
+  if (!res.ok) {
+    // not-found (missing preset file) — lets fetchPreset try the next candidate
+    throw new Error(PRESET_DEP_NOT_FOUND);
+  }
+  return res;
+}
+
+async function getDefaultBranchName(urlEncodedRepo: string, endpoint: string): Promise<string> {
+  const res = await gitlabRequest(`${endpoint}projects/${urlEncodedRepo}`);
+  const body = (await res.json()) as { default_branch?: string };
+  return body.default_branch ?? "master";
+}
+
+export async function fetchJSONFile(
+  repo: string,
+  fileName: string,
+  endpoint: string,
+  tag?: string,
+): Promise<Record<string, unknown> | null> {
+  const urlEncodedRepo = encodeURIComponent(repo);
+  const urlEncodedFile = encodeURIComponent(fileName);
+  const ref = tag ?? (await getDefaultBranchName(urlEncodedRepo, endpoint));
+  const url = `${endpoint}projects/${urlEncodedRepo}/repository/files/${urlEncodedFile}/raw?ref=${encodeURIComponent(ref)}`;
+  const res = await gitlabRequest(url);
+  return parsePreset(await res.text(), fileName);
+}
+
+export function getPresetFromEndpoint(
+  repo: string,
+  filePreset: string,
+  presetPath?: string,
+  endpoint: string = Endpoint,
+  tag?: string,
+): Promise<Record<string, unknown> | null> {
+  return fetchPreset({ repo, filePreset, presetPath, endpoint, tag, fetch: fetchJSONFile });
+}
+
+export function getPreset(config: {
+  repo: string;
+  presetName?: string;
+  presetPath?: string;
+  tag?: string;
+}): Promise<Record<string, unknown> | null> {
+  const { repo, presetName = "default", presetPath, tag } = config;
+  const injected = getInjectedPreset({ presetSource: "gitlab", repo, presetPath, presetName, tag });
+  if (injected) {
+    return Promise.resolve(injected);
+  }
+  return getPresetFromEndpoint(repo, presetName, presetPath, Endpoint, tag);
+}

--- a/packages/engine/src/shims/presets/http.ts
+++ b/packages/engine/src/shims/presets/http.ts
@@ -1,3 +1,24 @@
+/**
+ * Browser shim for renovate/dist/config/presets/http/index.js.
+ * A generic `http`-hosted preset is not fetched in the browser (arbitrary
+ * endpoints rarely serve CORS, and the transport is out of scope for 010), but
+ * manual injection still lets the user supply its content by hand.
+ */
+import { getInjectedPreset } from "./injection";
 import { makeUnsupportedGetPreset } from "./unsupported";
 
-export const getPreset = makeUnsupportedGetPreset("http");
+const fallback = makeUnsupportedGetPreset("http");
+
+export function getPreset(config: {
+  repo: string;
+  presetName?: string;
+  presetPath?: string;
+  tag?: string;
+}): Promise<Record<string, unknown> | null> {
+  const { repo, presetName = "", presetPath, tag } = config;
+  const injected = getInjectedPreset({ presetSource: "http", repo, presetPath, presetName, tag });
+  if (injected) {
+    return Promise.resolve(injected);
+  }
+  return fallback(config);
+}

--- a/packages/engine/src/shims/presets/injection.ts
+++ b/packages/engine/src/shims/presets/injection.ts
@@ -1,0 +1,83 @@
+/**
+ * Manual preset injection registry (roadmap 010) — the universal fallback for
+ * presets no browser fetcher can reach (self-hosted / air-gapped hosts without
+ * CORS, or hypothetical presets). The pipeline seeds it per run from the run
+ * options; every preset fetcher shim consults it before hitting the network
+ * and returns the user-supplied JSON if a matching entry exists.
+ *
+ * The registry is a module-level singleton deliberately: the shim fetchers and
+ * the pipeline import this exact module, so they share one map. Keyed by a
+ * canonical identity string the app can recompute from a failed node's
+ * `source` (same fields as `PresetSourceRef`), so a UI "provide content"
+ * action maps onto the fetcher's lookup with no coordination.
+ */
+import JSON5 from "json5";
+
+export interface PresetIdentity {
+  presetSource: string;
+  repo?: string;
+  presetPath?: string;
+  presetName?: string;
+  tag?: string;
+}
+
+/**
+ * Canonical, stable key for a preset identity. `presetName` normalises to
+ * "default" so a bare `owner/repo` (parsed as `presetName: "default"`) and an
+ * explicit `owner/repo:default` collide, matching how the fetchers resolve.
+ */
+export function presetInjectionKey(id: PresetIdentity): string {
+  return JSON.stringify([
+    id.presetSource,
+    id.repo ?? "",
+    id.presetPath ?? "",
+    id.presetName ?? "default",
+    id.tag ?? "",
+  ]);
+}
+
+let injections = new Map<string, Record<string, unknown>>();
+const usedKeys = new Set<string>();
+
+/** Seed the registry for a run. Replaces any previous contents. */
+export function setInjectedPresets(map: Record<string, Record<string, unknown>> | undefined): void {
+  injections = new Map(Object.entries(map ?? {}));
+  usedKeys.clear();
+}
+
+/** Clear the registry between runs. */
+export function resetInjectedPresets(): void {
+  injections = new Map();
+  usedKeys.clear();
+}
+
+/**
+ * Returns a fresh clone of the injected content for `id`, or undefined. Records
+ * the key as used so the trace can flag which nodes were user-supplied.
+ */
+export function getInjectedPreset(id: PresetIdentity): Record<string, unknown> | undefined {
+  const key = presetInjectionKey(id);
+  const value = injections.get(key);
+  if (value === undefined) {
+    return undefined;
+  }
+  usedKeys.add(key);
+  return structuredClone(value);
+}
+
+/** Injection keys actually consumed during the last run. */
+export function getUsedInjectionKeys(): string[] {
+  return [...usedKeys];
+}
+
+/**
+ * Parse user-pasted preset content (JSON5, the same superset Renovate accepts
+ * for preset files). Throws with a legible message on invalid input.
+ */
+export function parseInjectedPreset(text: string): Record<string, unknown> {
+  const parsed = JSON5.parse(text) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Preset content must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}

--- a/packages/engine/src/shims/presets/local.ts
+++ b/packages/engine/src/shims/presets/local.ts
@@ -1,3 +1,69 @@
-import { makeUnsupportedGetPreset } from "./unsupported";
+/**
+ * Browser shim for renovate/dist/config/presets/local/index.js.
+ * `local>` (and bare `owner/repo`) is not a host of its own — it reads the
+ * global `platform` + `endpoint` and delegates to that platform's resolver,
+ * exactly like upstream. The platform context comes from the run options (set
+ * through the real GlobalConfig by the pipeline), so this dispatch is
+ * unchanged from Renovate's; only the underlying transports are the browser
+ * shims.
+ */
+import { GlobalConfig } from "../../renovate-adapter";
+import * as forgejo from "./forgejo";
+import * as gitea from "./gitea";
+import * as github from "./github";
+import * as gitlab from "./gitlab";
+import { getInjectedPreset } from "./injection";
 
-export const getPreset = makeUnsupportedGetPreset("local");
+interface Resolver {
+  getPresetFromEndpoint(
+    repo: string,
+    filePreset: string,
+    presetPath?: string,
+    endpoint?: string,
+    tag?: string,
+  ): Promise<Record<string, unknown> | null>;
+}
+
+const resolvers: Record<string, Resolver> = { github, gitlab, gitea, forgejo };
+
+// Reachable only via a real Renovate run (their platform APIs have no browser
+// fetcher — either no CORS or no prefix of their own in this tool).
+const RUN_ONLY = new Set(["azure", "bitbucket", "bitbucket-server", "gerrit"]);
+// Platforms Renovate itself declares as unable to serve local presets.
+const NO_LOCAL_PRESETS = new Set(["codecommit", "scm-manager", "local"]);
+
+export function getPreset(config: {
+  repo: string;
+  presetName?: string;
+  presetPath?: string;
+  tag?: string;
+}): Promise<Record<string, unknown> | null> {
+  const { repo, presetName = "default", presetPath, tag } = config;
+  const injected = getInjectedPreset({ presetSource: "local", repo, presetPath, presetName, tag });
+  if (injected) {
+    return Promise.resolve(injected);
+  }
+
+  const platform = (GlobalConfig.get("platform") as string | undefined) ?? "github";
+  const endpoint = GlobalConfig.get("endpoint") as string | undefined;
+
+  const resolver = resolvers[platform];
+  if (resolver) {
+    return resolver.getPresetFromEndpoint(repo, presetName, presetPath, endpoint, tag);
+  }
+  if (RUN_ONLY.has(platform)) {
+    return Promise.reject(
+      new Error(
+        `local presets on '${platform}' are only reachable via a real Renovate run — ` +
+          `the ${platform} preset API is not available in the browser. ` +
+          `Provide the preset content manually to continue.`,
+      ),
+    );
+  }
+  if (NO_LOCAL_PRESETS.has(platform)) {
+    return Promise.reject(
+      new Error(`The platform you're using (${platform}) does not support local presets.`),
+    );
+  }
+  return Promise.reject(new Error(`Unknown platform '${platform}' for local preset.`));
+}

--- a/packages/engine/src/shims/presets/npm.ts
+++ b/packages/engine/src/shims/presets/npm.ts
@@ -9,6 +9,7 @@ import {
   PRESET_NOT_FOUND,
   PRESET_RENOVATE_CONFIG_NOT_FOUND,
 } from "renovate/dist/config/presets/util.js";
+import { getInjectedPreset } from "./injection";
 
 interface Packument {
   "dist-tags"?: Record<string, string>;
@@ -20,6 +21,10 @@ export async function getPreset(config: {
   presetName?: string;
 }): Promise<Record<string, unknown> | null> {
   const { repo: pkgName, presetName = "default" } = config;
+  const injected = getInjectedPreset({ presetSource: "npm", repo: pkgName, presetName });
+  if (injected) {
+    return injected;
+  }
   let latestVersion: { "renovate-config"?: Record<string, Record<string, unknown>> } | undefined;
   try {
     const res = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkgName)}`, {

--- a/packages/engine/src/shims/renovate-deps.ts
+++ b/packages/engine/src/shims/renovate-deps.ts
@@ -1,0 +1,107 @@
+/**
+ * Exact, dependency-free copies of the two Renovate transitive deps the forked
+ * `migrateConfig` (shims/migration.ts) needs: `dequal` (dequal@2.0.3) and the
+ * handful of `@sindresorhus/is@8.1.0` predicates. They live under renovate's
+ * own node_modules and are not resolvable from this package, and the fork's
+ * fixed-point / gating logic must match their behavior byte-for-byte, so they
+ * are vendored verbatim rather than re-implemented. Re-check on a renovate bump
+ * if either dependency's version changes.
+ */
+
+const has = Object.prototype.hasOwnProperty;
+
+/** Verbatim dequal@2.0.3. */
+export function dequal(foo: unknown, bar: unknown): boolean {
+  let ctor: unknown;
+  let len: number;
+  if (foo === bar) {
+    return true;
+  }
+  if (
+    foo &&
+    bar &&
+    typeof foo === "object" &&
+    typeof bar === "object" &&
+    (ctor = (foo as { constructor: unknown }).constructor) ===
+      (bar as { constructor: unknown }).constructor
+  ) {
+    if (ctor === Date) {
+      return (foo as Date).getTime() === (bar as Date).getTime();
+    }
+    if (ctor === RegExp) {
+      return foo.toString() === bar.toString();
+    }
+    if (ctor === Array) {
+      if ((len = (foo as unknown[]).length) === (bar as unknown[]).length) {
+        while (len-- && dequal((foo as unknown[])[len], (bar as unknown[])[len]));
+      }
+      return len === -1;
+    }
+    if (!ctor || typeof foo === "object") {
+      len = 0;
+      for (const key in foo as Record<string, unknown>) {
+        if (has.call(foo, key) && ++len && !has.call(bar, key)) {
+          return false;
+        }
+        if (
+          !(key in (bar as Record<string, unknown>)) ||
+          !dequal((foo as Record<string, unknown>)[key], (bar as Record<string, unknown>)[key])
+        ) {
+          return false;
+        }
+      }
+      return Object.keys(bar as Record<string, unknown>).length === len;
+    }
+  }
+  return foo !== foo && bar !== bar;
+}
+
+// @sindresorhus/is@8.1.0 predicates (Date/RegExp/Map/Set/typed-array branches
+// of the upstream copies are irrelevant to JSON config values but preserved so
+// behavior is identical).
+export function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+export function isBoolean(value: unknown): value is boolean {
+  return value === true || value === false;
+}
+
+function isFunction(value: unknown): boolean {
+  return typeof value === "function";
+}
+
+export function isArray(value: unknown): value is any[] {
+  return Array.isArray(value);
+}
+
+export function isObject(value: unknown): boolean {
+  return value !== null && (typeof value === "object" || isFunction(value));
+}
+
+function getObjectType(value: unknown): string {
+  return Object.prototype.toString.call(value).slice(8, -1);
+}
+
+function isMap(value: unknown): boolean {
+  return getObjectType(value) === "Map";
+}
+
+function isSet(value: unknown): boolean {
+  return getObjectType(value) === "Set";
+}
+
+export function isNonEmptyArray(value: unknown): value is any[] {
+  return isArray(value) && value.length > 0;
+}
+
+export function isNonEmptyObject(value: unknown): boolean {
+  return (
+    isObject(value) &&
+    !isFunction(value) &&
+    !isArray(value) &&
+    !isMap(value) &&
+    !isSet(value) &&
+    Object.keys(value as Record<string, unknown>).length > 0
+  );
+}

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -25,6 +25,7 @@ export function renovateShims(): Plugin {
       "_virtual/_rolldown/runtime.js": "rolldown-runtime.ts",
       "instrumentation/index.js": "instrumentation.ts",
       "logger/index.js": "logger.ts",
+      "config/migration.js": "migration.ts",
       "expose.js": "expose.ts",
       "config/presets/github/index.js": "presets/github.ts",
       "config/presets/npm/index.js": "presets/npm.ts",

--- a/packages/engine/src/trace/collector.ts
+++ b/packages/engine/src/trace/collector.ts
@@ -1,6 +1,24 @@
-import { toSerializable } from "./delta";
+import { computeDelta, snapshot, toSerializable } from "./delta";
+import { describeMigration } from "./migration-names";
 import type { LogLevel, PlatformContext, PresetNode, StageId, TraceEvent } from "./model";
 import { type ParsePresetFn, PresetTreeBuilder } from "./preset-tree";
+
+/**
+ * One granular migration step reported by the forked `migrateConfig` shim
+ * (004). `before`/`after` are full-document snapshots at the point the step
+ * fired; the collector turns them into a `migration-applied` event.
+ */
+export interface MigrationStepEmit {
+  /** Migration class name, or a synthetic post-processing block name. */
+  className: string;
+  key?: string;
+  /** For rename migrations, the key the value moved to. */
+  newKey?: string;
+  parentKey?: string;
+  pass: number;
+  before: unknown;
+  after: unknown;
+}
 
 /**
  * Collects trace events for the currently running pipeline. The logger shim
@@ -33,6 +51,44 @@ export class TraceCollector {
     };
     this.events.push(full);
     return full;
+  }
+
+  /**
+   * Entry point for the forked `migrateConfig` shim. Emits one granular
+   * `migration-applied` event per step. Stage-gated to migrate/preset so the
+   * migrateConfig calls Renovate makes during validation (packageRule
+   * deprecation checks) don't pollute the stream — the same gating the preset
+   * tree uses.
+   */
+  onMigrationStep(step: MigrationStepEmit): void {
+    if (this.stage !== "migrate" && this.stage !== "preset") {
+      return;
+    }
+    const { name, explanation } = describeMigration({
+      className: step.className,
+      key: step.key,
+      newKey: step.newKey,
+    });
+    const before = snapshot(step.before);
+    const after = snapshot(step.after);
+    const presetName = this.stage === "preset" ? this.tree.currentPresetName() : undefined;
+    this.emit({
+      kind: "migration-applied",
+      title: name,
+      before,
+      after,
+      delta: computeDelta(before, after),
+      migration: {
+        name,
+        className: step.className,
+        key: step.key,
+        newKey: step.newKey,
+        parentKey: step.parentKey,
+        pass: step.pass,
+        presetName,
+        explanation,
+      },
+    });
   }
 
   /** Entry point for the logger shim. Upgrades known messages to typed events. */
@@ -84,4 +140,9 @@ export function setCurrentCollector(collector: TraceCollector | null): void {
 /** Called by the logger shim; a no-op when no pipeline run is active. */
 export function emitLog(level: LogLevel, meta: unknown, msg: string | undefined): void {
   current?.onLog(level, meta, msg);
+}
+
+/** Called by the migration shim; a no-op when no pipeline run is active. */
+export function emitMigrationStep(step: MigrationStepEmit): void {
+  current?.onMigrationStep(step);
 }

--- a/packages/engine/src/trace/collector.ts
+++ b/packages/engine/src/trace/collector.ts
@@ -1,5 +1,5 @@
 import { toSerializable } from "./delta";
-import type { LogLevel, PresetNode, StageId, TraceEvent } from "./model";
+import type { LogLevel, PlatformContext, PresetNode, StageId, TraceEvent } from "./model";
 import { type ParsePresetFn, PresetTreeBuilder } from "./preset-tree";
 
 /**
@@ -13,8 +13,8 @@ export class TraceCollector {
   private stage: StageId = "parse";
   private tree: PresetTreeBuilder;
 
-  constructor(parsePreset?: ParsePresetFn) {
-    this.tree = new PresetTreeBuilder((event) => this.emit(event), parsePreset);
+  constructor(parsePreset?: ParsePresetFn, platformContext?: PlatformContext) {
+    this.tree = new PresetTreeBuilder((event) => this.emit(event), parsePreset, platformContext);
   }
 
   enterStage(stage: StageId): void {

--- a/packages/engine/src/trace/migration-names.ts
+++ b/packages/engine/src/trace/migration-names.ts
@@ -1,0 +1,134 @@
+/**
+ * Human-readable names and one-sentence deprecation explanations for the
+ * migration steps emitted during the migrate/preset stages (004).
+ *
+ * Renovate's migration classes carry no user-facing copy, so this is a curated
+ * map keyed by class name (custom migrations + the synthetic post-processing
+ * blocks the fork of `migrateConfig` emits) or by the deprecated key (the
+ * generic Rename/RemovePropertyMigration classes). Anything not covered falls
+ * back to a humanized class name so a new upstream migration still reads
+ * sensibly.
+ */
+
+export interface MigrationDescription {
+  name: string;
+  explanation?: string;
+}
+
+export interface DescribeMigrationInput {
+  /** Renovate's migration class name, or a synthetic post-processing name. */
+  className: string;
+  /** The config key the step acted on. */
+  key?: string;
+  /** For rename migrations, the key the value moved to. */
+  newKey?: string;
+}
+
+/** Explanations for `RenamePropertyMigration`, keyed by the deprecated key. */
+const RENAME_EXPLANATIONS: Record<string, string> = {
+  versionScheme: "Renamed to `versioning` — the option selects the versioning scheme for updates.",
+  endpoints: "Renamed to `hostRules` — per-host credentials and settings now live in one array.",
+  baseBranches:
+    "Renamed to `baseBranchPatterns` — the option accepts glob/regex patterns, so the plural name was clarified.",
+  regexManagers:
+    "Renamed to `customManagers` — custom managers are no longer limited to the regex strategy.",
+  aliases: "Renamed to `registryAliases` to make its purpose (registry URL aliases) explicit.",
+  masterIssue: "Renamed to `dependencyDashboard` along with the rest of the dashboard options.",
+  separatePatchReleases: "Renamed to `separateMinorPatch`.",
+  multipleMajorPrs: "Renamed to `separateMultipleMajor`.",
+  excludedPackageNames: "Renamed to `excludePackageNames` for naming consistency.",
+  exposeEnv: "Renamed to `exposeAllEnv`.",
+};
+
+/** Explanations keyed by migration class name (custom + post-processing). */
+const CLASS_EXPLANATIONS: Record<string, string> = {
+  BinarySourceMigration: 'The `binarySource: "auto"` value was renamed to `"global"`.',
+  SemanticCommitsMigration:
+    "`semanticCommits` is now an enum (`enabled` / `disabled` / `auto`) rather than a boolean.",
+  SemanticPrefixMigration:
+    "`semanticPrefix` is split into the structured `semanticCommitType` / `semanticCommitScope` options.",
+  ScheduleMigration: "Legacy schedule strings are normalized to Renovate's supported syntax.",
+  AzureGitLabAutomergeMigration:
+    "`gitLabAutomerge` / `azureAutoComplete` are replaced by the platform-neutral `platformAutomerge`.",
+  PlatformCommitMigration: "`platformCommit` became an enum (`auto` / `enabled` / `disabled`).",
+  BaseBranchMigration: "`baseBranch` (singular) is folded into the `baseBranchPatterns` array.",
+  PackageRulesMigration:
+    "Legacy packageRules matchers (`packageNames`, `packagePatterns`, `languages`, `paths`, …) are renamed to their `match*` equivalents.",
+  PackageNameMigration: "`packageName` is replaced by the array-valued `packageNames`.",
+  PackagePatternMigration: "`packagePattern` is replaced by the array-valued `packagePatterns`.",
+  PackagesMigration: "The top-level `packages` array is folded into `packageRules`.",
+  AutomergeMigration:
+    'The old `automerge: "minor" | "patch" | "any"` values expand into explicit per-update-type rules.',
+  MatchManagersMigration: "Manager names in `matchManagers` are updated to their current spelling.",
+  CustomManagersMigration: "`customType` is defaulted to `regex` on each custom manager entry.",
+  MatchDatasourcesMigration:
+    "Datasource ids in `matchDatasources` are updated to their current names.",
+  DatasourceMigration: "The `datasource` id is updated to its current name.",
+  NodeMigration: "The legacy `node` config block is normalized.",
+  HostRulesMigration:
+    "`hostRules` entries are updated to the current `matchHost` / credentials shape.",
+  FileMatchMigration: "`fileMatch` is renamed to `managerFilePatterns`.",
+  StabilityDaysMigration: "`stabilityDays` is replaced by `minimumReleaseAge`.",
+  ExtendsMigration: "`extends` preset names are normalized to their current form.",
+  // Synthetic post-processing blocks emitted by the forked migrateConfig.
+  LanguagePackageRules:
+    "A top-level language block (docker, python, …) is promoted into a `matchCategories` packageRule.",
+  FlattenNestedPackageRules:
+    "Nested `packageRules` inside a packageRule are flattened into one list.",
+  TemplateRewrite:
+    "Deprecated template placeholders (`{{baseDir}}`, `{{lookupName}}`, …) are rewritten to their current names.",
+  PipCompileFilePatterns: "pip-compile `managerFilePatterns` are rewritten from `.in` to `.txt`.",
+  GradleLiteMerge: "The removed `gradle-lite` config block is merged into `gradle`.",
+  GradleLiteManager: "`gradle-lite` in `matchManagers` is replaced by `gradle`.",
+  OptionTypeCoercion:
+    "The value is coerced to the option's declared type (e.g. a boolean under an object option becomes `{ enabled: … }`).",
+};
+
+/** Friendly labels for the synthetic post-processing steps. */
+const POST_LABELS: Record<string, string> = {
+  LanguagePackageRules: "Language block → packageRules",
+  FlattenNestedPackageRules: "Flatten nested packageRules",
+  TemplateRewrite: "Template placeholder rewrite",
+  OptionTypeCoercion: "Normalize option value type",
+  PipCompileFilePatterns: "pip-compile file patterns",
+  GradleLiteMerge: "gradle-lite → gradle",
+  GradleLiteManager: "gradle-lite → gradle (manager)",
+};
+
+/** Turn `PackageNameMigration` into `Package name`. */
+function humanize(className: string): string {
+  const base = className.replace(/Migration$/, "");
+  const spaced = base.replace(/([a-z0-9])([A-Z])/g, "$1 $2").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+export function describeMigration(input: DescribeMigrationInput): MigrationDescription {
+  const { className, key, newKey } = input;
+
+  if (className === "RenamePropertyMigration" && key) {
+    return {
+      name: newKey ? `${key} → ${newKey}` : `Rename ${key}`,
+      explanation:
+        RENAME_EXPLANATIONS[key] ??
+        (newKey ? `Renamed to \`${newKey}\`.` : "Renamed to its current option name."),
+    };
+  }
+
+  if (className === "RemovePropertyMigration" && key) {
+    return {
+      name: `Remove ${key}`,
+      explanation: `\`${key}\` was removed from Renovate and no longer has any effect.`,
+    };
+  }
+
+  if (POST_LABELS[className]) {
+    return { name: POST_LABELS[className], explanation: CLASS_EXPLANATIONS[className] };
+  }
+
+  const explanation = CLASS_EXPLANATIONS[className];
+  const label = humanize(className);
+  return {
+    name: key ? `${label} (${key})` : label,
+    explanation,
+  };
+}

--- a/packages/engine/src/trace/model.ts
+++ b/packages/engine/src/trace/model.ts
@@ -22,6 +22,31 @@ export interface ValidationMessage {
   message: string;
 }
 
+/**
+ * Per-step detail attached to a granular `migration-applied` event (004). Each
+ * step is one migration class (or one non-class post-processing block) that
+ * actually changed the config; the event's before/after are full-document
+ * snapshots so the stepper's diffs stay small.
+ */
+export interface MigrationStepInfo {
+  /** Human-readable label, e.g. `packageNames → matchPackageNames`. */
+  name: string;
+  /** Renovate's migration class name, e.g. `PackageNameMigration`. */
+  className: string;
+  /** The config key this step acted on (absent for post-processing blocks). */
+  key?: string;
+  /** For rename migrations, the key the value moved to. */
+  newKey?: string;
+  /** Parent key when the step fired inside a nested object subtree. */
+  parentKey?: string;
+  /** Fixed-point pass this step belongs to (1 = first pass). */
+  pass?: number;
+  /** Set when the step fired while migrating a preset on fetch (preset stage). */
+  presetName?: string;
+  /** One-sentence explanation of why the old form is deprecated. */
+  explanation?: string;
+}
+
 export type PresetSource =
   | "internal"
   | "github"
@@ -98,6 +123,8 @@ export interface TraceEvent {
   messages?: ValidationMessage[];
   level?: LogLevel;
   meta?: unknown;
+  /** Present on granular `migration-applied` events (004). */
+  migration?: MigrationStepInfo;
 }
 
 export interface PipelineInput {

--- a/packages/engine/src/trace/model.ts
+++ b/packages/engine/src/trace/model.ts
@@ -42,6 +42,12 @@ export interface PresetSourceRef {
   tag?: string;
   /** Positional parameters, e.g. `schedule:earlyMondays(...)` → ["..."] */
   params?: string[];
+  /**
+   * For `local>` / bare `owner/repo` nodes only: the platform + endpoint the
+   * run resolved them against (from the platform context / global config).
+   */
+  platform?: string;
+  endpoint?: string;
 }
 
 export type PresetNodeState =
@@ -101,6 +107,24 @@ export interface PipelineInput {
   content: string;
   /** Optional self-hosted/global options consulted by migration, validation and presets */
   globalConfig?: Record<string, unknown>;
+  /**
+   * Platform context defining `local>` resolution. Set through Renovate's real
+   * GlobalConfig before preset resolution. Defaults to `github`.
+   */
+  platform?: string;
+  /** Endpoint for the platform context; defaults to the platform's own API. */
+  endpoint?: string;
+  /**
+   * User-supplied preset content for otherwise-unreachable presets, keyed by
+   * the canonical injection key (see `presetInjectionKey`).
+   */
+  injectedPresets?: Record<string, Record<string, unknown>>;
+}
+
+/** The platform + endpoint a run resolved `local>` presets against. */
+export interface PlatformContext {
+  platform: string;
+  endpoint: string;
 }
 
 export interface TraceResult {
@@ -117,4 +141,11 @@ export interface TraceResult {
    * shim is active (browser bundle / shimmed tests) — undefined in plain Node.
    */
   presetTree?: PresetNode;
+  /** Platform + endpoint this run resolved `local>` presets against. */
+  platformContext: PlatformContext;
+  /**
+   * Injection keys served from user-supplied content during this run. The app
+   * matches these against each node's computed key to flag "user-supplied".
+   */
+  usedInjections: string[];
 }

--- a/packages/engine/src/trace/preset-tree.ts
+++ b/packages/engine/src/trace/preset-tree.ts
@@ -1,5 +1,11 @@
 import { toSerializable } from "./delta";
-import type { PresetNode, PresetSourceRef, TraceEvent, ValidationMessage } from "./model";
+import type {
+  PlatformContext,
+  PresetNode,
+  PresetSourceRef,
+  TraceEvent,
+  ValidationMessage,
+} from "./model";
 
 /**
  * Signature of renovate's `parsePreset` (config/presets/parse.js), injected by
@@ -58,6 +64,7 @@ export class PresetTreeBuilder {
   constructor(
     private readonly emit: EmitFn,
     private readonly parsePreset?: ParsePresetFn,
+    private readonly platformContext?: PlatformContext,
   ) {}
 
   /** Returns true when the log line was consumed as part of the preset tree. */
@@ -266,7 +273,7 @@ export class PresetTreeBuilder {
     }
     try {
       const parsed = this.parsePreset(raw);
-      return {
+      const ref: PresetSourceRef = {
         raw,
         presetSource: parsed.presetSource as PresetSourceRef["presetSource"],
         repo: parsed.repo,
@@ -275,6 +282,13 @@ export class PresetTreeBuilder {
         tag: parsed.tag,
         params: parsed.params,
       };
+      // `local>` (and bare owner/repo) resolves against the run's platform
+      // context — record it so the tree can show "via gitlab @ endpoint".
+      if (parsed.presetSource === "local" && this.platformContext) {
+        ref.platform = this.platformContext.platform;
+        ref.endpoint = this.platformContext.endpoint;
+      }
+      return ref;
     } catch {
       return { raw };
     }

--- a/packages/engine/src/trace/preset-tree.ts
+++ b/packages/engine/src/trace/preset-tree.ts
@@ -136,6 +136,15 @@ export class PresetTreeBuilder {
     return this.root;
   }
 
+  /**
+   * The preset currently being fetched, if any. During the preset stage a
+   * preset is migrated on fetch between its "Resolving preset" and its
+   * `resolveConfigPresets` entry logs, so it is the top frame's `pendingChild`.
+   */
+  currentPresetName(): string | undefined {
+    return this.top()?.pendingChild?.name;
+  }
+
   private top(): Frame | undefined {
     return this.frames.at(-1);
   }

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -1,0 +1,240 @@
+import { getDefaultConfig, getOptions, mergeChildConfig } from "../renovate-adapter";
+import type { PresetNode, TraceResult } from "./model";
+
+/**
+ * Roadmap 005: per-key merge provenance. Computed post-hoc from the trace data
+ * the engine already captures (the preset tree + final config) by replaying
+ * Renovate's real `mergeChildConfig` over the top-level layers — defaults, then
+ * each directly-extended preset in order, then the repo config — and attributing
+ * every top-level key to the layer(s) that produced its final value.
+ *
+ * No Renovate instrumentation is involved: `mergeChildConfig` is pure, so the
+ * replay reproduces the pipeline's merge exactly. The replay is top-level only
+ * (`root.children`, not the whole tree), so it is a handful of merges even for
+ * `config:recommended`.
+ */
+
+/** How a layer touched a key, in Renovate's merge semantics. */
+export type ProvenanceAction =
+  | "set"
+  | "overwrite"
+  | "concat"
+  | "shallow-merge"
+  | "deep-merge"
+  | "forced";
+
+/** Which layer a step is attributed to. */
+export type ProvenanceLayer =
+  | { kind: "defaults" }
+  | { kind: "preset"; nodeId: string; name: string }
+  | { kind: "repo" };
+
+export interface ProvenanceStep {
+  layer: ProvenanceLayer;
+  action: ProvenanceAction;
+  /** The value this layer merged onto (the losing value for overwrite/forced). */
+  before: unknown;
+  /** The key's value after this layer's contribution. */
+  after: unknown;
+  /** Contribution that did not change the value (empty-array concat, defaulted-then-overridden). */
+  noop?: boolean;
+  /** The key's value was further expanded by Renovate's nested-`extends` pass. */
+  expandedNested?: boolean;
+}
+
+export interface KeyProvenance {
+  key: string;
+  finalValue: unknown;
+  /** No preset or repo layer touched this key — it is a pure untouched default. */
+  isDefaultOnly: boolean;
+  /** Chronological chain: defaults first (when present), then presets in order, then repo. */
+  chain: ProvenanceStep[];
+}
+
+type Obj = Record<string, unknown>;
+
+function isPlainObject(v: unknown): v is Obj {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((x, i) => deepEqual(x, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    return (
+      ak.length === bk.length &&
+      ak.every((k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]))
+    );
+  }
+  return false;
+}
+
+interface Layer {
+  layer: ProvenanceLayer;
+  config: Obj;
+}
+
+/** Top-level merge layers, in the order Renovate merges them (presets then repo). */
+function buildLayers(root: PresetNode): Layer[] {
+  const layers: Layer[] = [];
+  // Same filter PresetTree's contribution replay uses: only non-nested,
+  // resolved children with a `resolved` payload participate in the top merge.
+  for (const child of root.children) {
+    if (child.nested || child.state !== "resolved" || child.resolved === undefined) {
+      continue;
+    }
+    layers.push({
+      layer: { kind: "preset", nodeId: child.id, name: child.name },
+      config: child.resolved as Obj,
+    });
+  }
+  const repo = structuredClone(root.input) as Obj;
+  delete repo.extends;
+  delete repo.ignorePresets;
+  layers.push({ layer: { kind: "repo" }, config: repo });
+  return layers;
+}
+
+/**
+ * Computes per-top-level-key provenance for a completed run, or `undefined`
+ * when the run lacks the data it needs (no final config, or preset resolution
+ * did not finish so the root has no `resolved`/`input`).
+ */
+export function computeProvenance(result: TraceResult): Map<string, KeyProvenance> | undefined {
+  const { finalConfig } = result;
+  const root = result.presetTree;
+  if (!finalConfig || !root || root.resolved === undefined || root.input === undefined) {
+    return undefined;
+  }
+
+  const optionMap = new Map<string, { mergeable: boolean; type: string }>();
+  for (const opt of getOptions()) {
+    optionMap.set(opt.name, { mergeable: Boolean(opt.mergeable), type: opt.type });
+  }
+
+  const defaults = getDefaultConfig() as Obj;
+  const resolved = root.resolved as Obj;
+  const layers = buildLayers(root);
+
+  const chains = new Map<string, ProvenanceStep[]>();
+  const lastLayerIndex = new Map<string, number>();
+
+  const pushStep = (key: string, step: ProvenanceStep, layerIndex: number): void => {
+    let arr = chains.get(key);
+    if (!arr) {
+      arr = [];
+      chains.set(key, arr);
+    }
+    arr.push(step);
+    lastLayerIndex.set(key, layerIndex);
+  };
+
+  // Replay the preset/repo merge, attributing each key the incoming layer owns.
+  let acc: Obj = {};
+  layers.forEach(({ layer, config }, layerIndex) => {
+    const before = acc;
+    const after = mergeChildConfig(structuredClone(before), structuredClone(config)) as Obj;
+
+    for (const key of Object.keys(config)) {
+      const opt = optionMap.get(key);
+      const parentVal = before[key];
+      const childVal = config[key];
+      const mergeableBranch = Boolean(opt?.mergeable) && Boolean(parentVal) && Boolean(childVal);
+      let action: ProvenanceAction;
+      let noop = false;
+      if (mergeableBranch) {
+        if (key === "constraints") {
+          action = "shallow-merge";
+        } else if (opt?.type === "array") {
+          action = "concat";
+          noop = Array.isArray(childVal) && childVal.length === 0;
+        } else {
+          action = "deep-merge";
+        }
+      } else {
+        action = parentVal === undefined ? "set" : "overwrite";
+      }
+      pushStep(
+        key,
+        { layer, action, before: parentVal, after: after[key], ...(noop ? { noop: true } : {}) },
+        layerIndex,
+      );
+    }
+
+    // `mergeChildConfig` re-flattens `config.force` over the top-level keys on
+    // every call, so a force-sourced win must be attributed to this layer.
+    const force = isPlainObject(after.force) ? after.force : undefined;
+    if (force) {
+      for (const fkey of Object.keys(force)) {
+        const finalVal = after[fkey];
+        const arr = chains.get(fkey);
+        const last = arr?.at(-1);
+        if (last && last.action === "forced" && deepEqual(last.after, finalVal)) {
+          continue; // already forced to this exact value by an earlier layer
+        }
+        if (arr && last && lastLayerIndex.get(fkey) === layerIndex) {
+          // this layer just recorded a step for the key — force overrides it
+          arr[arr.length - 1] = { layer, action: "forced", before: last.before, after: finalVal };
+        } else {
+          pushStep(
+            fkey,
+            { layer, action: "forced", before: before[fkey], after: finalVal },
+            layerIndex,
+          );
+        }
+      }
+    }
+
+    acc = after;
+  });
+
+  // Renovate runs a final nested-`extends` expansion over the combined config,
+  // which further resolves repo-supplied nested extends (e.g. packageRules[n].
+  // extends) that the plain replay leaves unexpanded. Correct those keys from
+  // the ground-truth resolved config and tag the responsible step.
+  for (const key of Object.keys(resolved)) {
+    const arr = chains.get(key);
+    if (arr && arr.length > 0 && !deepEqual(acc[key], resolved[key])) {
+      const last = arr[arr.length - 1];
+      if (last) {
+        arr[arr.length - 1] = { ...last, after: resolved[key], expandedNested: true };
+      }
+      acc[key] = resolved[key];
+    }
+  }
+
+  // Assemble per key of the final config, prepending the defaults layer.
+  const provenance = new Map<string, KeyProvenance>();
+  for (const key of Object.keys(finalConfig)) {
+    const presetRepoChain = chains.get(key) ?? [];
+    const chain: ProvenanceStep[] = [];
+    if (Object.prototype.hasOwnProperty.call(defaults, key)) {
+      const inResolved = Object.prototype.hasOwnProperty.call(resolved, key);
+      // The default is a no-op contribution when a later layer produced the
+      // final value regardless (overwritten scalar, empty-array concat, null
+      // object) — i.e. the final value equals the post-preset value.
+      const noop = inResolved && deepEqual(finalConfig[key], resolved[key]);
+      chain.push({
+        layer: { kind: "defaults" },
+        action: "set",
+        before: undefined,
+        after: defaults[key],
+        ...(noop ? { noop: true } : {}),
+      });
+    }
+    chain.push(...presetRepoChain);
+    provenance.set(key, {
+      key,
+      finalValue: finalConfig[key],
+      isDefaultOnly: presetRepoChain.length === 0,
+      chain,
+    });
+  }
+  return provenance;
+}

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -26,6 +26,39 @@ declare module "renovate/dist/config/massage.js" {
   export function massageConfig(config: RenovateConfig): RenovateConfig;
 }
 
+declare module "renovate/dist/config/migrations/migrations-service.js" {
+  /** One migration instance. `run` mutates the shared migratedConfig. */
+  export interface Migration {
+    readonly propertyName: string | RegExp;
+    readonly deprecated?: boolean;
+    /** Present on RenamePropertyMigration — the key the value moves to. */
+    readonly newPropertyName?: string;
+    run(value: unknown, key: string, parentKey?: string): void;
+  }
+  // Renovate ships this as a class with only static members; modelled here as
+  // a namespace so callers get the same `MigrationsService.getMigrations(...)`
+  // access without an extraneous-class lint warning.
+  export namespace MigrationsService {
+    const removedProperties: ReadonlySet<string>;
+    const renamedProperties: ReadonlyMap<string, string>;
+    function run(originalConfig: RenovateConfig, parentKey?: string): RenovateConfig;
+    function getMigrations(
+      originalConfig: RenovateConfig,
+      migratedConfig: RenovateConfig,
+    ): Migration[];
+    function getMigration(migrations: Migration[], key: string): Migration | undefined;
+    function isMigrated(originalConfig: RenovateConfig, migratedConfig: RenovateConfig): boolean;
+  }
+}
+
+declare module "renovate/dist/util/regex.js" {
+  export function regEx(pattern: string | RegExp, flags?: string, useCache?: boolean): RegExp;
+}
+
+declare module "renovate/dist/util/clone.js" {
+  export function clone<T>(input: T): T;
+}
+
 declare module "renovate/dist/config/validation.js" {
   export interface ValidationMessage {
     topic: string;

--- a/packages/engine/test/__snapshots__/migration-steps.json.final.json
+++ b/packages/engine/test/__snapshots__/migration-steps.json.final.json
@@ -1,0 +1,1170 @@
+{
+  "mode": "full",
+  "allowedHeaders": [
+    "X-*"
+  ],
+  "autodiscoverRepoOrder": null,
+  "autodiscoverRepoSort": null,
+  "allowedEnv": [],
+  "detectGlobalManagerConfig": false,
+  "detectHostRulesFromEnv": false,
+  "mergeConfidenceEndpoint": "https://developer.mend.io/",
+  "mergeConfidenceDatasources": [
+    "go",
+    "maven",
+    "npm",
+    "nuget",
+    "packagist",
+    "pypi",
+    "rubygems"
+  ],
+  "useCloudMetadataServices": true,
+  "userAgent": "Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)",
+  "allowedCommands": [],
+  "bumpVersions": [],
+  "postUpgradeTasks": {
+    "commands": [],
+    "fileFilters": [],
+    "executionMode": "update",
+    "installTools": {}
+  },
+  "onboardingBranch": "renovate/configure",
+  "onboardingAutoCloseAge": null,
+  "onboardingCommitMessage": null,
+  "configFileNames": null,
+  "onboardingConfigFileName": "renovate.json",
+  "onboardingNoDeps": "auto",
+  "onboardingPrTitle": "Configure Renovate",
+  "configMigration": false,
+  "productLinks": {
+    "documentation": "https://docs.renovatebot.com/",
+    "help": "https://github.com/renovatebot/renovate/discussions",
+    "homepage": "https://github.com/renovatebot/renovate"
+  },
+  "secrets": {},
+  "variables": {},
+  "statusCheckNames": {
+    "artifactError": "renovate/artifacts",
+    "configValidation": "renovate/config-validation",
+    "mergeConfidence": "renovate/merge-confidence",
+    "minimumReleaseAge": "renovate/stability-days"
+  },
+  "statusCheckWhen": {
+    "artifactError": "failed",
+    "configValidation": "always",
+    "mergeConfidence": "always",
+    "minimumReleaseAge": "always"
+  },
+  "extends": [],
+  "ignorePresets": [],
+  "migratePresets": {},
+  "minimumGroupSize": 1,
+  "presetCachePersistence": false,
+  "globalExtends": [],
+  "description": [],
+  "enabled": true,
+  "constraintsFiltering": "none",
+  "repositoryCache": "disabled",
+  "repositoryCacheType": "local",
+  "repositoryCacheForceLocal": false,
+  "reportType": null,
+  "reportPath": null,
+  "reportFormatting": false,
+  "force": null,
+  "forceCli": true,
+  "draftPR": false,
+  "dryRun": null,
+  "printConfig": false,
+  "binarySource": "global",
+  "redisUrl": null,
+  "redisPrefix": null,
+  "baseDir": null,
+  "cacheDir": null,
+  "containerbaseDir": null,
+  "customEnvVariables": {},
+  "env": {},
+  "customDatasources": {},
+  "dockerChildPrefix": "renovate_",
+  "dockerCliOptions": null,
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.76.9",
+  "dockerUser": "12021",
+  "composerIgnorePlatformReqs": [],
+  "goGetDirs": [
+    "./..."
+  ],
+  "logContext": null,
+  "onboarding": true,
+  "onboardingConfig": {
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  },
+  "onboardingRebaseCheckbox": false,
+  "forkProcessing": "auto",
+  "includeMirrors": false,
+  "forkCreation": true,
+  "forkToken": null,
+  "forkOrg": null,
+  "githubTokenWarn": true,
+  "encryptedWarning": null,
+  "inheritConfig": false,
+  "inheritConfigRepoName": "{{parentOrg}}/renovate-config",
+  "inheritConfigFileName": "org-inherited-config.json",
+  "inheritConfigStrict": false,
+  "requireConfig": "required",
+  "optimizeForDisabled": false,
+  "dependencyDashboard": false,
+  "dependencyDashboardApproval": false,
+  "dependencyDashboardAutoclose": false,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "dependencyDashboardCategory": null,
+  "dependencyDashboardHeader": "This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.",
+  "dependencyDashboardFooter": null,
+  "dependencyDashboardLabels": null,
+  "dependencyDashboardOSVVulnerabilitySummary": "none",
+  "configWarningReuseIssue": false,
+  "privateKey": null,
+  "privateKeyOld": null,
+  "privateKeyPath": null,
+  "privateKeyPathOld": null,
+  "encrypted": null,
+  "timezone": null,
+  "schedule": [
+    "at any time"
+  ],
+  "automergeSchedule": [
+    "at any time"
+  ],
+  "updateNotScheduled": true,
+  "persistRepoData": false,
+  "exposeAllEnv": false,
+  "allowPlugins": false,
+  "allowScripts": false,
+  "allowShellExecutorForPostUpgradeCommands": false,
+  "allowCustomCrateRegistries": false,
+  "ignorePlugins": false,
+  "ignoreScripts": true,
+  "platform": "github",
+  "endpoint": null,
+  "token": null,
+  "username": null,
+  "password": null,
+  "npmrc": null,
+  "npmrcMerge": false,
+  "npmToken": null,
+  "skipArtifactsUpdate": false,
+  "skipInstalls": null,
+  "autodiscover": false,
+  "autodiscoverFilter": null,
+  "autodiscoverNamespaces": null,
+  "autodiscoverProjects": null,
+  "autodiscoverTopics": null,
+  "prCommitsPerRunLimit": 0,
+  "repositories": [],
+  "baseBranchPatterns": [
+    "next"
+  ],
+  "useBaseBranchConfig": "none",
+  "gitAuthor": null,
+  "gitPrivateKey": null,
+  "gitPrivateKeyPassphrase": null,
+  "gitIgnoredAuthors": [],
+  "gitTimeout": 0,
+  "enabledManagers": [],
+  "includePaths": [],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**"
+  ],
+  "excludeCommitPaths": [],
+  "executionTimeout": 15,
+  "registryAliases": {},
+  "defaultRegistryUrls": null,
+  "registryUrls": null,
+  "extractVersion": null,
+  "versionCompatibility": null,
+  "versioning": "semver",
+  "azureWorkItemId": 0,
+  "autoApprove": false,
+  "ignoreDeps": [],
+  "updateInternalDeps": false,
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "lodash"
+      ],
+      "automerge": true
+    }
+  ],
+  "autoReplaceGlobalMatch": true,
+  "replacementApproach": "replace",
+  "pinDigests": false,
+  "separateMajorMinor": true,
+  "separateMultipleMajor": false,
+  "separateMultipleMinor": false,
+  "separateMinorPatch": false,
+  "ignoreUnstable": true,
+  "ignoreDeprecated": true,
+  "followTag": null,
+  "maxMajorIncrement": 500,
+  "respectLatest": true,
+  "rangeStrategy": "pin",
+  "branchPrefix": "renovate/",
+  "branchPrefixOld": "renovate/",
+  "bumpVersion": null,
+  "major": {},
+  "minor": {},
+  "patch": {},
+  "pin": {
+    "rebaseWhen": "behind-base-branch",
+    "groupName": "Pin Dependencies",
+    "groupSlug": "pin-dependencies",
+    "commitMessageAction": "Pin",
+    "group": {
+      "commitMessageTopic": "dependencies",
+      "commitMessageExtra": ""
+    }
+  },
+  "digest": {
+    "branchTopic": "{{{depNameSanitized}}}-digest",
+    "commitMessageExtra": "to {{newDigestShort}}",
+    "commitMessageTopic": "{{{depName}}} digest"
+  },
+  "pinDigest": {
+    "groupName": "Pin Dependencies",
+    "groupSlug": "pin-dependencies",
+    "commitMessageAction": "Pin",
+    "group": {
+      "commitMessageTopic": "dependencies",
+      "commitMessageExtra": ""
+    }
+  },
+  "rollback": {
+    "branchTopic": "{{{depNameSanitized}}}-rollback",
+    "commitMessageAction": "Roll back",
+    "semanticCommitType": "fix"
+  },
+  "replacement": {
+    "branchTopic": "{{{depNameSanitized}}}-replacement",
+    "commitMessageAction": "Replace",
+    "commitMessageExtra": "with {{newName}} {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{#if isSingleVersion}}{{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
+    "prBodyNotes": [
+      "This is a special PR that replaces `{{{depName}}}` with the community suggested minimal stable replacement version."
+    ]
+  },
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "commitMessageLowerCase": "auto",
+  "keepUpdatedLabel": null,
+  "rollbackPrs": false,
+  "recreateWhen": "auto",
+  "rebaseWhen": "auto",
+  "rebaseLabel": "rebase",
+  "stopUpdatingLabel": "stop-updating",
+  "minimumReleaseAge": null,
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "abandonmentThreshold": null,
+  "dependencyDashboardReportAbandonment": true,
+  "internalChecksAsSuccess": false,
+  "internalChecksFilter": "strict",
+  "processEnv": {},
+  "prCreation": "immediate",
+  "prNotPendingHours": 25,
+  "commitHourlyLimit": 0,
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 10,
+  "branchConcurrentLimit": null,
+  "bbAutoResolvePrTasks": false,
+  "bbUseDefaultReviewers": true,
+  "bbUseDevelopmentBranch": false,
+  "automerge": false,
+  "automergeType": "pr",
+  "automergeStrategy": "auto",
+  "automergeComment": "automergeComment",
+  "ignoreTests": false,
+  "vulnerabilityAlerts": {
+    "groupName": null,
+    "schedule": [],
+    "dependencyDashboardApproval": false,
+    "minimumReleaseAge": null,
+    "rangeStrategy": "update-lockfile",
+    "commitMessageSuffix": "[SECURITY]",
+    "branchTopic": "{{{datasource}}}-{{{depNameSanitized}}}-vulnerability",
+    "prCreation": "immediate",
+    "vulnerabilityFixStrategy": "lowest"
+  },
+  "osvVulnerabilityAlerts": false,
+  "pruneBranchAfterAutomerge": true,
+  "branchName": "{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}",
+  "additionalBranchPrefix": "",
+  "branchTopic": "{{{depNameSanitized}}}-{{{newMajor}}}{{#if separateMinorPatch}}{{#if isPatch}}.{{{newMinor}}}{{/if}}{{/if}}{{#if separateMultipleMinor}}{{#if isMinor}}.{{{newMinor}}}{{/if}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}",
+  "commitMessage": "{{{commitMessagePrefix}}} {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
+  "commitBody": null,
+  "commitBodyTable": false,
+  "commitMessagePrefix": null,
+  "commitMessageAction": "Update",
+  "commitMessageTopic": "dependency {{depName}}",
+  "commitMessageExtra": "to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}",
+  "commitMessageSuffix": null,
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+  "prTitle": null,
+  "prTitleStrict": false,
+  "prHeader": null,
+  "prFooter": "This PR has been generated by [Mend Renovate](https://github.com/renovatebot/renovate).",
+  "customizeDashboard": {},
+  "lockFileMaintenance": {
+    "enabled": false,
+    "recreateWhen": "always",
+    "branchTopic": "lock-file-maintenance",
+    "commitMessageAction": "Lock file maintenance",
+    "commitMessageTopic": null,
+    "commitMessageExtra": null,
+    "schedule": [
+      "before 4am on monday"
+    ],
+    "groupName": null,
+    "prBodyDefinitions": {
+      "Change": "All locks refreshed"
+    }
+  },
+  "hashedBranchLength": null,
+  "groupName": null,
+  "groupSlug": null,
+  "group": {
+    "branchTopic": "{{{groupSlug}}}",
+    "commitMessageTopic": "{{{groupName}}}"
+  },
+  "groupSingleUpdates": false,
+  "labels": [],
+  "addLabels": [],
+  "assignees": [],
+  "assigneesFromCodeOwners": false,
+  "expandCodeOwnersGroups": false,
+  "assigneesSampleSize": null,
+  "assignAutomerge": false,
+  "ignoreReviewers": [],
+  "reviewers": [],
+  "reviewersFromCodeOwners": false,
+  "filterUnavailableUsers": false,
+  "forkModeDisallowMaintainerEdits": false,
+  "confidential": false,
+  "reviewersSampleSize": null,
+  "additionalReviewers": [],
+  "postUpdateOptions": [],
+  "constraints": {},
+  "hostRules": [],
+  "cacheHardTtlMinutes": 10080,
+  "cacheTtlOverride": {},
+  "prBodyDefinitions": {
+    "Package": "{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} → {{{newNameLinked}}}{{/unless}}{{/if}}",
+    "Type": "{{{depType}}}",
+    "Update": "{{{updateType}}}",
+    "Current value": "{{{currentValue}}}",
+    "New value": "{{{newValue}}}",
+    "Change": "`{{{displayFrom}}}` → `{{{displayTo}}}`",
+    "Pending": "{{{displayPending}}}",
+    "References": "{{{references}}}",
+    "Package file": "{{{packageFile}}}",
+    "Age": "{{#if newVersion}}![age](https://developer.mend.io/api/mc/badges/age/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+    "Adoption": "{{#if newVersion}}![adoption](https://developer.mend.io/api/mc/badges/adoption/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{newVersion}}}?slim=true){{/if}}",
+    "Passing": "{{#if newVersion}}![passing](https://developer.mend.io/api/mc/badges/compatibility/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}",
+    "Confidence": "{{#if newVersion}}![confidence](https://developer.mend.io/api/mc/badges/confidence/{{datasource}}/{{replace '/' '%2f' packageName}}/{{{currentVersion}}}/{{{newVersion}}}?slim=true){{/if}}"
+  },
+  "prBodyHeadingDefinitions": {
+    "Age": "[Age](https://docs.renovatebot.com/merge-confidence/)",
+    "Adoption": "[Adoption](https://docs.renovatebot.com/merge-confidence/)",
+    "Passing": "[Passing](https://docs.renovatebot.com/merge-confidence/)",
+    "Confidence": "[Confidence](https://docs.renovatebot.com/merge-confidence/)"
+  },
+  "prBodyColumns": [
+    "Package",
+    "Type",
+    "Update",
+    "Change",
+    "Pending"
+  ],
+  "prBodyNotes": [],
+  "suppressNotifications": [],
+  "pruneStaleBranches": true,
+  "unicodeEmoji": true,
+  "gitLabIgnoreApprovals": false,
+  "customManagers": [],
+  "fetchChangeLogs": "pr",
+  "cloneSubmodules": false,
+  "cloneSubmodulesFilter": [
+    "*"
+  ],
+  "ignorePrAuthor": false,
+  "allowedUnsafeExecutions": [],
+  "gitNoVerify": [
+    "commit",
+    "push"
+  ],
+  "updatePinnedDependencies": true,
+  "gitUrl": "default",
+  "writeDiscoveredRepos": null,
+  "platformAutomerge": true,
+  "userStrings": {
+    "ignoreTopic": "Renovate Ignore Notification",
+    "ignoreMajor": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for *any* future `{{{newMajor}}}.x` releases. But if you manually upgrade to `{{{newMajor}}}.x` then Renovate will re-enable `minor` and `patch` updates automatically.",
+    "ignoreDigest": "Because you closed this PR without merging, Renovate will ignore this update. You will not get PRs for the `{{{depName}}}` `{{{newDigestShort}}}` update again.",
+    "ignoreOther": "Because you closed this PR without merging, Renovate will ignore this update (`{{{newValue}}}`). You will get a PR once a newer version is released. To ignore this dependency forever, add it to the `ignoreDeps` array of your Renovate config.",
+    "artifactErrorWarning": "You probably do not want to merge this PR as-is."
+  },
+  "platformCommit": "auto",
+  "branchNameStrict": false,
+  "checkedBranches": [],
+  "rebaseAllOpenBranches": false,
+  "logLevelRemap": [],
+  "milestone": null,
+  "httpCacheTtlDays": 90,
+  "prCacheSyncMaxPages": 100,
+  "dockerMaxPages": 20,
+  "deleteConfigFile": false,
+  "deleteAdditionalConfigFile": false,
+  "s3Endpoint": null,
+  "s3PathStyle": false,
+  "cachePrivatePackages": false,
+  "configValidationError": false,
+  "toolSettings": {
+    "jvmMaxMemory": 512,
+    "jvmMemory": 512
+  },
+  "constraintsVersioning": {},
+  "ant": {
+    "managerFilePatterns": [
+      "**/build.xml"
+    ]
+  },
+  "ansible": {
+    "managerFilePatterns": [
+      "/(^|/)tasks/[^/]+\\.ya?ml$/"
+    ]
+  },
+  "ansible-galaxy": {
+    "managerFilePatterns": [
+      "/(^|/)(galaxy|requirements)(\\.ansible)?\\.ya?ml$/"
+    ]
+  },
+  "argocd": {
+    "managerFilePatterns": []
+  },
+  "asdf": {
+    "managerFilePatterns": [
+      "/(^|/)\\.tool-versions$/"
+    ]
+  },
+  "azure-pipelines": {
+    "managerFilePatterns": [
+      "/(^|/).azuredevops/.+\\.ya?ml$/",
+      "/azure.*pipelines?.*\\.ya?ml$/"
+    ],
+    "enabled": false
+  },
+  "batect": {
+    "managerFilePatterns": [
+      "/(^|/)batect(-bundle)?\\.ya?ml$/"
+    ]
+  },
+  "batect-wrapper": {
+    "managerFilePatterns": [
+      "/(^|/)batect$/"
+    ],
+    "versioning": "semver"
+  },
+  "bazel": {
+    "managerFilePatterns": [
+      "/(^|/)WORKSPACE(|\\.bazel|\\.bzlmod)$/",
+      "/\\.WORKSPACE\\.bazel$/",
+      "/\\.bzl$/"
+    ]
+  },
+  "bazel-module": {
+    "managerFilePatterns": [
+      "/(^|/|\\.)MODULE\\.bazel$/"
+    ]
+  },
+  "bazelisk": {
+    "managerFilePatterns": [
+      "/(^|/)\\.bazelversion$/"
+    ],
+    "pinDigests": false,
+    "versioning": "semver"
+  },
+  "bicep": {
+    "managerFilePatterns": [
+      "/\\.bicep$/"
+    ]
+  },
+  "bitbucket-pipelines": {
+    "managerFilePatterns": [
+      "**/*-pipelines.yml"
+    ]
+  },
+  "bitrise": {
+    "managerFilePatterns": [
+      "/(^|/)bitrise\\.ya?ml$/"
+    ]
+  },
+  "buildkite": {
+    "managerFilePatterns": [
+      "/buildkite\\.ya?ml/",
+      "/\\.buildkite/.+\\.ya?ml$/"
+    ],
+    "commitMessageTopic": "buildkite plugin {{depName}}",
+    "commitMessageExtra": "to {{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{{newValue}}}{{/if}}"
+  },
+  "buildpacks": {
+    "commitMessageTopic": "buildpack {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)project\\.toml$/"
+    ],
+    "pinDigests": false
+  },
+  "bun": {
+    "managerFilePatterns": [
+      "/(^|/)bun\\.lockb?$/",
+      "/(^|/)package\\.json$/"
+    ],
+    "digest": {
+      "prBodyDefinitions": {
+        "Change": "{{#if displayFrom}}`{{{displayFrom}}}` → {{else}}{{#if currentValue}}`{{{currentValue}}}` → {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+      }
+    },
+    "prBodyDefinitions": {
+      "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` → {{else}}{{#if currentValue}}`{{{currentValue}}}` → {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+    }
+  },
+  "bun-version": {
+    "managerFilePatterns": [
+      "/(^|/)\\.bun-version$/"
+    ],
+    "versioning": "npm"
+  },
+  "bundler": {
+    "managerFilePatterns": [
+      "/(^|/)Gemfile$/"
+    ],
+    "versioning": "ruby"
+  },
+  "cake": {
+    "managerFilePatterns": [
+      "/\\.cake$/"
+    ]
+  },
+  "cargo": {
+    "commitMessageTopic": "Rust crate {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)Cargo\\.toml$/"
+    ]
+  },
+  "cdnurl": {
+    "managerFilePatterns": [],
+    "versioning": "semver"
+  },
+  "circleci": {
+    "managerFilePatterns": [
+      "/(^|/)\\.circleci/.+\\.ya?ml$/"
+    ]
+  },
+  "cloudbuild": {
+    "managerFilePatterns": [
+      "/(^|/)cloudbuild\\.ya?ml/"
+    ]
+  },
+  "cocoapods": {
+    "managerFilePatterns": [
+      "/(^|/)Podfile$/"
+    ],
+    "versioning": "ruby"
+  },
+  "composer": {
+    "managerFilePatterns": [
+      "/(^|/)([\\w-]*)composer\\.json$/"
+    ],
+    "versioning": "composer"
+  },
+  "conan": {
+    "managerFilePatterns": [
+      "/(^|/)conanfile\\.(txt|py)$/"
+    ],
+    "datasource": "conan",
+    "versioning": "conan"
+  },
+  "copier": {
+    "managerFilePatterns": [
+      "/(^|/)\\.copier-answers(\\..+)?\\.ya?ml/"
+    ],
+    "versioning": "pep440"
+  },
+  "cpanfile": {
+    "managerFilePatterns": [
+      "/(^|/)cpanfile$/"
+    ]
+  },
+  "crossplane": {
+    "managerFilePatterns": []
+  },
+  "crow": {
+    "managerFilePatterns": [
+      "/^\\.crow(?:/[^/]+)?\\.ya?ml$/"
+    ]
+  },
+  "deno": {
+    "managerFilePatterns": [
+      "/(^|/)deno\\.lock$/",
+      "/(^|/)deno\\.(json|jsonc)$/"
+    ],
+    "digest": {
+      "prBodyDefinitions": {
+        "Change": "{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+      }
+    },
+    "prBodyDefinitions": {
+      "Change": "{{#if (equals datasource \"npm\")}}[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}}){{else}}{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}{{/if}}"
+    }
+  },
+  "deps-edn": {
+    "managerFilePatterns": [
+      "/(^|/)(?:deps|bb)\\.edn$/"
+    ],
+    "versioning": "maven"
+  },
+  "devbox": {
+    "managerFilePatterns": [
+      "/(^|/)devbox\\.json$/"
+    ]
+  },
+  "devcontainer": {
+    "managerFilePatterns": [
+      "/^.devcontainer/devcontainer.json$/",
+      "/^.devcontainer.json$/"
+    ]
+  },
+  "docker-compose": {
+    "managerFilePatterns": [
+      "/(^|/)(?:docker-)?compose[^/]*\\.ya?ml$/"
+    ]
+  },
+  "dockerfile": {
+    "managerFilePatterns": [
+      "/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/",
+      "/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/"
+    ]
+  },
+  "droneci": {
+    "managerFilePatterns": [
+      "/(^|/)\\.drone\\.yml$/"
+    ]
+  },
+  "fleet": {
+    "managerFilePatterns": [
+      "/(^|/)fleet\\.ya?ml/"
+    ]
+  },
+  "flux": {
+    "managerFilePatterns": [
+      "/(?:^|/)gotk-components\\.ya?ml$/"
+    ]
+  },
+  "fvm": {
+    "managerFilePatterns": [
+      "/(^|/)\\.fvm/fvm_config\\.json$/",
+      "/(^|/)\\.fvmrc$/"
+    ],
+    "versioning": "semver"
+  },
+  "git-submodules": {
+    "enabled": false,
+    "versioning": "git",
+    "managerFilePatterns": [
+      "/(^|/)\\.gitmodules$/"
+    ]
+  },
+  "github-actions": {
+    "managerFilePatterns": [
+      "/(^|/)(workflow-templates|\\.(?:github|gitea|forgejo)/(?:workflows|actions))/.+\\.ya?ml$/",
+      "/(^|/)action\\.ya?ml$/"
+    ]
+  },
+  "gitlabci": {
+    "managerFilePatterns": [
+      "/\\.gitlab-ci\\.ya?ml$/"
+    ]
+  },
+  "gitlabci-include": {
+    "managerFilePatterns": [
+      "/\\.gitlab-ci\\.ya?ml$/"
+    ]
+  },
+  "glasskube": {
+    "managerFilePatterns": []
+  },
+  "gleam": {
+    "managerFilePatterns": [
+      "/(^|/)gleam.toml$/"
+    ],
+    "versioning": "hex"
+  },
+  "gomod": {
+    "managerFilePatterns": [
+      "/(^|/)go\\.mod$/"
+    ],
+    "pinDigests": false
+  },
+  "gradle": {
+    "managerFilePatterns": [
+      "/\\.gradle(\\.kts)?$/",
+      "/(^|/)gradle\\.properties$/",
+      "/(^|/)gradle/.+\\.toml$/",
+      "/(^|/)buildSrc/.+\\.kt$/",
+      "/\\.versions\\.toml$/",
+      "/(^|/)versions.props$/",
+      "/(^|/)versions.lock$/"
+    ],
+    "timeout": 600,
+    "versioning": "gradle"
+  },
+  "gradle-wrapper": {
+    "managerFilePatterns": [
+      "/(^|/)gradle/wrapper/gradle-wrapper\\.properties$/"
+    ],
+    "versioning": "gradle"
+  },
+  "haskell-cabal": {
+    "managerFilePatterns": [
+      "/\\.cabal$/"
+    ],
+    "pinDigests": false
+  },
+  "helm-requirements": {
+    "registryAliases": {
+      "stable": "https://charts.helm.sh/stable"
+    },
+    "commitMessageTopic": "helm chart {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)requirements\\.ya?ml$/"
+    ]
+  },
+  "helm-values": {
+    "commitMessageTopic": "helm values {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)values\\.ya?ml$/"
+    ],
+    "pinDigests": false
+  },
+  "helmfile": {
+    "registryAliases": {
+      "stable": "https://charts.helm.sh/stable"
+    },
+    "commitMessageTopic": "helm chart {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?$/",
+      "/(^|/)helmfile\\.d/.+\\.ya?ml(?:\\.gotmpl)?$/"
+    ]
+  },
+  "helmsman": {
+    "managerFilePatterns": []
+  },
+  "helmv3": {
+    "registryAliases": {
+      "stable": "https://charts.helm.sh/stable"
+    },
+    "commitMessageTopic": "helm chart {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)Chart\\.ya?ml$/"
+    ]
+  },
+  "hermit": {
+    "managerFilePatterns": [
+      "/(^|/)bin/hermit$/"
+    ],
+    "excludeCommitPaths": [
+      "**/bin/hermit"
+    ],
+    "versioning": "hermit"
+  },
+  "homeassistant-manifest": {
+    "managerFilePatterns": [
+      "/(^|/)manifest\\.json$/"
+    ]
+  },
+  "homebrew": {
+    "commitMessageTopic": "Homebrew Formula {{depName}}",
+    "managerFilePatterns": [
+      "/^Formula/\\w*/?[^/]+[.]rb$/"
+    ]
+  },
+  "html": {
+    "managerFilePatterns": [
+      "/\\.html?$/"
+    ],
+    "versioning": "semver",
+    "digest": {
+      "enabled": false
+    },
+    "pinDigests": false
+  },
+  "jenkins": {
+    "managerFilePatterns": [
+      "/(^|/)plugins\\.(txt|ya?ml)$/"
+    ]
+  },
+  "jsonnet-bundler": {
+    "managerFilePatterns": [
+      "/(^|/)jsonnetfile\\.json$/"
+    ],
+    "datasource": "git-tags"
+  },
+  "kotlin-script": {
+    "managerFilePatterns": [
+      "/^.+\\.main\\.kts$/"
+    ]
+  },
+  "kubernetes": {
+    "managerFilePatterns": []
+  },
+  "kustomize": {
+    "managerFilePatterns": [
+      "/(^|/)kustomization\\.ya?ml$/"
+    ],
+    "pinDigests": false
+  },
+  "leiningen": {
+    "managerFilePatterns": [
+      "/(^|/)project\\.clj$/"
+    ],
+    "versioning": "maven"
+  },
+  "maven": {
+    "managerFilePatterns": [
+      "/(^|/|\\.)pom\\.xml$/",
+      "/(^|/)pom\\.template\\.xml$/",
+      "/^(((\\.mvn)|(\\.m2))/)?settings\\.xml$/",
+      "/(^|/)\\.mvn/extensions\\.xml$/"
+    ]
+  },
+  "maven-wrapper": {
+    "managerFilePatterns": [
+      "/(^|\\/).mvn/wrapper/maven-wrapper.properties$/",
+      "/(^|\\/)mvnw(.cmd)?$/"
+    ]
+  },
+  "meteor": {
+    "managerFilePatterns": [
+      "/(^|/)package\\.js$/"
+    ]
+  },
+  "mint": {
+    "managerFilePatterns": [
+      "/(^|/)Mintfile$/"
+    ]
+  },
+  "mise": {
+    "managerFilePatterns": [
+      "**/{,.}mise{,.*}.toml",
+      "**/{,.}mise/config{,.*}.toml",
+      "**/.config/mise{,.*}.toml",
+      "**/.config/mise/{mise,config}{,.*}.toml",
+      "**/.config/mise/conf.d/*.toml",
+      "**/.rtx{,.*}.toml"
+    ],
+    "pinDigests": false
+  },
+  "mix": {
+    "managerFilePatterns": [
+      "/(^|/)mix\\.exs$/"
+    ]
+  },
+  "nix": {
+    "managerFilePatterns": [
+      "/(^|/)flake\\.nix$/"
+    ],
+    "commitMessageTopic": "nix",
+    "commitMessageExtra": "to {{newValue}}",
+    "enabled": false
+  },
+  "nodenv": {
+    "managerFilePatterns": [
+      "/(^|/)\\.node-version$/"
+    ],
+    "versioning": "node"
+  },
+  "npm": {
+    "managerFilePatterns": [
+      "/(^|/)package\\.json$/",
+      "/(^|/)pnpm-workspace\\.yaml$/",
+      "/(^|/)\\.yarnrc\\.yml$/"
+    ],
+    "digest": {
+      "prBodyDefinitions": {
+        "Change": "{{#if displayFrom}}`{{{displayFrom}}}` → {{else}}{{#if currentValue}}`{{{currentValue}}}` → {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}"
+      }
+    },
+    "prBodyDefinitions": {
+      "Change": "[{{#if displayFrom}}`{{{displayFrom}}}` → {{else}}{{#if currentValue}}`{{{currentValue}}}` → {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})"
+    }
+  },
+  "nuget": {
+    "managerFilePatterns": [
+      "/\\.(?:cs|fs|vb|sql)proj$/",
+      "/\\.(?:props|targets)$/",
+      "/(^|/)dotnet-tools\\.json$/",
+      "/(^|/)global\\.json$/"
+    ],
+    "rangeStrategy": "bump",
+    "packageRules": [
+      {
+        "matchDepTypes": [
+          "msbuild-sdk"
+        ],
+        "rangeStrategy": "bump"
+      }
+    ]
+  },
+  "nvm": {
+    "managerFilePatterns": [
+      "/(^|/)\\.nvmrc$/"
+    ],
+    "versioning": "node",
+    "pinDigests": false
+  },
+  "ocb": {
+    "managerFilePatterns": []
+  },
+  "osgi": {
+    "managerFilePatterns": [
+      "/(^|/)src/main/features/.+\\.json$/"
+    ]
+  },
+  "pep621": {
+    "managerFilePatterns": [
+      "/(^|/)pyproject\\.toml$/"
+    ]
+  },
+  "pep723": {
+    "managerFilePatterns": []
+  },
+  "pip-compile": {
+    "managerFilePatterns": [],
+    "lockFileMaintenance": {
+      "enabled": true,
+      "branchTopic": "pip-compile-refresh",
+      "commitMessageAction": "Refresh pip-compile outputs"
+    }
+  },
+  "pip_requirements": {
+    "managerFilePatterns": [
+      "/(^|/)[\\w-]*requirements([-._]\\w+)?\\.(txt|pip)$/"
+    ]
+  },
+  "pip_setup": {
+    "managerFilePatterns": [
+      "/(^|/)setup\\.py$/"
+    ]
+  },
+  "pipenv": {
+    "managerFilePatterns": [
+      "/(^|/)Pipfile$/"
+    ]
+  },
+  "pixi": {
+    "managerFilePatterns": [
+      "/(^|/)pyproject\\.toml$/",
+      "/(^|/)pixi\\.toml$/"
+    ]
+  },
+  "poetry": {
+    "managerFilePatterns": [
+      "/(^|/)pyproject\\.toml$/"
+    ]
+  },
+  "pre-commit": {
+    "commitMessageTopic": "pre-commit hook {{depName}}",
+    "enabled": false,
+    "managerFilePatterns": [
+      "/(^|/)\\.pre-commit-config\\.ya?ml$/"
+    ],
+    "prBodyNotes": [
+      "Note: The `pre-commit` manager in Renovate is not supported by the `pre-commit` maintainers or community. Please do not report any problems there, instead [create a Discussion in the Renovate repository](https://github.com/renovatebot/renovate/discussions/new) if you have any questions."
+    ]
+  },
+  "proto": {
+    "managerFilePatterns": [
+      "**/.prototools"
+    ]
+  },
+  "pub": {
+    "managerFilePatterns": [
+      "/(^|/)pubspec\\.ya?ml$/"
+    ]
+  },
+  "puppet": {
+    "managerFilePatterns": [
+      "/(^|/)Puppetfile$/"
+    ]
+  },
+  "pyenv": {
+    "managerFilePatterns": [
+      "/(^|/)\\.python-version$/"
+    ],
+    "versioning": "docker",
+    "pinDigests": false
+  },
+  "quadlet": {
+    "managerFilePatterns": [
+      "/.+\\.container$/",
+      "/.+\\.image$/",
+      "/.+\\.volume$/"
+    ]
+  },
+  "renovate-config": {
+    "managerFilePatterns": [
+      "renovate.json",
+      "renovate.jsonc",
+      "renovate.json5",
+      ".github/renovate.json",
+      ".github/renovate.jsonc",
+      ".github/renovate.json5",
+      ".gitlab/renovate.json",
+      ".gitlab/renovate.jsonc",
+      ".gitlab/renovate.json5",
+      ".renovaterc",
+      ".renovaterc.json",
+      ".renovaterc.jsonc",
+      ".renovaterc.json5"
+    ]
+  },
+  "ruby-version": {
+    "managerFilePatterns": [
+      "/(^|/)\\.ruby-version$/"
+    ],
+    "versioning": "ruby"
+  },
+  "runtime-version": {
+    "managerFilePatterns": [
+      "/(^|/)runtime.txt$/"
+    ],
+    "pinDigests": false
+  },
+  "rust-toolchain": {
+    "commitMessageTopic": "Rust",
+    "managerFilePatterns": [
+      "/(^|/)rust-toolchain(\\.toml)?$/"
+    ]
+  },
+  "sbt": {
+    "managerFilePatterns": [
+      "/\\.sbt$/",
+      "/project/[^/]*\\.scala$/",
+      "/project/build\\.properties$/",
+      "/(^|/)repositories$/"
+    ],
+    "versioning": "ivy"
+  },
+  "scalafmt": {
+    "managerFilePatterns": [
+      "/(^|/)\\.scalafmt.conf$/"
+    ]
+  },
+  "setup-cfg": {
+    "managerFilePatterns": [
+      "/(^|/)setup\\.cfg$/"
+    ],
+    "versioning": "pep440"
+  },
+  "sveltos": {
+    "managerFilePatterns": []
+  },
+  "swift": {
+    "managerFilePatterns": [
+      "/(^|/)Package\\.swift/"
+    ],
+    "versioning": "swift",
+    "pinDigests": false
+  },
+  "tekton": {
+    "managerFilePatterns": []
+  },
+  "terraform": {
+    "commitMessageTopic": "Terraform {{depName}}",
+    "managerFilePatterns": [
+      "**/*.tf",
+      "**/*.tofu"
+    ],
+    "pinDigests": false
+  },
+  "terraform-version": {
+    "managerFilePatterns": [
+      "/(^|/)\\.terraform-version$/"
+    ],
+    "versioning": "hashicorp",
+    "extractVersion": "^v(?<version>.*)$"
+  },
+  "terragrunt": {
+    "commitMessageTopic": "Terragrunt dependency {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)terragrunt\\.hcl$/"
+    ]
+  },
+  "terragrunt-version": {
+    "managerFilePatterns": [
+      "/(^|/)\\.terragrunt-version$/"
+    ],
+    "versioning": "hashicorp",
+    "extractVersion": "^v(?<version>.+)$"
+  },
+  "tflint-plugin": {
+    "commitMessageTopic": "TFLint plugin {{depName}}",
+    "managerFilePatterns": [
+      "/\\.tflint\\.hcl$/"
+    ],
+    "extractVersion": "^v(?<version>.*)$"
+  },
+  "travis": {
+    "managerFilePatterns": [
+      "/^\\.travis\\.ya?ml$/"
+    ],
+    "major": {
+      "enabled": false
+    },
+    "versioning": "node"
+  },
+  "typst": {
+    "managerFilePatterns": [
+      "/\\.typ$/"
+    ]
+  },
+  "unity3d": {
+    "managerFilePatterns": [
+      "**/ProjectSettings/ProjectVersion.txt"
+    ]
+  },
+  "velaci": {
+    "managerFilePatterns": [
+      "/(^|/)\\.vela\\.ya?ml$/"
+    ]
+  },
+  "vendir": {
+    "commitMessageTopic": "vendir {{depName}}",
+    "managerFilePatterns": [
+      "/(^|/)vendir\\.yml$/"
+    ]
+  },
+  "woodpecker": {
+    "managerFilePatterns": [
+      "/^\\.woodpecker(?:/[^/]+)?\\.ya?ml$/"
+    ]
+  },
+  "xcodegen": {
+    "managerFilePatterns": [
+      "**/project.yml"
+    ],
+    "pinDigests": false
+  },
+  "regex": {
+    "pinDigests": false
+  },
+  "jsonata": {
+    "pinDigests": false
+  }
+}

--- a/packages/engine/test/fixtures/migration-steps.json
+++ b/packages/engine/test/fixtures/migration-steps.json
@@ -1,0 +1,13 @@
+{
+  "pinVersions": true,
+  "baseBranch": "next",
+  "semanticCommits": true,
+  "versionScheme": "semver",
+  "binarySource": "auto",
+  "packageRules": [
+    {
+      "packageNames": ["lodash"],
+      "automerge": true
+    }
+  ]
+}

--- a/packages/engine/test/golden.node.test.ts
+++ b/packages/engine/test/golden.node.test.ts
@@ -43,7 +43,12 @@ async function reference(fileName: string, content: string): Promise<Record<stri
 }
 
 describe("golden reference", () => {
-  for (const name of ["legacy-config.json", "internal-presets.json", "invalid.json"]) {
+  for (const name of [
+    "legacy-config.json",
+    "migration-steps.json",
+    "internal-presets.json",
+    "invalid.json",
+  ]) {
     it(`engine matches renovate's own output for ${name}`, async () => {
       const content = fixture(name);
       const expected = await reference(name, content);

--- a/packages/engine/test/migration-drift.node.test.ts
+++ b/packages/engine/test/migration-drift.node.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Upstream-drift tripwire for the forked `migrateConfig`.
+ *
+ * `src/shims/migration.ts` copies the control flow of
+ * `renovate/dist/config/migration.js` line-for-line. When Renovate is bumped
+ * that upstream file can change, silently invalidating the fork. This test
+ * pins a hash of the upstream source; when it changes, re-diff the fork against
+ * the new upstream and update the expected hash below.
+ */
+import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const renovateRoot = dirname(require.resolve("renovate/package.json"));
+
+function hashOf(distRelPath: string): string {
+  const source = readFileSync(join(renovateRoot, "dist", distRelPath), "utf8");
+  return createHash("sha256").update(source).digest("hex");
+}
+
+describe("migrateConfig fork stays in sync with upstream", () => {
+  it("upstream config/migration.js is unchanged since the fork was written", () => {
+    // renovate 43.275.0. If this fails after a renovate bump: open
+    // node_modules/renovate/dist/config/migration.js, re-diff it against
+    // src/shims/migration.ts, port any changes, then update this hash.
+    expect(hashOf("config/migration.js")).toBe(
+      "8597eaf3e9cd9e5221ee72e69c89b939235f7ac7bc180f26472a0f2dcd30e9bc",
+    );
+  });
+
+  it("upstream MigrationsService.run is unchanged since the fork was written", () => {
+    // The fork re-implements MigrationsService.run's per-key dispatch. If this
+    // fails, re-check runMigrations() in src/shims/migration.ts.
+    expect(hashOf("config/migrations/migrations-service.js")).toBe(
+      "e1862cb3a432d6e49959beedabb1537390c046bb9cd9bf549e3c6c0adefc10d4",
+    );
+  });
+});

--- a/packages/engine/test/pipeline.shimmed.test.ts
+++ b/packages/engine/test/pipeline.shimmed.test.ts
@@ -13,7 +13,12 @@ function fixture(name: string): string {
 }
 
 describe("shimmed pipeline matches golden snapshots", () => {
-  for (const name of ["legacy-config.json", "internal-presets.json", "invalid.json"]) {
+  for (const name of [
+    "legacy-config.json",
+    "migration-steps.json",
+    "internal-presets.json",
+    "invalid.json",
+  ]) {
     it(`produces the golden final config for ${name}`, async () => {
       const result = await runPipeline({ fileName: name, content: fixture(name) });
       await expect(JSON.stringify(result.finalConfig, null, 2)).toMatchFileSnapshot(
@@ -40,6 +45,40 @@ describe("trace shape", () => {
       preset: "ok",
       merge: "ok",
     });
+  });
+
+  it("emits discrete, named migration steps for a legacy config", async () => {
+    const result = await runPipeline({
+      fileName: "migration-steps.json",
+      content: fixture("migration-steps.json"),
+    });
+    const steps = result.events.filter(
+      (e) => e.kind === "migration-applied" && e.stage === "migrate",
+    );
+    // several distinct migrations, each with a non-empty diff and a name
+    expect(steps.length).toBeGreaterThan(3);
+    for (const step of steps) {
+      expect(step.delta?.length).toBeGreaterThan(0);
+      expect(step.migration?.name).toBeTruthy();
+      expect(step.migration?.className).toBeTruthy();
+      expect(step.before).toBeDefined();
+      expect(step.after).toBeDefined();
+    }
+    // a top-level rename surfaces with its old → new name + the target key
+    const rename = steps.find((s) => s.migration?.key === "versionScheme");
+    expect(rename?.migration?.className).toBe("RenamePropertyMigration");
+    expect(rename?.migration?.newKey).toBe("versioning");
+    expect(rename?.migration?.name).toBe("versionScheme → versioning");
+    expect(rename?.migration?.explanation).toBeTruthy();
+    // the packageRules matcher rename (packageNames → matchPackageNames) fires
+    expect(steps.some((s) => s.migration?.className === "PackageRulesMigration")).toBe(true);
+    // the last migrate-stage step's `after` equals the real migrated config,
+    // which is also what stage-complete carries
+    const stageComplete = result.events.findLast(
+      (e) => e.stage === "migrate" && e.kind === "stage-complete",
+    );
+    const lastStep = steps.at(-1);
+    expect(lastStep?.after).toEqual(stageComplete?.after);
   });
 
   it("tracks visited presets and preset-fetch events", async () => {

--- a/packages/engine/test/preset-fetchers.test.ts
+++ b/packages/engine/test/preset-fetchers.test.ts
@@ -4,7 +4,7 @@
  * recursion, and error containment are covered together.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { runPipeline, setPresetAuth } from "../src/index";
+import { presetInjectionKey, runPipeline, setPresetAuth } from "../src/index";
 
 const GITHUB_PRESET_BODY = JSON.stringify({
   labels: ["from-github-preset"],
@@ -116,16 +116,152 @@ describe("npm preset fetcher", () => {
   });
 });
 
-describe("unsupported sources", () => {
-  it("reports gitlab presets as unsupported without killing the run", async () => {
+const PRESET_BODY = JSON.stringify({ labels: ["from-preset"], rangeStrategy: "bump" });
+
+function base64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+describe("gitlab preset fetcher", () => {
+  it("resolves the default branch then the raw file, sending PRIVATE-TOKEN", async () => {
+    setPresetAuth({ gitlabToken: "gl-token" });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/projects/example-org%2Frenovate-config")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response(PRESET_BODY, { status: 200 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
     const result = await runPipeline({
       fileName: "renovate.json",
-      content: '{ "extends": ["gitlab>some-org/renovate-config"] }',
+      content: '{ "extends": ["gitlab>example-org/renovate-config"] }',
     });
 
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/example-org%2Frenovate-config/repository/files/default.json/raw?ref=main",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "PRIVATE-TOKEN": "gl-token" }),
+      }),
+    );
+    expect(result.stageStatus.preset).toBe("ok");
+    expect(result.finalConfig?.labels).toEqual(["from-preset"]);
+  });
+});
+
+describe("gitea/forgejo preset fetchers", () => {
+  it("fetches from the gitea contents API and decodes base64", async () => {
+    const body = JSON.stringify({ type: "file", encoding: "base64", content: base64(PRESET_BODY) });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["gitea>example-org/renovate-config"] }',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gitea.com/api/v1/repos/example-org/renovate-config/contents/default.json",
+      expect.objectContaining({ headers: expect.objectContaining({ accept: "application/json" }) }),
+    );
+    expect(result.stageStatus.preset).toBe("ok");
+    expect(result.finalConfig?.labels).toEqual(["from-preset"]);
+  });
+
+  it("fetches forgejo presets from codeberg.org with a token header", async () => {
+    setPresetAuth({ forgejoToken: "fj-token" });
+    const body = JSON.stringify({ type: "file", encoding: "base64", content: base64(PRESET_BODY) });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(body, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["forgejo>example-org/renovate-config"] }',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://codeberg.org/api/v1/repos/example-org/renovate-config/contents/default.json",
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "token fj-token" }),
+      }),
+    );
+    expect(result.finalConfig?.labels).toEqual(["from-preset"]);
+  });
+});
+
+describe("local> dispatch via platform context", () => {
+  it("resolves local> against the configured gitlab platform", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes("/projects/example-org%2Frepo") && !url.includes("/files/")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ default_branch: "main" }), { status: 200 }),
+        );
+      }
+      return Promise.resolve(new Response(PRESET_BODY, { status: 200 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["local>example-org/repo"] }',
+      platform: "gitlab",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://gitlab.com/api/v4/projects/example-org%2Frepo/repository/files/default.json/raw",
+      ),
+      expect.anything(),
+    );
+    expect(result.stageStatus.preset).toBe("ok");
+    expect(result.finalConfig?.labels).toEqual(["from-preset"]);
+    // trace records which platform the local node resolved against
+    const localNode = result.presetTree?.children[0];
+    expect(localNode?.source?.platform).toBe("gitlab");
+    expect(localNode?.source?.endpoint).toBe("https://gitlab.com/api/v4/");
+  });
+
+  it("gives an honest per-platform message for run-only platforms", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["local>example-org/repo"] }',
+      platform: "bitbucket",
+    });
     expect(result.stageStatus.preset).toBe("error");
     expect(result.stageStatus.merge).toBe("ok");
     const presetError = result.events.find((e) => e.kind === "preset-error");
-    expect(presetError?.title).toContain("not supported in the browser");
+    expect(presetError?.title).toContain("only reachable via a real Renovate run");
+  });
+
+  it("reports platforms that cannot serve local presets", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["local>example-org/repo"] }',
+      platform: "codecommit",
+    });
+    expect(result.stageStatus.preset).toBe("error");
+    const presetError = result.events.find((e) => e.kind === "preset-error");
+    expect(presetError?.title).toContain("does not support local presets");
+  });
+});
+
+describe("manual preset injection", () => {
+  it("serves injected content without fetching and flags the used key", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("network blocked"));
+    vi.stubGlobal("fetch", fetchMock);
+    const key = presetInjectionKey({ presetSource: "gitlab", repo: "some-org/repo" });
+
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["gitlab>some-org/repo"] }',
+      injectedPresets: { [key]: { labels: ["from-injection"] } },
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.stageStatus.preset).toBe("ok");
+    expect(result.finalConfig?.labels).toEqual(["from-injection"]);
+    expect(result.usedInjections).toContain(key);
   });
 });

--- a/packages/engine/test/preset-fetchers.test.ts
+++ b/packages/engine/test/preset-fetchers.test.ts
@@ -93,6 +93,30 @@ describe("github preset fetcher", () => {
   });
 });
 
+describe("migration steps during preset fetch", () => {
+  it("emits preset-stage migration steps tagged with the preset name", async () => {
+    // Renovate migrates every preset on fetch; a preset carrying a deprecated
+    // option therefore produces migration-applied events during the preset
+    // stage, tagged with the preset they belong to.
+    const legacyPreset = JSON.stringify({ versionScheme: "semver", labels: ["x"] });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(legacyPreset, { status: 200 })));
+
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: '{ "extends": ["github>example-org/renovate-config"] }',
+    });
+
+    const presetSteps = result.events.filter(
+      (e) => e.kind === "migration-applied" && e.stage === "preset",
+    );
+    expect(presetSteps.length).toBeGreaterThan(0);
+    const rename = presetSteps.find((s) => s.migration?.key === "versionScheme");
+    expect(rename?.migration?.newKey).toBe("versioning");
+    expect(rename?.migration?.presetName).toBe("github>example-org/renovate-config");
+    expect(rename?.delta?.length).toBeGreaterThan(0);
+  });
+});
+
 describe("npm preset fetcher", () => {
   it("resolves renovate-config from the latest packument version", async () => {
     const packument = {

--- a/packages/engine/test/provenance.shimmed.test.ts
+++ b/packages/engine/test/provenance.shimmed.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Shimmed-project tests for roadmap 005 merge provenance. Uses in-memory
+ * injected presets (no network) to build a config that exercises every merge
+ * shape: preset-over-preset scalar overwrite, packageRules concat from
+ * preset+repo, a repo key explicitly set to its default, an untouched default,
+ * a repo packageRules[n].extends that triggers the nested-expansion correction,
+ * and a force-carrying preset.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeProvenance,
+  type KeyProvenance,
+  presetInjectionKey,
+  runPipeline,
+} from "../src/index";
+
+const injectedPresets = {
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/preset-a" })]: {
+    rangeStrategy: "bump",
+    addLabels: ["a"],
+    packageRules: [{ matchPackageNames: ["left-pad"], enabled: false }],
+    force: { rebaseWhen: "behind-base-branch" },
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/preset-b" })]: {
+    rangeStrategy: "replace",
+    addLabels: ["b"],
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/nested-rule" })]: {
+    enabled: false,
+  },
+};
+
+const repoConfig = JSON.stringify({
+  extends: ["github>test-org/preset-a", "github>test-org/preset-b"],
+  automerge: false,
+  packageRules: [{ matchDepTypes: ["devDependencies"], extends: ["github>test-org/nested-rule"] }],
+});
+
+async function provenance(): Promise<Map<string, KeyProvenance>> {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: repoConfig,
+    injectedPresets,
+  });
+  expect(result.stageStatus.preset).toBe("ok");
+  const prov = computeProvenance(result);
+  expect(prov).toBeDefined();
+  return prov as Map<string, KeyProvenance>;
+}
+
+/** Layer label for a step, for terse assertions. */
+function layerName(layer: KeyProvenance["chain"][number]["layer"]): string {
+  return layer.kind === "preset" ? layer.name : layer.kind;
+}
+
+describe("computeProvenance", () => {
+  it("(a) attributes a later preset overwriting an earlier preset's scalar", async () => {
+    const prov = await provenance();
+    const range = prov.get("rangeStrategy");
+    expect(range).toBeDefined();
+    expect(range?.finalValue).toBe("replace");
+    expect(range?.isDefaultOnly).toBe(false);
+    const nonDefault = range!.chain.filter((s) => s.layer.kind !== "defaults");
+    expect(nonDefault.map((s) => [layerName(s.layer), s.action])).toEqual([
+      ["github>test-org/preset-a", "set"],
+      ["github>test-org/preset-b", "overwrite"],
+    ]);
+    // the overwrite records preset-a's losing value
+    expect(nonDefault[1]?.before).toBe("bump");
+    expect(nonDefault[1]?.after).toBe("replace");
+  });
+
+  it("(b) records packageRules concat from preset + repo", async () => {
+    const prov = await provenance();
+    const rules = prov.get("packageRules");
+    expect(rules).toBeDefined();
+    const nonDefault = rules!.chain.filter((s) => s.layer.kind !== "defaults");
+    expect(nonDefault.map((s) => [layerName(s.layer), s.action])).toEqual([
+      ["github>test-org/preset-a", "set"],
+      ["repo", "concat"],
+    ]);
+    // addLabels (mergeable) concat across the two presets
+    const labels = prov.get("addLabels");
+    const labelSteps = labels!.chain.filter((s) => s.layer.kind !== "defaults");
+    expect(labelSteps.map((s) => s.action)).toEqual(["set", "concat"]);
+    expect(labels?.finalValue).toEqual(["a", "b"]);
+  });
+
+  it("(c) a repo key explicitly set to its default is not default-only", async () => {
+    const prov = await provenance();
+    const automerge = prov.get("automerge");
+    expect(automerge).toBeDefined();
+    expect(automerge?.finalValue).toBe(false);
+    expect(automerge?.isDefaultOnly).toBe(false);
+    // the repo layer set it, atop a (no-op) defaults base
+    expect(automerge!.chain.some((s) => s.layer.kind === "repo" && s.action === "set")).toBe(true);
+  });
+
+  it("(d) an untouched key is default-only", async () => {
+    const prov = await provenance();
+    const branchPrefix = prov.get("branchPrefix");
+    expect(branchPrefix).toBeDefined();
+    expect(branchPrefix?.isDefaultOnly).toBe(true);
+    expect(branchPrefix?.chain).toHaveLength(1);
+    expect(branchPrefix?.chain[0]?.layer.kind).toBe("defaults");
+  });
+
+  it("(e) tags the nested-extends expansion on the repo packageRules step", async () => {
+    const prov = await provenance();
+    const rules = prov.get("packageRules");
+    const repoStep = rules!.chain.find((s) => s.layer.kind === "repo");
+    expect(repoStep?.expandedNested).toBe(true);
+    // the injected nested preset (enabled:false) is merged in, extends removed
+    const finalRules = rules?.finalValue as Record<string, unknown>[];
+    const devRule = finalRules.find((r) => Array.isArray(r.matchDepTypes));
+    expect(devRule).toMatchObject({ matchDepTypes: ["devDependencies"], enabled: false });
+    expect(devRule).not.toHaveProperty("extends");
+  });
+
+  it("(f) attributes a force-sourced win to the preset that forced it", async () => {
+    const prov = await provenance();
+    const rebaseWhen = prov.get("rebaseWhen");
+    expect(rebaseWhen).toBeDefined();
+    expect(rebaseWhen?.finalValue).toBe("behind-base-branch");
+    const forced = rebaseWhen!.chain.find((s) => s.action === "forced");
+    expect(forced).toBeDefined();
+    expect(layerName(forced!.layer)).toBe("github>test-org/preset-a");
+    // forced exactly once (deduped across the later layers that re-flatten force)
+    expect(rebaseWhen!.chain.filter((s) => s.action === "forced")).toHaveLength(1);
+  });
+
+  it("holds the round-trip property: every key's last step reproduces the final value", async () => {
+    const prov = await provenance();
+    for (const [key, entry] of prov) {
+      const last = entry.chain.at(-1);
+      expect(last, `chain for ${key} is empty`).toBeDefined();
+      expect(last?.after, `round-trip mismatch for ${key}`).toEqual(entry.finalValue);
+    }
+  });
+
+  it("returns undefined when preset resolution did not complete", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify({ extends: ["github>test-org/does-not-resolve"] }),
+    });
+    // no injection for this preset and no network → preset stage errors, root
+    // has no resolved payload
+    expect(result.stageStatus.preset).toBe("error");
+    expect(computeProvenance(result)).toBeUndefined();
+  });
+});

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -23,7 +23,11 @@ export default defineConfig({
         plugins: [renovateShims()],
         test: {
           name: "shimmed",
-          include: ["test/pipeline.shimmed.test.ts", "test/preset-fetchers.test.ts"],
+          include: [
+            "test/pipeline.shimmed.test.ts",
+            "test/preset-fetchers.test.ts",
+            "test/provenance.shimmed.test.ts",
+          ],
           environment: "node",
           server: {
             deps: {

--- a/roadmap/004-migration-step-through.md
+++ b/roadmap/004-migration-step-through.md
@@ -1,6 +1,30 @@
 # 004 — Migration step-through
 
-Milestone: M2 · Status: planned
+Milestone: M2 · Status: done 2026-07-23
+
+> Implemented as specified. ESM live bindings can't be monkey-patched, so
+> `migrateConfig` is instrumented the same way the rest of the engine is: a
+> faithful line-for-line fork of `config/migration.js` lives in
+> `src/shims/migration.ts` and the vite shim plugin swaps it in. The fork
+> re-uses Renovate's REAL `MigrationsService.getMigrations` / `getMigration`
+> (never re-listing the registry) and clones the shared migratedConfig around
+> each `migration.run` + deprecated-delete to detect what a class actually
+> changed; synthetic steps wrap the non-class post-processing (template
+> rewrites, language→packageRules, nested packageRules flattening, pip-compile,
+> gradle-lite). A shared `{root, path}` context is threaded through the
+> recursion so every step carries a full-document before/after snapshot (the
+> full path-threading, not the fallback) — the cumulative diff and per-preset
+> grouping come straight from the event stream. Steps reuse the
+> `migration-applied` event kind with a new `migration` field (name, className,
+> key/newKey, parentKey, pass, presetName, explanation); the pipeline dropped
+> its old aggregate migration blob but keeps stage-complete as the fallback
+> view. The collector stage-gates steps to migrate/preset so validation-time
+> migrateConfig calls stay out of the stream, and reads the currently-resolving
+> preset from the preset-tree builder. `dequal` and the `@sindresorhus/is`
+> predicates the fork needs are vendored verbatim (they're unresolvable
+> Renovate transitive deps). A golden drift tripwire hashes the two upstream
+> sources so a renovate bump forces a re-diff. The absolute fidelity net —
+> shimmed `finalConfig` equals the golden output — is unchanged and still green.
 
 ## Summary
 

--- a/roadmap/005-merge-provenance-view.md
+++ b/roadmap/005-merge-provenance-view.md
@@ -1,6 +1,22 @@
 # 005 — Merge provenance view
 
-Milestone: M2 · Status: planned
+Milestone: M2 · Status: done 2026-07-23
+
+> Implemented as specified, computed post-hoc — no Renovate instrumentation.
+> `computeProvenance` replays Renovate's real `mergeChildConfig` over the
+> top-level layers already captured in the trace (defaults → each directly
+> extended preset in order → repo config), attributing every top-level key to
+> the layer(s) that produced its final value. Because `mergeChildConfig` is
+> pure this reproduces the pipeline's merge exactly; the replay is top-level
+> only (`root.children`), so it stays a handful of merges even for
+> `config:recommended`. A final correction pass reconciles Renovate's
+> nested-`extends` expansion (repo `packageRules[n].extends`) against the
+> ground-truth resolved config, and `force` wins are attributed per merge call
+> since Renovate re-flattens `config.force` on every call. The view replaces
+> the old value-equality filter: default-only keys are hidden behind a toggle,
+> a key explicitly set to its default value now correctly shows as set by that
+> layer. Clicking a preset badge in a chain selects that node in the resolution
+> tree (the cheap half of 011's reverse lookup).
 
 ## Summary
 

--- a/roadmap/010-preset-hosting-coverage.md
+++ b/roadmap/010-preset-hosting-coverage.md
@@ -1,6 +1,24 @@
 # 010 — Preset hosting coverage + `local>` semantics
 
-Milestone: M2 · Status: planned
+Milestone: M2 · Status: done 2026-07-23
+
+> Implemented as specified. New `gitlab` / `gitea` / `forgejo` fetcher shims
+> mirror `github.ts` (plain `fetch` + Renovate's own `fetchPreset`/`parsePreset`
+> for the file-candidate and sub-preset logic); Gitea/Forgejo share one
+> contents-API helper that decodes base64 with browser-native `atob` (no Node
+> `Buffer`). Default endpoints are the CORS-verified public hosts — `gitlab.com`,
+> `gitea.com`, and (deviating from upstream's `code.forgejo.org`, which sends no
+> CORS) `codeberg.org` for Forgejo. `setPresetAuth` grew per-host token fields
+> (GitLab `PRIVATE-TOKEN`, Gitea/Forgejo `Authorization: token`). `local>`
+> resolves through Renovate's real `GlobalConfig` `platform`/`endpoint` — set
+> from new `PipelineInput.platform`/`endpoint` run options — so the upstream
+> dispatch logic is reproduced unchanged; unsupported platforms fail with honest
+> per-platform messages instead of a generic stub. A module-level injection
+> registry (keyed by a canonical `presetInjectionKey`) lets every fetcher serve
+> user-supplied content before hitting the network; the trace reports which keys
+> were used so the UI flags `user-supplied` nodes. `PresetSourceRef` gained
+> `platform`/`endpoint` (populated for `local>` nodes only) and `TraceResult`
+> gained `platformContext` + `usedInjections`.
 
 ## Summary
 

--- a/roadmap/011-preset-tree-legibility-at-scale.md
+++ b/roadmap/011-preset-tree-legibility-at-scale.md
@@ -1,6 +1,26 @@
 # 011 — Preset tree legibility at scale
 
-Milestone: M2 · Status: planned
+Milestone: M2 · Status: done 2026-07-23
+
+> Implemented as specified. The tree is flattened to an ordered array of
+> visible rows and rendered windowed: only the rows intersecting the
+> `.preset-tree` scroll viewport are mounted (fixed 26px rows, top/bottom
+> spacers), so `config:recommended`'s ~1,100 nodes never mount at once — the
+> flat-table view windows the same way. All per-node and per-subtree
+> aggregates (own options / packageRules, subtree roll-ups, the search
+> haystack, structural identities) are computed in a single walk
+> (`computeTreeStats`) once per result, never per render. Contribution stats
+> are pure derivations of each node's migrated `input`, so they stayed
+> app-side — no engine change was needed. Expansion persists across re-runs
+> by keying on a stable structural identity (the `>`-joined name-path from
+> root, disambiguating identical-named siblings by occurrence index) instead
+> of the per-run `pN` ids; stale identities are dropped on a new result.
+> "Hide zero-contribution" shortcuts pure `extends` routers, promoting their
+> contributing descendants up a level with a clickable elided-path chip that
+> names the skipped chain. Reverse lookup (005's chain click) and dedup
+> cycling both auto-expand the target's ancestors and scroll it into view.
+> The reverse-lookup part of the scope links to 005's provenance data rather
+> than adding a new per-key index here.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -8,7 +8,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [001](001-engine-and-config-input.md)         | Trace engine + config input               | M0/M1                | done    |
 | [002](002-preset-resolution-tree.md)          | Preset resolution tree                    | M1 (MVP centerpiece) | done    |
 | [003](003-inline-option-docs.md)              | Inline option documentation               | M1                   | done    |
-| [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | planned |
+| [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done    |
 | [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | planned |
 | [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
 | [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M3                   | planned |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -9,7 +9,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [002](002-preset-resolution-tree.md)          | Preset resolution tree                    | M1 (MVP centerpiece) | done    |
 | [003](003-inline-option-docs.md)              | Inline option documentation               | M1                   | done    |
 | [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done    |
-| [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | planned |
+| [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done    |
 | [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
 | [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M3                   | planned |
 | [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -15,4 +15,4 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |
 | [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M3                   | planned |
 | [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
-| [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | planned |
+| [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done    |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -14,5 +14,5 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M3                   | planned |
 | [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |
 | [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M3                   | planned |
-| [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | planned |
+| [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | planned |


### PR DESCRIPTION
Implements all four M2 roadmap items (004, 005, 010, 011), one commit per feature.

## 010 — Preset hosting coverage + `local>` semantics
- Real in-browser fetchers for `gitlab>`, `gitea>`, `forgejo>` (CORS verified against gitlab.com, gitea.com, codeberg.org — including auth-header preflights; Forgejo defaults to codeberg.org since code.forgejo.org sends no CORS headers).
- Per-host tokens (GitHub / GitLab `PRIVATE-TOKEN` / Gitea/Forgejo `token`).
- Platform context (platform + endpoint) set through Renovate's real `GlobalConfig`, giving `local>` and bare `owner/repo` references their upstream dispatch semantics; unreachable platforms fail with honest per-platform messages.
- Manual preset injection as the universal fallback: paste JSON5 for any unreachable preset, the pipeline re-runs with it and the node gets a `user-supplied` badge.
- README support matrix.

## 004 — Migration step-through
- The shim plugin routes `config/migration.js` to a faithful fork that keeps `MigrationsService`'s registry live while snapshotting full-document before/after around every migration that changed something — including nested subtree recursion, fixed-point re-passes, and the non-class post-processing blocks. Also covers presets migrated on fetch; validate-stage crosstalk is stage-gated out.
- Output fidelity enforced by the existing shimmed-vs-golden `finalConfig` assertions plus an upstream-drift tripwire test on the forked source.
- Stepper UI on the migrate stage: per-step names + curated explanations, prev/next, cumulative diff, jump-to-end, copy-migrated-config; per-preset steps surface in the tree detail panel.

## 005 — Merge provenance view
- `computeProvenance` replays the top-level merge fold post-hoc with Renovate's real `mergeChildConfig`, attributing every key per layer: set / overwrite (losing values kept) / array concat / `constraints` shallow-merge / object deep-merge / per-call `force` re-flatten, with reconciliation of repo-supplied nested `extends` against the ground-truth resolved config.
- Effective config is now a filterable per-key view: winning-layer badges, expandable override chains with struck-through losing values, layer/overridden/free-text filters.
- "Is default" is now a presence test — an option explicitly set to its default value is correctly attributed to the layer that set it; default-only keys are hidden behind a toggle.
- Preset badges in a chain click through to the corresponding tree node.

## 011 — Preset tree legibility at scale
- Summary header with the honest cost of an expansion (presets, fetched vs internal, rules, options, depth, duplicates, errors).
- Per-node contribution badges with collapsed-subtree roll-ups; hide-zero-contribution toggle that shortcuts pure `extends` routers with a recoverable elided-path chip.
- Search across preset names/sources, option keys set, and package names/patterns in contributed packageRules — pruning the tree to matching paths with dimmed ancestors.
- Duplicate ×N badges that cycle through occurrences; sortable flat-table view (one row per unique preset).
- Hand-rolled windowed rendering over the flattened visible rows (no new dependencies); expansion state survives re-runs via name-path identity.

## Verification
- Full suite green after each feature: oxlint, oxfmt, typecheck (both packages), 11 golden + 31 shimmed engine tests, app build.
- Browser-verified end to end: 2-step migration stepper on a legacy config, tree summary at 1,076 presets, "aws-sdk" search pruning, provenance chain (`config:recommended` sets → `group:monorepos` appends) with click-through to the tree, failing `github>` preset + manual injection re-run to 1,077 resolved with `user-supplied` badge. No console errors.

Roadmap docs updated: 004/005/010/011 marked done with implementation notes; only M3 (006–009) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ