### PR TITLE
feat: Milestone 3 — packageRules simulator, global + inherited config layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
         run: pnpm --filter @renovate-config-visualizer/engine test:shimmed
       - name: OAuth worker tests
         run: pnpm --filter @renovate-config-visualizer/oauth-worker test
+      - name: Dev module graph (Node-only import leaks)
+        # `vite dev` serves renovate's transitive deps raw (no CJS interop),
+        # a regime neither the Node tests nor the production build exercise.
+        run: pnpm --filter @renovate-config-visualizer/app check:dev-graph
       - name: Browser bundle build
         # Sign-in (009) is enabled only when these repo Actions variables are
         # set; absent = empty string = feature cleanly off (PAT UX remains).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   (manager, datasource, package name, versions, update type, …) and see which
   `packageRules` entries match — rule by rule, clause by clause, using
   Renovate's real matcher code — plus the final per-dependency config the
-  matching rules merge together.
+  matching rules merge together. Version ranges (`matchCurrentVersion`) are
+  evaluated by Renovate's real versioning modules for every ecosystem except
+  `conda`, whose ~3 MB WebAssembly parser is excluded from the browser bundle
+  (such clauses report an honest error instead).
 - **Golden tests** prove the shims don't alter behavior: the same fixtures run
   once against untouched Renovate modules and once through the browser module
   graph, and must produce byte-identical results.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ running in your browser**. Think "compiler explorer for Renovate configs".
   top-level options; the rest just contribute grouping packageRules), with
   windowed rendering, contribution roll-ups, search, a flat-table view and a
   "hide zero-contribution routers" toggle.
+- A **packageRules simulator**: describe a hypothetical dependency update
+  (manager, datasource, package name, versions, update type, …) and see which
+  `packageRules` entries match — rule by rule, clause by clause, using
+  Renovate's real matcher code — plus the final per-dependency config the
+  matching rules merge together.
 - **Golden tests** prove the shims don't alter behavior: the same fixtures run
   once against untouched Renovate modules and once through the browser module
   graph, and must produce byte-identical results.

--- a/README.md
+++ b/README.md
@@ -82,12 +82,27 @@ Note: Renovate's config code is not a public API, so the `renovate` dependency
 is pinned exactly and every Renovate release PR runs the full CI (golden tests
 plus browser build) to catch breakage per release.
 
+## Global + inherited config layers
+
+Self-hosted administrators can paste a **global config** (the JSON form of
+`config.js` / env / CLI) and an **inherited config** (`inheritConfig`)
+alongside the repo config. The pipeline then models the full layer stack a
+real Renovate run uses — defaults → `globalExtends` presets → global config →
+inherited config (validated with Renovate's `inherit` rules, its presets
+resolved, global-only options stripped) → repo presets → repo config — with
+two extra stages in the timeline and `global config` / `inherited config`
+badges in the per-key provenance view. Repo configs that try to set
+global-only options get Renovate's own boundary warning. `platform` /
+`endpoint` from the global config drive the platform-context control: it shows
+them marked "from global config", and changing it becomes an explicit,
+visibly-warned override.
+
 ## Sharing & loading
 
 **Shareable links** — _Copy link_ (next to _Run pipeline_) puts a link on your
 clipboard that reopens the current analysis: the config text, the file format,
-a non-default platform/endpoint, and your current view (selected stage, the
-selected preset node, the migration step). It is stored compressed in the URL
+a non-default platform/endpoint, any global/inherited config layers, and your
+current view (selected stage, the selected preset node, the migration step). It is stored compressed in the URL
 _fragment_ (`#config=…`), so it never reaches any server log, and opening a link
 auto-runs the same pipeline. The link records the Renovate version it was made
 with and warns you if you're now on a different one, since results can drift.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "check:dev-graph": "node scripts/check-dev-module-graph.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/app/scripts/check-dev-module-graph.mjs
+++ b/packages/app/scripts/check-dev-module-graph.mjs
@@ -1,0 +1,85 @@
+/**
+ * Guards the dev server's module graph against Node-only leaks.
+ *
+ * The test matrix covers two module regimes: Node (vitest golden/shimmed,
+ * where CJS default-imports interop fine) and the production build (rolldown
+ * converts CJS to ESM). `vite dev` is a third regime with weaker interop:
+ * renovate is excluded from prebundling, so its transitive deps are served
+ * raw from @fs — a CJS package reached by an ESM default import there throws
+ * "doesn't provide an export named: 'default'" at runtime only. That is
+ * invisible to every other check, so this script boots the dev server
+ * programmatically, crawls every literal import from the app entry (through
+ * the dynamic engine import), and fails on specifiers that only work in Node:
+ * `got` and its CJS cache chain (must stay cut by the merge-confidence shim)
+ * and un-aliased `node:` builtins.
+ */
+import { createServer } from "vite";
+
+const BANNED = [
+  {
+    pattern: /\/got@|\/got\//,
+    why: "got (Node HTTP) — the merge-confidence shim must keep it out",
+  },
+  {
+    pattern: /http-cache-semantics/,
+    why: "CJS dep of got's cache chain; no default export in dev",
+  },
+  { pattern: /cacheable-request|cacheable-lookup/, why: "got cache chain" },
+  { pattern: /^node:|\/@id\/node:/, why: "Node builtin reaching the browser graph" },
+];
+
+const server = await createServer({
+  logLevel: "error",
+  server: { middlewareMode: true },
+  optimizeDeps: { noDiscovery: true },
+});
+
+const importRe =
+  /from\s*["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)|import\s*["']([^"']+)["']/g;
+const seen = new Map(); // url -> importer
+const queue = ["/src/main.tsx"];
+seen.set(queue[0], "(entry)");
+const violations = [];
+
+while (queue.length > 0) {
+  const url = queue.shift();
+  // Prebundled chunks are already ESM-converted; crawling into them is noise.
+  if (url.includes("/.vite/") || url.endsWith(".css")) {
+    continue;
+  }
+  let result;
+  try {
+    result = await server.transformRequest(url);
+  } catch {
+    continue; // assets / virtual modules the transform pipeline rejects
+  }
+  if (!result?.code) {
+    continue;
+  }
+  for (const match of result.code.matchAll(importRe)) {
+    const spec = match[1] ?? match[2] ?? match[3];
+    if (!spec || spec.startsWith("data:")) {
+      continue;
+    }
+    for (const { pattern, why } of BANNED) {
+      if (pattern.test(spec)) {
+        violations.push(`${spec}\n    imported by ${url}\n    (${why})`);
+      }
+    }
+    if (spec.startsWith("/") && !seen.has(spec)) {
+      seen.set(spec, url);
+      queue.push(spec);
+    }
+  }
+}
+
+await server.close();
+
+if (violations.length > 0) {
+  console.error(`Dev module graph check FAILED — ${violations.length} banned import(s):\n`);
+  for (const v of violations) {
+    console.error(`  ${v}\n`);
+  }
+  process.exit(1);
+}
+console.log(`Dev module graph clean: ${seen.size} modules crawled, no Node-only imports.`);

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -11,6 +11,7 @@ import { type AuthState, GithubAuthHint } from "./components/GithubAuthHint";
 import { MessagesPanel } from "./components/MessagesPanel";
 import { MigrationSteps } from "./components/MigrationSteps";
 import { identityForNodeId, nodeIdForIdentity, PresetTree } from "./components/PresetTree";
+import { RuleSimulator } from "./components/RuleSimulator";
 import { StageDiff } from "./components/StageDiff";
 import { StageTimeline } from "./components/StageTimeline";
 import { OptionDocsProvider } from "./option-docs";
@@ -268,7 +269,14 @@ export function App() {
   const hasGlobalContext = globalPlatform !== undefined || globalEndpoint !== undefined;
   const reflectGlobal = hasGlobalContext && !platformOverride;
   const displayPlatform = reflectGlobal && globalPlatform !== undefined ? globalPlatform : platform;
-  const displayEndpoint = reflectGlobal && globalEndpoint !== undefined ? globalEndpoint : endpoint;
+  // A global-config platform also displaces the toolbar endpoint (it belongs
+  // to the toolbar's platform): fall back to the global platform's default.
+  const displayEndpoint =
+    reflectGlobal && globalEndpoint !== undefined
+      ? globalEndpoint
+      : reflectGlobal && globalPlatform !== undefined
+        ? (PLATFORM_ENDPOINTS[globalPlatform] ?? "")
+        : endpoint;
 
   // An override only exists relative to global-config values; when the global
   // config stops defining platform/endpoint, snap back to normal behavior.
@@ -982,6 +990,7 @@ export function App() {
               installUrl={installUrl()}
             />
             <EffectiveConfig result={result} onSelectPreset={setSelectedNodeId} />
+            <RuleSimulator result={result} />
           </>
         ) : null}
       </main>

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -125,6 +125,33 @@ interface RunInputs {
   content: string;
   platform: string;
   endpoint: string;
+  /** Parsed 008 layers; absent = layer off. */
+  globalConfig?: Record<string, unknown>;
+  inheritedConfig?: Record<string, unknown>;
+  /** The user explicitly overrode the global config's platform/endpoint. */
+  platformOverride?: boolean;
+}
+
+interface LayerParse {
+  config?: Record<string, unknown>;
+  error?: string;
+}
+
+/** Parses an optional JSON config layer (008). Empty text = layer off. */
+function parseLayerText(text: string): LayerParse {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return { error: "must be a JSON object" };
+    }
+    return { config: parsed as Record<string, unknown> };
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 /** Non-secret settings (platform/endpoint) persist across tabs → localStorage. */
@@ -182,6 +209,11 @@ export function App() {
   const [forgejoToken, setForgejoToken] = useState(() => readSession(FORGEJO_TOKEN_KEY, ""));
   const [platform, setPlatform] = useState(() => readLocal(PLATFORM_KEY, "github"));
   const [endpoint, setEndpoint] = useState(() => readLocal(ENDPOINT_KEY, "https://api.github.com"));
+  // 008 layer inputs (JSON text; empty = layer off) + the explicit override of
+  // the global config's platform/endpoint (010 "reflect, then override").
+  const [globalText, setGlobalText] = useState("");
+  const [inheritedText, setInheritedText] = useState("");
+  const [platformOverride, setPlatformOverride] = useState(false);
   // OAuth sign-in (009). Configured only when both build-time vars are present;
   // otherwise the whole feature stays hidden and the PAT fallback remains.
   const oauthConfig = useMemo(() => getOAuthConfig(), []);
@@ -225,6 +257,27 @@ export function App() {
     setMigrationStepIndex(0);
   }, [result]);
 
+  const globalParse = useMemo(() => parseLayerText(globalText), [globalText]);
+  const inheritedParse = useMemo(() => parseLayerText(inheritedText), [inheritedText]);
+  // Platform context values the global config carries (008/010 interplay): the
+  // control reflects them unless the user explicitly overrides.
+  const globalPlatform =
+    typeof globalParse.config?.platform === "string" ? globalParse.config.platform : undefined;
+  const globalEndpoint =
+    typeof globalParse.config?.endpoint === "string" ? globalParse.config.endpoint : undefined;
+  const hasGlobalContext = globalPlatform !== undefined || globalEndpoint !== undefined;
+  const reflectGlobal = hasGlobalContext && !platformOverride;
+  const displayPlatform = reflectGlobal && globalPlatform !== undefined ? globalPlatform : platform;
+  const displayEndpoint = reflectGlobal && globalEndpoint !== undefined ? globalEndpoint : endpoint;
+
+  // An override only exists relative to global-config values; when the global
+  // config stops defining platform/endpoint, snap back to normal behavior.
+  useEffect(() => {
+    if (!hasGlobalContext) {
+      setPlatformOverride(false);
+    }
+  }, [hasGlobalContext]);
+
   // Apply pending link view state after the run's result exists. Declared after
   // the reset effect so it wins over the reset for a decoded link.
   useEffect(() => {
@@ -250,9 +303,37 @@ export function App() {
     }
   }, [result]);
 
+  // An unparseable 008 layer never silently runs without it — block instead.
+  function blockedByLayerErrors(): boolean {
+    if (globalParse.error) {
+      setFatal(
+        `The global config is not valid JSON (${globalParse.error}). Fix it or clear the field to run.`,
+      );
+      return true;
+    }
+    if (inheritedParse.error) {
+      setFatal(
+        `The inherited config is not valid JSON (${inheritedParse.error}). Fix it or clear the field to run.`,
+      );
+      return true;
+    }
+    return false;
+  }
+
   async function onRun(overrideInjected?: InjectionMap, overrideInputs?: RunInputs) {
     const injectedPresets = overrideInjected ?? injected;
-    const inputs: RunInputs = overrideInputs ?? { fileName, content, platform, endpoint };
+    if (!overrideInputs && blockedByLayerErrors()) {
+      return;
+    }
+    const inputs: RunInputs = overrideInputs ?? {
+      fileName,
+      content,
+      platform,
+      endpoint,
+      globalConfig: globalParse.config,
+      inheritedConfig: inheritedParse.config,
+      platformOverride: platformOverride && hasGlobalContext,
+    };
     setRunning(true);
     setFatal(null);
     try {
@@ -324,6 +405,12 @@ export function App() {
       persistLocal(PLATFORM_KEY, nextPlatform);
       setEndpoint(nextEndpoint);
       persistLocal(ENDPOINT_KEY, nextEndpoint);
+      // 008 layers ride along in v2 links; absent = layers off.
+      setGlobalText(payload.globalConfig ? JSON.stringify(payload.globalConfig, null, 2) : "");
+      setInheritedText(
+        payload.inheritedConfig ? JSON.stringify(payload.inheritedConfig, null, 2) : "",
+      );
+      setPlatformOverride(payload.platformOverride === true);
       pendingViewRef.current = payload.view ?? null;
       const current = await getRenovateVersion();
       if (!cancelled && payload.renovate && payload.renovate !== current) {
@@ -337,6 +424,9 @@ export function App() {
           content: payload.config,
           platform: nextPlatform,
           endpoint: nextEndpoint,
+          globalConfig: payload.globalConfig,
+          inheritedConfig: payload.inheritedConfig,
+          platformOverride: payload.platformOverride === true,
         });
       }
     })();
@@ -355,6 +445,11 @@ export function App() {
   const onTokenChange = makeTokenHandler(TOKEN_KEY, setToken);
 
   function onPlatformChange(value: string) {
+    // With a global config supplying platform/endpoint, a manual change is an
+    // explicit override (008/010) — flagged with a visible warning below.
+    if (hasGlobalContext) {
+      setPlatformOverride(true);
+    }
     setPlatform(value);
     persistLocal(PLATFORM_KEY, value);
     // Snap the endpoint to the new platform's default; the user can still edit.
@@ -364,6 +459,9 @@ export function App() {
   }
 
   function onEndpointChange(value: string) {
+    if (hasGlobalContext) {
+      setPlatformOverride(true);
+    }
     setEndpoint(value);
     persistLocal(ENDPOINT_KEY, value);
   }
@@ -386,7 +484,7 @@ export function App() {
     void onRun(next);
   }
 
-  const usesLocal = platform !== "github";
+  const usesLocal = displayPlatform !== "github";
 
   // Granular migrate-stage steps (004); the migrate stage shows the stepper
   // when any exist, otherwise falls back to the whole-stage blob diff.
@@ -424,6 +522,9 @@ export function App() {
       platform,
       endpoint,
       renovate,
+      globalConfig: globalParse.config,
+      inheritedConfig: inheritedParse.config,
+      platformOverride: platformOverride && hasGlobalContext,
       view,
     });
     const url = buildShareUrl(shareToken);
@@ -469,6 +570,9 @@ export function App() {
       repoEndpoint = endpoint;
     }
 
+    if (blockedByLayerErrors()) {
+      return;
+    }
     setRepoLoading(true);
     setFatal(null);
     setNotice(null);
@@ -497,6 +601,9 @@ export function App() {
         content: loaded.content,
         platform: repoPlatform,
         endpoint: repoEndpoint || endpoint,
+        globalConfig: globalParse.config,
+        inheritedConfig: inheritedParse.config,
+        platformOverride: platformOverride && hasGlobalContext,
       });
     } catch (err) {
       const e = err as { name?: string; probed?: string[]; err?: { message?: string } };
@@ -541,6 +648,73 @@ export function App() {
         </p>
 
         <ConfigEditor fileName={fileName} value={content} onChange={setContent} />
+
+        <details className="advanced-settings">
+          <summary>
+            Global config (self-hosted admin)
+            <span className="advanced-hint">
+              {" "}
+              — the layer set via config.js / env / CLI
+              {globalParse.config ? " · active" : ""}
+              {globalParse.error ? " · invalid JSON" : ""}
+            </span>
+          </summary>
+          <div className="advanced-body">
+            <p className="advanced-note">
+              JSON only. Merges between the defaults and the repo config, after its own{" "}
+              <code>globalExtends</code> presets; options like <code>platform</code>,{" "}
+              <code>endpoint</code> or <code>onboarding</code> become run context instead of
+              merging. Leave empty to run without this layer.
+            </p>
+            <textarea
+              className="layer-editor"
+              placeholder='{ "globalExtends": ["config:best-practices"], "platform": "gitlab" }'
+              value={globalText}
+              onChange={(e) => setGlobalText(e.target.value)}
+              spellCheck={false}
+              rows={8}
+            />
+            {globalParse.error ? (
+              <p className="layer-editor-error">
+                Not valid JSON: {globalParse.error}. The pipeline won&apos;t run until this parses
+                or the field is cleared.
+              </p>
+            ) : null}
+          </div>
+        </details>
+
+        <details className="advanced-settings">
+          <summary>
+            Inherited config (inheritConfig)
+            <span className="advanced-hint">
+              {" "}
+              — the org-level layer between global and repo config
+              {inheritedParse.config ? " · active" : ""}
+              {inheritedParse.error ? " · invalid JSON" : ""}
+            </span>
+          </summary>
+          <div className="advanced-body">
+            <p className="advanced-note">
+              JSON only. Validated with Renovate&apos;s <code>inherit</code> rules, its presets
+              resolved, global-only options stripped — then merged between the global layer and the
+              repo config. Leave empty to run without this layer.
+            </p>
+            <textarea
+              className="layer-editor"
+              placeholder='{ "extends": ["github>my-org/renovate-config"], "automerge": false }'
+              value={inheritedText}
+              onChange={(e) => setInheritedText(e.target.value)}
+              spellCheck={false}
+              rows={8}
+            />
+            {inheritedParse.error ? (
+              <p className="layer-editor-error">
+                Not valid JSON: {inheritedParse.error}. The pipeline won&apos;t run until this
+                parses or the field is cleared.
+              </p>
+            ) : null}
+          </div>
+        </details>
 
         <form
           className="repo-load"
@@ -636,24 +810,64 @@ export function App() {
             <div className="advanced-row">
               <label>
                 Platform
-                <select value={platform} onChange={(e) => onPlatformChange(e.target.value)}>
+                <select value={displayPlatform} onChange={(e) => onPlatformChange(e.target.value)}>
                   {PLATFORMS.map((p) => (
                     <option key={p} value={p}>
                       {p}
                     </option>
                   ))}
+                  {!PLATFORMS.includes(displayPlatform) ? (
+                    <option value={displayPlatform}>{displayPlatform}</option>
+                  ) : null}
                 </select>
               </label>
               <label className="grow">
                 Endpoint
                 <input
                   type="text"
-                  placeholder={PLATFORM_ENDPOINTS[platform] || "not fetched in the browser"}
-                  value={endpoint}
+                  placeholder={PLATFORM_ENDPOINTS[displayPlatform] || "not fetched in the browser"}
+                  value={displayEndpoint}
                   onChange={(e) => onEndpointChange(e.target.value)}
                 />
               </label>
             </div>
+            {reflectGlobal ? (
+              <p className="advanced-note platform-from-global">
+                <span className="badge prov-global">from global config</span>{" "}
+                {globalPlatform !== undefined ? (
+                  <>
+                    platform <code>{globalPlatform}</code>
+                  </>
+                ) : null}
+                {globalPlatform !== undefined && globalEndpoint !== undefined ? " and " : null}
+                {globalEndpoint !== undefined ? (
+                  <>
+                    endpoint <code>{globalEndpoint}</code>
+                  </>
+                ) : null}{" "}
+                come from the pasted global config — a real Renovate run would use them. Changing
+                the control overrides them for this visualization.
+              </p>
+            ) : null}
+            {platformOverride && hasGlobalContext ? (
+              <p className="advanced-note platform-override-warning">
+                Overriding <code>platform</code>/<code>endpoint</code> from the global config — a
+                real Renovate run would use <code>{globalPlatform ?? displayPlatform}</code>
+                {" / "}
+                <code>
+                  {globalEndpoint ??
+                    (PLATFORM_ENDPOINTS[globalPlatform ?? ""] || "the platform default")}
+                </code>
+                .{" "}
+                <button
+                  type="button"
+                  className="platform-override-clear"
+                  onClick={() => setPlatformOverride(false)}
+                >
+                  use global config values
+                </button>
+              </p>
+            ) : null}
             {usesLocal && !(platform in PLATFORM_ENDPOINTS && PLATFORM_ENDPOINTS[platform]) ? (
               <p className="advanced-note">
                 <code>{platform}</code> presets are not fetched in the browser — a real Renovate run

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -48,6 +48,12 @@ function layerLabel(layer: ProvenanceStep["layer"]): string {
   if (layer.kind === "defaults") {
     return "default";
   }
+  if (layer.kind === "global") {
+    return "global config";
+  }
+  if (layer.kind === "inherited") {
+    return "inherited config";
+  }
   if (layer.kind === "repo") {
     return "repo config";
   }

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -1,0 +1,615 @@
+import { useEffect, useMemo, useState } from "react";
+import type {
+  ClauseEvaluation,
+  DependencyDescriptor,
+  RuleEvaluation,
+  SimulationResult,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
+import { OptionKey } from "../option-docs";
+import { ConfigJson } from "./ConfigJson";
+
+/**
+ * Roadmap 006: the packageRules simulator. Describe a hypothetical dependency
+ * update and see which of the CURRENT run's `finalConfig.packageRules` match
+ * — rule by rule, clause by clause, with the config each matching rule
+ * merges — plus the final per-dependency config Renovate would use.
+ * Evaluation is on demand (Simulate button; quick-fill presets also run) via
+ * the engine's `simulatePackageRules`, loaded through the same dynamic import
+ * that keeps the renovate chunk out of the initial bundle.
+ */
+
+interface FormState {
+  manager: string;
+  datasource: string;
+  packageName: string;
+  depName: string;
+  depType: string;
+  packageFile: string;
+  currentValue: string;
+  currentVersion: string;
+  newValue: string;
+  updateType: string;
+  lockedVersion: string;
+  lockFiles: string;
+  versioning: string;
+  sourceUrl: string;
+  registryUrls: string;
+  categories: string;
+  repository: string;
+  baseBranch: string;
+  currentVersionTimestamp: string;
+}
+
+const EMPTY_FORM: FormState = {
+  manager: "",
+  datasource: "",
+  packageName: "",
+  depName: "",
+  depType: "",
+  packageFile: "",
+  currentValue: "",
+  currentVersion: "",
+  newValue: "",
+  updateType: "",
+  lockedVersion: "",
+  lockFiles: "",
+  versioning: "",
+  sourceUrl: "",
+  registryUrls: "",
+  categories: "",
+  repository: "",
+  baseBranch: "",
+  currentVersionTimestamp: "",
+};
+
+const UPDATE_TYPES = [
+  "major",
+  "minor",
+  "patch",
+  "pin",
+  "digest",
+  "lockFileMaintenance",
+  "rollback",
+  "replacement",
+  "bump",
+];
+
+/** Quick-fill presets for common dependency shapes. */
+const QUICK_FILLS: { label: string; fill: Partial<FormState> }[] = [
+  {
+    label: "npm dependency",
+    fill: {
+      manager: "npm",
+      datasource: "npm",
+      packageFile: "package.json",
+      packageName: "lodash",
+      depType: "dependencies",
+      currentValue: "4.17.20",
+      newValue: "4.17.21",
+      updateType: "patch",
+    },
+  },
+  {
+    label: "Dockerfile image",
+    fill: {
+      manager: "dockerfile",
+      datasource: "docker",
+      packageFile: "Dockerfile",
+      packageName: "node",
+      currentValue: "20-alpine",
+      newValue: "22-alpine",
+      updateType: "major",
+    },
+  },
+  {
+    label: "GitHub Action",
+    fill: {
+      manager: "github-actions",
+      datasource: "github-tags",
+      packageFile: ".github/workflows/ci.yml",
+      packageName: "actions/checkout",
+      currentValue: "v4",
+      newValue: "v5",
+      updateType: "major",
+    },
+  },
+  {
+    label: "pep621 / pip",
+    fill: {
+      manager: "pep621",
+      datasource: "pypi",
+      packageFile: "pyproject.toml",
+      packageName: "requests",
+      depType: "project.dependencies",
+      currentValue: "2.31.0",
+      newValue: "2.32.0",
+      updateType: "minor",
+    },
+  },
+];
+
+function trimmed(value: string): string | undefined {
+  const t = value.trim();
+  return t === "" ? undefined : t;
+}
+
+function list(value: string): string[] | undefined {
+  const items = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+  return items.length > 0 ? items : undefined;
+}
+
+function toDescriptor(form: FormState): DependencyDescriptor {
+  // "bump" is a real Renovate updateType, but matchUpdateTypes only sees it
+  // via the isBump flag on in-range updates — set both.
+  const updateType = trimmed(form.updateType);
+  return {
+    manager: trimmed(form.manager),
+    datasource: trimmed(form.datasource),
+    packageName: trimmed(form.packageName),
+    depName: trimmed(form.depName),
+    depType: trimmed(form.depType),
+    packageFile: trimmed(form.packageFile),
+    currentValue: trimmed(form.currentValue),
+    currentVersion: trimmed(form.currentVersion),
+    newValue: trimmed(form.newValue),
+    updateType,
+    ...(updateType === "bump" ? { isBump: true } : {}),
+    lockedVersion: trimmed(form.lockedVersion),
+    lockFiles: list(form.lockFiles),
+    versioning: trimmed(form.versioning),
+    sourceUrl: trimmed(form.sourceUrl),
+    registryUrls: list(form.registryUrls),
+    categories: list(form.categories),
+    repository: trimmed(form.repository),
+    baseBranch: trimmed(form.baseBranch),
+    currentVersionTimestamp: trimmed(form.currentVersionTimestamp),
+  };
+}
+
+function previewValue(value: unknown, max = 60): string {
+  const text = JSON.stringify(value) ?? "undefined";
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+function inputsPreview(clause: ClauseEvaluation): string {
+  const entries = Object.entries(clause.inputValues);
+  if (entries.length === 0) {
+    return "no input value set";
+  }
+  return entries.map(([key, value]) => `${key} = ${previewValue(value, 40)}`).join(", ");
+}
+
+function clauseIcon(state: ClauseEvaluation["state"]): string {
+  if (state === "matched") {
+    return "✓";
+  }
+  if (state === "no-match" || state === "error") {
+    return "✗";
+  }
+  return "⚠";
+}
+
+function clauseExplanation(clause: ClauseEvaluation): string {
+  switch (clause.state) {
+    case "matched":
+      return `matched (${inputsPreview(clause)})`;
+    case "no-match":
+      return `no match against ${inputsPreview(clause)}`;
+    default:
+      return clause.note ?? clause.state;
+  }
+}
+
+const VERDICT_LABEL: Record<RuleEvaluation["verdict"], string> = {
+  matched: "matched",
+  "no-match": "no match",
+  "not-simulated": "not simulated",
+};
+
+/** Short label: the rule's first present selector clause + value preview. */
+function ruleLabel(rule: RuleEvaluation): string {
+  const first = rule.clauses[0];
+  if (!first) {
+    return "no match* selectors";
+  }
+  return `${first.key}: ${previewValue(first.value, 48)}`;
+}
+
+function RuleRow({ rule }: { rule: RuleEvaluation }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className={`sim-rule${expanded ? " expanded" : ""}`}>
+      <button
+        type="button"
+        className="sim-rule-head"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+      >
+        <span className="caret">{expanded ? "▾" : "▸"}</span>
+        <span className="sim-rule-index">#{rule.index + 1}</span>
+        <span className="sim-rule-label">{ruleLabel(rule)}</span>
+        <span className={`badge sim-verdict verdict-${rule.verdict}`}>
+          {VERDICT_LABEL[rule.verdict]}
+        </span>
+      </button>
+      {expanded ? (
+        <div className="sim-rule-detail">
+          {rule.clauses.length === 0 ? (
+            <p className="empty-note">No match* clauses — the rule applies to everything.</p>
+          ) : (
+            <ul className="sim-clauses">
+              {rule.clauses.map((clause) => (
+                <li key={clause.key} className={`sim-clause state-${clause.state}`}>
+                  <span className="sim-clause-icon">{clauseIcon(clause.state)}</span>
+                  <span className="sim-clause-text">
+                    <code>{clause.key}</code>: {previewValue(clause.value, 60)} —{" "}
+                    {clauseExplanation(clause)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {rule.notes.map((note) => (
+            <p key={note} className="sim-note">
+              {note}
+            </p>
+          ))}
+          {rule.merged && rule.merged.length > 0 ? (
+            <div className="sim-merged">
+              <div className="sim-merged-title">Applied to the dependency config</div>
+              <ul>
+                {rule.merged.map((m) => (
+                  <li key={m.key}>
+                    <span className="sim-merged-key">
+                      <OptionKey name={m.key} flagUnknown />
+                    </span>
+                    {"before" in m ? (
+                      <>
+                        {" "}
+                        <span className="sim-merged-before">{previewValue(m.before)}</span> →{" "}
+                      </>
+                    ) : (
+                      " → "
+                    )}
+                    <span className="sim-merged-after">{previewValue(m.after)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <label className="sim-field">
+      {label}
+      <input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => onChange(e.target.value)}
+        spellCheck={false}
+      />
+    </label>
+  );
+}
+
+export function RuleSimulator({ result }: { result: TraceResult }) {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [sim, setSim] = useState<SimulationResult | null>(null);
+  const [ranKey, setRanKey] = useState<string | null>(null);
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // A new run invalidates any previous simulation (the rules may differ).
+  useEffect(() => {
+    setSim(null);
+    setRanKey(null);
+    setError(null);
+  }, [result]);
+
+  const finalConfig = result.finalConfig;
+  const packageRules = useMemo(
+    () => (Array.isArray(finalConfig?.packageRules) ? finalConfig.packageRules : []),
+    [finalConfig],
+  );
+
+  // Keys the rules changed vs. the pre-rules effective config, for the final
+  // section's summary chips.
+  const changedKeys = useMemo(() => {
+    if (!sim || !finalConfig) {
+      return [];
+    }
+    const base: Record<string, unknown> = { ...finalConfig };
+    delete base.packageRules;
+    const keys = new Set([...Object.keys(base), ...Object.keys(sim.finalDependencyConfig)]);
+    return [...keys]
+      .filter((key) => JSON.stringify(base[key]) !== JSON.stringify(sim.finalDependencyConfig[key]))
+      .toSorted();
+  }, [sim, finalConfig]);
+
+  if (!finalConfig) {
+    return null;
+  }
+
+  async function simulate(nextForm: FormState) {
+    if (!finalConfig) {
+      return;
+    }
+    setRunning(true);
+    setError(null);
+    try {
+      const engine = await import("@renovate-config-visualizer/engine");
+      const simResult = await engine.simulatePackageRules({
+        config: finalConfig,
+        dep: toDescriptor(nextForm),
+      });
+      setSim(simResult);
+      setRanKey(JSON.stringify(nextForm));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  function quickFill(fill: Partial<FormState>) {
+    const next = { ...EMPTY_FORM, ...fill };
+    setForm(next);
+    void simulate(next);
+  }
+
+  if (packageRules.length === 0) {
+    return (
+      <div className="card">
+        <div className="card-title">packageRules simulator</div>
+        <p className="empty-note">
+          This config has no <code>packageRules</code> — nothing to simulate. Rules added by presets
+          would appear here after a run that resolves them.
+        </p>
+      </div>
+    );
+  }
+
+  const stale = sim !== null && ranKey !== JSON.stringify(form);
+  const matchedCount = sim?.rules.filter((r) => r.verdict === "matched").length ?? 0;
+
+  return (
+    <div className="card">
+      <div className="card-title">
+        packageRules simulator
+        <span className="sim-title-hint">
+          {" "}
+          — which of the {packageRules.length} rule{packageRules.length === 1 ? "" : "s"} hit a
+          hypothetical update?
+        </span>
+      </div>
+      <div className="sim-presets">
+        {QUICK_FILLS.map(({ label, fill }) => (
+          <button key={label} type="button" onClick={() => quickFill(fill)}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="sim-form">
+        <Field
+          label="manager"
+          value={form.manager}
+          onChange={(v) => setForm({ ...form, manager: v })}
+          placeholder="npm"
+        />
+        <Field
+          label="datasource"
+          value={form.datasource}
+          onChange={(v) => setForm({ ...form, datasource: v })}
+          placeholder="npm"
+        />
+        <Field
+          label="packageName"
+          value={form.packageName}
+          onChange={(v) => setForm({ ...form, packageName: v })}
+          placeholder="lodash"
+        />
+        <Field
+          label="depName"
+          value={form.depName}
+          onChange={(v) => setForm({ ...form, depName: v })}
+          placeholder="= packageName"
+        />
+        <Field
+          label="depType"
+          value={form.depType}
+          onChange={(v) => setForm({ ...form, depType: v })}
+          placeholder="dependencies"
+        />
+        <Field
+          label="packageFile"
+          value={form.packageFile}
+          onChange={(v) => setForm({ ...form, packageFile: v })}
+          placeholder="package.json"
+        />
+        <Field
+          label="currentValue"
+          value={form.currentValue}
+          onChange={(v) => setForm({ ...form, currentValue: v })}
+          placeholder="4.17.20"
+        />
+        <Field
+          label="newValue"
+          value={form.newValue}
+          onChange={(v) => setForm({ ...form, newValue: v })}
+          placeholder="4.17.21"
+        />
+        <label className="sim-field">
+          updateType
+          <select
+            value={form.updateType}
+            onChange={(e) => setForm({ ...form, updateType: e.target.value })}
+          >
+            <option value="">(unset)</option>
+            {UPDATE_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <details className="sim-more">
+        <summary>
+          More fields
+          <span className="advanced-hint"> — versioning, lock files, URLs, categories, age…</span>
+        </summary>
+        <div className="sim-form">
+          <Field
+            label="currentVersion"
+            value={form.currentVersion}
+            onChange={(v) => setForm({ ...form, currentVersion: v })}
+          />
+          <Field
+            label="lockedVersion"
+            value={form.lockedVersion}
+            onChange={(v) => setForm({ ...form, lockedVersion: v })}
+          />
+          <Field
+            label="lockFiles (comma-separated)"
+            value={form.lockFiles}
+            onChange={(v) => setForm({ ...form, lockFiles: v })}
+            placeholder="package-lock.json"
+          />
+          <Field
+            label="versioning"
+            value={form.versioning}
+            onChange={(v) => setForm({ ...form, versioning: v })}
+            placeholder="semver"
+          />
+          <Field
+            label="sourceUrl"
+            value={form.sourceUrl}
+            onChange={(v) => setForm({ ...form, sourceUrl: v })}
+            placeholder="https://github.com/lodash/lodash"
+          />
+          <Field
+            label="registryUrls (comma-separated)"
+            value={form.registryUrls}
+            onChange={(v) => setForm({ ...form, registryUrls: v })}
+            placeholder="https://registry.npmjs.org"
+          />
+          <Field
+            label="categories (comma-separated)"
+            value={form.categories}
+            onChange={(v) => setForm({ ...form, categories: v })}
+            placeholder="js"
+          />
+          <Field
+            label="repository"
+            value={form.repository}
+            onChange={(v) => setForm({ ...form, repository: v })}
+            placeholder="my-org/my-repo"
+          />
+          <Field
+            label="baseBranch"
+            value={form.baseBranch}
+            onChange={(v) => setForm({ ...form, baseBranch: v })}
+            placeholder="main"
+          />
+          <Field
+            label="currentVersionTimestamp"
+            value={form.currentVersionTimestamp}
+            onChange={(v) => setForm({ ...form, currentVersionTimestamp: v })}
+            placeholder="2024-01-01T00:00:00.000Z"
+          />
+        </div>
+      </details>
+      <div className="sim-actions">
+        <button
+          type="button"
+          className="primary"
+          onClick={() => void simulate(form)}
+          disabled={running}
+        >
+          {running ? "Simulating…" : "Simulate"}
+        </button>
+        {stale ? (
+          <span className="sim-stale">inputs changed — simulate again to refresh</span>
+        ) : null}
+      </div>
+
+      {error ? <p className="sim-error">Simulation failed: {error}</p> : null}
+
+      {sim ? (
+        <div className="sim-results">
+          {[...sim.errors, ...sim.warnings].length > 0 ? (
+            <ul className="messages sim-messages">
+              {sim.errors.map((m, i) => (
+                <li key={`e${i}`} className="error">
+                  <strong>{m.topic}</strong>: {m.message}
+                </li>
+              ))}
+              {sim.warnings.map((m, i) => (
+                <li key={`w${i}`} className="warn">
+                  <strong>{m.topic}</strong>: {m.message}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {sim.notes.map((note) => (
+            <p key={note} className="sim-note">
+              {note}
+            </p>
+          ))}
+          <div className="sim-summary">
+            {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched
+          </div>
+          <div className="sim-rules">
+            {sim.rules.map((rule) => (
+              <RuleRow key={rule.index} rule={rule} />
+            ))}
+          </div>
+          <div className="sim-final">
+            <div className="sim-merged-title">Final per-dependency config</div>
+            {changedKeys.length > 0 ? (
+              <p className="sim-changed">
+                Rules changed:{" "}
+                {changedKeys.map((key, i) => (
+                  <span key={key}>
+                    {i > 0 ? ", " : null}
+                    <code>
+                      <OptionKey name={key} flagUnknown />
+                    </code>
+                  </span>
+                ))}
+              </p>
+            ) : (
+              <p className="sim-changed">No rule changed anything for this dependency.</p>
+            )}
+            <details>
+              <summary>Show the full resolved dependency config</summary>
+              <pre className="config-view">
+                <ConfigJson value={sim.finalDependencyConfig} />
+              </pre>
+            </details>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/components/StageDiff.tsx
+++ b/packages/app/src/components/StageDiff.tsx
@@ -13,6 +13,23 @@ export const StageDiff = memo(function StageDiff({ result, stage }: Props) {
   const failed = stageEvents.findLast((e) => e.kind === "stage-error");
 
   if (result.stageStatus[stage] === "skipped") {
+    // The 008 layer stages skip when their input is absent, not on failure.
+    if (stage === "global") {
+      return (
+        <div className="empty-note">
+          No global config provided — add one under &ldquo;Global config (self-hosted admin)&rdquo;
+          to model a self-hosted run&rsquo;s admin layer.
+        </div>
+      );
+    }
+    if (stage === "inherit") {
+      return (
+        <div className="empty-note">
+          No inherited config provided — add one under &ldquo;Inherited config
+          (inheritConfig)&rdquo; to model the layer injected between global and repo config.
+        </div>
+      );
+    }
     return <div className="empty-note">Stage was skipped because an earlier stage failed.</div>;
   }
   if (failed) {

--- a/packages/app/src/components/StageTimeline.tsx
+++ b/packages/app/src/components/StageTimeline.tsx
@@ -1,8 +1,19 @@
 import type { StageId, TraceResult } from "@renovate-config-visualizer/engine";
 
-const STAGE_ORDER: StageId[] = ["parse", "migrate", "massage", "validate", "preset", "merge"];
+const STAGE_ORDER: StageId[] = [
+  "global",
+  "inherit",
+  "parse",
+  "migrate",
+  "massage",
+  "validate",
+  "preset",
+  "merge",
+];
 
 const STAGE_LABELS: Record<StageId, string> = {
+  global: "Global config",
+  inherit: "Inherited",
   parse: "Parse",
   migrate: "Migrate",
   massage: "Massage",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1280,3 +1280,292 @@ pre.config-view.prov-before {
   padding: 0;
   text-decoration: underline;
 }
+
+/* ---------- packageRules simulator (006) ---------- */
+
+.sim-title-hint {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+.sim-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.6rem 0.75rem 0;
+}
+
+.sim-presets button {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.7rem;
+}
+
+.sim-presets button:hover {
+  border-color: var(--accent);
+}
+
+.sim-form {
+  display: grid;
+  gap: 0.5rem 0.75rem;
+  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+  padding: 0.6rem 0.75rem 0;
+}
+
+.sim-field {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.78rem;
+  gap: 0.15rem;
+}
+
+.sim-field input,
+.sim-field select {
+  background: light-dark(#ffffff, #0d1117);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  padding: 0.25rem 0.45rem;
+}
+
+.sim-more {
+  padding: 0.5rem 0.75rem 0;
+}
+
+.sim-more > summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.sim-more .sim-form {
+  padding: 0.5rem 0 0;
+}
+
+.sim-actions {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.sim-actions button.primary {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 0.3rem 1rem;
+}
+
+.sim-actions button.primary:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
+.sim-stale {
+  color: var(--warn);
+  font-size: 0.82rem;
+}
+
+.sim-error {
+  color: var(--error);
+  padding: 0 0.75rem 0.75rem;
+}
+
+.sim-results {
+  border-top: 1px solid var(--border);
+  margin-top: 0.25rem;
+  padding: 0.6rem 0.75rem 0.75rem;
+}
+
+.sim-messages {
+  margin: 0 0 0.5rem;
+  padding-left: 1.25rem;
+}
+
+.sim-note {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0.25rem 0;
+}
+
+.sim-summary {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.sim-rules {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.sim-rule {
+  border-bottom: 1px solid var(--border);
+}
+
+.sim-rule:last-child {
+  border-bottom: none;
+}
+
+.sim-rule-head {
+  align-items: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 0.85rem;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  text-align: left;
+  width: 100%;
+}
+
+.sim-rule-head:hover {
+  background: var(--surface);
+}
+
+.sim-rule-head .caret {
+  color: var(--muted);
+  width: 0.8rem;
+}
+
+.sim-rule-index {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sim-rule-label {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge.sim-verdict.verdict-matched {
+  border-color: var(--ok);
+  color: var(--ok);
+}
+
+.badge.sim-verdict.verdict-no-match {
+  color: var(--muted);
+}
+
+.badge.sim-verdict.verdict-not-simulated {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
+.sim-rule-detail {
+  border-top: 1px dashed var(--border);
+  padding: 0.5rem 0.75rem 0.6rem 1.9rem;
+}
+
+.sim-clauses {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sim-clause {
+  display: flex;
+  font-size: 0.82rem;
+  gap: 0.45rem;
+  padding: 0.15rem 0;
+}
+
+.sim-clause-icon {
+  width: 1rem;
+}
+
+.sim-clause.state-matched .sim-clause-icon {
+  color: var(--ok);
+}
+
+.sim-clause.state-no-match .sim-clause-icon,
+.sim-clause.state-error .sim-clause-icon {
+  color: var(--error);
+}
+
+.sim-clause.state-invalid .sim-clause-icon,
+.sim-clause.state-not-simulated .sim-clause-icon {
+  color: var(--warn);
+}
+
+.sim-clause-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.sim-merged {
+  background: var(--surface);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.7rem;
+}
+
+.sim-merged ul {
+  list-style: none;
+  margin: 0.25rem 0 0;
+  padding: 0;
+}
+
+.sim-merged li {
+  overflow-wrap: anywhere;
+  padding: 0.1rem 0;
+}
+
+.sim-merged-title {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.sim-merged-key {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.sim-merged-before {
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  text-decoration: line-through;
+}
+
+.sim-merged-after {
+  color: var(--ok);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.sim-final {
+  margin-top: 0.75rem;
+}
+
+.sim-changed {
+  font-size: 0.85rem;
+  margin: 0.35rem 0;
+}
+
+.sim-final > details > summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  margin-bottom: 0.4rem;
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -575,6 +575,46 @@ button.badge.dup {
   padding: 0.4rem 0.6rem;
 }
 
+/* ---------- global + inherited config layers (008) ---------- */
+
+textarea.layer-editor {
+  background: light-dark(#ffffff, #0d1117);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: inherit;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  padding: 0.5rem 0.6rem;
+  resize: vertical;
+  width: 100%;
+}
+
+textarea.layer-editor:focus {
+  border-color: var(--accent);
+  outline: 1px solid var(--accent);
+}
+
+.layer-editor-error {
+  color: var(--error);
+  font-size: 0.85rem;
+  margin: 0.4rem 0 0;
+}
+
+.platform-override-warning {
+  color: var(--warn);
+}
+
+.platform-override-clear {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0;
+  text-decoration: underline;
+}
+
 .advanced-note {
   color: var(--muted);
   font-size: 0.8rem;
@@ -1026,6 +1066,17 @@ button.badge.dup {
 .badge.prov-preset {
   border-color: #8250df;
   color: #8250df;
+}
+
+/* 008 layer badges — distinct hues next to the repo blue / preset purple */
+.badge.prov-global {
+  border-color: light-dark(#1b7c83, #56d4dd);
+  color: light-dark(#1b7c83, #56d4dd);
+}
+
+.badge.prov-inherited {
+  border-color: light-dark(#bf3989, #ff80c8);
+  color: light-dark(#bf3989, #ff80c8);
 }
 
 .badge.prov-overridden {

--- a/packages/app/src/share.ts
+++ b/packages/app/src/share.ts
@@ -33,18 +33,33 @@ export interface ShareState {
   platform: string;
   endpoint: string;
   renovate: string;
+  /** Parsed 008 layers; omitted from the link when absent. */
+  globalConfig?: Record<string, unknown>;
+  inheritedConfig?: Record<string, unknown>;
+  /** The platform/endpoint explicitly override the global config's values. */
+  platformOverride?: boolean;
   view?: ShareView;
 }
 
-/** The decoded payload as stored in the fragment. */
+/**
+ * The decoded payload as stored in the fragment. v2 (008) added the optional
+ * global/inherited config layers; v1 payloads simply lack them.
+ */
 export interface SharePayload {
-  v: 1;
+  v: 1 | 2;
   renovate: string;
   config: string;
   fileName: ShareFileName;
   platform?: string;
   endpoint?: string;
+  globalConfig?: Record<string, unknown>;
+  inheritedConfig?: Record<string, unknown>;
+  platformOverride?: boolean;
   view?: ShareView;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
 async function pipeThrough(bytes: Uint8Array, stream: GenericTransformStream): Promise<Uint8Array> {
@@ -82,7 +97,7 @@ function base64urlToBytes(token: string): Uint8Array {
 /** Encodes state into the fragment token (the value after `#config=`). */
 export async function encodeShare(state: ShareState): Promise<string> {
   const payload: SharePayload = {
-    v: 1,
+    v: 2,
     renovate: state.renovate,
     config: state.config,
     fileName: state.fileName,
@@ -93,6 +108,15 @@ export async function encodeShare(state: ShareState): Promise<string> {
   }
   if (state.endpoint && state.endpoint !== DEFAULT_ENDPOINT) {
     payload.endpoint = state.endpoint;
+  }
+  if (state.globalConfig) {
+    payload.globalConfig = state.globalConfig;
+  }
+  if (state.inheritedConfig) {
+    payload.inheritedConfig = state.inheritedConfig;
+  }
+  if (state.platformOverride) {
+    payload.platformOverride = true;
   }
   const view = normalizeView(state.view);
   if (view) {
@@ -127,10 +151,11 @@ export async function decodeShare(token: string): Promise<SharePayload | null> {
     const bytes = base64urlToBytes(token);
     const json = new TextDecoder().decode(await inflateRaw(bytes));
     const parsed: unknown = JSON.parse(json);
+    const version = (parsed as { v?: unknown } | null)?.v;
     if (
       typeof parsed !== "object" ||
       parsed === null ||
-      (parsed as { v?: unknown }).v !== 1 ||
+      (version !== 1 && version !== 2) ||
       typeof (parsed as { config?: unknown }).config !== "string"
     ) {
       return null;
@@ -138,6 +163,16 @@ export async function decodeShare(token: string): Promise<SharePayload | null> {
     const p = parsed as SharePayload;
     // Normalize fileName to the two supported values.
     p.fileName = p.fileName === "renovate.json5" ? "renovate.json5" : "renovate.json";
+    // Layer configs (v2) must be plain objects; drop anything else.
+    if (!isPlainObject(p.globalConfig)) {
+      delete p.globalConfig;
+    }
+    if (!isPlainObject(p.inheritedConfig)) {
+      delete p.inheritedConfig;
+    }
+    if (typeof p.platformOverride !== "boolean") {
+      delete p.platformOverride;
+    }
     return p;
   } catch {
     return null;

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,15 @@
 export { runPipeline } from "./pipeline";
+export {
+  type ClauseEvaluation,
+  type ClauseState,
+  type DependencyDescriptor,
+  type MergedKey,
+  type RuleEvaluation,
+  type RuleVerdict,
+  simulatePackageRules,
+  type SimulationInput,
+  type SimulationResult,
+} from "./simulate-package-rules";
 export { setPresetAuth, type PresetAuth } from "./auth";
 export { renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -1,6 +1,8 @@
 import {
   getDefaultConfig,
+  getOptions,
   GlobalConfig,
+  InheritConfig,
   massageConfig,
   memCache,
   mergeChildConfig,
@@ -37,16 +39,44 @@ const ENDPOINT_DEFAULTS: Record<string, string> = {
 
 function resolvePlatformContext(input: PipelineInput): PlatformContext {
   const globalConfig = input.globalConfig ?? {};
+  const globalPlatform =
+    typeof globalConfig.platform === "string" ? globalConfig.platform : undefined;
+  const globalEndpoint =
+    typeof globalConfig.endpoint === "string" ? globalConfig.endpoint : undefined;
+  // An override only exists relative to global-config values (008/010).
+  const overridden =
+    input.platformOverride === true &&
+    (globalPlatform !== undefined || globalEndpoint !== undefined);
   const platform =
-    (typeof globalConfig.platform === "string" ? globalConfig.platform : undefined) ??
-    input.platform ??
+    (overridden ? (input.platform ?? globalPlatform) : (globalPlatform ?? input.platform)) ??
     "github";
   const endpoint =
-    (typeof globalConfig.endpoint === "string" ? globalConfig.endpoint : undefined) ??
-    input.endpoint ??
+    (overridden ? (input.endpoint ?? globalEndpoint) : (globalEndpoint ?? input.endpoint)) ??
     ENDPOINT_DEFAULTS[platform] ??
     "";
-  return { platform, endpoint };
+  return overridden ? { platform, endpoint, overridden } : { platform, endpoint };
+}
+
+/**
+ * Renovate's `removeGlobalConfig` (dist/config/index.js) reimplemented — the
+ * upstream module also drags the full modules/manager graph (100+ Node-only
+ * manager modules) into any bundle that imports it, so the visualizer keeps
+ * this pure 7-line getOptions() loop local instead of deep-importing it.
+ */
+function removeGlobalConfig(
+  config: Record<string, unknown>,
+  keepInherited: boolean,
+): Record<string, unknown> {
+  const outputConfig = { ...config };
+  for (const option of getOptions()) {
+    if (keepInherited && option.inheritConfigSupport) {
+      continue;
+    }
+    if (option.globalOnly) {
+      delete outputConfig[option.name];
+    }
+  }
+  return outputConfig;
 }
 
 // Renovate's config modules hold module-level state (GlobalConfig, memCache,
@@ -65,6 +95,8 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
   setCurrentCollector(collector);
 
   const stageStatus: Record<StageId, StageStatus> = {
+    global: "skipped",
+    inherit: "skipped",
     parse: "skipped",
     migrate: "skipped",
     massage: "skipped",
@@ -76,6 +108,9 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
   const warnings: ValidationMessage[] = [];
   let visitedPresets: TraceResult["visitedPresets"] = { merged: [], unmerged: [] };
   let finalConfig: Record<string, unknown> | undefined;
+  // Assembled 008 merge layers; undefined = layer absent or failed validation.
+  let globalLayer: Record<string, unknown> | undefined;
+  let inheritedLayer: Record<string, unknown> | undefined;
 
   const result = (): TraceResult => ({
     events: collector.events,
@@ -88,18 +123,148 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
     presetTree: collector.finalizePresetTree(),
     platformContext,
     usedInjections: getUsedInjectionKeys(),
+    ...(globalLayer || inheritedLayer
+      ? {
+          layerConfigs: {
+            ...(globalLayer ? { globalResolved: snapshot(globalLayer) } : {}),
+            ...(inheritedLayer ? { inheritedResolved: snapshot(inheritedLayer) } : {}),
+          },
+        }
+      : {}),
   });
 
   try {
     memCache.init();
     setInjectedPresets(input.injectedPresets);
-    // Platform context defines `local>`; the pasted global config (008) still
-    // wins over the explicit options, matching how a real run is configured.
+    // Platform context defines `local>`. It already accounts for the pasted
+    // global config (008) — its values win unless explicitly overridden — so
+    // the resolved context is authoritative here.
     GlobalConfig.set({
+      ...input.globalConfig,
       platform: platformContext.platform,
       endpoint: platformContext.endpoint,
-      ...input.globalConfig,
     } as Parameters<typeof GlobalConfig.set>[0]);
+
+    const defaults = getDefaultConfig() as Record<string, unknown>;
+
+    // global config layer (008) — upstream workers/global/config/parse order:
+    // migrate/massage/validate, resolve globalExtends UNDER the config, then
+    // GlobalConfig.set captures the ~55 global-context options; the remainder
+    // it returns is what merges into the repo-level run config.
+    if (input.globalConfig) {
+      collector.enterStage("global");
+      collector.emit({ kind: "stage-start", title: "Assemble global (self-hosted) config" });
+      const rawGlobal = snapshot(input.globalConfig);
+      let globalCfg = migrateConfig(snapshot(rawGlobal)).migratedConfig;
+      globalCfg = massageConfig(globalCfg);
+      const globalValidation = await validateConfig("global", globalCfg);
+      errors.push(...globalValidation.errors);
+      warnings.push(...globalValidation.warnings);
+      emitValidationMessages(collector, globalValidation);
+      stageStatus.global = globalValidation.errors.length > 0 ? "error" : "ok";
+      if (Array.isArray(globalCfg.globalExtends) && globalCfg.globalExtends.length > 0) {
+        try {
+          // upstream resolveGlobalExtends: presets merge UNDER the config
+          const { config: resolvedExtends } = await resolveConfigPresets({
+            extends: globalCfg.globalExtends,
+            ignorePresets: globalCfg.ignorePresets,
+          });
+          globalCfg = mergeChildConfig(resolvedExtends, globalCfg);
+        } catch (err) {
+          stageStatus.global = "error";
+          const message = describeError(err, "globalExtends resolution failed");
+          errors.push(message);
+          collector.emit({ kind: "stage-error", title: message.message, messages: [message] });
+        }
+        delete globalCfg.globalExtends;
+      }
+      // Re-capture with the fully assembled config (globalExtends may set
+      // captured options); the platform context stays authoritative.
+      globalLayer = GlobalConfig.set({
+        ...globalCfg,
+        platform: platformContext.platform,
+        endpoint: platformContext.endpoint,
+      } as Parameters<typeof GlobalConfig.set>[0]) as Record<string, unknown>;
+      collector.emit({
+        kind: "stage-complete",
+        title: "Global config layer assembled",
+        before: rawGlobal,
+        after: snapshot(globalLayer),
+        delta: computeDelta(rawGlobal, globalLayer),
+      });
+    }
+
+    // inherited config layer (008) — the upstream mergeInheritedConfig recipe
+    // minus platform fetch/decrypt/templating: validate("inherit") (errors
+    // exclude the layer, as upstream aborts), strip global-only options with
+    // keepInherited semantics, resolve presets, validate again, strip again,
+    // then InheritConfig.set captures its options and returns the remainder.
+    if (input.inheritedConfig) {
+      collector.enterStage("inherit");
+      collector.emit({ kind: "stage-start", title: "Merge inherited config (inheritConfig)" });
+      const rawInherited = snapshot(input.inheritedConfig);
+      let inheritedCfg = migrateConfig(snapshot(rawInherited)).migratedConfig;
+      inheritedCfg = massageConfig(inheritedCfg);
+      const inheritValidation = await validateConfig("inherit", inheritedCfg);
+      errors.push(...inheritValidation.errors);
+      warnings.push(...inheritValidation.warnings);
+      emitValidationMessages(collector, inheritValidation);
+      if (inheritValidation.errors.length > 0) {
+        stageStatus.inherit = "error";
+        collector.emit({
+          kind: "stage-error",
+          title: "Inherited config failed validation — layer not merged",
+          messages: inheritValidation.errors,
+        });
+      } else {
+        try {
+          let filtered: Record<string, unknown> | undefined = removeGlobalConfig(
+            inheritedCfg,
+            true,
+          );
+          if (filtered.extends != null) {
+            // upstream resolves against the run config assembled so far
+            const base = mergeChildConfig(snapshot(defaults), snapshot(globalLayer ?? {}));
+            const { config: resolved } = await resolveConfigPresets(
+              filtered,
+              base,
+              base.ignorePresets as string[] | undefined,
+            );
+            const resolvedValidation = await validateConfig("inherit", resolved);
+            errors.push(...resolvedValidation.errors);
+            warnings.push(...resolvedValidation.warnings);
+            emitValidationMessages(collector, resolvedValidation);
+            if (resolvedValidation.errors.length > 0) {
+              stageStatus.inherit = "error";
+              collector.emit({
+                kind: "stage-error",
+                title: "Presets inside the inherited config failed validation — layer not merged",
+                messages: resolvedValidation.errors,
+              });
+              filtered = undefined;
+            } else {
+              filtered = removeGlobalConfig(resolved, true);
+            }
+          }
+          if (filtered) {
+            inheritedLayer = InheritConfig.set(filtered);
+            stageStatus.inherit = "ok";
+            collector.emit({
+              kind: "stage-complete",
+              title: "Inherited config layer assembled",
+              before: rawInherited,
+              after: snapshot(inheritedLayer),
+              delta: computeDelta(rawInherited, inheritedLayer),
+            });
+          }
+        } catch (err) {
+          stageStatus.inherit = "error";
+          const message = describeError(err, "Inherited config preset resolution failed");
+          errors.push(message);
+          collector.emit({ kind: "stage-error", title: message.message, messages: [message] });
+        }
+      }
+    }
 
     // parse
     collector.enterStage("parse");
@@ -155,22 +320,7 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
     const validation = await validateConfig("repo", config);
     errors.push(...validation.errors);
     warnings.push(...validation.warnings);
-    for (const error of validation.errors) {
-      collector.emit({
-        kind: "validation-message",
-        title: error.message,
-        level: "error",
-        messages: [error],
-      });
-    }
-    for (const warning of validation.warnings) {
-      collector.emit({
-        kind: "validation-message",
-        title: warning.message,
-        level: "warn",
-        messages: [warning],
-      });
-    }
+    emitValidationMessages(collector, validation);
     stageStatus.validate = validation.errors.length > 0 ? "error" : "ok";
     collector.emit({
       kind: "stage-complete",
@@ -201,11 +351,18 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
       config = preResolve;
     }
 
-    // merge with defaults
+    // merge with defaults (and, when present, the 008 layers in between:
+    // defaults → global remainder → inherited remainder → repo config)
     collector.enterStage("merge");
     collector.emit({ kind: "stage-start", title: "Merge onto default config" });
-    const defaults = getDefaultConfig() as Record<string, unknown>;
-    finalConfig = mergeChildConfig(defaults, config);
+    let base = defaults;
+    if (globalLayer) {
+      base = mergeChildConfig(snapshot(base), snapshot(globalLayer));
+    }
+    if (inheritedLayer) {
+      base = mergeChildConfig(snapshot(base), snapshot(inheritedLayer));
+    }
+    finalConfig = mergeChildConfig(base, config);
     stageStatus.merge = "ok";
     collector.emit({
       kind: "stage-complete",
@@ -218,22 +375,45 @@ async function execute(input: PipelineInput): Promise<TraceResult> {
     return result();
   } finally {
     GlobalConfig.reset();
+    InheritConfig.reset();
     memCache.reset();
     resetInjectedPresets();
     setCurrentCollector(null);
   }
 }
 
-function describeError(err: unknown): ValidationMessage {
+function emitValidationMessages(
+  collector: TraceCollector,
+  validation: { errors: ValidationMessage[]; warnings: ValidationMessage[] },
+): void {
+  for (const error of validation.errors) {
+    collector.emit({
+      kind: "validation-message",
+      title: error.message,
+      level: "error",
+      messages: [error],
+    });
+  }
+  for (const warning of validation.warnings) {
+    collector.emit({
+      kind: "validation-message",
+      title: warning.message,
+      level: "warn",
+      messages: [warning],
+    });
+  }
+}
+
+function describeError(err: unknown, topic = "Preset resolution failed"): ValidationMessage {
   if (err && typeof err === "object" && "validationError" in err) {
     const e = err as { validationError?: string; validationMessage?: string; message?: string };
     return {
-      topic: e.validationError ?? "Preset resolution failed",
+      topic: e.validationError ?? topic,
       message: e.validationMessage ?? e.message ?? String(err),
     };
   }
   return {
-    topic: "Preset resolution failed",
+    topic,
     message: err instanceof Error ? err.message : String(err),
   };
 }

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -50,8 +50,15 @@ function resolvePlatformContext(input: PipelineInput): PlatformContext {
   const platform =
     (overridden ? (input.platform ?? globalPlatform) : (globalPlatform ?? input.platform)) ??
     "github";
+  // Without an override, a global-config platform also invalidates the
+  // explicit endpoint — it belongs to the toolbar's platform, not this one; a
+  // real run would use the global endpoint or the platform's own default.
+  const explicitEndpoint =
+    !overridden && globalPlatform !== undefined && globalEndpoint === undefined
+      ? undefined
+      : input.endpoint;
   const endpoint =
-    (overridden ? (input.endpoint ?? globalEndpoint) : (globalEndpoint ?? input.endpoint)) ??
+    (overridden ? (explicitEndpoint ?? globalEndpoint) : (globalEndpoint ?? explicitEndpoint)) ??
     ENDPOINT_DEFAULTS[platform] ??
     "";
   return overridden ? { platform, endpoint, overridden } : { platform, endpoint };
@@ -83,10 +90,19 @@ function removeGlobalConfig(
 // the active trace collector), so runs must never overlap.
 let queue: Promise<unknown> = Promise.resolve();
 
-export function runPipeline(input: PipelineInput): Promise<TraceResult> {
-  const run = queue.then(() => execute(input));
+/**
+ * Serializes every engine entry point that touches renovate's stateful
+ * modules through one queue, so e.g. a packageRules simulation (006) never
+ * interleaves with a pipeline run.
+ */
+export function enqueueEngineTask<T>(task: () => Promise<T>): Promise<T> {
+  const run = queue.then(() => task());
   queue = run.catch(() => undefined);
   return run;
+}
+
+export function runPipeline(input: PipelineInput): Promise<TraceResult> {
+  return enqueueEngineTask(() => execute(input));
 }
 
 async function execute(input: PipelineInput): Promise<TraceResult> {

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -18,4 +18,13 @@ export { getConfig as getDefaultConfig } from "renovate/dist/config/defaults.js"
 export { GlobalConfig } from "renovate/dist/config/global.js";
 export { InheritConfig } from "renovate/dist/config/inherit.js";
 export { getOptions } from "renovate/dist/config/options/index.js";
+// The simulator (006) needs the matcher registry only; `applyPackageRules`
+// itself is deliberately NOT re-exported — its merge tail is replicated in
+// simulate-package-rules.ts, and pulling the real one in would drag slugify +
+// template compilation into the browser bundle. The golden/shimmed tests
+// deep-import it directly as the behavioral oracle.
+export {
+  default as packageRuleMatchers,
+  type PackageRuleMatcher,
+} from "renovate/dist/util/package-rules/matchers.js";
 export * as memCache from "renovate/dist/util/cache/memory/index.js";

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -16,5 +16,6 @@ export { parsePreset } from "renovate/dist/config/presets/parse.js";
 export { mergeChildConfig } from "renovate/dist/config/utils.js";
 export { getConfig as getDefaultConfig } from "renovate/dist/config/defaults.js";
 export { GlobalConfig } from "renovate/dist/config/global.js";
+export { InheritConfig } from "renovate/dist/config/inherit.js";
 export { getOptions } from "renovate/dist/config/options/index.js";
 export * as memCache from "renovate/dist/util/cache/memory/index.js";

--- a/packages/engine/src/shims/merge-confidence.ts
+++ b/packages/engine/src/shims/merge-confidence.ts
@@ -1,0 +1,14 @@
+/**
+ * Browser shim for renovate/dist/util/merge-confidence/index.js, whose real
+ * implementation drags got (a Node-only HTTP stack, via util/http) into the
+ * bundle — got crashes at module-evaluation time in the browser. The only
+ * consumer in the browsered subgraph is the MergeConfidenceMatcher
+ * (util/package-rules/merge-confidence.js), which calls `getApiToken()` and
+ * throws MISSING_API_CREDENTIALS when it is undefined — exactly what a
+ * browser run, which can define no merge-confidence host rule, should see.
+ * The 006 simulator never invokes that matcher, reporting `matchConfidence`
+ * clauses as "not simulated" instead.
+ */
+export function getApiToken(): string | undefined {
+  return undefined;
+}

--- a/packages/engine/src/shims/versioning-conda.ts
+++ b/packages/engine/src/shims/versioning-conda.ts
@@ -1,0 +1,44 @@
+/**
+ * Browser stub for renovate/dist/modules/versioning/conda/index.js.
+ *
+ * The real conda scheme parses versions through `@baszalmstra/rattler`, a
+ * Rust-compiled WebAssembly module that inlines to ~3.9 MB of the browser
+ * bundle — over half the app — while every other versioning scheme combined
+ * is ~0.4 MB. Since the registry (`modules/versioning/api.js`) imports the
+ * scheme statically, the only way to keep the WASM out of the bundle is to
+ * replace the module. The stub keeps `conda` registered so registry lookups
+ * behave normally, but every API call throws an honest error; the simulator
+ * surfaces it as a per-clause ⚠ error on `matchCurrentVersion`.
+ */
+
+export const id = "conda";
+
+function unsupported(): never {
+  throw new Error(
+    "conda versioning is not supported in the browser build — its parser is a ~3 MB " +
+      "WebAssembly module excluded to keep the bundle small. Use a different `versioning` scheme.",
+  );
+}
+
+/** Every member of Renovate's VersioningApi, each honestly refusing. */
+export const api = {
+  isValid: unsupported,
+  isVersion: unsupported,
+  isSingleVersion: unsupported,
+  isStable: unsupported,
+  isCompatible: unsupported,
+  getMajor: unsupported,
+  getMinor: unsupported,
+  getPatch: unsupported,
+  equals: unsupported,
+  isGreaterThan: unsupported,
+  isLessThanRange: unsupported,
+  getSatisfyingVersion: unsupported,
+  minSatisfyingVersion: unsupported,
+  getNewValue: unsupported,
+  getPinnedValue: unsupported,
+  sortVersions: unsupported,
+  matches: unsupported,
+  subset: unsupported,
+  intersects: unsupported,
+};

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -38,6 +38,9 @@ export function renovateShims(): Plugin {
       "util/cache/package/index.js": "package-cache.ts",
       "util/hash.js": "hash.ts",
       "util/merge-confidence/index.js": "merge-confidence.ts",
+      // conda's version parser is a ~3.9 MB inlined WASM blob (rattler) —
+      // over half the bundle for one niche scheme; see shims/versioning-conda.ts
+      "modules/versioning/conda/index.js": "versioning-conda.ts",
     }).map(([dist, shim]) => [path.join(renovateDist, dist), path.join(shimDir, shim)]),
   );
 

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -37,6 +37,7 @@ export function renovateShims(): Plugin {
       "modules/datasource/index.js": "datasource-index.ts",
       "util/cache/package/index.js": "package-cache.ts",
       "util/hash.js": "hash.ts",
+      "util/merge-confidence/index.js": "merge-confidence.ts",
     }).map(([dist, shim]) => [path.join(renovateDist, dist), path.join(shimDir, shim)]),
   );
 

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -1,0 +1,459 @@
+import { enqueueEngineTask } from "./pipeline";
+import {
+  GlobalConfig,
+  memCache,
+  mergeChildConfig,
+  packageRuleMatchers,
+  validateConfig,
+} from "./renovate-adapter";
+import type { ValidationMessage } from "./trace/model";
+
+/**
+ * Roadmap 006: the packageRules simulator. Evaluates a completed run's
+ * `finalConfig.packageRules` against a user-described hypothetical dependency
+ * update using Renovate's REAL matcher registry (upstream
+ * `lib/util/package-rules/matchers.ts`, via the adapter), records a
+ * per-clause verdict for every rule, and replicates `applyPackageRules`'s merge tail
+ * (removeMatchers + mergeChildConfig, cumulative and in order) so the final
+ * per-dependency config matches what Renovate would compute.
+ *
+ * The one deliberate gap: `matchConfidence` needs a Merge Confidence API
+ * token and upstream THROWS without one, so rules containing it are reported
+ * as "not-simulated" instead of being decided — mirroring that a real run
+ * would abort rather than silently match or skip.
+ */
+
+/** Everything the 18 matchers can read about a hypothetical dependency update. */
+export interface DependencyDescriptor {
+  manager?: string;
+  datasource?: string;
+  packageName?: string;
+  /** Defaults to `packageName` when omitted. */
+  depName?: string;
+  depType?: string;
+  packageFile?: string;
+  lockFiles?: string[];
+  currentValue?: string;
+  currentVersion?: string;
+  lockedVersion?: string;
+  newValue?: string;
+  updateType?: string;
+  /** In-range "bump" updates match `matchUpdateTypes: ["bump"]`. */
+  isBump?: boolean;
+  versioning?: string;
+  sourceUrl?: string;
+  registryUrls?: string[];
+  categories?: string[];
+  repository?: string;
+  baseBranch?: string;
+  /** ISO timestamp of the current version's release (matchCurrentAge). */
+  currentVersionTimestamp?: string;
+  /** Read only by matchConfidence, which is never simulated. */
+  mergeConfidenceLevel?: string;
+}
+
+export interface SimulationInput {
+  /** The effective config whose packageRules run (a run's `finalConfig`). */
+  config: Record<string, unknown>;
+  dep: DependencyDescriptor;
+}
+
+export type ClauseState = "matched" | "no-match" | "not-simulated" | "invalid" | "error";
+
+export interface ClauseEvaluation {
+  /** The `match*` selector key, e.g. `matchPackageNames`. */
+  key: string;
+  /** The clause's value inside the rule. */
+  value: unknown;
+  state: ClauseState;
+  /** The input fields the matcher consulted, for human explanations. */
+  inputValues: Record<string, unknown>;
+  /** Present for not-simulated / invalid / error states. */
+  note?: string;
+}
+
+export type RuleVerdict = "matched" | "no-match" | "not-simulated";
+
+/** One key the rule changed on the cumulative per-dependency config. */
+export interface MergedKey {
+  key: string;
+  before?: unknown;
+  after?: unknown;
+}
+
+export interface RuleEvaluation {
+  /** Position in `packageRules`. */
+  index: number;
+  verdict: RuleVerdict;
+  /** Every `match*` clause present on the rule, in matcher-registry order. */
+  clauses: ClauseEvaluation[];
+  /** Keys this rule set/changed when it merged (matched rules only). */
+  merged?: MergedKey[];
+  /** Rule-level caveats (ignored selectors, uncompiled templates, …). */
+  notes: string[];
+}
+
+export interface SimulationResult {
+  rules: RuleEvaluation[];
+  /** Exactly what `applyPackageRules` would return (dep fields included). */
+  rawFinalConfig: Record<string, unknown>;
+  /**
+   * `rawFinalConfig` without `packageRules` and without synthetic descriptor
+   * fields that no rule changed — the per-dependency config for display.
+   */
+  finalDependencyConfig: Record<string, unknown>;
+  /** `validateConfig("repo", { packageRules })` output for the rules block. */
+  errors: ValidationMessage[];
+  warnings: ValidationMessage[];
+  /** Simulation-level caveats. */
+  notes: string[];
+}
+
+interface MatcherDescriptor {
+  /** The packageRules selector the matcher reads. */
+  readonly key: string;
+  /** The input-config fields the matcher consults, for UI explanations. */
+  readonly inputFields: readonly string[];
+}
+
+/**
+ * Selector key + read fields for each entry of Renovate's matcher registry,
+ * by position. Must stay aligned with the upstream registry
+ * (`lib/util/package-rules/matchers.ts`) — length-checked at runtime.
+ */
+const MATCHER_TABLE: readonly MatcherDescriptor[] = [
+  { key: "matchConfidence", inputFields: ["mergeConfidenceLevel"] },
+  { key: "matchRepositories", inputFields: ["repository"] },
+  { key: "matchBaseBranches", inputFields: ["baseBranch"] },
+  { key: "matchCategories", inputFields: ["categories"] },
+  { key: "matchManagers", inputFields: ["manager"] },
+  { key: "matchFileNames", inputFields: ["packageFile", "lockFiles"] },
+  { key: "matchDatasources", inputFields: ["datasource"] },
+  { key: "matchPackageNames", inputFields: ["packageName"] },
+  { key: "matchDepNames", inputFields: ["depName"] },
+  { key: "matchDepTypes", inputFields: ["depType", "depTypes"] },
+  { key: "matchCurrentValue", inputFields: ["currentValue"] },
+  {
+    key: "matchCurrentVersion",
+    inputFields: ["versioning", "currentValue", "currentVersion", "lockedVersion"],
+  },
+  { key: "matchUpdateTypes", inputFields: ["updateType", "isBump"] },
+  { key: "matchSourceUrls", inputFields: ["sourceUrl"] },
+  { key: "matchRegistryUrls", inputFields: ["registryUrls"] },
+  { key: "matchNewValue", inputFields: ["newValue"] },
+  { key: "matchCurrentAge", inputFields: ["currentVersionTimestamp"] },
+  { key: "matchJsonata", inputFields: [] },
+];
+
+const KNOWN_SELECTORS = new Set(MATCHER_TABLE.map((entry) => entry.key));
+
+const NOT_SIMULATED_NOTE =
+  "not simulated — matchConfidence requires a Merge Confidence API token; " +
+  "a real Renovate run without one throws instead of evaluating the rule";
+
+export function simulatePackageRules(input: SimulationInput): Promise<SimulationResult> {
+  return enqueueEngineTask(() => execute(input));
+}
+
+/** The descriptor as config fields, undefineds dropped, depName defaulted. */
+function buildDepFields(dep: DependencyDescriptor): Record<string, unknown> {
+  const withDefaults: DependencyDescriptor = {
+    ...dep,
+    ...(dep.depName === undefined && dep.packageName !== undefined
+      ? { depName: dep.packageName }
+      : {}),
+  };
+  const fields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(withDefaults)) {
+    if (value !== undefined) {
+      fields[key] = value;
+    }
+  }
+  return fields;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return a === b || JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Upstream removeMatchers: strip every key starting with match/exclude. */
+function removeMatchers(rule: Record<string, unknown>): Record<string, unknown> {
+  const out = { ...rule };
+  for (const key of Object.keys(out)) {
+    if (key.startsWith("match") || key.startsWith("exclude")) {
+      delete out[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * ASCII approximation of the `slugify` package with `{ lower: true }` (used
+ * upstream to derive `groupSlug` from `groupName`): keep word chars and
+ * slugify's allowed punctuation, collapse whitespace to `-`, lowercase.
+ */
+function slugifyLite(input: string): string {
+  return input
+    .normalize()
+    .trim()
+    .replace(/[^\w\s$*_+~.()'"!\-:@]+/g, "")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+}
+
+/**
+ * Upstream compiles Handlebars templates in override/sourceUrl values; the
+ * simulator applies them verbatim and notes when a template was present.
+ */
+function applyTemplate(value: string, field: string, notes: string[]): string {
+  if (value.includes("{{")) {
+    notes.push(
+      `${field} contains a Handlebars template — the simulator does not compile templates and applied it verbatim`,
+    );
+  }
+  return value;
+}
+
+async function evaluateRule(
+  index: number,
+  inputConfig: Record<string, unknown>,
+  rule: Record<string, unknown>,
+): Promise<RuleEvaluation> {
+  const clauses: ClauseEvaluation[] = [];
+  const notes: string[] = [];
+  let verdict: RuleVerdict = "matched";
+
+  for (const [position, entry] of MATCHER_TABLE.entries()) {
+    const value = rule[entry.key];
+    // MergeConfidenceMatcher skips null too (isNullOrUndefined); the rest
+    // check isUndefined only.
+    const present = entry.key === "matchConfidence" ? value != null : value !== undefined;
+    if (!present) {
+      continue;
+    }
+    const inputValues: Record<string, unknown> = {};
+    for (const field of entry.inputFields) {
+      if (inputConfig[field] !== undefined) {
+        inputValues[field] = inputConfig[field];
+      }
+    }
+    if (entry.key === "matchConfidence") {
+      clauses.push({
+        key: entry.key,
+        value,
+        state: "not-simulated",
+        inputValues,
+        note: NOT_SIMULATED_NOTE,
+      });
+      // The registry evaluates matchConfidence FIRST, so a real run throws
+      // before any other clause of this rule is consulted.
+      verdict = "not-simulated";
+      continue;
+    }
+    const matcher = packageRuleMatchers[position];
+    if (!matcher) {
+      throw new Error(
+        `Renovate's matcher registry no longer aligns with the simulator table (index ${position})`,
+      );
+    }
+    try {
+      const raw = await matcher.matches(inputConfig, rule);
+      if (raw === true) {
+        clauses.push({ key: entry.key, value, state: "matched", inputValues });
+      } else if (raw === false) {
+        clauses.push({ key: entry.key, value, state: "no-match", inputValues });
+        if (verdict === "matched") {
+          verdict = "no-match";
+        }
+      } else {
+        clauses.push({
+          key: entry.key,
+          value,
+          state: "invalid",
+          inputValues,
+          note:
+            "the matcher returned null for this clause (invalid or incomplete input) — " +
+            "Renovate skips it, so it does not affect whether the rule matches",
+        });
+      }
+    } catch (err) {
+      clauses.push({
+        key: entry.key,
+        value,
+        state: "error",
+        inputValues,
+        note: `matcher threw: ${err instanceof Error ? err.message : String(err)} — treated as not matching`,
+      });
+      if (verdict === "matched") {
+        verdict = "no-match";
+      }
+    }
+  }
+
+  const ignored = Object.keys(rule).filter(
+    (key) => (key.startsWith("match") || key.startsWith("exclude")) && !KNOWN_SELECTORS.has(key),
+  );
+  if (ignored.length > 0) {
+    notes.push(
+      `no matcher reads ${ignored.map((k) => `\`${k}\``).join(", ")} — Renovate strips such keys without ever matching on them`,
+    );
+  }
+
+  return { index, verdict, clauses, notes };
+}
+
+/** Keys whose value changed between two cumulative configs. */
+function diffKeys(before: Record<string, unknown>, after: Record<string, unknown>): MergedKey[] {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const merged: MergedKey[] = [];
+  for (const key of keys) {
+    if (!jsonEqual(before[key], after[key])) {
+      merged.push({
+        key,
+        ...(key in before ? { before: before[key] } : {}),
+        ...(key in after ? { after: after[key] } : {}),
+      });
+    }
+  }
+  return merged;
+}
+
+async function execute(input: SimulationInput): Promise<SimulationResult> {
+  if (MATCHER_TABLE.length !== packageRuleMatchers.length) {
+    throw new Error(
+      `Renovate ships ${packageRuleMatchers.length} package-rule matchers but the simulator knows ${MATCHER_TABLE.length}`,
+    );
+  }
+  try {
+    memCache.init();
+    GlobalConfig.set({} as Parameters<typeof GlobalConfig.set>[0]);
+
+    const depFields = buildDepFields(input.dep);
+    // Upstream builds PackageRuleInputConfig by layering the update's fields
+    // over the effective config, so rules (e.g. matchJsonata) can reference
+    // config-level values too.
+    const inputConfig: Record<string, unknown> = { ...input.config, ...depFields };
+
+    const rawRules = Array.isArray(input.config.packageRules) ? input.config.packageRules : [];
+    const notes: string[] = [];
+
+    const errors: ValidationMessage[] = [];
+    const warnings: ValidationMessage[] = [];
+    if (input.config.packageRules !== undefined) {
+      const validation = await validateConfig("repo", {
+        packageRules: input.config.packageRules,
+      });
+      errors.push(...validation.errors);
+      warnings.push(...validation.warnings);
+    }
+
+    const rules: RuleEvaluation[] = [];
+    let config: Record<string, unknown> = { ...inputConfig };
+    let anyNotSimulated = false;
+
+    for (const [index, rawRule] of rawRules.entries()) {
+      if (!isPlainObject(rawRule)) {
+        rules.push({
+          index,
+          verdict: "no-match",
+          clauses: [],
+          notes: ["not an object — ignored by the simulator (validation flags it)"],
+        });
+        continue;
+      }
+      const evaluation = await evaluateRule(index, inputConfig, rawRule);
+      rules.push(evaluation);
+      if (evaluation.verdict === "not-simulated") {
+        anyNotSimulated = true;
+        continue;
+      }
+      if (evaluation.verdict !== "matched") {
+        continue;
+      }
+
+      // ---- upstream applyPackageRules merge tail, replicated ----
+      const before = config;
+      config = { ...config };
+      const toApply = removeMatchers(rawRule);
+      if (config.groupSlug && rawRule.groupName && !rawRule.groupSlug) {
+        toApply.groupSlug = slugifyLite(String(rawRule.groupName));
+        evaluation.notes.push(
+          "groupSlug derived from groupName with a simplified slugify (ASCII-equivalent to Renovate's)",
+        );
+      }
+      const force = isPlainObject(toApply.force) ? toApply.force : undefined;
+      if (force?.enabled === false || (toApply.enabled === false && config.enabled !== false)) {
+        config.skipReason = "package-rules";
+      }
+      if (force?.enabled || toApply.enabled) {
+        delete config.skipReason;
+        delete config.skipStage;
+      }
+      if (
+        typeof toApply.overrideDatasource === "string" &&
+        toApply.overrideDatasource !== config.datasource
+      ) {
+        config.datasource = toApply.overrideDatasource;
+      }
+      if (
+        typeof toApply.overrideDepName === "string" &&
+        toApply.overrideDepName !== config.depName
+      ) {
+        config.depName = applyTemplate(
+          toApply.overrideDepName,
+          "overrideDepName",
+          evaluation.notes,
+        );
+      }
+      if (
+        typeof toApply.overridePackageName === "string" &&
+        toApply.overridePackageName !== config.packageName
+      ) {
+        config.packageName = applyTemplate(
+          toApply.overridePackageName,
+          "overridePackageName",
+          evaluation.notes,
+        );
+      }
+      if (typeof toApply.sourceUrl === "string") {
+        toApply.sourceUrl = applyTemplate(toApply.sourceUrl, "sourceUrl", evaluation.notes);
+      }
+      delete toApply.overrideDatasource;
+      delete toApply.overrideDepName;
+      delete toApply.overridePackageName;
+      config = mergeChildConfig(config, toApply) as Record<string, unknown>;
+      evaluation.merged = diffKeys(before, config);
+    }
+
+    if (anyNotSimulated) {
+      notes.push(
+        "a real Renovate run would abort with MISSING_API_CREDENTIALS on the first matchConfidence rule — " +
+          "such rules are reported as not simulated and never merge here",
+      );
+    }
+
+    const finalDependencyConfig = { ...config };
+    delete finalDependencyConfig.packageRules;
+    for (const [key, value] of Object.entries(depFields)) {
+      if (key in finalDependencyConfig && jsonEqual(finalDependencyConfig[key], value)) {
+        delete finalDependencyConfig[key];
+      }
+    }
+
+    return {
+      rules,
+      rawFinalConfig: config,
+      finalDependencyConfig,
+      errors,
+      warnings,
+      notes,
+    };
+  } finally {
+    GlobalConfig.reset();
+    memCache.reset();
+  }
+}

--- a/packages/engine/src/trace/model.ts
+++ b/packages/engine/src/trace/model.ts
@@ -1,6 +1,14 @@
 import type { Operation } from "fast-json-patch";
 
-export type StageId = "parse" | "migrate" | "massage" | "validate" | "preset" | "merge";
+export type StageId =
+  | "global"
+  | "inherit"
+  | "parse"
+  | "migrate"
+  | "massage"
+  | "validate"
+  | "preset"
+  | "merge";
 
 export type StageStatus = "ok" | "error" | "skipped";
 
@@ -134,6 +142,8 @@ export interface PipelineInput {
   content: string;
   /** Optional self-hosted/global options consulted by migration, validation and presets */
   globalConfig?: Record<string, unknown>;
+  /** Optional inherited config (`inheritConfig`, 008) — a parsed JSON object. */
+  inheritedConfig?: Record<string, unknown>;
   /**
    * Platform context defining `local>` resolution. Set through Renovate's real
    * GlobalConfig before preset resolution. Defaults to `github`.
@@ -141,6 +151,12 @@ export interface PipelineInput {
   platform?: string;
   /** Endpoint for the platform context; defaults to the platform's own API. */
   endpoint?: string;
+  /**
+   * When true, `platform`/`endpoint` above win over the global config's own
+   * values (an explicit user override, 008/010); the run's platformContext is
+   * then marked `overridden`.
+   */
+  platformOverride?: boolean;
   /**
    * User-supplied preset content for otherwise-unreachable presets, keyed by
    * the canonical injection key (see `presetInjectionKey`).
@@ -152,6 +168,8 @@ export interface PipelineInput {
 export interface PlatformContext {
   platform: string;
   endpoint: string;
+  /** The user explicitly overrode the global config's platform/endpoint. */
+  overridden?: boolean;
 }
 
 export interface TraceResult {
@@ -170,6 +188,17 @@ export interface TraceResult {
   presetTree?: PresetNode;
   /** Platform + endpoint this run resolved `local>` presets against. */
   platformContext: PlatformContext;
+  /**
+   * The assembled merge layers of a run with global/inherited inputs (008):
+   * exactly what merged between the defaults and the repo's resolved config,
+   * for the provenance replay. Absent when neither layer was provided.
+   */
+  layerConfigs?: {
+    /** Global config after migrate/massage/`globalExtends` resolution, minus the options `GlobalConfig.set` captures. */
+    globalResolved?: Record<string, unknown>;
+    /** Inherited config after migrate/massage/preset resolution, minus global-only and `InheritConfig`-captured options. */
+    inheritedResolved?: Record<string, unknown>;
+  };
   /**
    * Injection keys served from user-supplied content during this run. The app
    * matches these against each node's computed key to flag "user-supplied".

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -3,10 +3,12 @@ import type { PresetNode, TraceResult } from "./model";
 
 /**
  * Roadmap 005: per-key merge provenance. Computed post-hoc from the trace data
- * the engine already captures (the preset tree + final config) by replaying
- * Renovate's real `mergeChildConfig` over the top-level layers — defaults, then
- * each directly-extended preset in order, then the repo config — and attributing
- * every top-level key to the layer(s) that produced its final value.
+ * the engine already captures (the preset tree + final config + 008 layer
+ * configs) by replaying Renovate's real `mergeChildConfig` over the top-level
+ * layers — defaults, then the global and inherited layers (when provided),
+ * then each directly-extended preset in order, then the repo config — and
+ * attributing every top-level key to the layer(s) that produced its final
+ * value.
  *
  * No Renovate instrumentation is involved: `mergeChildConfig` is pure, so the
  * replay reproduces the pipeline's merge exactly. The replay is top-level only
@@ -26,6 +28,8 @@ export type ProvenanceAction =
 /** Which layer a step is attributed to. */
 export type ProvenanceLayer =
   | { kind: "defaults" }
+  | { kind: "global" }
+  | { kind: "inherited" }
   | { kind: "preset"; nodeId: string; name: string }
   | { kind: "repo" };
 
@@ -45,9 +49,9 @@ export interface ProvenanceStep {
 export interface KeyProvenance {
   key: string;
   finalValue: unknown;
-  /** No preset or repo layer touched this key — it is a pure untouched default. */
+  /** No global/inherited/preset/repo layer touched this key — a pure untouched default. */
   isDefaultOnly: boolean;
-  /** Chronological chain: defaults first (when present), then presets in order, then repo. */
+  /** Chronological chain: defaults first (when present), then global/inherited, presets in order, repo. */
   chain: ProvenanceStep[];
 }
 
@@ -80,9 +84,19 @@ interface Layer {
   config: Obj;
 }
 
-/** Top-level merge layers, in the order Renovate merges them (presets then repo). */
-function buildLayers(root: PresetNode): Layer[] {
+/**
+ * Top-level merge layers, in the order Renovate merges them: the 008 layers
+ * (global, then inherited — already assembled by the pipeline, i.e. extends
+ * resolved and captured/global-only options stripped), then presets, then repo.
+ */
+function buildLayers(root: PresetNode, layerConfigs: TraceResult["layerConfigs"]): Layer[] {
   const layers: Layer[] = [];
+  if (layerConfigs?.globalResolved) {
+    layers.push({ layer: { kind: "global" }, config: layerConfigs.globalResolved });
+  }
+  if (layerConfigs?.inheritedResolved) {
+    layers.push({ layer: { kind: "inherited" }, config: layerConfigs.inheritedResolved });
+  }
   // Same filter PresetTree's contribution replay uses: only non-nested,
   // resolved children with a `resolved` payload participate in the top merge.
   for (const child of root.children) {
@@ -120,7 +134,12 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
 
   const defaults = getDefaultConfig() as Obj;
   const resolved = root.resolved as Obj;
-  const layers = buildLayers(root);
+  const layers = buildLayers(root, result.layerConfigs);
+  // 008 layers merge before any preset; their accumulated result is the base
+  // the repo-level resolution (ground truth `resolved`) merged onto.
+  const baseLayerCount = layers.filter(
+    (l) => l.layer.kind === "global" || l.layer.kind === "inherited",
+  ).length;
 
   const chains = new Map<string, ProvenanceStep[]>();
   const lastLayerIndex = new Map<string, number>();
@@ -135,11 +154,16 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
     lastLayerIndex.set(key, layerIndex);
   };
 
-  // Replay the preset/repo merge, attributing each key the incoming layer owns.
+  // Replay the layer/preset/repo merge, attributing each key the incoming
+  // layer owns.
   let acc: Obj = {};
+  let accBase: Obj = {};
   layers.forEach(({ layer, config }, layerIndex) => {
     const before = acc;
     const after = mergeChildConfig(structuredClone(before), structuredClone(config)) as Obj;
+    if (layerIndex < baseLayerCount) {
+      accBase = after;
+    }
 
     for (const key of Object.keys(config)) {
       const opt = optionMap.get(key);
@@ -197,15 +221,22 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
   // Renovate runs a final nested-`extends` expansion over the combined config,
   // which further resolves repo-supplied nested extends (e.g. packageRules[n].
   // extends) that the plain replay leaves unexpanded. Correct those keys from
-  // the ground-truth resolved config and tag the responsible step.
+  // the ground-truth resolved config and tag the responsible step. With 008
+  // layers present the expectation is `resolved` merged onto the layers'
+  // accumulated base — a global packageRules entry legitimately makes the
+  // replay differ from the repo-only `resolved` without any nested expansion.
+  const expected =
+    baseLayerCount > 0
+      ? (mergeChildConfig(structuredClone(accBase), structuredClone(resolved)) as Obj)
+      : resolved;
   for (const key of Object.keys(resolved)) {
     const arr = chains.get(key);
-    if (arr && arr.length > 0 && !deepEqual(acc[key], resolved[key])) {
+    if (arr && arr.length > 0 && !deepEqual(acc[key], expected[key])) {
       const last = arr[arr.length - 1];
       if (last) {
-        arr[arr.length - 1] = { ...last, after: resolved[key], expandedNested: true };
+        arr[arr.length - 1] = { ...last, after: expected[key], expandedNested: true };
       }
-      acc[key] = resolved[key];
+      acc[key] = expected[key];
     }
   }
 

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -135,6 +135,30 @@ declare module "renovate/dist/config/inherit.js" {
   }
 }
 
+declare module "renovate/dist/util/package-rules/matchers.js" {
+  /**
+   * One instantiated matcher from Renovate's registry. `matches` returns
+   * null/undefined when its clause is absent from the rule, otherwise whether
+   * the input satisfies the clause (JsonataMatcher is async — always await).
+   */
+  export interface PackageRuleMatcher {
+    matches(
+      inputConfig: Record<string, unknown>,
+      packageRule: Record<string, unknown>,
+    ): boolean | null | undefined | Promise<boolean | null | undefined>;
+  }
+  /** The 18 matchers, in evaluation order. */
+  const matchers: readonly PackageRuleMatcher[];
+  export default matchers;
+}
+
+declare module "renovate/dist/util/package-rules/index.js" {
+  export function applyPackageRules(
+    inputConfig: RenovateConfig,
+    stageName?: string,
+  ): Promise<RenovateConfig>;
+}
+
 declare module "renovate/dist/util/cache/memory/index.js" {
   export function init(): void;
   export function reset(): void;

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -122,6 +122,19 @@ declare module "renovate/dist/config/presets/util.js" {
   export function parsePreset(content: string, fileName: string): Record<string, unknown>;
 }
 
+declare module "renovate/dist/config/inherit.js" {
+  // Renovate ships this as a class with only static members; modelled here as
+  // a namespace so callers get the same `InheritConfig.set(...)` access
+  // without an extraneous-class lint warning.
+  export namespace InheritConfig {
+    const OPTIONS: readonly string[];
+    function get(key: string): unknown;
+    /** Captures the inherit-supported options into module state and RETURNS the config with them stripped. */
+    function set(config: RenovateConfig): RenovateConfig;
+    function reset(): void;
+  }
+}
+
 declare module "renovate/dist/util/cache/memory/index.js" {
   export function init(): void;
   export function reset(): void;

--- a/packages/engine/test/global-inherit.shimmed.test.ts
+++ b/packages/engine/test/global-inherit.shimmed.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Shimmed-project tests for roadmap 008 global + inherited config layers.
+ * Uses in-memory injected presets (no network) so `globalExtends` and the
+ * inherited config's `extends` resolve deterministically. Covers the merge
+ * precedence (defaults < globalExtends < global < inherited < repo), the
+ * global-only boundary in repo/inherited configs, provenance layer steps, and
+ * that absent layers keep the pipeline byte-identical to a plain run.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeProvenance,
+  type KeyProvenance,
+  presetInjectionKey,
+  runPipeline,
+} from "../src/index";
+
+const injectedPresets = {
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/global-preset" })]: {
+    rangeStrategy: "widen",
+    addLabels: ["from-global-extends"],
+    prHourlyLimit: 7,
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/inherited-preset" })]: {
+    addLabels: ["from-inherited-preset"],
+    prConcurrentLimit: 3,
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/repo-preset" })]: {
+    minimumReleaseAge: "3 days",
+  },
+};
+
+const globalConfig = {
+  platform: "gitlab",
+  endpoint: "https://gitlab.example.com/api/v4/",
+  globalExtends: ["github>test-org/global-preset"],
+  rangeStrategy: "bump",
+  labels: ["global-label"],
+  onboarding: false,
+  dryRun: "full",
+};
+
+const inheritedConfig = {
+  extends: ["github>test-org/inherited-preset"],
+  rangeStrategy: "pin",
+  automerge: true,
+  // globalOnly without inheritConfigSupport → stripped (with a warning)
+  autodiscover: true,
+  binarySource: "install",
+  // globalOnly WITH inheritConfigSupport → kept through the strip, then
+  // captured (and removed) by InheritConfig.set
+  onboarding: false,
+};
+
+const repoConfig = JSON.stringify({
+  extends: ["github>test-org/repo-preset"],
+  rangeStrategy: "replace",
+  dryRun: "full",
+});
+
+function runAll() {
+  return runPipeline({
+    fileName: "renovate.json",
+    content: repoConfig,
+    globalConfig,
+    inheritedConfig,
+    injectedPresets,
+  });
+}
+
+describe("global + inherited config layers", () => {
+  it("(a) merges with the real precedence: defaults < globalExtends < global < inherited < repo", async () => {
+    const result = await runAll();
+    expect(result.stageStatus.global).toBe("ok");
+    expect(result.stageStatus.inherit).toBe("ok");
+    expect(result.stageStatus.merge).toBe("ok");
+    const final = result.finalConfig!;
+    // set by every layer — the repo config wins
+    expect(final.rangeStrategy).toBe("replace");
+    // globalExtends-only key survives to the final config
+    expect(final.prHourlyLimit).toBe(7);
+    // global-only key survives
+    expect(final.labels).toEqual(["global-label"]);
+    // inherited-only key survives
+    expect(final.automerge).toBe(true);
+    // repo-preset key survives
+    expect(final.minimumReleaseAge).toBe("3 days");
+    // mergeable array concatenates across the layer stack in merge order
+    expect(final.addLabels).toEqual(["from-global-extends", "from-inherited-preset"]);
+    // the assembled global layer: globalExtends resolved UNDER the config,
+    // GlobalConfig-captured options (platform/endpoint/onboarding/dryRun) gone
+    const globalResolved = result.layerConfigs?.globalResolved;
+    expect(globalResolved).toBeDefined();
+    expect(globalResolved?.rangeStrategy).toBe("bump");
+    expect(globalResolved).not.toHaveProperty("globalExtends");
+    expect(globalResolved).not.toHaveProperty("platform");
+    expect(globalResolved).not.toHaveProperty("endpoint");
+    expect(globalResolved).not.toHaveProperty("onboarding");
+    expect(globalResolved).not.toHaveProperty("dryRun");
+    // captured global options never leak into the final config as layer values
+    expect(final.onboarding).toBe(true); // still the untouched default
+    expect(final.dryRun).toBe("full"); // repo tried to set it (warned, but merged as written)
+  });
+
+  it("(b) surfaces validateConfig warnings for globalOnly options in the repo config", async () => {
+    const result = await runAll();
+    const boundaryWarnings = result.warnings.filter((w) =>
+      w.message.includes("reserved only for Renovate's global configuration"),
+    );
+    // repo `dryRun` + inherited `autodiscover`/`binarySource`
+    expect(boundaryWarnings.length).toBeGreaterThanOrEqual(3);
+    expect(boundaryWarnings.some((w) => w.message.includes(`"dryRun"`))).toBe(true);
+    const events = result.events.filter(
+      (e) =>
+        e.stage === "validate" && e.kind === "validation-message" && e.title.includes(`"dryRun"`),
+    );
+    expect(events.length).toBe(1);
+  });
+
+  it("(c) resolves inherited-config presets and strips global options with keepInherited semantics", async () => {
+    const result = await runAll();
+    const inheritedResolved = result.layerConfigs?.inheritedResolved;
+    expect(inheritedResolved).toBeDefined();
+    // preset content resolved into the layer
+    expect(inheritedResolved?.prConcurrentLimit).toBe(3);
+    expect(result.finalConfig?.prConcurrentLimit).toBe(3);
+    // globalOnly options stripped from the layer …
+    expect(inheritedResolved).not.toHaveProperty("autodiscover");
+    expect(inheritedResolved).not.toHaveProperty("binarySource");
+    // … and inheritConfigSupport options captured by InheritConfig.set
+    expect(inheritedResolved).not.toHaveProperty("onboarding");
+    // the inherited `autodiscover: true` never reaches the final config —
+    // only the untouched default (false) remains
+    expect(result.finalConfig?.autodiscover).toBe(false);
+    // the strip is warned about, not silent
+    expect(result.warnings.some((w) => w.message.includes(`"autodiscover"`))).toBe(true);
+  });
+
+  it("(d) provenance chains contain global and inherited layer steps", async () => {
+    const result = await runAll();
+    const provenance = computeProvenance(result);
+    expect(provenance).toBeDefined();
+    const range = (provenance as Map<string, KeyProvenance>).get("rangeStrategy");
+    expect(range?.finalValue).toBe("replace");
+    const nonDefault = range!.chain.filter((s) => s.layer.kind !== "defaults");
+    expect(nonDefault.map((s) => [s.layer.kind, s.action])).toEqual([
+      ["global", "set"],
+      ["inherited", "overwrite"],
+      ["repo", "overwrite"],
+    ]);
+    expect(nonDefault[1]?.before).toBe("bump");
+    expect(nonDefault[2]?.before).toBe("pin");
+    // a key set only by the global layer is attributed to it and not default-only
+    const labels = (provenance as Map<string, KeyProvenance>).get("labels");
+    expect(labels?.isDefaultOnly).toBe(false);
+    expect(labels?.chain.some((s) => s.layer.kind === "global")).toBe(true);
+    // round-trip property still holds with the extra layers
+    for (const [key, entry] of provenance as Map<string, KeyProvenance>) {
+      expect(entry.chain.at(-1)?.after, `round-trip mismatch for ${key}`).toEqual(entry.finalValue);
+    }
+  });
+
+  it("(e) absent layers report skipped stages and add nothing to the trace", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: repoConfig,
+      injectedPresets,
+    });
+    expect(result.stageStatus.global).toBe("skipped");
+    expect(result.stageStatus.inherit).toBe("skipped");
+    expect(result.layerConfigs).toBeUndefined();
+    expect(result.events.some((e) => e.stage === "global" || e.stage === "inherit")).toBe(false);
+    const provenance = computeProvenance(result);
+    expect(provenance).toBeDefined();
+    for (const entry of (provenance as Map<string, KeyProvenance>).values()) {
+      expect(
+        entry.chain.some((s) => s.layer.kind === "global" || s.layer.kind === "inherited"),
+      ).toBe(false);
+    }
+    expect(result.finalConfig?.rangeStrategy).toBe("replace");
+    expect(result.finalConfig?.labels).toEqual([]); // untouched default
+  });
+
+  it("records the platform context from the global config, and the explicit override", async () => {
+    const reflected = await runAll();
+    expect(reflected.platformContext).toEqual({
+      platform: "gitlab",
+      endpoint: "https://gitlab.example.com/api/v4/",
+    });
+    const overridden = await runPipeline({
+      fileName: "renovate.json",
+      content: repoConfig,
+      globalConfig,
+      inheritedConfig,
+      injectedPresets,
+      platform: "github",
+      endpoint: "https://api.github.com/",
+      platformOverride: true,
+    });
+    expect(overridden.platformContext).toEqual({
+      platform: "github",
+      endpoint: "https://api.github.com/",
+      overridden: true,
+    });
+  });
+
+  it("excludes an inherited layer that fails validation, surfacing the errors", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: repoConfig,
+      inheritedConfig: { enabledManagers: ["not-a-real-manager"] },
+      injectedPresets,
+    });
+    expect(result.stageStatus.inherit).toBe("error");
+    expect(result.layerConfigs?.inheritedResolved).toBeUndefined();
+    expect(result.errors.length).toBeGreaterThan(0);
+    // the run continues; the final config simply lacks the layer
+    expect(result.finalConfig?.rangeStrategy).toBe("replace");
+  });
+});

--- a/packages/engine/test/global-inherit.shimmed.test.ts
+++ b/packages/engine/test/global-inherit.shimmed.test.ts
@@ -203,6 +203,23 @@ describe("global + inherited config layers", () => {
     });
   });
 
+  it("displaces the explicit endpoint when the global config sets only the platform", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: repoConfig,
+      globalConfig: { platform: "gitlab" },
+      injectedPresets,
+      platform: "github",
+      endpoint: "https://api.github.com/",
+    });
+    // the explicit endpoint belongs to the toolbar's platform — a real run
+    // would use the global platform's own default
+    expect(result.platformContext).toEqual({
+      platform: "gitlab",
+      endpoint: "https://gitlab.com/api/v4/",
+    });
+  });
+
   it("excludes an inherited layer that fails validation, surfacing the errors", async () => {
     const result = await runPipeline({
       fileName: "renovate.json",

--- a/packages/engine/test/pipeline.shimmed.test.ts
+++ b/packages/engine/test/pipeline.shimmed.test.ts
@@ -38,6 +38,8 @@ describe("trace shape", () => {
     expect(migration).toBeDefined();
     expect(migration?.delta?.length).toBeGreaterThan(0);
     expect(result.stageStatus).toEqual({
+      global: "skipped",
+      inherit: "skipped",
       parse: "ok",
       migrate: "ok",
       massage: "ok",

--- a/packages/engine/test/simulate-package-rules.node.test.ts
+++ b/packages/engine/test/simulate-package-rules.node.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Golden twin of simulate-package-rules.shimmed.test.ts: the same oracle
+ * parity against Renovate's real `applyPackageRules`, but through untouched
+ * renovate modules (no shims) — proving the simulator replicates upstream
+ * behavior, not an artifact of the browser module graph.
+ */
+import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
+import { describe, expect, it } from "vitest";
+import type { DependencyDescriptor } from "../src/index";
+import { simulatePackageRules } from "../src/index";
+
+const npmDep: DependencyDescriptor = {
+  manager: "npm",
+  datasource: "npm",
+  packageName: "lodash",
+  depType: "dependencies",
+  packageFile: "package.json",
+  currentValue: "4.17.20",
+  newValue: "4.17.21",
+  updateType: "patch",
+  versioning: "semver",
+};
+
+describe("simulatePackageRules (golden)", () => {
+  it("matches Renovate's real applyPackageRules output (oracle parity)", async () => {
+    const config = {
+      groupSlug: "pre-existing",
+      enabled: true,
+      packageRules: [
+        { matchPackageNames: ["*", "!react"], addLabels: ["all-but-react"] },
+        { matchCurrentVersion: "<5", matchUpdateTypes: ["patch", "minor"], automerge: true },
+        { matchDatasources: ["npm"], groupName: "My NPM Packages" },
+        { matchPackageNames: ["lodash"], overrideDatasource: "github-tags", enabled: false },
+        { matchCurrentAge: "gibberish", matchManagers: ["npm"], prPriority: 5 },
+        { matchDepTypes: ["devDependencies"], labels: ["dev-only"] },
+        { matchJsonata: ["manager = 'npm'"], addLabels: ["via-jsonata"] },
+      ],
+    };
+    const dep: DependencyDescriptor = {
+      ...npmDep,
+      currentVersionTimestamp: "2020-01-01T00:00:00.000Z",
+    };
+    const simulated = await simulatePackageRules({ config, dep });
+    const oracle = await applyPackageRules({
+      ...config,
+      ...dep,
+      depName: dep.depName ?? dep.packageName,
+    });
+    expect(simulated.rawFinalConfig).toEqual(oracle);
+    expect(oracle.groupSlug).toBe("my-npm-packages");
+    expect(oracle.datasource).toBe("github-tags");
+    expect(oracle.skipReason).toBe("package-rules");
+    expect(oracle.addLabels).toEqual(["all-but-react", "via-jsonata"]);
+  });
+
+  it("agrees with upstream on exclusion patterns and rule order", async () => {
+    const config = {
+      packageRules: [
+        { matchPackageNames: ["*", "!lodash"], labels: ["not-lodash"] },
+        { matchManagers: ["npm"], automerge: false },
+        { matchDatasources: ["npm"], automerge: true },
+      ],
+    };
+    const simulated = await simulatePackageRules({ config, dep: npmDep });
+    const oracle = await applyPackageRules({
+      ...config,
+      ...npmDep,
+      depName: npmDep.packageName,
+    });
+    expect(simulated.rawFinalConfig).toEqual(oracle);
+    expect(simulated.rules.map((r) => r.verdict)).toEqual(["no-match", "matched", "matched"]);
+    expect(oracle.automerge).toBe(true);
+  });
+});

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Shimmed-project tests for the roadmap 006 packageRules simulator. The
+ * strongest assertion is oracle parity: for rules without matchConfidence the
+ * simulator's rawFinalConfig must equal what Renovate's REAL
+ * `applyPackageRules` computes over the same input (run through the same
+ * shimmed module graph). A golden twin (simulate-package-rules.node.test.ts)
+ * asserts the same parity unshimmed.
+ */
+import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
+import { describe, expect, it } from "vitest";
+import type { DependencyDescriptor } from "../src/index";
+import { simulatePackageRules } from "../src/index";
+
+const npmDep: DependencyDescriptor = {
+  manager: "npm",
+  datasource: "npm",
+  packageName: "lodash",
+  depType: "dependencies",
+  packageFile: "package.json",
+  currentValue: "4.17.20",
+  newValue: "4.17.21",
+  updateType: "patch",
+  versioning: "semver",
+};
+
+/** The PackageRuleInputConfig the way the simulator builds it, for the oracle. */
+function oracleInput(
+  config: Record<string, unknown>,
+  dep: DependencyDescriptor,
+): Record<string, unknown> {
+  return { ...config, ...dep, depName: dep.depName ?? dep.packageName };
+}
+
+describe("simulatePackageRules", () => {
+  it("reports clause tri-state: matched, no-match, and absent clauses omitted", async () => {
+    const config = {
+      packageRules: [
+        { matchPackageNames: ["lodash"], matchDatasources: ["npm"], automerge: true },
+        { matchPackageNames: ["react"], labels: ["react"] },
+      ],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    expect(result.rules).toHaveLength(2);
+
+    const [first, second] = result.rules;
+    expect(first?.verdict).toBe("matched");
+    // registry order: datasources before package names
+    expect(first?.clauses.map((c) => [c.key, c.state])).toEqual([
+      ["matchDatasources", "matched"],
+      ["matchPackageNames", "matched"],
+    ]);
+    expect(first?.clauses[1]?.inputValues).toEqual({ packageName: "lodash" });
+    expect(first?.merged?.some((m) => m.key === "automerge" && m.after === true)).toBe(true);
+
+    expect(second?.verdict).toBe("no-match");
+    expect(second?.clauses).toEqual([
+      expect.objectContaining({ key: "matchPackageNames", state: "no-match" }),
+    ]);
+    expect(second?.merged).toBeUndefined();
+
+    expect(result.finalDependencyConfig.automerge).toBe(true);
+    expect(result.finalDependencyConfig).not.toHaveProperty("labels");
+    expect(result.finalDependencyConfig).not.toHaveProperty("packageRules");
+    // unchanged synthetic dep fields are stripped from the display config
+    expect(result.finalDependencyConfig).not.toHaveProperty("packageName");
+  });
+
+  it("honors !-prefixed exclusion patterns inside match* arrays", async () => {
+    const config = {
+      packageRules: [{ matchPackageNames: ["*", "!lodash"], labels: ["not-lodash"] }],
+    };
+    const excluded = await simulatePackageRules({ config, dep: npmDep });
+    expect(excluded.rules[0]?.verdict).toBe("no-match");
+
+    const other = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, packageName: "react", depName: undefined },
+    });
+    expect(other.rules[0]?.verdict).toBe("matched");
+    expect(other.rawFinalConfig.labels).toEqual(["not-lodash"]);
+  });
+
+  it("evaluates matchCurrentVersion ranges through the real versioning modules", async () => {
+    const config = {
+      packageRules: [
+        { matchCurrentVersion: "<5", labels: ["below-5"] },
+        { matchCurrentVersion: "<4", labels: ["below-4"] },
+      ],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    expect(result.rules[0]?.verdict).toBe("matched");
+    expect(result.rules[1]?.verdict).toBe("no-match");
+    expect(result.rawFinalConfig.labels).toEqual(["below-5"]);
+  });
+
+  it("matches bump updates via matchUpdateTypes + isBump", async () => {
+    const config = { packageRules: [{ matchUpdateTypes: ["bump"], automerge: true }] };
+    const bump = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, updateType: "minor", isBump: true },
+    });
+    expect(bump.rules[0]?.verdict).toBe("matched");
+
+    const plain = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, updateType: "minor" },
+    });
+    expect(plain.rules[0]?.verdict).toBe("no-match");
+  });
+
+  it("merges multiple matching rules cumulatively, in order", async () => {
+    const config = {
+      packageRules: [
+        { matchManagers: ["npm"], automerge: false, addLabels: ["from-first"] },
+        { matchDatasources: ["npm"], automerge: true, addLabels: ["from-second"] },
+      ],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    expect(result.rules.map((r) => r.verdict)).toEqual(["matched", "matched"]);
+    // scalar: the later rule wins; mergeable list: concatenated in order
+    expect(result.rawFinalConfig.automerge).toBe(true);
+    expect(result.rawFinalConfig.addLabels).toEqual(["from-first", "from-second"]);
+    const second = result.rules[1];
+    expect(second?.merged?.find((m) => m.key === "automerge")).toEqual({
+      key: "automerge",
+      before: false,
+      after: true,
+    });
+  });
+
+  it("reports matchConfidence rules as not simulated instead of deciding them", async () => {
+    const config = {
+      packageRules: [
+        {
+          matchConfidence: ["high"],
+          matchPackageNames: ["lodash"],
+          automerge: true,
+        },
+      ],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    expect(result.rules[0]?.verdict).toBe("not-simulated");
+    const clause = result.rules[0]?.clauses.find((c) => c.key === "matchConfidence");
+    expect(clause?.state).toBe("not-simulated");
+    expect(clause?.note).toMatch(/Merge Confidence API token/);
+    // the rule never merges, and the caveat is surfaced at result level
+    expect(result.rawFinalConfig.automerge).toBeUndefined();
+    expect(result.notes.some((n) => n.includes("MISSING_API_CREDENTIALS"))).toBe(true);
+  });
+
+  it("treats a present clause that returns null as skipped, like upstream", async () => {
+    const config = {
+      packageRules: [
+        {
+          matchPackageNames: ["lodash"],
+          matchCurrentAge: "gibberish",
+          labels: ["aged"],
+        },
+      ],
+    };
+    const result = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, currentVersionTimestamp: "2020-01-01T00:00:00.000Z" },
+    });
+    const clause = result.rules[0]?.clauses.find((c) => c.key === "matchCurrentAge");
+    expect(clause?.state).toBe("invalid");
+    // upstream skips null even for present clauses — the rule still matches
+    expect(result.rules[0]?.verdict).toBe("matched");
+    expect(result.rawFinalConfig.labels).toEqual(["aged"]);
+  });
+
+  it("evaluates matchJsonata against the whole input config", async () => {
+    const config = {
+      schedule: ["before 5am"],
+      packageRules: [{ matchJsonata: ["manager = 'npm' and schedule"], labels: ["jsonata"] }],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    expect(result.rules[0]?.verdict).toBe("matched");
+    expect(result.rawFinalConfig.labels).toEqual(["jsonata"]);
+  });
+
+  it("matches Renovate's real applyPackageRules output (oracle parity)", async () => {
+    const config = {
+      groupSlug: "pre-existing",
+      enabled: true,
+      packageRules: [
+        { matchPackageNames: ["*", "!react"], addLabels: ["all-but-react"] },
+        { matchCurrentVersion: "<5", matchUpdateTypes: ["patch", "minor"], automerge: true },
+        { matchDatasources: ["npm"], groupName: "My NPM Packages" },
+        { matchPackageNames: ["lodash"], overrideDatasource: "github-tags", enabled: false },
+        { matchCurrentAge: "gibberish", matchManagers: ["npm"], prPriority: 5 },
+        { matchDepTypes: ["devDependencies"], labels: ["dev-only"] },
+      ],
+    };
+    const dep: DependencyDescriptor = {
+      ...npmDep,
+      currentVersionTimestamp: "2020-01-01T00:00:00.000Z",
+    };
+    const simulated = await simulatePackageRules({ config, dep });
+    const oracle = await applyPackageRules(oracleInput(config, dep));
+    expect(simulated.rawFinalConfig).toEqual(oracle);
+    // spot-check the interesting bits actually exercised the merge tail
+    expect(oracle.groupSlug).toBe("my-npm-packages");
+    expect(oracle.datasource).toBe("github-tags");
+    expect(oracle.skipReason).toBe("package-rules");
+    expect(oracle.prPriority).toBe(5);
+  });
+
+  it("surfaces validateConfig messages for a bogus matcher key", async () => {
+    const config = {
+      packageRules: [{ matchFoo: ["x"], matchPackageNames: ["lodash"], automerge: true }],
+    };
+    const result = await simulatePackageRules({ config, dep: npmDep });
+    const all = [...result.errors, ...result.warnings];
+    expect(all.some((m) => m.message.includes("matchFoo"))).toBe(true);
+    // the unknown selector is also flagged on the rule itself
+    expect(result.rules[0]?.notes.some((n) => n.includes("matchFoo"))).toBe(true);
+    // …but, like upstream, it does not influence matching
+    expect(result.rules[0]?.verdict).toBe("matched");
+  });
+
+  it("returns an empty simulation for a config without packageRules", async () => {
+    const result = await simulatePackageRules({ config: { automerge: true }, dep: npmDep });
+    expect(result.rules).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.finalDependencyConfig.automerge).toBe(true);
+  });
+});

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -93,6 +93,20 @@ describe("simulatePackageRules", () => {
     expect(result.rawFinalConfig.labels).toEqual(["below-5"]);
   });
 
+  it("reports conda versioning as a clause error (WASM parser shimmed out of the browser)", async () => {
+    const config = {
+      packageRules: [{ matchCurrentVersion: ">=1.0", labels: ["conda"] }],
+    };
+    const result = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, versioning: "conda", currentValue: "1.2.3" },
+    });
+    expect(result.rules[0]?.verdict).toBe("no-match");
+    const clause = result.rules[0]?.clauses[0];
+    expect(clause?.state).toBe("error");
+    expect(clause?.note).toMatch(/conda versioning is not supported in the browser/);
+  });
+
   it("matches bump updates via matchUpdateTypes + isBump", async () => {
     const config = { packageRules: [{ matchUpdateTypes: ["bump"], automerge: true }] };
     const bump = await simulatePackageRules({

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         test: {
           name: "shimmed",
           include: [
+            "test/global-inherit.shimmed.test.ts",
             "test/pipeline.shimmed.test.ts",
             "test/preset-fetchers.test.ts",
             "test/provenance.shimmed.test.ts",

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
             "test/preset-fetchers.test.ts",
             "test/provenance.shimmed.test.ts",
             "test/repo-config.test.ts",
+            "test/simulate-package-rules.shimmed.test.ts",
           ],
           environment: "node",
           server: {

--- a/roadmap/006-package-rules-simulator.md
+++ b/roadmap/006-package-rules-simulator.md
@@ -18,6 +18,13 @@ Milestone: M3 · Status: done 2026-07-23
 > as ⚠ invalid but — like upstream — does not fail the rule. The real
 > merge-confidence module is shimmed (`getApiToken()` → undefined, identical
 > browser behavior) because it drags got (Node-only HTTP) into the bundle.
+> The `conda` versioning scheme is likewise shimmed to an honest stub: its
+> parser (`@baszalmstra/rattler`) is a Rust WebAssembly module that inlines
+> to ~3.9 MB — over half the entire app — while the other ~53 schemes
+> combined are ~0.4 MB, and the registry imports it statically so it would
+> load on the first pipeline run. `matchCurrentVersion` with
+> `versioning: conda` reports a per-clause error naming the limitation; all
+> other schemes use Renovate's real code.
 > UI: a "packageRules simulator" card below the effective config with a
 > compact descriptor form (+ collapsed "more fields"), four quick-fill
 > presets, on-demand evaluation (button; quick-fills auto-run), per-rule rows

--- a/roadmap/006-package-rules-simulator.md
+++ b/roadmap/006-package-rules-simulator.md
@@ -1,6 +1,31 @@
 # 006 — packageRules simulator
 
-Milestone: M3 · Status: planned
+Milestone: M3 · Status: done 2026-07-23
+
+> Implemented as specified. The engine's `simulatePackageRules` evaluates a
+> completed run's `finalConfig.packageRules` against a user-described update
+> using Renovate's REAL matcher registry
+> (`renovate/dist/util/package-rules/matchers.js`, all 18 matchers, registry
+> order) and replicates `applyPackageRules`'s merge tail (removeMatchers +
+> cumulative `mergeChildConfig`, skipReason/override/groupSlug handling).
+> Golden + shimmed tests assert **oracle parity**: the simulated final config
+> must equal what the real `applyPackageRules` returns. Deliberate gaps:
+> `matchConfidence` needs a Merge Confidence API token and upstream throws
+> without one, so such rules report "not simulated" instead of a verdict;
+> Handlebars templates in `override*`/`sourceUrl` values are applied verbatim
+> with a visible note; `groupSlug` uses an ASCII-equivalent slugify. A present
+> clause whose matcher returns null (e.g. bad `matchCurrentAge` input) shows
+> as ⚠ invalid but — like upstream — does not fail the rule. The real
+> merge-confidence module is shimmed (`getApiToken()` → undefined, identical
+> browser behavior) because it drags got (Node-only HTTP) into the bundle.
+> UI: a "packageRules simulator" card below the effective config with a
+> compact descriptor form (+ collapsed "more fields"), four quick-fill
+> presets, on-demand evaluation (button; quick-fills auto-run), per-rule rows
+> with verdict badges, per-clause ✓/✗/⚠ explanations, per-rule applied diffs,
+> `validateConfig` messages for the rules block, and the final per-dependency
+> config with changed-key highlights. Rule-level provenance beyond the
+> per-rule diff list and batch mode (the roadmap stretch goal) were skipped;
+> simulator state is not encoded in share links.
 
 ## Summary
 

--- a/roadmap/008-global-and-inherited-config.md
+++ b/roadmap/008-global-and-inherited-config.md
@@ -1,6 +1,31 @@
 # 008 — Global + inherited config layers
 
-Milestone: M3 · Status: planned
+Milestone: M3 · Status: done 2026-07-23
+
+> Implemented as specified. Two new pipeline stages (`global`, `inherit`) run
+> before the repo stages and skip byte-identically when their input is absent.
+> The global layer replicates upstream `parseConfigs`: migrate/massage/
+> `validateConfig("global")`, `globalExtends` resolved and merged UNDER the
+> config, then Renovate's real `GlobalConfig.set` captures the ~55 run-context
+> options — the stripped remainder is the merge layer, so defaults stay
+> unstripped and an absent global config behaves exactly like an empty one.
+> The inherited layer replicates `mergeInheritedConfig` minus platform
+> fetch/decrypt/templating: `validateConfig("inherit")` (errors exclude the
+> layer, where upstream aborts the run), `removeGlobalConfig(…, keepInherited)`,
+> preset resolution against the assembled base, re-validate, re-strip, then
+> `InheritConfig.set` captures its 11 options. Deviations: inherited configs
+> are also migrated+massaged (upstream only validates) so the trace shows
+> canonical forms, and `removeGlobalConfig` is reimplemented as its pure
+> 7-line `getOptions()` loop because deep-importing `dist/config/index.js`
+> would pull the whole modules/manager graph into the browser bundle
+> (`InheritConfig` is re-exported through the adapter as usual). 005's
+> provenance replays the layers before the presets (`layerConfigs` on the
+> trace), with the nested-`extends` correction now measured against the repo
+> resolution merged onto the layer base. The platform-context control reflects
+> global-config `platform`/`endpoint` ("from global config"), a manual change
+> becomes a warned override recorded as `platformContext.overridden`, and v2
+> share links carry both layers (v1 links still decode; tokens and injected
+> presets stay excluded).
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,16 +3,16 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.agents/spec/renovate-config-visualizer.md).
 
-| #                                             | Feature                                   | Milestone            | Status  |
-| --------------------------------------------- | ----------------------------------------- | -------------------- | ------- |
-| [001](001-engine-and-config-input.md)         | Trace engine + config input               | M0/M1                | done    |
-| [002](002-preset-resolution-tree.md)          | Preset resolution tree                    | M1 (MVP centerpiece) | done    |
-| [003](003-inline-option-docs.md)              | Inline option documentation               | M1                   | done    |
-| [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done    |
-| [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done    |
-| [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
-| [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done    |
-| [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | done    |
-| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | done    |
-| [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
-| [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done    |
+| #                                             | Feature                                   | Milestone            | Status |
+| --------------------------------------------- | ----------------------------------------- | -------------------- | ------ |
+| [001](001-engine-and-config-input.md)         | Trace engine + config input               | M0/M1                | done   |
+| [002](002-preset-resolution-tree.md)          | Preset resolution tree                    | M1 (MVP centerpiece) | done   |
+| [003](003-inline-option-docs.md)              | Inline option documentation               | M1                   | done   |
+| [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done   |
+| [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done   |
+| [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | done   |
+| [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done   |
+| [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | done   |
+| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | done   |
+| [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done   |
+| [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done   |

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -12,7 +12,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done    |
 | [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | planned |
 | [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done    |
-| [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | planned |
+| [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | done    |
 | [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | done    |
 | [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done    |


### PR DESCRIPTION
Implements the final two roadmap items, completing the roadmap:

## 008 — Global + inherited config layers
- Two new collapsed input slots: **global (self-hosted admin) config** and **inherited (`inheritConfig`) config**, JSON per roadmap scope.
- New pipeline stages mirror the real Renovate order (defaults → `globalExtends` presets → global remainder → inherited remainder → repo): each layer is migrated/massaged/validated with the layer-appropriate rules (`validateConfig("global"/"inherit")`), `globalExtends` merges *under* the global config, inherited presets are resolved with global-only options stripped (`keepInherited` semantics), and `GlobalConfig`/`InheritConfig` capture their run-context options exactly like upstream.
- Provenance view gains **global config** / **inherited config** layer badges; global-only options set in repo config surface upstream's own validation warning.
- The platform-context control now **reflects** `platform`/`endpoint` from the pasted global config ("from global config" chip); changing it becomes an explicit override with a visible warning and is recorded on the trace. A global platform also displaces the toolbar endpoint (it belongs to the toolbar's platform) in favor of the platform's default.
- Share links bump to **v2** carrying the new layers + override flag; v1 links still decode.
- Absent layers are byte-identical to the previous behavior (golden snapshots unchanged).

## 006 — packageRules simulator
- New engine entry point `simulatePackageRules`: evaluates every rule of the run's effective config against Renovate's **real matcher registry** (all 18 matchers), reporting per-clause results — matched / no match / not simulated / invalid — and replicating `applyPackageRules`' merge tail exactly (match-key stripping, `groupSlug`, `override*`, skip handling). The real `applyPackageRules` serves as the oracle in tests.
- Simulator card in the app: dependency descriptor form with quick-fill presets (npm dep, Dockerfile image, GitHub Action, pep621/pip), per-rule verdict rows expandable to clause-by-clause explanations (`matchSourceUrls: no match against no input value set`), per-rule applied diffs, and the final resolved per-dependency config.
- `matchConfidence` is reported honestly as *not simulated* (requires a Merge Confidence API token; upstream would throw). Exclusions are `!`-prefixed patterns inside `match*` lists, shown as such.
- Rule validation (unknown keys, "at least one selector") comes from the real `validateConfig`.

## Verification
- Engine: golden 13/13, shimmed 63/63 (18 new tests incl. oracle-parity against `applyPackageRules` and full layer-precedence coverage); lint/format/typecheck clean; `renovate/dist` import boundary clean; app build passes.
- Browser-verified end to end: global+inherited stages with correct diffs (globalExtends resolution, global-only stripping), provenance chains (default → global sets → inherited overwrites), platform reflection + endpoint displacement, simulator against `config:recommended` (3 of 712 rules matched for an npm patch, correct clause explanations, final per-dependency config) — zero console errors on a fresh load.

Out of scope (per roadmap): `config.js` JavaScript parsing, secrets/decryption, batch simulation mode, real dependency extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ