### PR TITLE
feat: Milestone 4 — shareable links + repo fetch, Sign in with GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,15 @@ jobs:
         run: pnpm --filter @renovate-config-visualizer/engine test:golden
       - name: Shimmed tests (browser module graph)
         run: pnpm --filter @renovate-config-visualizer/engine test:shimmed
+      - name: OAuth worker tests
+        run: pnpm --filter @renovate-config-visualizer/oauth-worker test
       - name: Browser bundle build
+        # Sign-in (009) is enabled only when these repo Actions variables are
+        # set; absent = empty string = feature cleanly off (PAT UX remains).
+        env:
+          VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
+          VITE_OAUTH_WORKER_URL: ${{ vars.VITE_OAUTH_WORKER_URL }}
+          VITE_GITHUB_APP_SLUG: ${{ vars.VITE_GITHUB_APP_SLUG }}
         run: pnpm --filter @renovate-config-visualizer/app build
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ Note: Renovate's config code is not a public API, so the `renovate` dependency
 is pinned exactly and every Renovate release PR runs the full CI (golden tests
 plus browser build) to catch breakage per release.
 
+## Sharing & loading
+
+**Shareable links** — _Copy link_ (next to _Run pipeline_) puts a link on your
+clipboard that reopens the current analysis: the config text, the file format,
+a non-default platform/endpoint, and your current view (selected stage, the
+selected preset node, the migration step). It is stored compressed in the URL
+_fragment_ (`#config=…`), so it never reaches any server log, and opening a link
+auto-runs the same pipeline. The link records the Renovate version it was made
+with and warns you if you're now on a different one, since results can drift.
+Links **never** contain your tokens or any manually injected preset content.
+
+**Load from repo** — type a repository reference into the _Load from repo_ box
+and the app fetches its Renovate config for you: `owner/repo`,
+`github.com/owner/repo`, a full URL (`https://gitlab.com/org/repo`,
+`https://codeberg.org/org/repo`), or an `scp`-style `git@host:org/repo.git`. A
+known host (github.com, gitlab.com, gitea.com, codeberg.org) also sets the
+platform context so `local>` presets resolve; a bare `owner/repo` uses the
+platform context you've selected. An optional _ref_ picks a branch/tag (default
+branch otherwise). It probes Renovate's documented config-file locations in
+order — `renovate.json{,c,5}`, `.github/`, `.gitlab/`, `.renovaterc{,.json…}`,
+then the `package.json` `renovate` key — and tells you which file won. Private
+repos use the same per-host tokens as preset fetching (stored in `localStorage`
+only); hosts that block browser (CORS) requests can't be reached from the page.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -29,8 +29,24 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   graph, and must produce byte-identical results.
 
 Configs never leave the browser except for the preset fetches they themselves
-declare. Optional per-host tokens (for rate limits / private repos) are stored
-in `localStorage` only.
+declare. Optional per-host tokens (for rate limits / private repos) live in
+`sessionStorage` only — they are cleared when you close the tab, and never go
+into a URL.
+
+### Privacy & security
+
+- All GitHub/GitLab/Gitea/Forgejo/npm content fetches go **browser →
+  host API** directly; nothing proxies your config or presets.
+- **Sign in with GitHub** (when enabled — see below) adds exactly one piece of
+  server infrastructure: a stateless Cloudflare Worker
+  ([`packages/oauth-worker`](packages/oauth-worker)) that does nothing but the
+  OAuth `code → token` (and `refresh_token → token`) exchange, because a static
+  site cannot hold the `client_secret` GitHub still requires. The Worker
+  **never sees a config, a preset, or an API request** — only the OAuth
+  exchange passes through it, stateless and unlogged. All content fetches still
+  go straight to `api.github.com`.
+- Tokens (OAuth or personal access token) live in `sessionStorage`/memory,
+  cleared when the tab closes; never `localStorage`, never a URL.
 
 ## Preset hosting support
 
@@ -87,8 +103,35 @@ platform context you've selected. An optional _ref_ picks a branch/tag (default
 branch otherwise). It probes Renovate's documented config-file locations in
 order — `renovate.json{,c,5}`, `.github/`, `.gitlab/`, `.renovaterc{,.json…}`,
 then the `package.json` `renovate` key — and tells you which file won. Private
-repos use the same per-host tokens as preset fetching (stored in `localStorage`
-only); hosts that block browser (CORS) requests can't be reached from the page.
+repos use the same GitHub sign-in / per-host tokens as preset fetching (stored
+in `sessionStorage` only); hosts that block browser (CORS) requests can't be
+reached from the page.
+
+## Sign in with GitHub
+
+Reaching **private** GitHub presets (`extends: ["github>my-org/renovate-config"]`)
+or loading a private repo's config needs authentication. The trustworthy way is
+a redirect sign-in with an explicit consent screen and a per-repository,
+read-only grant — not pasting a personal access token that can read all your
+private repos into a web app.
+
+When configured, a **Sign in with GitHub** button appears in the toolbar; it
+uses a [GitHub App](packages/oauth-worker/README.md) whose only permission is
+**Contents: read-only**, so the consent screen truthfully reads "read the
+contents of the repositories you select". Signing in also raises the API rate
+limit from 60 to 5,000 requests/hour. Sign-out clears the local token; the chip
+also links to GitHub's authorization page for true revocation.
+
+A **personal access token** fallback remains under _Platform context & per-host
+tokens_ (advanced settings) for GitHub Enterprise Server, orgs where the app
+install can't be approved, or Worker outages.
+
+Sign-in is **off by default**: it only turns on when the deploy provides the
+`VITE_GITHUB_CLIENT_ID` and `VITE_OAUTH_WORKER_URL` build variables (plus an
+optional `VITE_GITHUB_APP_SLUG`). Without them the app runs exactly as before,
+with the PAT fallback as the only GitHub auth. Provisioning (GitHub App +
+Worker + repo variables) is documented in
+[`packages/oauth-worker/README.md`](packages/oauth-worker/README.md).
 
 ## Development
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,14 +1,27 @@
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
-import type { OptionIndex, StageId, TraceResult } from "@renovate-config-visualizer/engine";
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  OptionIndex,
+  RepoPlatform,
+  StageId,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
 import { ConfigEditor } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
 import { MessagesPanel } from "./components/MessagesPanel";
 import { MigrationSteps } from "./components/MigrationSteps";
-import { PresetTree } from "./components/PresetTree";
+import { identityForNodeId, nodeIdForIdentity, PresetTree } from "./components/PresetTree";
 import { StageDiff } from "./components/StageDiff";
 import { StageTimeline } from "./components/StageTimeline";
 import { OptionDocsProvider } from "./option-docs";
-import { loadOptionIndex, run } from "./run";
+import { getRenovateVersion, loadOptionIndex, loadRepoConfig, run } from "./run";
+import {
+  buildShareUrl,
+  decodeShare,
+  encodeShare,
+  readShareToken,
+  type ShareFileName,
+  type ShareView,
+} from "./share";
 
 const DEFAULT_CONFIG = `{
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -39,7 +52,67 @@ const PLATFORM_ENDPOINTS: Record<string, string> = {
 
 const PLATFORMS = Object.keys(PLATFORM_ENDPOINTS);
 
+/** Platforms whose repos can be fetched from the browser (roadmap 007/010). */
+const FETCHABLE_PLATFORMS = new Set<RepoPlatform>(["github", "gitlab", "gitea", "forgejo"]);
+
+/** Known public hosts → the platform that serves their repos. */
+const HOST_PLATFORM: Record<string, RepoPlatform> = {
+  "github.com": "github",
+  "gitlab.com": "gitlab",
+  "gitea.com": "gitea",
+  "codeberg.org": "forgejo",
+};
+
+/** Strips a trailing `.git` and slashes from a repo path. */
+function stripRepoSuffix(path: string): string {
+  return path.replace(/\.git$/, "").replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Parses a repo reference liberally: `org/repo`, `github.com/org/repo`, a full
+ * URL (`https://gitlab.com/org/repo`), or scp-style (`git@github.com:org/repo.git`).
+ * Returns the host (null for a bare slug) and the repo path (may be nested for
+ * GitLab subgroups), or null when it is not a recognizable reference.
+ */
+function parseRepoRef(raw: string): { host: string | null; repo: string } | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const scp = /^git@([^:]+):(.+)$/.exec(trimmed);
+  if (scp?.[1] && scp[2]) {
+    return { host: scp[1], repo: stripRepoSuffix(scp[2]) };
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    try {
+      const u = new URL(trimmed);
+      const repo = stripRepoSuffix(u.pathname);
+      return repo ? { host: u.host, repo } : null;
+    } catch {
+      return null;
+    }
+  }
+  const path = stripRepoSuffix(trimmed);
+  const segments = path.split("/");
+  // A first segment that looks like a domain (contains a dot) is treated as a
+  // host; owners/groups never contain dots on the supported hosts.
+  if (segments.length >= 3 && segments[0]?.includes(".")) {
+    return { host: segments[0], repo: segments.slice(1).join("/") };
+  }
+  if (segments.length < 2 || segments.some((s) => s === "")) {
+    return null;
+  }
+  return { host: null, repo: path };
+}
+
 type InjectionMap = Record<string, Record<string, unknown>>;
+
+interface RunInputs {
+  fileName: ShareFileName;
+  content: string;
+  platform: string;
+  endpoint: string;
+}
 
 function readStored(key: string, fallback: string): string {
   return localStorage.getItem(key) ?? fallback;
@@ -73,20 +146,62 @@ export function App() {
   // interruptible instead of blocking the main thread.
   const deferredStage = useDeferredValue(selectedStage);
   const [fatal, setFatal] = useState<string | null>(null);
+  // Non-fatal notices (version drift, load-from-repo results, bad share link).
+  const [notice, setNotice] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState<OptionIndex | null>(null);
   // Preset-tree selection is owned here so a provenance chain (005) can select
   // a preset node in the tree. Node ids restart every run, so reset on result.
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  // Migration stepper index, owned here so a shareable link (007) can restore
+  // the step; reset to 0 on a new result just like the uncontrolled stepper.
+  const [migrationStepIndex, setMigrationStepIndex] = useState(0);
+  const [copied, setCopied] = useState(false);
+  // View state pending from a decoded link, applied once the run produces a
+  // result (identities → node ids need the resolved tree). A ref, not state, so
+  // consuming it does not trigger a render.
+  const pendingViewRef = useRef<ShareView | null>(null);
+  // Load-from-repo form.
+  const [repoInput, setRepoInput] = useState("");
+  const [repoRef, setRepoRef] = useState("");
+  const [repoLoading, setRepoLoading] = useState(false);
+
   useEffect(() => {
     setSelectedNodeId(null);
+    setMigrationStepIndex(0);
   }, [result]);
 
-  async function onRun(overrideInjected?: InjectionMap) {
+  // Apply pending link view state after the run's result exists. Declared after
+  // the reset effect so it wins over the reset for a decoded link.
+  useEffect(() => {
+    if (!result) {
+      return;
+    }
+    const pending = pendingViewRef.current;
+    if (!pending) {
+      return;
+    }
+    pendingViewRef.current = null;
+    if (pending.stage) {
+      setSelectedStage(pending.stage);
+    }
+    if (typeof pending.step === "number") {
+      setMigrationStepIndex(pending.step);
+    }
+    if (pending.node && result.presetTree) {
+      const id = nodeIdForIdentity(result.presetTree, pending.node);
+      if (id) {
+        setSelectedNodeId(id);
+      }
+    }
+  }, [result]);
+
+  async function onRun(overrideInjected?: InjectionMap, overrideInputs?: RunInputs) {
     const injectedPresets = overrideInjected ?? injected;
+    const inputs: RunInputs = overrideInputs ?? { fileName, content, platform, endpoint };
     setRunning(true);
     setFatal(null);
     try {
-      const traceResult = await run({ fileName, content, platform, endpoint, injectedPresets });
+      const traceResult = await run({ ...inputs, injectedPresets });
       setResult(traceResult);
       const firstError = (Object.entries(traceResult.stageStatus) as [StageId, string][]).find(
         ([, status]) => status === "error",
@@ -100,6 +215,54 @@ export function App() {
       setRunning(false);
     }
   }
+
+  // On mount: if the URL carries a shared config, decode it, populate state and
+  // auto-run so the link opens the same analysis. Runs once.
+  useEffect(() => {
+    const shareToken = readShareToken(window.location.hash);
+    if (!shareToken) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const payload = await decodeShare(shareToken);
+      if (cancelled) {
+        return;
+      }
+      if (!payload) {
+        setNotice("This shared link could not be read; showing the default config instead.");
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+        return;
+      }
+      const nextPlatform = payload.platform ?? "github";
+      const nextEndpoint = payload.endpoint ?? "https://api.github.com";
+      setContent(payload.config);
+      setFileName(payload.fileName);
+      setPlatform(nextPlatform);
+      persist(PLATFORM_KEY, nextPlatform);
+      setEndpoint(nextEndpoint);
+      persist(ENDPOINT_KEY, nextEndpoint);
+      pendingViewRef.current = payload.view ?? null;
+      const current = await getRenovateVersion();
+      if (!cancelled && payload.renovate && payload.renovate !== current) {
+        setNotice(
+          `This link was created with Renovate v${payload.renovate}; you're on v${current} — results may differ.`,
+        );
+      }
+      if (!cancelled) {
+        void onRun(undefined, {
+          fileName: payload.fileName,
+          content: payload.config,
+          platform: nextPlatform,
+          endpoint: nextEndpoint,
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function makeTokenHandler(key: string, setter: (v: string) => void) {
     return (value: string) => {
@@ -144,6 +307,120 @@ export function App() {
     [result],
   );
 
+  const migrateStepperMounted = deferredStage === "migrate" && migrateSteps.length > 0;
+
+  // Encodes the CURRENT state (config + view) into a link and copies it. Never
+  // continuously syncs the hash (huge configs would thrash the URL) — on demand
+  // only. Also mirrors the copied link into the address bar.
+  async function onCopyLink() {
+    const renovate = result?.renovateVersion ?? (await getRenovateVersion());
+    const view: ShareView = { stage: selectedStage };
+    if (selectedNodeId && result?.presetTree) {
+      const identity = identityForNodeId(result.presetTree, selectedNodeId);
+      if (identity) {
+        view.node = identity;
+      }
+    }
+    if (migrateStepperMounted) {
+      view.step = migrationStepIndex;
+    }
+    const shareToken = await encodeShare({
+      config: content,
+      fileName,
+      platform,
+      endpoint,
+      renovate,
+      view,
+    });
+    const url = buildShareUrl(shareToken);
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      // Clipboard can be unavailable (insecure context); the URL bar still updates.
+    }
+    history.replaceState(null, "", url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  // Fetches a repo's Renovate config file and runs it. Derives the platform
+  // from a known host (and sets the platform context so a later run resolves
+  // `local>` correctly); a bare slug uses the current platform context.
+  async function onLoadRepo() {
+    const parsed = parseRepoRef(repoInput);
+    if (!parsed) {
+      setNotice("Enter a repo as owner/repo, github.com/owner/repo, or a full repository URL.");
+      return;
+    }
+    let repoPlatform: RepoPlatform;
+    let repoEndpoint: string;
+    const knownHost = parsed.host ? HOST_PLATFORM[parsed.host] : undefined;
+    if (parsed.host && !knownHost) {
+      setNotice(
+        `Unknown host ${parsed.host}. Set the platform and endpoint in "Platform context" below, then load with the owner/repo form.`,
+      );
+      return;
+    }
+    if (knownHost) {
+      repoPlatform = knownHost;
+      repoEndpoint = PLATFORM_ENDPOINTS[knownHost] ?? "";
+    } else {
+      if (!FETCHABLE_PLATFORMS.has(platform as RepoPlatform)) {
+        setNotice(
+          `The current platform context (${platform}) can't be fetched from the browser. Choose github, gitlab, gitea or forgejo in "Platform context", or use a full URL.`,
+        );
+        return;
+      }
+      repoPlatform = platform as RepoPlatform;
+      repoEndpoint = endpoint;
+    }
+
+    setRepoLoading(true);
+    setFatal(null);
+    setNotice(null);
+    try {
+      const loaded = await loadRepoConfig({
+        platform: repoPlatform,
+        repo: parsed.repo,
+        endpoint: repoEndpoint || undefined,
+        ref: repoRef.trim() || undefined,
+      });
+      const nextFileName: ShareFileName = loaded.fileName.endsWith(".json5")
+        ? "renovate.json5"
+        : "renovate.json";
+      if (knownHost) {
+        setPlatform(repoPlatform);
+        persist(PLATFORM_KEY, repoPlatform);
+        setEndpoint(repoEndpoint);
+        persist(ENDPOINT_KEY, repoEndpoint);
+      }
+      setContent(loaded.content);
+      setFileName(nextFileName);
+      setNotice(`Loaded ${loaded.fileName} from ${parsed.repo}`);
+      await onRun(undefined, {
+        fileName: nextFileName,
+        content: loaded.content,
+        platform: repoPlatform,
+        endpoint: repoEndpoint || endpoint,
+      });
+    } catch (err) {
+      const e = err as { name?: string; probed?: string[]; err?: { message?: string } };
+      if (e?.name === "RepoConfigNotFoundError") {
+        const count = e.probed?.length ?? 0;
+        setFatal(
+          `No Renovate config found in ${parsed.repo} (tried ${count} locations). It may keep its config elsewhere, on a non-default branch, or in a private repo needing a token.`,
+        );
+      } else {
+        const detail = e?.err?.message ?? (err instanceof Error ? err.message : String(err));
+        setFatal(
+          `Could not load from ${repoEndpoint || "the default endpoint"}: ${detail}. For a private repo add a token below; some hosts block browser (CORS) requests entirely.`,
+        );
+      }
+    } finally {
+      setRepoLoading(false);
+    }
+  }
+
   return (
     <OptionDocsProvider index={optionIndex}>
       <main>
@@ -161,6 +438,32 @@ export function App() {
 
         <ConfigEditor fileName={fileName} value={content} onChange={setContent} />
 
+        <form
+          className="repo-load"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void onLoadRepo();
+          }}
+        >
+          <input
+            type="text"
+            className="repo-load-ref"
+            placeholder="Load from repo — owner/repo, github.com/owner/repo, or a full URL"
+            value={repoInput}
+            onChange={(e) => setRepoInput(e.target.value)}
+          />
+          <input
+            type="text"
+            className="repo-load-branch"
+            placeholder="ref (default branch)"
+            value={repoRef}
+            onChange={(e) => setRepoRef(e.target.value)}
+          />
+          <button type="submit" disabled={repoLoading || repoInput.trim() === ""}>
+            {repoLoading ? "Loading…" : "Load"}
+          </button>
+        </form>
+
         <div className="toolbar">
           <select value={fileName} onChange={(e) => setFileName(e.target.value as typeof fileName)}>
             <option value="renovate.json">renovate.json</option>
@@ -174,6 +477,14 @@ export function App() {
           />
           <button type="button" className="primary" onClick={() => onRun()} disabled={running}>
             {running ? "Running…" : "Run pipeline"}
+          </button>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => void onCopyLink()}
+            title="Copy a link that reopens this config and view — never includes your tokens"
+          >
+            {copied ? "Copied!" : "Copy link"}
           </button>
         </div>
 
@@ -250,6 +561,14 @@ export function App() {
         </details>
 
         {fatal ? <p style={{ color: "var(--error)" }}>{fatal}</p> : null}
+        {notice ? (
+          <p className="app-notice">
+            {notice}
+            <button type="button" className="app-notice-dismiss" onClick={() => setNotice(null)}>
+              dismiss
+            </button>
+          </p>
+        ) : null}
 
         {result ? (
           <>
@@ -261,8 +580,13 @@ export function App() {
                   <span className="rendering-note"> rendering…</span>
                 ) : null}
               </div>
-              {deferredStage === "migrate" && migrateSteps.length > 0 ? (
-                <MigrationSteps steps={migrateSteps} finalConfig={finalMigrated} />
+              {migrateStepperMounted ? (
+                <MigrationSteps
+                  steps={migrateSteps}
+                  finalConfig={finalMigrated}
+                  index={migrationStepIndex}
+                  onIndexChange={setMigrationStepIndex}
+                />
               ) : (
                 <StageDiff result={result} stage={deferredStage} />
               )}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -7,12 +7,25 @@ import type {
 } from "@renovate-config-visualizer/engine";
 import { ConfigEditor } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
+import { type AuthState, GithubAuthHint } from "./components/GithubAuthHint";
 import { MessagesPanel } from "./components/MessagesPanel";
 import { MigrationSteps } from "./components/MigrationSteps";
 import { identityForNodeId, nodeIdForIdentity, PresetTree } from "./components/PresetTree";
 import { StageDiff } from "./components/StageDiff";
 import { StageTimeline } from "./components/StageTimeline";
 import { OptionDocsProvider } from "./option-docs";
+import {
+  beginSignIn,
+  completeCallback,
+  getOAuthConfig,
+  getStoredUser,
+  installUrl,
+  isSignedIn,
+  readCallbackParams,
+  REVOKE_URL,
+  signOut,
+  type StoredUser,
+} from "./oauth";
 import { getRenovateVersion, loadOptionIndex, loadRepoConfig, run } from "./run";
 import {
   buildShareUrl,
@@ -114,11 +127,12 @@ interface RunInputs {
   endpoint: string;
 }
 
-function readStored(key: string, fallback: string): string {
+/** Non-secret settings (platform/endpoint) persist across tabs → localStorage. */
+function readLocal(key: string, fallback: string): string {
   return localStorage.getItem(key) ?? fallback;
 }
 
-function persist(key: string, value: string): void {
+function persistLocal(key: string, value: string): void {
   if (value) {
     localStorage.setItem(key, value);
   } else {
@@ -126,16 +140,54 @@ function persist(key: string, value: string): void {
   }
 }
 
+/** Per-host tokens are secrets → sessionStorage (cleared when the tab closes). */
+function readSession(key: string, fallback: string): string {
+  return sessionStorage.getItem(key) ?? fallback;
+}
+
+function persistSession(key: string, value: string): void {
+  if (value) {
+    sessionStorage.setItem(key, value);
+  } else {
+    sessionStorage.removeItem(key);
+  }
+}
+
+// One-time migration (009): the four PAT fields move from localStorage to
+// sessionStorage. Copy any legacy value across (without clobbering a session
+// value) and drop the localStorage copy. Runs once at module load, before the
+// component reads its initial state. platform/endpoint stay in localStorage.
+const TOKEN_STORAGE_KEYS = [TOKEN_KEY, GITLAB_TOKEN_KEY, GITEA_TOKEN_KEY, FORGEJO_TOKEN_KEY];
+for (const key of TOKEN_STORAGE_KEYS) {
+  const legacy = localStorage.getItem(key);
+  if (legacy !== null) {
+    if (sessionStorage.getItem(key) === null) {
+      sessionStorage.setItem(key, legacy);
+    }
+    localStorage.removeItem(key);
+  }
+}
+
+/** Starts the redirect sign-in, stashing the current fragment to restore it. */
+function onSignIn(): void {
+  void beginSignIn(window.location.hash);
+}
+
 export function App() {
   const [content, setContent] = useState(DEFAULT_CONFIG);
   const [fileName, setFileName] = useState<"renovate.json" | "renovate.json5">("renovate.json");
-  const [token, setToken] = useState(() => readStored(TOKEN_KEY, ""));
-  const [gitlabToken, setGitlabToken] = useState(() => readStored(GITLAB_TOKEN_KEY, ""));
-  const [giteaToken, setGiteaToken] = useState(() => readStored(GITEA_TOKEN_KEY, ""));
-  const [forgejoToken, setForgejoToken] = useState(() => readStored(FORGEJO_TOKEN_KEY, ""));
-  const [platform, setPlatform] = useState(() => readStored(PLATFORM_KEY, "github"));
-  const [endpoint, setEndpoint] = useState(() =>
-    readStored(ENDPOINT_KEY, "https://api.github.com"),
+  const [token, setToken] = useState(() => readSession(TOKEN_KEY, ""));
+  const [gitlabToken, setGitlabToken] = useState(() => readSession(GITLAB_TOKEN_KEY, ""));
+  const [giteaToken, setGiteaToken] = useState(() => readSession(GITEA_TOKEN_KEY, ""));
+  const [forgejoToken, setForgejoToken] = useState(() => readSession(FORGEJO_TOKEN_KEY, ""));
+  const [platform, setPlatform] = useState(() => readLocal(PLATFORM_KEY, "github"));
+  const [endpoint, setEndpoint] = useState(() => readLocal(ENDPOINT_KEY, "https://api.github.com"));
+  // OAuth sign-in (009). Configured only when both build-time vars are present;
+  // otherwise the whole feature stays hidden and the PAT fallback remains.
+  const oauthConfig = useMemo(() => getOAuthConfig(), []);
+  const [signedIn, setSignedIn] = useState(() => (oauthConfig ? isSignedIn() : false));
+  const [authUser, setAuthUser] = useState<StoredUser | null>(() =>
+    oauthConfig ? getStoredUser() : null,
   );
   const [injected, setInjected] = useState<InjectionMap>({});
   const [running, setRunning] = useState(false);
@@ -164,6 +216,9 @@ export function App() {
   const [repoInput, setRepoInput] = useState("");
   const [repoRef, setRepoRef] = useState("");
   const [repoLoading, setRepoLoading] = useState(false);
+  // When a GitHub load fails with a not-found/auth/rate-limit error, offer the
+  // sign-in / install hint next to the failure (009). null = no hint.
+  const [repoAuthHint, setRepoAuthHint] = useState<{ rateLimited: boolean } | null>(null);
 
   useEffect(() => {
     setSelectedNodeId(null);
@@ -216,15 +271,42 @@ export function App() {
     }
   }
 
-  // On mount: if the URL carries a shared config, decode it, populate state and
-  // auto-run so the link opens the same analysis. Runs once.
+  // On mount: first complete an OAuth callback if the URL carries one (QUERY
+  // params ?code&state), then — reading the possibly-restored fragment — decode
+  // a shared config, populate state and auto-run. OAuth runs before the share
+  // decode so a share link survives a sign-in round-trip. Runs once.
   useEffect(() => {
-    const shareToken = readShareToken(window.location.hash);
-    if (!shareToken) {
-      return;
-    }
     let cancelled = false;
     void (async () => {
+      // 1. OAuth callback (009): validate state, exchange via the Worker, store
+      // the token, then strip the query and restore the pre-sign-in fragment.
+      const callback = oauthConfig ? readCallbackParams(window.location.search) : null;
+      if (callback) {
+        try {
+          const { user, returnHash } = await completeCallback(callback.code, callback.state);
+          if (cancelled) {
+            return;
+          }
+          setSignedIn(true);
+          setAuthUser(user);
+          history.replaceState(null, "", window.location.pathname + returnHash);
+        } catch (err) {
+          if (cancelled) {
+            return;
+          }
+          setNotice(
+            `GitHub sign-in failed: ${err instanceof Error ? err.message : String(err)}. You can still use the app signed out.`,
+          );
+          history.replaceState(null, "", window.location.pathname);
+          return;
+        }
+      }
+
+      // 2. Shared config (007) from the URL fragment (survives the OAuth strip).
+      const shareToken = readShareToken(window.location.hash);
+      if (!shareToken) {
+        return;
+      }
       const payload = await decodeShare(shareToken);
       if (cancelled) {
         return;
@@ -239,9 +321,9 @@ export function App() {
       setContent(payload.config);
       setFileName(payload.fileName);
       setPlatform(nextPlatform);
-      persist(PLATFORM_KEY, nextPlatform);
+      persistLocal(PLATFORM_KEY, nextPlatform);
       setEndpoint(nextEndpoint);
-      persist(ENDPOINT_KEY, nextEndpoint);
+      persistLocal(ENDPOINT_KEY, nextEndpoint);
       pendingViewRef.current = payload.view ?? null;
       const current = await getRenovateVersion();
       if (!cancelled && payload.renovate && payload.renovate !== current) {
@@ -267,23 +349,35 @@ export function App() {
   function makeTokenHandler(key: string, setter: (v: string) => void) {
     return (value: string) => {
       setter(value);
-      persist(key, value);
+      persistSession(key, value);
     };
   }
   const onTokenChange = makeTokenHandler(TOKEN_KEY, setToken);
 
   function onPlatformChange(value: string) {
     setPlatform(value);
-    persist(PLATFORM_KEY, value);
+    persistLocal(PLATFORM_KEY, value);
     // Snap the endpoint to the new platform's default; the user can still edit.
     const next = PLATFORM_ENDPOINTS[value] ?? "";
     setEndpoint(next);
-    persist(ENDPOINT_KEY, next);
+    persistLocal(ENDPOINT_KEY, next);
   }
 
   function onEndpointChange(value: string) {
     setEndpoint(value);
-    persist(ENDPOINT_KEY, value);
+    persistLocal(ENDPOINT_KEY, value);
+  }
+
+  const authState: AuthState = !oauthConfig
+    ? "unconfigured"
+    : signedIn
+      ? "signed-in"
+      : "signed-out";
+
+  function onSignOut() {
+    signOut();
+    setSignedIn(false);
+    setAuthUser(null);
   }
 
   function onInject(key: string, contentObj: Record<string, unknown>) {
@@ -378,6 +472,7 @@ export function App() {
     setRepoLoading(true);
     setFatal(null);
     setNotice(null);
+    setRepoAuthHint(null);
     try {
       const loaded = await loadRepoConfig({
         platform: repoPlatform,
@@ -390,9 +485,9 @@ export function App() {
         : "renovate.json";
       if (knownHost) {
         setPlatform(repoPlatform);
-        persist(PLATFORM_KEY, repoPlatform);
+        persistLocal(PLATFORM_KEY, repoPlatform);
         setEndpoint(repoEndpoint);
-        persist(ENDPOINT_KEY, repoEndpoint);
+        persistLocal(ENDPOINT_KEY, repoEndpoint);
       }
       setContent(loaded.content);
       setFileName(nextFileName);
@@ -405,16 +500,25 @@ export function App() {
       });
     } catch (err) {
       const e = err as { name?: string; probed?: string[]; err?: { message?: string } };
+      let detail = "";
       if (e?.name === "RepoConfigNotFoundError") {
         const count = e.probed?.length ?? 0;
         setFatal(
           `No Renovate config found in ${parsed.repo} (tried ${count} locations). It may keep its config elsewhere, on a non-default branch, or in a private repo needing a token.`,
         );
       } else {
-        const detail = e?.err?.message ?? (err instanceof Error ? err.message : String(err));
+        detail = e?.err?.message ?? (err instanceof Error ? err.message : String(err));
         setFatal(
-          `Could not load from ${repoEndpoint || "the default endpoint"}: ${detail}. For a private repo add a token below; some hosts block browser (CORS) requests entirely.`,
+          `Could not load from ${repoEndpoint || "the default endpoint"}: ${detail}. For a private repo, sign in or add a token; some hosts block browser (CORS) requests entirely.`,
         );
+      }
+      // Offer the sign-in / install hint for GitHub loads that look like a
+      // private-repo (not-found) or auth/rate-limit failure (009).
+      if (oauthConfig && repoPlatform === "github") {
+        const rateLimited = /rate limit or missing token/i.test(detail);
+        if (e?.name === "RepoConfigNotFoundError" || rateLimited) {
+          setRepoAuthHint({ rateLimited });
+        }
       }
     } finally {
       setRepoLoading(false);
@@ -469,12 +573,44 @@ export function App() {
             <option value="renovate.json">renovate.json</option>
             <option value="renovate.json5">renovate.json5</option>
           </select>
-          <input
-            type="password"
-            placeholder="GitHub token (optional, for preset rate limits) — stays in your browser"
-            value={token}
-            onChange={(e) => onTokenChange(e.target.value)}
-          />
+          {oauthConfig ? (
+            signedIn ? (
+              <span className="gh-auth-chip" title="Signed in with GitHub">
+                {authUser?.avatarUrl ? (
+                  <img
+                    className="gh-auth-avatar"
+                    src={authUser.avatarUrl}
+                    alt=""
+                    width={18}
+                    height={18}
+                  />
+                ) : null}
+                <span className="gh-auth-login">{authUser?.login || "signed in"}</span>
+                <button type="button" className="gh-auth-signout" onClick={onSignOut}>
+                  Sign out
+                </button>
+                <a
+                  className="gh-auth-revoke"
+                  href={REVOKE_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  title="Revoke this app's access on GitHub (sign-out only clears the local token)"
+                >
+                  revoke
+                </a>
+              </span>
+            ) : (
+              <button
+                type="button"
+                className="gh-signin"
+                onClick={onSignIn}
+                title="Sign in to reach private GitHub presets and repositories (read-only)"
+              >
+                Sign in with GitHub
+              </button>
+            )
+          ) : null}
+          <span className="toolbar-spacer" />
           <button type="button" className="primary" onClick={() => onRun()} disabled={running}>
             {running ? "Running…" : "Run pipeline"}
           </button>
@@ -524,12 +660,34 @@ export function App() {
                 reaches them. You can still provide their content manually from a failed node below.
               </p>
             ) : null}
+            {oauthConfig ? (
+              <p className="advanced-note">
+                Signing in with GitHub (top of the page) is the recommended way to reach private
+                GitHub presets and repos. A personal access token is only a fallback — for GitHub
+                Enterprise Server, when the app installation can&apos;t be approved, or if the
+                sign-in service is unavailable.
+              </p>
+            ) : (
+              <p className="advanced-note">
+                A GitHub personal access token lifts preset rate limits and reaches private
+                repositories. It stays in this browser tab only.
+              </p>
+            )}
             <div className="advanced-row">
+              <label className="grow">
+                GitHub personal access token (fallback)
+                <input
+                  type="password"
+                  placeholder="optional — stays in this browser tab"
+                  value={token}
+                  onChange={(e) => onTokenChange(e.target.value)}
+                />
+              </label>
               <label className="grow">
                 GitLab token (PRIVATE-TOKEN)
                 <input
                   type="password"
-                  placeholder="optional — stays in your browser"
+                  placeholder="optional — stays in this browser tab"
                   value={gitlabToken}
                   onChange={(e) =>
                     makeTokenHandler(GITLAB_TOKEN_KEY, setGitlabToken)(e.target.value)
@@ -540,7 +698,7 @@ export function App() {
                 Gitea token
                 <input
                   type="password"
-                  placeholder="optional — stays in your browser"
+                  placeholder="optional — stays in this browser tab"
                   value={giteaToken}
                   onChange={(e) => makeTokenHandler(GITEA_TOKEN_KEY, setGiteaToken)(e.target.value)}
                 />
@@ -549,7 +707,7 @@ export function App() {
                 Forgejo token
                 <input
                   type="password"
-                  placeholder="optional — stays in your browser"
+                  placeholder="optional — stays in this browser tab"
                   value={forgejoToken}
                   onChange={(e) =>
                     makeTokenHandler(FORGEJO_TOKEN_KEY, setForgejoToken)(e.target.value)
@@ -561,6 +719,14 @@ export function App() {
         </details>
 
         {fatal ? <p style={{ color: "var(--error)" }}>{fatal}</p> : null}
+        {repoAuthHint ? (
+          <GithubAuthHint
+            authState={authState}
+            rateLimited={repoAuthHint.rateLimited}
+            onSignIn={onSignIn}
+            installUrl={installUrl()}
+          />
+        ) : null}
         {notice ? (
           <p className="app-notice">
             {notice}
@@ -597,6 +763,9 @@ export function App() {
               onInject={onInject}
               selectedId={selectedNodeId}
               onSelectNode={setSelectedNodeId}
+              authState={authState}
+              onSignIn={onSignIn}
+              installUrl={installUrl()}
             />
             <EffectiveConfig result={result} onSelectPreset={setSelectedNodeId} />
           </>

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -119,15 +119,28 @@ function LayerBadge({
   const clickable = layer.kind === "preset" && onSelectPreset;
   const className = `badge prov-layer ${layerClass(layer)}`;
   if (clickable) {
+    // Not a <button>: KeyRow renders this inside its row-toggle button, and
+    // buttons cannot nest. stopPropagation keeps the row from toggling too.
     return (
-      <button
-        type="button"
+      <span
+        role="button"
+        tabIndex={0}
         className={className}
         title="Show this preset in the resolution tree"
-        onClick={() => onSelectPreset(layer.nodeId)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelectPreset(layer.nodeId);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onSelectPreset(layer.nodeId);
+          }
+        }}
       >
         {layerLabel(layer)}
-      </button>
+      </span>
     );
   }
   return <span className={className}>{layerLabel(layer)}</span>;

--- a/packages/app/src/components/GithubAuthHint.tsx
+++ b/packages/app/src/components/GithubAuthHint.tsx
@@ -1,0 +1,49 @@
+/**
+ * Roadmap 009 — the error-path UX (the "core UX" of the sign-in feature). A
+ * small hint shown next to a failed GitHub preset/repo fetch that turns the
+ * failure into the likely next action: sign in (private preset / rate limit) or
+ * check the app installation (signed in but still failing).
+ *
+ * Deliberately decoupled from oauth.ts: callers pass the current auth state, an
+ * onSignIn callback, and the install URL as plain props.
+ */
+
+/** Whether sign-in is configured, and if so whether the user is signed in. */
+export type AuthState = "unconfigured" | "signed-out" | "signed-in";
+
+export function GithubAuthHint({
+  authState,
+  rateLimited = false,
+  onSignIn,
+  installUrl,
+}: {
+  authState: AuthState;
+  /** A rate-limit (vs not-found/auth) failure — tunes the signed-out copy. */
+  rateLimited?: boolean;
+  onSignIn: () => void;
+  installUrl: string;
+}) {
+  if (authState === "unconfigured") {
+    return null;
+  }
+  if (authState === "signed-out") {
+    return (
+      <p className="gh-auth-hint">
+        {rateLimited ? "Hit GitHub's unauthenticated rate limit (60 req/h). " : "Private preset? "}
+        <button type="button" className="gh-inline-signin" onClick={onSignIn}>
+          Sign in with GitHub
+        </button>{" "}
+        {rateLimited ? "to raise the limit to 5,000 req/h." : "to access it."}
+      </p>
+    );
+  }
+  return (
+    <p className="gh-auth-hint">
+      Signed in, still failing? The app may not be installed on this repository.{" "}
+      <a href={installUrl} target="_blank" rel="noreferrer">
+        Manage repository access
+      </a>
+      .
+    </p>
+  );
+}

--- a/packages/app/src/components/MigrationSteps.tsx
+++ b/packages/app/src/components/MigrationSteps.tsx
@@ -12,6 +12,13 @@ interface Props {
   finalConfig?: unknown;
   /** Tighter layout for the preset detail panel. */
   compact?: boolean;
+  /**
+   * Controlled step index. When provided (with onIndexChange), the parent owns
+   * the index — used so a shareable link (007) can restore the step. Falls back
+   * to internal state when omitted (the uncontrolled PresetDetail instance).
+   */
+  index?: number;
+  onIndexChange?: (index: number) => void;
 }
 
 /**
@@ -21,14 +28,30 @@ interface Props {
  * per-step diff (small) and the cumulative diff (stage start → current step)
  * come straight from the event stream.
  */
-export const MigrationSteps = memo(function MigrationSteps({ steps, finalConfig, compact }: Props) {
-  const [index, setIndex] = useState(0);
+export const MigrationSteps = memo(function MigrationSteps({
+  steps,
+  finalConfig,
+  compact,
+  index,
+  onIndexChange,
+}: Props) {
+  const controlled = index !== undefined;
+  const [internalIndex, setInternalIndex] = useState(0);
   const [cumulative, setCumulative] = useState(false);
   const [copied, setCopied] = useState(false);
+  const activeIndex = controlled ? index : internalIndex;
+  const setIndex = (next: number) => {
+    if (controlled) {
+      onIndexChange?.(next);
+    } else {
+      setInternalIndex(next);
+    }
+  };
 
-  // A re-run replaces the event list; reset to the first step.
+  // A re-run replaces the event list; reset to the first step. When controlled,
+  // the parent owns the reset (it clears its index on new results).
   useEffect(() => {
-    setIndex(0);
+    setInternalIndex(0);
     setCopied(false);
   }, [steps]);
 
@@ -36,7 +59,7 @@ export const MigrationSteps = memo(function MigrationSteps({ steps, finalConfig,
     return null;
   }
 
-  const clamped = Math.min(index, steps.length - 1);
+  const clamped = Math.min(Math.max(activeIndex, 0), steps.length - 1);
   const step = steps[clamped];
   if (!step) {
     return null;

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -308,6 +308,21 @@ function computeTreeStats(root: PresetNode): TreeStats {
   };
 }
 
+/**
+ * Structural identity (`>`-joined name-path) of a node id in this result's
+ * tree, or null. Identities are stable across re-runs of the same config, so
+ * they are what a shareable link (007) stores for the selected node. Reuses the
+ * same single-walk machinery the tree renders with.
+ */
+export function identityForNodeId(root: PresetNode, id: string): string | null {
+  return computeTreeStats(root).identityById.get(id) ?? null;
+}
+
+/** The current run's node id for a stored structural identity, or null. */
+export function nodeIdForIdentity(root: PresetNode, identity: string): string | null {
+  return computeTreeStats(root).idByIdentity.get(identity) ?? null;
+}
+
 /** Node ids whose subtree (self or any descendant) matches the query. */
 function computeSubtreeMatch(
   root: PresetNode,

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -6,8 +6,24 @@ import type {
   TraceResult,
 } from "@renovate-config-visualizer/engine";
 import { ConfigJson } from "./ConfigJson";
+import { type AuthState, GithubAuthHint } from "./GithubAuthHint";
 import { JsonDiff } from "./JsonDiff";
 import { MigrationSteps } from "./MigrationSteps";
+
+/**
+ * A failed GitHub preset node whose error is the private-repo (not-found) or
+ * auth/rate-limit kind — the cases where signing in is the likely fix (009).
+ * Matches the exact strings the engine's github fetcher emits.
+ */
+function githubAuthFailure(node: PresetNode): { match: boolean; rateLimited: boolean } {
+  if (node.state !== "error" || node.source?.presetSource !== "github") {
+    return { match: false, rateLimited: false };
+  }
+  const msg = node.error?.message ?? "";
+  const rateLimited = /rate limit or missing token/i.test(msg);
+  const notFound = /dep not found/i.test(msg);
+  return { match: rateLimited || notFound, rateLimited };
+}
 
 type InjectionKeyFn = (id: {
   presetSource: string;
@@ -729,12 +745,19 @@ export const PresetTree = memo(function PresetTree({
   onInject,
   selectedId,
   onSelectNode,
+  authState,
+  onSignIn,
+  installUrl,
 }: {
   result: TraceResult;
   onInject: (key: string, content: Record<string, unknown>) => void;
   /** Controlled selection, so provenance chains (005) can select a preset node. */
   selectedId: string | null;
   onSelectNode: (id: string | null) => void;
+  /** Sign-in state + hooks for the failed-GitHub-node hint (009). */
+  authState: AuthState;
+  onSignIn: () => void;
+  installUrl: string;
 }) {
   const root = result.presetTree;
   const helpers = useEngineHelpers();
@@ -1026,6 +1049,9 @@ export const PresetTree = memo(function PresetTree({
             usedInjections={usedInjections}
             onInject={onInject}
             migrationSteps={migrationStepsByPreset.get(selected.name) ?? []}
+            authState={authState}
+            onSignIn={onSignIn}
+            installUrl={installUrl}
           />
         ) : (
           <div className="preset-panel-hint">Select a preset to inspect it.</div>
@@ -1158,6 +1184,9 @@ function PresetDetail({
   usedInjections,
   onInject,
   migrationSteps,
+  authState,
+  onSignIn,
+  installUrl,
 }: {
   node: PresetNode;
   parent: PresetNode | undefined;
@@ -1167,11 +1196,15 @@ function PresetDetail({
   usedInjections: ReadonlySet<string>;
   onInject: (key: string, content: Record<string, unknown>) => void;
   migrationSteps: TraceEvent[];
+  authState: AuthState;
+  onSignIn: () => void;
+  installUrl: string;
 }) {
   const contribution = useContribution(node, parent);
   const stateLabel = STATE_LABELS[node.state];
   const key = nodeInjectionKey(node.source, injectionKey);
   const userSupplied = key !== null && usedInjections.has(key);
+  const ghFailure = githubAuthFailure(node);
   const migrationChanged =
     node.fetched !== undefined &&
     node.input !== undefined &&
@@ -1192,6 +1225,14 @@ function PresetDetail({
         </p>
       ) : null}
       {node.error ? <p className="preset-node-error">{node.error.message}</p> : null}
+      {ghFailure.match ? (
+        <GithubAuthHint
+          authState={authState}
+          rateLimited={ghFailure.rateLimited}
+          onSignIn={onSignIn}
+          installUrl={installUrl}
+        />
+      ) : null}
       {stateLabel && !node.error ? <p className="empty-note">{stateLabel}</p> : null}
       {node.state === "error" ? (
         <PresetInjector node={node} injectionKey={injectionKey} parse={parse} onInject={onInject} />

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1161,3 +1161,71 @@ pre.config-view.prov-before {
   font-size: 0.8rem;
   text-decoration: underline;
 }
+
+/* ---------- sign in with GitHub (009) ---------- */
+
+.toolbar-spacer {
+  flex: 1;
+}
+
+.toolbar button.gh-signin {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.gh-auth-chip {
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 0.4rem;
+  padding: 0.2rem 0.5rem 0.2rem 0.35rem;
+}
+
+.gh-auth-avatar {
+  border-radius: 50%;
+  display: block;
+}
+
+.gh-auth-login {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.gh-auth-signout {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0;
+}
+
+.gh-auth-revoke {
+  color: var(--muted);
+  font-size: 0.75rem;
+  text-decoration: underline;
+}
+
+.gh-auth-hint {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0.25rem 0 0.4rem;
+}
+
+.preset-panel .gh-auth-hint {
+  padding-left: 0;
+}
+
+.gh-inline-signin {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1085,3 +1085,79 @@ pre.config-view.prov-before {
   text-decoration: line-through;
   text-decoration-color: var(--error);
 }
+
+/* ---------- shareable links + load from repo (007) ---------- */
+
+.toolbar button.secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: inherit;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.repo-load {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0;
+}
+
+.repo-load input {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font-size: 0.9rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.repo-load-ref {
+  flex: 1;
+  min-width: 14rem;
+}
+
+.repo-load-branch {
+  width: 11rem;
+}
+
+.repo-load button {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 0.4rem 0.9rem;
+}
+
+.repo-load button:disabled {
+  opacity: 0.6;
+}
+
+.app-notice {
+  align-items: baseline;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--warn);
+  border-radius: 6px;
+  color: inherit;
+  display: flex;
+  font-size: 0.88rem;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin: 0.5rem 0;
+  padding: 0.5rem 0.75rem;
+}
+
+.app-notice-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  font-size: 0.8rem;
+  text-decoration: underline;
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1008,7 +1008,7 @@ button.badge.dup {
   flex: none;
 }
 
-button.badge.prov-layer {
+.badge.prov-layer[role="button"] {
   background: transparent;
   cursor: pointer;
 }

--- a/packages/app/src/oauth.ts
+++ b/packages/app/src/oauth.ts
@@ -1,0 +1,348 @@
+/**
+ * Roadmap 009 — "Sign in with GitHub". Pure logic, no React.
+ *
+ * Authorization-code flow + PKCE + `state`, driven entirely by the SPA. The
+ * only server piece is the token-exchange Worker (packages/oauth-worker): the
+ * browser cannot call GitHub's token endpoint (no CORS, `client_secret`
+ * required), so `code → token` and `refresh_token → token` go through it. Every
+ * GitHub *content* fetch still goes browser → api.github.com directly.
+ *
+ * Tokens live in memory, mirrored to `sessionStorage` (never `localStorage`,
+ * never a URL) so a reload inside the token lifetime does not force re-auth but
+ * closing the tab clears them. GitHub Apps issue 8 h user tokens with a 6-month
+ * refresh token; refreshing is a Worker round-trip.
+ */
+
+export interface OAuthConfig {
+  clientId: string;
+  workerUrl: string;
+  /** Optional app slug for a direct install/manage link. */
+  appSlug?: string;
+}
+
+export interface StoredUser {
+  login: string;
+  avatarUrl: string;
+}
+
+/** Where a signed-in user revokes this app's grant (cannot be done from JS). */
+export const REVOKE_URL = "https://github.com/settings/apps/authorizations";
+
+const AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
+const USER_API = "https://api.github.com/user";
+
+/** sessionStorage keys, all under the `rcv.oauth.*` prefix. */
+const K = {
+  pending: "rcv.oauth.pending",
+  token: "rcv.oauth.token",
+  tokenExpiresAt: "rcv.oauth.tokenExpiresAt",
+  refreshToken: "rcv.oauth.refreshToken",
+  refreshTokenExpiresAt: "rcv.oauth.refreshTokenExpiresAt",
+  user: "rcv.oauth.user",
+} as const;
+
+/** Returns the OAuth config only when fully configured, else null (feature off). */
+export function getOAuthConfig(): OAuthConfig | null {
+  const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID?.trim();
+  const workerUrl = import.meta.env.VITE_OAUTH_WORKER_URL?.trim();
+  if (!clientId || !workerUrl) {
+    return null;
+  }
+  const appSlug = import.meta.env.VITE_GITHUB_APP_SLUG?.trim() || undefined;
+  return { clientId, workerUrl: workerUrl.replace(/\/+$/, ""), appSlug };
+}
+
+/** Where the user manages / installs the app on repositories. */
+export function installUrl(): string {
+  const cfg = getOAuthConfig();
+  if (cfg?.appSlug) {
+    return `https://github.com/apps/${cfg.appSlug}/installations/new`;
+  }
+  return "https://github.com/settings/installations";
+}
+
+// ---------------------------------------------------------------------------
+// PKCE / random helpers
+// ---------------------------------------------------------------------------
+
+function base64url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) {
+    bin += String.fromCharCode(b);
+  }
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function randomToken(byteLength: number): string {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes);
+}
+
+async function pkceChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64url(new Uint8Array(digest));
+}
+
+/** redirect_uri that works for both the Pages base path and localhost. */
+function redirectUri(): string {
+  return window.location.origin + window.location.pathname;
+}
+
+// ---------------------------------------------------------------------------
+// Token state (memory + sessionStorage mirror)
+// ---------------------------------------------------------------------------
+
+interface TokenState {
+  token: string;
+  /** epoch ms; Number.MAX_SAFE_INTEGER when the token does not expire. */
+  tokenExpiresAt: number;
+  refreshToken?: string;
+  refreshTokenExpiresAt?: number;
+}
+
+let memToken: TokenState | null = null;
+let memLoaded = false;
+
+function loadTokenState(): TokenState | null {
+  const token = sessionStorage.getItem(K.token);
+  if (!token) {
+    return null;
+  }
+  const expiresAt = Number(sessionStorage.getItem(K.tokenExpiresAt) ?? "0");
+  const refreshToken = sessionStorage.getItem(K.refreshToken) ?? undefined;
+  const refreshExp = sessionStorage.getItem(K.refreshTokenExpiresAt);
+  return {
+    token,
+    tokenExpiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+    refreshToken,
+    refreshTokenExpiresAt: refreshExp ? Number(refreshExp) : undefined,
+  };
+}
+
+function currentToken(): TokenState | null {
+  if (!memLoaded) {
+    memToken = loadTokenState();
+    memLoaded = true;
+  }
+  return memToken;
+}
+
+function storeTokenState(state: TokenState): void {
+  memToken = state;
+  memLoaded = true;
+  sessionStorage.setItem(K.token, state.token);
+  sessionStorage.setItem(K.tokenExpiresAt, String(state.tokenExpiresAt));
+  if (state.refreshToken) {
+    sessionStorage.setItem(K.refreshToken, state.refreshToken);
+  } else {
+    sessionStorage.removeItem(K.refreshToken);
+  }
+  if (state.refreshTokenExpiresAt) {
+    sessionStorage.setItem(K.refreshTokenExpiresAt, String(state.refreshTokenExpiresAt));
+  } else {
+    sessionStorage.removeItem(K.refreshTokenExpiresAt);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Worker exchange
+// ---------------------------------------------------------------------------
+
+interface TokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+}
+
+async function postWorker(path: string, body: unknown): Promise<TokenResponse> {
+  const cfg = getOAuthConfig();
+  if (!cfg) {
+    throw new Error("Sign-in is not configured.");
+  }
+  const res = await fetch(`${cfg.workerUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const data = (await res.json().catch(() => ({}))) as TokenResponse;
+  if (!res.ok || data.error || !data.access_token) {
+    throw new Error(
+      data.error_description || data.error || `Token exchange failed (HTTP ${res.status}).`,
+    );
+  }
+  return data;
+}
+
+function applyTokenResponse(data: TokenResponse): void {
+  const now = Date.now();
+  const tokenExpiresAt =
+    typeof data.expires_in === "number" ? now + data.expires_in * 1000 : Number.MAX_SAFE_INTEGER;
+  storeTokenState({
+    // access_token presence is guaranteed by postWorker.
+    token: data.access_token as string,
+    tokenExpiresAt,
+    refreshToken: data.refresh_token,
+    refreshTokenExpiresAt:
+      typeof data.refresh_token_expires_in === "number"
+        ? now + data.refresh_token_expires_in * 1000
+        : undefined,
+  });
+}
+
+async function fetchUser(token: string): Promise<StoredUser> {
+  const res = await fetch(USER_API, {
+    headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json" },
+  });
+  if (!res.ok) {
+    throw new Error(`Could not load your GitHub profile (HTTP ${res.status}).`);
+  }
+  const body = (await res.json()) as { login?: string; avatar_url?: string };
+  const user: StoredUser = { login: body.login ?? "", avatarUrl: body.avatar_url ?? "" };
+  sessionStorage.setItem(K.user, JSON.stringify(user));
+  return user;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function isSignedIn(): boolean {
+  return currentToken() !== null;
+}
+
+export function getStoredUser(): StoredUser | null {
+  const raw = sessionStorage.getItem(K.user);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as StoredUser;
+    return typeof parsed.login === "string" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Stashes `{ state, verifier, returnHash }` in sessionStorage and redirects to
+ * GitHub's authorize page. `returnHash` (the current fragment) is restored
+ * after the callback so a share link survives a sign-in round-trip.
+ */
+export async function beginSignIn(returnHash: string): Promise<void> {
+  const cfg = getOAuthConfig();
+  if (!cfg) {
+    return;
+  }
+  const state = randomToken(16);
+  const verifier = randomToken(32);
+  const challenge = await pkceChallenge(verifier);
+  sessionStorage.setItem(K.pending, JSON.stringify({ state, verifier, returnHash }));
+
+  const url = new URL(AUTHORIZE_URL);
+  url.searchParams.set("client_id", cfg.clientId);
+  url.searchParams.set("redirect_uri", redirectUri());
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  // GitHub Apps derive user-token permissions from the app itself, so no
+  // `scope` parameter is sent.
+  window.location.assign(url.toString());
+}
+
+/** OAuth callback params from a query string, or null when not a callback. */
+export function readCallbackParams(search: string): { code: string; state: string } | null {
+  const params = new URLSearchParams(search);
+  const code = params.get("code");
+  const state = params.get("state");
+  return code && state ? { code, state } : null;
+}
+
+/**
+ * Validates `state`, exchanges the code via the Worker, stores the token and
+ * loads the user profile. Returns the user and the stashed return-hash. Throws
+ * on state mismatch or exchange failure (caller stays signed out).
+ */
+export async function completeCallback(
+  code: string,
+  state: string,
+): Promise<{ user: StoredUser; returnHash: string }> {
+  const pendingRaw = sessionStorage.getItem(K.pending);
+  sessionStorage.removeItem(K.pending);
+  if (!pendingRaw) {
+    throw new Error("No pending sign-in to match this response.");
+  }
+  let pending: { state?: string; verifier?: string; returnHash?: string };
+  try {
+    pending = JSON.parse(pendingRaw);
+  } catch {
+    throw new Error("Sign-in state was corrupted.");
+  }
+  if (!pending.state || pending.state !== state || !pending.verifier) {
+    throw new Error("Sign-in state mismatch; aborting for safety.");
+  }
+  const data = await postWorker("/exchange", {
+    code,
+    code_verifier: pending.verifier,
+    redirect_uri: redirectUri(),
+  });
+  applyTokenResponse(data);
+  const user = await fetchUser(data.access_token as string);
+  return { user, returnHash: pending.returnHash ?? "" };
+}
+
+let refreshInFlight: Promise<string | null> | null = null;
+
+/**
+ * A valid access token, silently refreshing when expired (single-flight). Null
+ * when signed out or when a refresh is impossible/fails (falls back to signed
+ * out — public presets keep working unauthenticated).
+ */
+export async function getValidToken(): Promise<string | null> {
+  const state = currentToken();
+  if (!state) {
+    return null;
+  }
+  const skewMs = 60_000;
+  if (Date.now() < state.tokenExpiresAt - skewMs) {
+    return state.token;
+  }
+  const refreshExpired =
+    typeof state.refreshTokenExpiresAt === "number" && Date.now() >= state.refreshTokenExpiresAt;
+  if (!state.refreshToken || refreshExpired) {
+    signOut();
+    return null;
+  }
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      try {
+        const data = await postWorker("/refresh", { refresh_token: state.refreshToken });
+        applyTokenResponse(data);
+        return currentToken()?.token ?? null;
+      } catch {
+        signOut();
+        return null;
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  return refreshInFlight;
+}
+
+/**
+ * Drops all `rcv.oauth.*` state. Revocation itself cannot be done from the
+ * browser — the sign-out UI links to {@link REVOKE_URL} for true revocation.
+ */
+export function signOut(): void {
+  memToken = null;
+  memLoaded = true;
+  for (const key of Object.values(K)) {
+    sessionStorage.removeItem(key);
+  }
+}

--- a/packages/app/src/run.ts
+++ b/packages/app/src/run.ts
@@ -1,4 +1,10 @@
-import type { OptionIndex, PipelineInput, TraceResult } from "@renovate-config-visualizer/engine";
+import type {
+  OptionIndex,
+  PipelineInput,
+  RepoConfigRequest,
+  RepoConfigResult,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
 
 const TOKEN_KEYS = {
   githubToken: "rcv.githubToken",
@@ -7,18 +13,29 @@ const TOKEN_KEYS = {
   forgejoToken: "rcv.forgejoToken",
 } as const;
 
+type Engine = typeof import("@renovate-config-visualizer/engine");
+
 /**
- * Dynamic import keeps the heavy renovate chunk out of the initial page load;
- * Vite code-splits it automatically behind this call.
+ * Pushes the per-host tokens from localStorage into the engine's preset auth.
+ * Shared by every entry point that fetches (pipeline runs AND repo-config
+ * loads) so both reach private repos / lift rate limits identically.
  */
-export async function run(input: PipelineInput): Promise<TraceResult> {
-  const engine = await import("@renovate-config-visualizer/engine");
+function ensureAuth(engine: Engine): void {
   engine.setPresetAuth({
     githubToken: localStorage.getItem(TOKEN_KEYS.githubToken) ?? undefined,
     gitlabToken: localStorage.getItem(TOKEN_KEYS.gitlabToken) ?? undefined,
     giteaToken: localStorage.getItem(TOKEN_KEYS.giteaToken) ?? undefined,
     forgejoToken: localStorage.getItem(TOKEN_KEYS.forgejoToken) ?? undefined,
   });
+}
+
+/**
+ * Dynamic import keeps the heavy renovate chunk out of the initial page load;
+ * Vite code-splits it automatically behind this call.
+ */
+export async function run(input: PipelineInput): Promise<TraceResult> {
+  const engine = await import("@renovate-config-visualizer/engine");
+  ensureAuth(engine);
   return engine.runPipeline(input);
 }
 
@@ -26,4 +43,17 @@ export async function run(input: PipelineInput): Promise<TraceResult> {
 export async function loadOptionIndex(): Promise<OptionIndex> {
   const engine = await import("@renovate-config-visualizer/engine");
   return engine.getOptionIndex();
+}
+
+/** The bundled Renovate version — for the shareable-link version-drift check. */
+export async function getRenovateVersion(): Promise<string> {
+  const engine = await import("@renovate-config-visualizer/engine");
+  return engine.renovateVersion;
+}
+
+/** Probes a repository for its Renovate config file (roadmap 007). */
+export async function loadRepoConfig(req: RepoConfigRequest): Promise<RepoConfigResult> {
+  const engine = await import("@renovate-config-visualizer/engine");
+  ensureAuth(engine);
+  return engine.fetchRepoConfig(req);
 }

--- a/packages/app/src/run.ts
+++ b/packages/app/src/run.ts
@@ -5,7 +5,11 @@ import type {
   RepoConfigResult,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
+import { getValidToken } from "./oauth";
 
+// Per-host PATs now live in sessionStorage (roadmap 009/010 storage rules):
+// they are secrets, so they follow the OAuth token and clear when the tab
+// closes. Platform/endpoint (non-secrets) stay in localStorage — see App.tsx.
 const TOKEN_KEYS = {
   githubToken: "rcv.githubToken",
   gitlabToken: "rcv.gitlabToken",
@@ -16,16 +20,18 @@ const TOKEN_KEYS = {
 type Engine = typeof import("@renovate-config-visualizer/engine");
 
 /**
- * Pushes the per-host tokens from localStorage into the engine's preset auth.
- * Shared by every entry point that fetches (pipeline runs AND repo-config
- * loads) so both reach private repos / lift rate limits identically.
+ * Pushes the per-host tokens into the engine's preset auth. Shared by every
+ * entry point that fetches (pipeline runs AND repo-config loads) so both reach
+ * private repos / lift rate limits identically. A GitHub OAuth token (009),
+ * silently refreshed when needed, wins over the GitHub PAT fallback.
  */
-function ensureAuth(engine: Engine): void {
+async function ensureAuth(engine: Engine): Promise<void> {
+  const oauthToken = await getValidToken();
   engine.setPresetAuth({
-    githubToken: localStorage.getItem(TOKEN_KEYS.githubToken) ?? undefined,
-    gitlabToken: localStorage.getItem(TOKEN_KEYS.gitlabToken) ?? undefined,
-    giteaToken: localStorage.getItem(TOKEN_KEYS.giteaToken) ?? undefined,
-    forgejoToken: localStorage.getItem(TOKEN_KEYS.forgejoToken) ?? undefined,
+    githubToken: oauthToken ?? sessionStorage.getItem(TOKEN_KEYS.githubToken) ?? undefined,
+    gitlabToken: sessionStorage.getItem(TOKEN_KEYS.gitlabToken) ?? undefined,
+    giteaToken: sessionStorage.getItem(TOKEN_KEYS.giteaToken) ?? undefined,
+    forgejoToken: sessionStorage.getItem(TOKEN_KEYS.forgejoToken) ?? undefined,
   });
 }
 
@@ -35,7 +41,7 @@ function ensureAuth(engine: Engine): void {
  */
 export async function run(input: PipelineInput): Promise<TraceResult> {
   const engine = await import("@renovate-config-visualizer/engine");
-  ensureAuth(engine);
+  await ensureAuth(engine);
   return engine.runPipeline(input);
 }
 
@@ -54,6 +60,6 @@ export async function getRenovateVersion(): Promise<string> {
 /** Probes a repository for its Renovate config file (roadmap 007). */
 export async function loadRepoConfig(req: RepoConfigRequest): Promise<RepoConfigResult> {
   const engine = await import("@renovate-config-visualizer/engine");
-  ensureAuth(engine);
+  await ensureAuth(engine);
   return engine.fetchRepoConfig(req);
 }

--- a/packages/app/src/share.ts
+++ b/packages/app/src/share.ts
@@ -1,0 +1,158 @@
+/**
+ * Roadmap 007 — shareable-link codec. Encodes the input config and current
+ * view state into the URL fragment so an analysis can be reproduced from a
+ * link alone. Pure functions, no React.
+ *
+ * Wire format: `#config=<token>` where token is
+ *   JSON → UTF-8 → deflate-raw → base64url (no padding).
+ * The fragment (never a query string) keeps configs out of any server logs.
+ *
+ * Tokens and manually-injected presets are NEVER encoded. The Renovate version
+ * current at encode time rides along so the opener can warn on version drift.
+ */
+import type { StageId } from "@renovate-config-visualizer/engine";
+
+const DEFAULT_PLATFORM = "github";
+const DEFAULT_ENDPOINT = "https://api.github.com";
+const FRAGMENT_KEY = "config";
+
+export type ShareFileName = "renovate.json" | "renovate.json5";
+
+export interface ShareView {
+  stage?: StageId;
+  /** Selected preset node's STRUCTURAL identity (stable across runs), not its id. */
+  node?: string | null;
+  /** Migration step index (only meaningful while the migrate stepper is mounted). */
+  step?: number;
+}
+
+/** The app-facing shape passed to encodeShare. */
+export interface ShareState {
+  config: string;
+  fileName: ShareFileName;
+  platform: string;
+  endpoint: string;
+  renovate: string;
+  view?: ShareView;
+}
+
+/** The decoded payload as stored in the fragment. */
+export interface SharePayload {
+  v: 1;
+  renovate: string;
+  config: string;
+  fileName: ShareFileName;
+  platform?: string;
+  endpoint?: string;
+  view?: ShareView;
+}
+
+async function pipeThrough(bytes: Uint8Array, stream: GenericTransformStream): Promise<Uint8Array> {
+  const writer = stream.writable.getWriter();
+  // Copy into a fresh ArrayBuffer-backed view — TextEncoder / atob outputs can
+  // be typed as ArrayBufferLike, which the stream writer's types reject.
+  void writer.write(new Uint8Array(bytes));
+  void writer.close();
+  const buf = await new Response(stream.readable).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+function deflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
+  return pipeThrough(bytes, new CompressionStream("deflate-raw"));
+}
+
+function inflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
+  return pipeThrough(bytes, new DecompressionStream("deflate-raw"));
+}
+
+function bytesToBase64url(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) {
+    bin += String.fromCharCode(b);
+  }
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlToBytes(token: string): Uint8Array {
+  const b64 = token.replace(/-/g, "+").replace(/_/g, "/");
+  const bin = atob(b64);
+  return Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+}
+
+/** Encodes state into the fragment token (the value after `#config=`). */
+export async function encodeShare(state: ShareState): Promise<string> {
+  const payload: SharePayload = {
+    v: 1,
+    renovate: state.renovate,
+    config: state.config,
+    fileName: state.fileName,
+  };
+  // Omit platform/endpoint when they equal the defaults.
+  if (state.platform && state.platform !== DEFAULT_PLATFORM) {
+    payload.platform = state.platform;
+  }
+  if (state.endpoint && state.endpoint !== DEFAULT_ENDPOINT) {
+    payload.endpoint = state.endpoint;
+  }
+  const view = normalizeView(state.view);
+  if (view) {
+    payload.view = view;
+  }
+  const json = JSON.stringify(payload);
+  const compressed = await deflateRaw(new TextEncoder().encode(json));
+  return bytesToBase64url(compressed);
+}
+
+/** Drops empty view fields; returns undefined when nothing worth encoding. */
+function normalizeView(view: ShareView | undefined): ShareView | undefined {
+  if (!view) {
+    return undefined;
+  }
+  const out: ShareView = {};
+  if (view.stage) {
+    out.stage = view.stage;
+  }
+  if (view.node) {
+    out.node = view.node;
+  }
+  if (typeof view.step === "number" && view.step > 0) {
+    out.step = view.step;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Decodes a fragment token back to a payload, or null on any failure. */
+export async function decodeShare(token: string): Promise<SharePayload | null> {
+  try {
+    const bytes = base64urlToBytes(token);
+    const json = new TextDecoder().decode(await inflateRaw(bytes));
+    const parsed: unknown = JSON.parse(json);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      (parsed as { v?: unknown }).v !== 1 ||
+      typeof (parsed as { config?: unknown }).config !== "string"
+    ) {
+      return null;
+    }
+    const p = parsed as SharePayload;
+    // Normalize fileName to the two supported values.
+    p.fileName = p.fileName === "renovate.json5" ? "renovate.json5" : "renovate.json";
+    return p;
+  } catch {
+    return null;
+  }
+}
+
+/** Extracts the token from a `#config=…` location hash, or null. */
+export function readShareToken(hash: string): string | null {
+  const raw = hash.startsWith("#") ? hash.slice(1) : hash;
+  const params = new URLSearchParams(raw);
+  return params.get(FRAGMENT_KEY);
+}
+
+/** Builds the full shareable URL from the current location + a token. */
+export function buildShareUrl(token: string): string {
+  const { origin, pathname } = window.location;
+  return `${origin}${pathname}#${FRAGMENT_KEY}=${token}`;
+}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  /** GitHub App client id — enables "Sign in with GitHub" when set (009). */
+  readonly VITE_GITHUB_CLIENT_ID?: string;
+  /** Token-exchange Worker base URL — required alongside the client id (009). */
+  readonly VITE_OAUTH_WORKER_URL?: string;
+  /** GitHub App slug — optional; enables a direct install/manage link (009). */
+  readonly VITE_GITHUB_APP_SLUG?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,6 +15,13 @@ export {
   type PresetIdentity,
   presetInjectionKey,
 } from "./shims/presets/injection";
+export {
+  fetchRepoConfig,
+  RepoConfigNotFoundError,
+  type RepoConfigRequest,
+  type RepoConfigResult,
+  type RepoPlatform,
+} from "./shims/repo-config";
 export type {
   LogLevel,
   MigrationStepInfo,

--- a/packages/engine/src/shims/repo-config.ts
+++ b/packages/engine/src/shims/repo-config.ts
@@ -1,0 +1,288 @@
+/**
+ * Roadmap 007 — "Load from repo". Probes a repository's documented Renovate
+ * config-file locations (in Renovate's own order) using the same browser
+ * fetch() transports as the preset fetchers, and returns the first file that
+ * exists as raw text. Kept free of any app concerns: it only knows platforms,
+ * repos, endpoints and refs.
+ *
+ * The raw-file transports here intentionally mirror — rather than reuse — the
+ * preset fetchers in ./presets/*: those wrap Renovate's fetchPreset/parsePreset
+ * (file-candidate recursion, JSON parsing, sub-preset lookup), semantics we do
+ * NOT want here. We want the file's exact text, one probe per candidate, so the
+ * few transport lines (URL shape, auth header, error mapping) are duplicated.
+ */
+import { ExternalHostError } from "renovate/dist/types/errors/external-host-error.js";
+import { getPresetAuth } from "../auth";
+
+export type RepoPlatform = "github" | "gitlab" | "gitea" | "forgejo";
+
+export interface RepoConfigRequest {
+  platform: RepoPlatform;
+  repo: string;
+  endpoint?: string;
+  ref?: string;
+}
+
+export interface RepoConfigResult {
+  /** The winning file's name (e.g. `renovate.json5`, `.github/renovate.json`). */
+  fileName: string;
+  /** Raw file text; for package.json, the JSON.stringify'd `renovate` value. */
+  content: string;
+  /** Every candidate probed, in order, up to and including the winner. */
+  probed: string[];
+}
+
+/** Thrown when every documented location was probed and none held a config. */
+export class RepoConfigNotFoundError extends Error {
+  readonly probed: string[];
+  constructor(repo: string, probed: string[]) {
+    super(`No Renovate config found in ${repo} (tried ${probed.length} locations)`);
+    this.name = "RepoConfigNotFoundError";
+    this.probed = probed;
+  }
+}
+
+/**
+ * Mirrors `configFileNames` in renovate/dist/config/app-strings.js after
+ * brace-expansion (`renovate.json{,c,5}` → .json/.jsonc/.json5), in order.
+ * detectConfigFile walks this list and the first existing file wins. Hardcoded
+ * because upstream exports `getConfigFileNames()`, not the raw `configFileNames`
+ * array; keep in sync with the pinned Renovate version.
+ */
+const CONFIG_FILE_NAMES = [
+  "renovate.json",
+  "renovate.jsonc",
+  "renovate.json5",
+  ".github/renovate.json",
+  ".github/renovate.jsonc",
+  ".github/renovate.json5",
+  ".gitlab/renovate.json",
+  ".gitlab/renovate.jsonc",
+  ".gitlab/renovate.json5",
+  ".renovaterc",
+  ".renovaterc.json",
+  ".renovaterc.jsonc",
+  ".renovaterc.json5",
+  "package.json",
+];
+
+/** Default (CORS-enabled) API roots, matching the preset fetchers' Endpoints. */
+const DEFAULT_ENDPOINTS: Record<RepoPlatform, string> = {
+  github: "https://api.github.com/",
+  gitlab: "https://gitlab.com/api/v4/",
+  gitea: "https://gitea.com/",
+  forgejo: "https://codeberg.org/",
+};
+
+/** A 404-equivalent: this candidate is absent, move on to the next one. */
+const NOT_FOUND = Symbol("repo-config-not-found");
+
+function withTrailingSlash(endpoint: string): string {
+  return endpoint.endsWith("/") ? endpoint : `${endpoint}/`;
+}
+
+/** Base64 → UTF-8 using browser-native primitives (Gitea/Forgejo contents API). */
+function decodeBase64(input: string): string {
+  const bin = atob(input.replace(/\s/g, ""));
+  const bytes = Uint8Array.from(bin, (ch) => ch.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/** Maps a non-ok response to either NOT_FOUND (404) or an ExternalHostError. */
+function classifyBadResponse(platform: RepoPlatform, status: number): typeof NOT_FOUND {
+  if (status === 401 || status === 403 || status === 429) {
+    throw new ExternalHostError(
+      new Error(
+        `${platform} API rejected the request (HTTP ${status}) — rate limit or missing token`,
+      ),
+      platform,
+    );
+  }
+  return NOT_FOUND;
+}
+
+function unreachable(platform: RepoPlatform, endpoint: string, err: unknown): never {
+  throw new ExternalHostError(
+    new Error(
+      `Could not reach the ${platform} endpoint ${endpoint} from the browser — ` +
+        `likely missing CORS headers or a network block (${err instanceof Error ? err.message : String(err)})`,
+    ),
+    platform,
+  );
+}
+
+async function githubRaw(
+  repo: string,
+  path: string,
+  endpoint: string,
+  ref?: string,
+): Promise<string | typeof NOT_FOUND> {
+  const query = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+  const url = `${endpoint}repos/${repo}/contents/${path}${query}`;
+  const headers: Record<string, string> = { accept: "application/vnd.github.raw+json" };
+  const { githubToken } = getPresetAuth();
+  if (githubToken) {
+    headers.authorization = `Bearer ${githubToken}`;
+  }
+  let res: Response;
+  try {
+    res = await fetch(url, { headers });
+  } catch (err) {
+    unreachable("github", endpoint, err);
+  }
+  if (!res.ok) {
+    return classifyBadResponse("github", res.status);
+  }
+  return res.text();
+}
+
+async function gitlabRaw(
+  repo: string,
+  path: string,
+  endpoint: string,
+  ref: string,
+): Promise<string | typeof NOT_FOUND> {
+  const url = `${endpoint}projects/${encodeURIComponent(repo)}/repository/files/${encodeURIComponent(path)}/raw?ref=${encodeURIComponent(ref)}`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  const { gitlabToken } = getPresetAuth();
+  if (gitlabToken) {
+    headers["PRIVATE-TOKEN"] = gitlabToken;
+  }
+  let res: Response;
+  try {
+    res = await fetch(url, { headers });
+  } catch (err) {
+    unreachable("gitlab", endpoint, err);
+  }
+  if (!res.ok) {
+    return classifyBadResponse("gitlab", res.status);
+  }
+  return res.text();
+}
+
+async function gitlabDefaultBranch(repo: string, endpoint: string): Promise<string> {
+  const headers: Record<string, string> = { accept: "application/json" };
+  const { gitlabToken } = getPresetAuth();
+  if (gitlabToken) {
+    headers["PRIVATE-TOKEN"] = gitlabToken;
+  }
+  let res: Response;
+  try {
+    res = await fetch(`${endpoint}projects/${encodeURIComponent(repo)}`, { headers });
+  } catch (err) {
+    unreachable("gitlab", endpoint, err);
+  }
+  if (!res.ok) {
+    // A missing project aborts (no point probing 14 files under it).
+    classifyBadResponse("gitlab", res.status);
+    throw new ExternalHostError(
+      new Error(`GitLab project ${repo} not found (HTTP ${res.status})`),
+      "gitlab",
+    );
+  }
+  const body = (await res.json()) as { default_branch?: string };
+  return body.default_branch ?? "master";
+}
+
+async function giteaLikeRaw(
+  platform: "gitea" | "forgejo",
+  repo: string,
+  path: string,
+  endpoint: string,
+  ref?: string,
+): Promise<string | typeof NOT_FOUND> {
+  const query = ref ? `?ref=${encodeURIComponent(ref)}` : "";
+  const url = `${endpoint}api/v1/repos/${repo}/contents/${encodeURIComponent(path)}${query}`;
+  const headers: Record<string, string> = { accept: "application/json" };
+  const auth = getPresetAuth();
+  const token = platform === "gitea" ? auth.giteaToken : auth.forgejoToken;
+  if (token) {
+    headers.authorization = `token ${token}`;
+  }
+  let res: Response;
+  try {
+    res = await fetch(url, { headers });
+  } catch (err) {
+    unreachable(platform, endpoint, err);
+  }
+  if (!res.ok) {
+    return classifyBadResponse(platform, res.status);
+  }
+  const body = (await res.json()) as { type?: string; content?: string };
+  if (body.type && body.type !== "file") {
+    return NOT_FOUND;
+  }
+  return body.content ? decodeBase64(body.content) : "";
+}
+
+/**
+ * Probes the documented config-file locations in order and returns the first
+ * that exists as raw text. A 404-equivalent moves to the next candidate; any
+ * ExternalHostError (CORS / auth / rate limit) aborts immediately — probing 14
+ * files against a blocked host is pointless. Throws RepoConfigNotFoundError
+ * once every candidate has been exhausted.
+ */
+export async function fetchRepoConfig(req: RepoConfigRequest): Promise<RepoConfigResult> {
+  const { platform, repo } = req;
+  const endpoint = withTrailingSlash(req.endpoint || DEFAULT_ENDPOINTS[platform]);
+  // GitLab's raw endpoint requires an explicit ref; resolve the default branch
+  // once up front rather than per probe.
+  const gitlabRef =
+    platform === "gitlab" ? (req.ref ?? (await gitlabDefaultBranch(repo, endpoint))) : req.ref;
+
+  const probed: string[] = [];
+  for (const fileName of CONFIG_FILE_NAMES) {
+    probed.push(fileName);
+    let raw: string | typeof NOT_FOUND;
+    if (platform === "github") {
+      raw = await githubRaw(repo, fileName, endpoint, req.ref);
+    } else if (platform === "gitlab") {
+      raw = await gitlabRaw(repo, fileName, endpoint, gitlabRef as string);
+    } else {
+      raw = await giteaLikeRaw(platform, repo, fileName, endpoint, req.ref);
+    }
+    if (raw === NOT_FOUND) {
+      continue;
+    }
+    if (fileName === "package.json") {
+      const extracted = extractPackageJsonConfig(raw);
+      if (extracted === null) {
+        continue; // no `renovate` key or unparseable — treat as exhausted
+      }
+      return { fileName, content: extracted, probed };
+    }
+    // Empty config file is `{}` upstream.
+    return { fileName, content: raw.trim() === "" ? "{}" : raw, probed };
+  }
+
+  throw new RepoConfigNotFoundError(repo, probed);
+}
+
+/**
+ * Extracts the `renovate` key from a package.json body. An object value is
+ * returned pretty-printed; a string value becomes `{ "extends": [value] }`
+ * (Renovate's shorthand). Returns null on parse error or a missing key so the
+ * probe loop continues.
+ */
+function extractPackageJsonConfig(raw: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return null;
+  }
+  const value = (parsed as Record<string, unknown>).renovate;
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return JSON.stringify({ extends: [value] }, null, 2);
+  }
+  if (typeof value === "object" && value !== null) {
+    return JSON.stringify(value, null, 2);
+  }
+  return null;
+}

--- a/packages/engine/test/repo-config.test.ts
+++ b/packages/engine/test/repo-config.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Shimmed-project tests for fetchRepoConfig (roadmap 007 "Load from repo"),
+ * with fetch stubbed — no live network. Covers the probe order, 404
+ * fall-through, package.json `renovate` key handling, CORS abort and the
+ * exhausted-search error.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchRepoConfig, RepoConfigNotFoundError, setPresetAuth } from "../src/index";
+
+const CONFIG_BODY = JSON.stringify({ extends: ["config:recommended"] });
+
+function ok(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+function notFound(): Response {
+  return new Response("not found", { status: 404 });
+}
+function base64(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64");
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  setPresetAuth({});
+});
+
+describe("fetchRepoConfig — github", () => {
+  it("returns the first existing file (first-hit-wins order)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok(CONFIG_BODY));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/org/repo/contents/renovate.json",
+      expect.objectContaining({
+        headers: expect.objectContaining({ accept: "application/vnd.github.raw+json" }),
+      }),
+    );
+    expect(result.fileName).toBe("renovate.json");
+    expect(result.content).toBe(CONFIG_BODY);
+    expect(result.probed).toEqual(["renovate.json"]);
+  });
+
+  it("falls through 404s to a later candidate", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/contents/.github/renovate.json5")) {
+        return Promise.resolve(ok(CONFIG_BODY));
+      }
+      return Promise.resolve(notFound());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+
+    expect(result.fileName).toBe(".github/renovate.json5");
+    expect(result.probed).toEqual([
+      "renovate.json",
+      "renovate.jsonc",
+      "renovate.json5",
+      ".github/renovate.json",
+      ".github/renovate.jsonc",
+      ".github/renovate.json5",
+    ]);
+  });
+
+  it("treats an empty file as {}", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ok("")));
+    const result = await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+    expect(result.content).toBe("{}");
+  });
+
+  it("passes an explicit ref through as ?ref=", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok(CONFIG_BODY));
+    vi.stubGlobal("fetch", fetchMock);
+    await fetchRepoConfig({ platform: "github", repo: "org/repo", ref: "v2" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/repos/org/repo/contents/renovate.json?ref=v2",
+      expect.anything(),
+    );
+  });
+
+  it("sends the github token as a bearer header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok(CONFIG_BODY));
+    vi.stubGlobal("fetch", fetchMock);
+    setPresetAuth({ githubToken: "gh-token" });
+    await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer gh-token" }),
+      }),
+    );
+  });
+});
+
+describe("fetchRepoConfig — package.json renovate key", () => {
+  function pkgOnly(body: string) {
+    return vi.fn((url: string) => {
+      if (url.endsWith("/contents/package.json")) {
+        return Promise.resolve(ok(body));
+      }
+      return Promise.resolve(notFound());
+    });
+  }
+
+  it("extracts an object value pretty-printed", async () => {
+    const pkg = JSON.stringify({ name: "x", renovate: { extends: ["config:base"] } });
+    vi.stubGlobal("fetch", pkgOnly(pkg));
+    const result = await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+    expect(result.fileName).toBe("package.json");
+    expect(result.content).toBe(JSON.stringify({ extends: ["config:base"] }, null, 2));
+  });
+
+  it("wraps a string value as { extends: [value] }", async () => {
+    const pkg = JSON.stringify({ renovate: "github>org/shared" });
+    vi.stubGlobal("fetch", pkgOnly(pkg));
+    const result = await fetchRepoConfig({ platform: "github", repo: "org/repo" });
+    expect(result.content).toBe(JSON.stringify({ extends: ["github>org/shared"] }, null, 2));
+  });
+
+  it("throws not-found when package.json has no renovate key", async () => {
+    const pkg = JSON.stringify({ name: "x", version: "1.0.0" });
+    vi.stubGlobal("fetch", pkgOnly(pkg));
+    await expect(fetchRepoConfig({ platform: "github", repo: "org/repo" })).rejects.toBeInstanceOf(
+      RepoConfigNotFoundError,
+    );
+  });
+});
+
+describe("fetchRepoConfig — errors", () => {
+  it("aborts immediately on a CORS/network failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+    vi.stubGlobal("fetch", fetchMock);
+    // ExternalHostError wraps the detail in `.err`.
+    await expect(fetchRepoConfig({ platform: "github", repo: "org/repo" })).rejects.toMatchObject({
+      err: { message: expect.stringMatching(/Could not reach/) },
+    });
+    // aborted after the very first probe rather than walking all 14
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts on a rate-limit / auth rejection", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("rate limited", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchRepoConfig({ platform: "github", repo: "org/repo" })).rejects.toMatchObject({
+      err: { message: expect.stringMatching(/rate limit or missing token/) },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws RepoConfigNotFoundError listing every probed location", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(notFound()));
+    await expect(fetchRepoConfig({ platform: "github", repo: "org/repo" })).rejects.toMatchObject({
+      name: "RepoConfigNotFoundError",
+      probed: expect.arrayContaining(["renovate.json", "package.json"]),
+    });
+  });
+});
+
+describe("fetchRepoConfig — gitlab", () => {
+  it("resolves the default branch once, then probes raw files with that ref", async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/projects/org%2Frepo")) {
+        return Promise.resolve(ok(JSON.stringify({ default_branch: "main" })));
+      }
+      if (url.includes("/files/renovate.json/raw")) {
+        return Promise.resolve(ok(CONFIG_BODY));
+      }
+      return Promise.resolve(notFound());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRepoConfig({ platform: "gitlab", repo: "org/repo" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/projects/org%2Frepo/repository/files/renovate.json/raw?ref=main",
+      expect.objectContaining({ headers: expect.objectContaining({ accept: "application/json" }) }),
+    );
+    expect(result.fileName).toBe("renovate.json");
+    expect(result.content).toBe(CONFIG_BODY);
+  });
+});
+
+describe("fetchRepoConfig — gitea/forgejo", () => {
+  it("decodes base64 contents from the gitea API", async () => {
+    const body = JSON.stringify({ type: "file", encoding: "base64", content: base64(CONFIG_BODY) });
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith("/contents/renovate.json")) {
+        return Promise.resolve(ok(body));
+      }
+      return Promise.resolve(notFound());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchRepoConfig({ platform: "gitea", repo: "org/repo" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://gitea.com/api/v1/repos/org/repo/contents/renovate.json",
+      expect.anything(),
+    );
+    expect(result.content).toBe(CONFIG_BODY);
+  });
+});

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
             "test/pipeline.shimmed.test.ts",
             "test/preset-fetchers.test.ts",
             "test/provenance.shimmed.test.ts",
+            "test/repo-config.test.ts",
           ],
           environment: "node",
           server: {

--- a/packages/oauth-worker/README.md
+++ b/packages/oauth-worker/README.md
@@ -1,0 +1,103 @@
+# @renovate-config-visualizer/oauth-worker
+
+A single-purpose Cloudflare Worker: the token-exchange proxy that lets the
+static SPA complete "Sign in with GitHub" (roadmap
+[009](../../roadmap/009-github-oauth-sign-in.md)).
+
+## Why this exists
+
+A pure static SPA cannot finish GitHub's OAuth flow on its own: GitHub still
+requires the `client_secret` at the token exchange (even with PKCE), and it
+serves no CORS on `github.com/login/*`. So a minimal serverless "gatekeeper" is
+unavoidable. This Worker is that gatekeeper and nothing more — it turns an OAuth
+`code` (or a `refresh_token`) into a GitHub user token by appending the secret,
+and forwards the result.
+
+### Privacy boundary (also stated in the root README)
+
+> The Worker never sees a config, a preset, or an API request — only the OAuth
+> code/refresh exchange passes through it, stateless and unlogged. All GitHub
+> content fetches go browser → `api.github.com` directly. The `client_secret`
+> lives only in the Worker secret store; request/response bodies and tokens are
+> never logged.
+
+## Endpoints
+
+All requests must carry an allow-listed `Origin`; anything else gets `403`
+before GitHub is contacted. Responses reflect the exact matched origin (never
+`*`).
+
+- `POST /exchange` — body `{ code, code_verifier, redirect_uri }` →
+  `authorization_code` grant → GitHub's token JSON verbatim
+  (`access_token`, `expires_in`, `refresh_token`, `refresh_token_expires_in`,
+  `token_type`, `scope`) or an `{ error, ... }` passthrough.
+- `POST /refresh` — body `{ refresh_token }` → `refresh_token` grant, same
+  response shape.
+- Everything else → `404`. `OPTIONS` preflights are answered for allowed
+  origins.
+
+## Configuration
+
+| Name                   | Kind   | Notes                                                       |
+| ---------------------- | ------ | ----------------------------------------------------------- |
+| `GITHUB_CLIENT_ID`     | var    | GitHub App client id (public).                              |
+| `ALLOWED_ORIGINS`      | var    | Comma-separated exact origins allowed to call the Worker.   |
+| `GITHUB_CLIENT_SECRET` | secret | GitHub App client secret. Never in `wrangler.jsonc` or git. |
+
+## Provisioning
+
+### 1. Create the GitHub App
+
+Settings → Developer settings → **GitHub Apps** → New GitHub App:
+
+- **Permissions → Repository → Contents: Read-only** — this permission ONLY.
+  Nothing else. The consent screen then truthfully reads "read the contents of
+  the repositories you select".
+- **Expire user authorization tokens: ON** (8 h tokens + 6-month refresh token).
+- **Request user authorization (OAuth) during installation: ON**.
+- **Enable Device Flow: OFF** (CORS-blocked from browsers anyway).
+- **Callback URL**: add both
+  - `https://secustor.github.io/renovate-config-visualizer/` (production Pages)
+  - `http://localhost:5173/` (local dev)
+- Note the **Client ID**, and generate a **Client secret**.
+
+### 2. Deploy the Worker
+
+```bash
+cd packages/oauth-worker
+pnpm dlx wrangler deploy
+pnpm dlx wrangler secret put GITHUB_CLIENT_SECRET   # paste the client secret
+```
+
+Set the vars (edit `wrangler.jsonc` `vars`, or via the dashboard / `wrangler`):
+
+- `GITHUB_CLIENT_ID` = the App's client id
+- `ALLOWED_ORIGINS` = `https://secustor.github.io,http://localhost:5173`
+
+Note the deployed Worker URL (e.g. `https://rcv-oauth-worker.<subdomain>.workers.dev`).
+
+### 3. Set the repo Actions variables
+
+So the Pages build turns the feature on (Settings → Secrets and variables →
+Actions → **Variables**):
+
+- `VITE_GITHUB_CLIENT_ID` = the App's client id
+- `VITE_OAUTH_WORKER_URL` = the deployed Worker URL
+- `VITE_GITHUB_APP_SLUG` = the App's slug (optional; enables a direct
+  install/manage link — the URL segment in
+  `https://github.com/apps/<slug>`)
+
+Until these are set, the app builds cleanly with the feature **off**: no
+sign-in UI appears and the personal-access-token fallback (advanced settings)
+remains the only GitHub auth.
+
+## Development
+
+```bash
+pnpm --filter @renovate-config-visualizer/oauth-worker test        # vitest, fetch stubbed
+pnpm --filter @renovate-config-visualizer/oauth-worker typecheck
+```
+
+The request handler is the pure exported `handleRequest(req, env)` so the tests
+run without wrangler. `wrangler` itself is only needed to deploy and is invoked
+via `pnpm dlx` (no devDependency, no `node_modules` weight).

--- a/packages/oauth-worker/package.json
+++ b/packages/oauth-worker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@renovate-config-visualizer/oauth-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "deploy": "pnpm dlx wrangler deploy"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/oauth-worker/src/index.ts
+++ b/packages/oauth-worker/src/index.ts
@@ -1,0 +1,204 @@
+/**
+ * GitHub OAuth token-exchange proxy (roadmap 009).
+ *
+ * A static SPA cannot complete GitHub's OAuth flow itself: the token endpoint
+ * still requires the `client_secret` (even with PKCE) and does not serve CORS
+ * on `github.com/login/*`. This Worker is the minimal "gatekeeper" that appends
+ * the secret and forwards the code / refresh exchange — and NOTHING else.
+ *
+ * Hard boundary: the Worker never sees a config, a preset, or an API request.
+ * It is stateless, persists nothing, and logs no request/response bodies or
+ * tokens. The client secret only ever lives in the Worker secret store.
+ *
+ * The request handler is a pure function so it can be unit-tested without
+ * wrangler (stub `globalThis.fetch`); the default export wires it to the
+ * Workers runtime.
+ */
+
+export interface Env {
+  /** GitHub App client id (public). Provided via `vars`. */
+  GITHUB_CLIENT_ID: string;
+  /** GitHub App client secret. Provided via `wrangler secret put`. */
+  GITHUB_CLIENT_SECRET: string;
+  /** Comma-separated list of exact origins allowed to call this Worker. */
+  ALLOWED_ORIGINS: string;
+}
+
+const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+interface ExchangeBody {
+  code?: unknown;
+  code_verifier?: unknown;
+  redirect_uri?: unknown;
+}
+
+interface RefreshBody {
+  refresh_token?: unknown;
+}
+
+/** The configured allow-list, trimmed and de-blanked. */
+function allowedOrigins(env: Env): string[] {
+  return (env.ALLOWED_ORIGINS ?? "")
+    .split(",")
+    .map((o) => o.trim())
+    .filter((o) => o.length > 0);
+}
+
+/** The request's Origin if (and only if) it is on the allow-list, else null. */
+function matchOrigin(req: Request, env: Env): string | null {
+  const origin = req.headers.get("origin");
+  if (!origin) {
+    return null;
+  }
+  return allowedOrigins(env).includes(origin) ? origin : null;
+}
+
+/** CORS headers reflecting exactly the (already-validated) origin — never `*`. */
+function corsHeaders(origin: string): Headers {
+  const headers = new Headers();
+  headers.set("access-control-allow-origin", origin);
+  headers.set("vary", "Origin");
+  headers.set("access-control-allow-methods", "POST, OPTIONS");
+  headers.set("access-control-allow-headers", "Content-Type");
+  headers.set("access-control-max-age", "86400");
+  return headers;
+}
+
+function jsonResponse(body: unknown, status: number, origin: string | null): Response {
+  const headers = origin ? corsHeaders(origin) : new Headers();
+  headers.set("content-type", "application/json");
+  return new Response(JSON.stringify(body), { status, headers });
+}
+
+/**
+ * Forwards a completed grant to GitHub and passes its JSON back verbatim.
+ * GitHub replies 200 even for `{ error: ... }` on this endpoint, so an error
+ * body is downgraded to 400. No body or token is ever logged.
+ */
+async function forwardToGitHub(params: URLSearchParams, origin: string): Promise<Response> {
+  let ghRes: Response;
+  try {
+    ghRes = await fetch(GITHUB_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: params.toString(),
+    });
+  } catch {
+    return jsonResponse({ error: "github_unreachable" }, 502, origin);
+  }
+
+  let payload: unknown;
+  try {
+    payload = await ghRes.json();
+  } catch {
+    return jsonResponse({ error: "github_bad_response" }, 502, origin);
+  }
+
+  const isError =
+    typeof payload === "object" &&
+    payload !== null &&
+    "error" in (payload as Record<string, unknown>);
+  const status = isError ? 400 : ghRes.ok ? 200 : ghRes.status;
+  return jsonResponse(payload, status, origin);
+}
+
+async function handleExchange(req: Request, env: Env, origin: string): Promise<Response> {
+  let body: ExchangeBody;
+  try {
+    body = (await req.json()) as ExchangeBody;
+  } catch {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "body must be JSON" },
+      400,
+      origin,
+    );
+  }
+  const code = typeof body.code === "string" ? body.code : "";
+  const codeVerifier = typeof body.code_verifier === "string" ? body.code_verifier : "";
+  const redirectUri = typeof body.redirect_uri === "string" ? body.redirect_uri : "";
+  if (!code || !codeVerifier) {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "code and code_verifier are required" },
+      400,
+      origin,
+    );
+  }
+  const params = new URLSearchParams({
+    client_id: env.GITHUB_CLIENT_ID,
+    client_secret: env.GITHUB_CLIENT_SECRET,
+    grant_type: "authorization_code",
+    code,
+    code_verifier: codeVerifier,
+  });
+  if (redirectUri) {
+    params.set("redirect_uri", redirectUri);
+  }
+  return forwardToGitHub(params, origin);
+}
+
+async function handleRefresh(req: Request, env: Env, origin: string): Promise<Response> {
+  let body: RefreshBody;
+  try {
+    body = (await req.json()) as RefreshBody;
+  } catch {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "body must be JSON" },
+      400,
+      origin,
+    );
+  }
+  const refreshToken = typeof body.refresh_token === "string" ? body.refresh_token : "";
+  if (!refreshToken) {
+    return jsonResponse(
+      { error: "invalid_request", error_description: "refresh_token is required" },
+      400,
+      origin,
+    );
+  }
+  const params = new URLSearchParams({
+    client_id: env.GITHUB_CLIENT_ID,
+    client_secret: env.GITHUB_CLIENT_SECRET,
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+  });
+  return forwardToGitHub(params, origin);
+}
+
+/**
+ * Pure request handler. Answers only same-listed-origin POSTs to /exchange and
+ * /refresh; a preflight from an allowed origin gets the CORS headers; anything
+ * from a non-listed origin is refused (403) before GitHub is ever contacted.
+ */
+export async function handleRequest(req: Request, env: Env): Promise<Response> {
+  const origin = matchOrigin(req, env);
+
+  if (req.method === "OPTIONS") {
+    if (!origin) {
+      return new Response(null, { status: 403 });
+    }
+    return new Response(null, { status: 204, headers: corsHeaders(origin) });
+  }
+
+  // Every real request must come from an allow-listed browser origin.
+  if (!origin) {
+    return jsonResponse({ error: "origin_not_allowed" }, 403, null);
+  }
+
+  const { pathname } = new URL(req.url);
+  if (req.method === "POST" && pathname === "/exchange") {
+    return handleExchange(req, env, origin);
+  }
+  if (req.method === "POST" && pathname === "/refresh") {
+    return handleRefresh(req, env, origin);
+  }
+  return jsonResponse({ error: "not_found" }, 404, origin);
+}
+
+export default {
+  fetch(req: Request, env: Env): Promise<Response> {
+    return handleRequest(req, env);
+  },
+};

--- a/packages/oauth-worker/test/handler.test.ts
+++ b/packages/oauth-worker/test/handler.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleRequest, type Env } from "../src/index";
+
+const ALLOWED = "https://secustor.github.io";
+const DEV = "http://localhost:5173";
+const EVIL = "https://evil.example";
+
+const env: Env = {
+  GITHUB_CLIENT_ID: "Iv1.testclientid",
+  GITHUB_CLIENT_SECRET: "super-secret-value",
+  ALLOWED_ORIGINS: `${ALLOWED}, ${DEV}`,
+};
+
+const ACCESS_TOKEN = "ghu_thisisasecrettokenvalue";
+
+/** A successful GitHub token response. */
+function ghTokenResponse() {
+  return new Response(
+    JSON.stringify({
+      access_token: ACCESS_TOKEN,
+      expires_in: 28800,
+      refresh_token: "ghr_refreshsecret",
+      refresh_token_expires_in: 15897600,
+      token_type: "bearer",
+      scope: "",
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function post(path: string, body: unknown, origin: string | null): Request {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (origin) {
+    headers.origin = origin;
+  }
+  return new Request(`https://worker.example${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+// Spy on every console method so we can assert nothing (least of all a token)
+// is ever logged.
+let consoleSpies: ReturnType<typeof vi.spyOn>[] = [];
+beforeEach(() => {
+  consoleSpies = (["log", "info", "warn", "error", "debug"] as const).map((m) =>
+    vi.spyOn(console, m).mockImplementation(() => {}),
+  );
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function assertNothingLogged() {
+  for (const spy of consoleSpies) {
+    expect(spy).not.toHaveBeenCalled();
+  }
+}
+
+describe("CORS gate", () => {
+  it("answers a preflight from an allowed origin with reflected CORS headers", async () => {
+    const req = new Request("https://worker.example/exchange", {
+      method: "OPTIONS",
+      headers: { origin: ALLOWED },
+    });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(204);
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED);
+    expect(res.headers.get("access-control-allow-origin")).not.toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toContain("POST");
+  });
+
+  it("rejects a preflight from a disallowed origin with 403 and no CORS headers", async () => {
+    const req = new Request("https://worker.example/exchange", {
+      method: "OPTIONS",
+      headers: { origin: EVIL },
+    });
+    const res = await handleRequest(req, env);
+    expect(res.status).toBe(403);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  it("refuses a real request from a disallowed origin without touching GitHub", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(
+      post("/exchange", { code: "x", code_verifier: "y" }, EVIL),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    assertNothingLogged();
+  });
+
+  it("refuses a request with no Origin header", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(
+      post("/exchange", { code: "x", code_verifier: "y" }, null),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /exchange", () => {
+  it("appends client id + secret and forwards the PKCE verifier, then returns the token verbatim", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ghTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleRequest(
+      post(
+        "/exchange",
+        {
+          code: "the-oauth-code",
+          code_verifier: "the-pkce-verifier",
+          redirect_uri: "https://secustor.github.io/renovate-config-visualizer/",
+        },
+        DEV,
+      ),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).toBe(DEV);
+    const json = (await res.json()) as { access_token?: string; refresh_token?: string };
+    expect(json.access_token).toBe(ACCESS_TOKEN);
+    expect(json.refresh_token).toBe("ghr_refreshsecret");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(GITHUB_TOKEN_URL());
+    const headers = init.headers as Record<string, string>;
+    expect(headers.accept).toBe("application/json");
+    const outgoing = String(init.body);
+    expect(outgoing).toContain("client_id=Iv1.testclientid");
+    expect(outgoing).toContain("client_secret=super-secret-value");
+    expect(outgoing).toContain("code=the-oauth-code");
+    expect(outgoing).toContain("code_verifier=the-pkce-verifier");
+    expect(outgoing).toContain("grant_type=authorization_code");
+
+    assertNothingLogged();
+  });
+
+  it("rejects a body missing code / code_verifier with 400 and no GitHub call", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(post("/exchange", { code: "only-code" }, ALLOWED), env);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /refresh", () => {
+  it("performs a refresh_token grant and returns the new token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ghTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleRequest(
+      post("/refresh", { refresh_token: "ghr_oldrefresh" }, ALLOWED),
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { access_token?: string };
+    expect(json.access_token).toBe(ACCESS_TOKEN);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const outgoing = String(init.body);
+    expect(outgoing).toContain("grant_type=refresh_token");
+    expect(outgoing).toContain("refresh_token=ghr_oldrefresh");
+    expect(outgoing).toContain("client_secret=super-secret-value");
+    assertNothingLogged();
+  });
+
+  it("rejects a body missing refresh_token with 400", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(post("/refresh", {}, ALLOWED), env);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GitHub error passthrough", () => {
+  it("passes a GitHub {error} body back (downgraded to 400) and logs nothing", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: "bad_verification_code", error_description: "expired" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      env,
+    );
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("bad_verification_code");
+    assertNothingLogged();
+  });
+
+  it("returns 502 when GitHub is unreachable, exposing no token", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      env,
+    );
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toContain(ACCESS_TOKEN);
+    assertNothingLogged();
+  });
+});
+
+describe("routing", () => {
+  it("404s an unknown route", async () => {
+    const res = await handleRequest(post("/nope", {}, ALLOWED), env);
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as { error?: string };
+    expect(json.error).toBe("not_found");
+  });
+});
+
+/** The GitHub token URL, duplicated here so the test pins the exact endpoint. */
+function GITHUB_TOKEN_URL() {
+  return "https://github.com/login/oauth/access_token";
+}

--- a/packages/oauth-worker/tsconfig.json
+++ b/packages/oauth-worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023", "WebWorker"]
+  },
+  "include": ["src", "test"]
+}

--- a/packages/oauth-worker/wrangler.jsonc
+++ b/packages/oauth-worker/wrangler.jsonc
@@ -1,0 +1,24 @@
+{
+  // Cloudflare Worker: GitHub OAuth token-exchange proxy for the Renovate
+  // Config Visualizer SPA. It does nothing but turn an OAuth `code` (or a
+  // `refresh_token`) into a GitHub user token — it never sees a config, a
+  // preset, or an API request. Stateless, no persistence, no body logging.
+  //
+  // Deploy: `pnpm dlx wrangler deploy` (see README.md for full provisioning).
+  "name": "rcv-oauth-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-07-01",
+
+  // Non-secret configuration. Override per environment / via the dashboard.
+  //   GITHUB_CLIENT_ID  — the GitHub App's client id (public, not a secret).
+  //   ALLOWED_ORIGINS   — comma-separated exact origins allowed to call this
+  //                       Worker; requests from any other origin get 403 and
+  //                       never reach GitHub.
+  "vars": {
+    "GITHUB_CLIENT_ID": "",
+    "ALLOWED_ORIGINS": "https://secustor.github.io,http://localhost:5173",
+  },
+
+  // GITHUB_CLIENT_SECRET is NOT stored here. Set it as an encrypted secret:
+  //   pnpm dlx wrangler secret put GITHUB_CLIENT_SECRET
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,15 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1)(yaml@2.9.0))
 
+  packages/oauth-worker:
+    devDependencies:
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1)(yaml@2.9.0))
+
 packages:
 
   '@arcanis/slice-ansi@1.1.1':

--- a/roadmap/007-shareable-links-and-repo-fetch.md
+++ b/roadmap/007-shareable-links-and-repo-fetch.md
@@ -1,6 +1,31 @@
 # 007 — Shareable links + fetch config from repo
 
-Milestone: M3 · Status: planned
+Milestone: M4 · Status: done 2026-07-23
+
+> Implemented as specified. Shareable links live entirely in the URL fragment
+> (`#config=<token>`): the payload — config text, file name, non-default
+> platform/endpoint, and view state (stage, selected preset's structural
+> identity, migration step) — is JSON → UTF-8 → native `CompressionStream`
+> `deflate-raw` → base64url, so no compression dependency and nothing hits
+> server logs. Tokens and injected presets are never encoded. The Renovate
+> version rides along for an honest version-drift notice on open. Opening a link
+> decodes, populates state and auto-runs, then translates the stored node
+> identity to the current run's node id (identities are stable across runs, ids
+> are not — the translation reuses `computeTreeStats` via helpers exported from
+> `PresetTree`). "Copy link" encodes on demand (never continuously syncing the
+> hash) and `history.replaceState`s the URL to match. Load-from-repo probes
+> Renovate's documented config-file locations in order via a new engine module
+> `shims/repo-config.ts` (`fetchRepoConfig`), reusing the 010 raw-file
+> transports/auth: first hit wins, a 404 falls through, an `ExternalHostError`
+> (CORS/auth/rate-limit) aborts the whole probe, `package.json`'s `renovate` key
+> is honored (object or `extends` string), and exhaustion throws a catchable
+> `RepoConfigNotFoundError`. A known host (github.com/gitlab.com/gitea.com/
+> codeberg.org) also sets the platform context so a later `local>` resolves;
+> a bare `owner/repo` uses the current context. Migration-step lifting gives the
+> top-level `MigrationSteps` optional controlled `index`/`onIndexChange` props
+> (the preset-detail instance stays uncontrolled). Deviations: none material —
+> the config-file-name list is hardcoded (upstream exports `getConfigFileNames()`
+> not the raw array) with a pointer to `config/app-strings.js`.
 
 ## Summary
 

--- a/roadmap/009-github-oauth-sign-in.md
+++ b/roadmap/009-github-oauth-sign-in.md
@@ -1,6 +1,39 @@
 # 009 — "Sign in with GitHub" instead of pasting a token
 
-Milestone: M3 · Status: planned
+Milestone: M4 · Status: done 2026-07-23
+
+> Implemented as specified. A new workspace package `packages/oauth-worker` is a
+> stateless Cloudflare Worker token-exchange proxy (pure `handleRequest(req,
+env)` + a thin default export; unit-tested with `fetch` stubbed, no wrangler
+> needed): CORS locked to an `ALLOWED_ORIGINS` allow-list (reflects the matched
+> origin, never `*`; other origins get 403 before GitHub is touched), `POST
+/exchange` and `POST /refresh` append the `client_secret` (Worker secret) and
+> pass GitHub's token JSON back verbatim, nothing logged. The SPA drives the
+> whole authorization-code + PKCE + `state` flow itself (`packages/app/src/
+oauth.ts`, pure logic): PKCE via `crypto.subtle`, token in memory mirrored to
+> `sessionStorage` (never `localStorage`, never a URL), silent single-flight
+> refresh, `signOut()` that clears `rcv.oauth.*` and links to GitHub's
+> authorization page for true revocation. The mount effect completes an OAuth
+> callback (QUERY `?code&state`) before the 007 share-hash decode and restores
+> the pre-sign-in fragment, so a share link survives the round-trip. `run.ts`
+> `ensureAuth` now prefers the (refreshable) OAuth token over the PAT for
+> `githubToken`. The four PAT fields moved from `localStorage` to
+> `sessionStorage` with a one-time migration, and the GitHub PAT input moved
+> from the toolbar into advanced settings as a labelled fallback. The error-path
+> UX — sign-in / "app not installed" hints on failed `github>` preset nodes and
+> on GitHub load-from-repo failures — is a shared `GithubAuthHint` component fed
+> minimal props (no coupling of `PresetTree` to `oauth.ts`).
+>
+> **Not yet provisioned (manual steps, documented in
+> `packages/oauth-worker/README.md`):** registering the GitHub App
+> (Contents:read-only, expiring tokens on, device flow off), deploying the
+> Worker + `wrangler secret put GITHUB_CLIENT_SECRET`, and setting the three
+> repo Actions variables (`VITE_GITHUB_CLIENT_ID`, `VITE_OAUTH_WORKER_URL`,
+> `VITE_GITHUB_APP_SLUG`). Until those exist the build variables are empty and
+> the whole feature stays hidden — the app works exactly as before with the PAT
+> fallback. One deliberate deviation: the Worker uses TypeScript's built-in
+> `WebWorker` lib for runtime globals instead of a `@cloudflare/workers-types`
+> devDependency, keeping the install network-free and CI lockfile-stable.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -13,6 +13,6 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
 | [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done    |
 | [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |
-| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | planned |
+| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | done    |
 | [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done    |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -11,8 +11,8 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done    |
 | [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done    |
 | [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
-| [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M3                   | planned |
+| [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done    |
 | [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |
-| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M3                   | planned |
+| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | planned |
 | [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done    |


### PR DESCRIPTION
Implements both M4 roadmap items (007, 009), plus a small pre-existing fix found during verification. Roadmap docs updated with implementation notes; 007/009 moved from M3 to M4 in the roadmap table per the milestone re-scope.

## 007 — Shareable links + fetch config from repo

- **Shareable links**: the config, file format, platform context and view state (selected stage, selected preset-node structural identity, migration step index) are encoded into the URL fragment as `#config=<base64url(deflate-raw)>` via the native `CompressionStream` API — no new dependency, nothing ever hits a server log, and tokens/injected presets are never included. Opening a link auto-runs the pipeline and restores the view; a version-drift notice appears when the link was made on a different Renovate version. Garbage hashes degrade to a notice + default state.
- **Load from repo**: accepts `owner/repo`, host URLs, or ssh forms; probes Renovate's real config-file detection order (mirrors `config/app-strings.js` + `workers/repository/init/merge.ts`, including the `package.json` `renovate`-key special case and empty-file→`{}` semantics) through the 010 platform transports (GitHub/GitLab/Gitea/Forgejo) with shared auth. Known-host URLs auto-derive the platform context (010's spec). The winning file is named in the success notice; 404s fall through, CORS/auth failures abort with an honest per-endpoint message.
- Engine: new `fetchRepoConfig` in `src/shims/repo-config.ts` (+14 tests: probe order, fallthrough, package.json cases, CORS/rate-limit abort, exhausted error, GitLab default-branch resolution, Gitea base64).

## 009 — Sign in with GitHub

- **New `packages/oauth-worker`**: a stateless Cloudflare Worker that does nothing but the OAuth `code`/`refresh_token` exchange — GitHub still requires the `client_secret` at the exchange and serves no CORS on `login/*`, so a pure SPA cannot do this alone. CORS locked to an explicit origin allow-list (never `*`), no body/token logging, secret only in the Worker secret store. 11 unit tests, including console-spy assertions that nothing is logged.
- **SPA flow**: PKCE + `state` authorization-code flow driven client-side against a GitHub App (Contents: read-only, per-repo grants, expiring tokens); callback exchange via the Worker; token in memory mirrored to `sessionStorage` with single-flight silent refresh; OAuth token takes precedence over the PAT. A share-link fragment survives the sign-in round trip.
- **Feature-gated**: hidden unless `VITE_GITHUB_CLIENT_ID`/`VITE_OAUTH_WORKER_URL` are set at build time (wired into CI from repo Actions variables — unset variables = feature cleanly off). Provisioning (GitHub App registration, `wrangler deploy`, secrets, repo variables) is manual and documented in `packages/oauth-worker/README.md`.
- **Migration**: all PAT fields moved localStorage → sessionStorage (one-time migration on load); the GitHub PAT drops to a "fallback" field in advanced settings. Failed `github>` preset nodes and repo loads now explain the likely fix (sign in when signed out; install the app on the repo when signed in).
- README privacy section rewritten around the Worker boundary: it never sees a config, preset, or API request; all GitHub content fetches stay browser → api.github.com.

## fix(005)

Provenance layer badges rendered a `<button>` nested inside the row-toggle `<button>` (invalid HTML, React hydration-error warning; badge clicks also toggled the row). Now a keyboard-accessible `span[role=button]` with `stopPropagation`.

## Verification

- Typecheck (3 packages), oxlint, oxfmt clean; app builds (with and without the `VITE_*` vars).
- Tests: engine 11 golden + 44 shimmed (14 new), oauth-worker 11 — all green.
- Browser-verified end to end on a dev server: share-link round trip (copy → fresh tab → auto-run → stage/node/migration-step restored, ancestors auto-expanded), bad-hash degradation, load-from-repo with `renovatebot/renovate` (winning file named, 1,092 presets resolved), legacy-token localStorage→sessionStorage migration, feature-off OAuth state (no sign-in UI, PAT fallback in advanced settings), and zero console errors after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ