### PR TITLE
First-load UX: progressive disclosure + plain-language glossary with docs links

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -13,7 +13,8 @@ import { MigrationSteps } from "./components/MigrationSteps";
 import { identityForNodeId, nodeIdForIdentity, PresetTree } from "./components/PresetTree";
 import { RuleSimulator } from "./components/RuleSimulator";
 import { StageDiff } from "./components/StageDiff";
-import { StageTimeline } from "./components/StageTimeline";
+import { STAGE_EXPLAINERS, STAGE_LABELS, StageTimeline } from "./components/StageTimeline";
+import { Term } from "./glossary";
 import { OptionDocsProvider } from "./option-docs";
 import {
   beginSignIn,
@@ -40,6 +41,28 @@ import {
 const DEFAULT_CONFIG = `{
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"]
+}
+`;
+
+// A richer starter config that gives every part of the app something to show:
+// a deprecated option (migrate), string shorthand (massage), presets and
+// packageRules for the simulator.
+const EXAMPLE_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "schedule": "before 6am on monday",
+  "semanticCommits": true,
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["react", "react-dom"],
+      "groupName": "react"
+    }
+  ]
 }
 `;
 
@@ -215,6 +238,10 @@ export function App() {
   const [globalText, setGlobalText] = useState("");
   const [inheritedText, setInheritedText] = useState("");
   const [platformOverride, setPlatformOverride] = useState(false);
+  // The single collapsed home of everything a typical repo user never touches
+  // (self-hosted layers, platform context, tokens). Auto-opens when a share
+  // link arrives carrying self-hosted layers, so their effect isn't invisible.
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   // OAuth sign-in (009). Configured only when both build-time vars are present;
   // otherwise the whole feature stays hidden and the PAT fallback remains.
   const oauthConfig = useMemo(() => getOAuthConfig(), []);
@@ -419,6 +446,9 @@ export function App() {
         payload.inheritedConfig ? JSON.stringify(payload.inheritedConfig, null, 2) : "",
       );
       setPlatformOverride(payload.platformOverride === true);
+      if (payload.globalConfig || payload.inheritedConfig) {
+        setAdvancedOpen(true);
+      }
       pendingViewRef.current = payload.view ?? null;
       const current = await getRenovateVersion();
       if (!cancelled && payload.renovate && payload.renovate !== current) {
@@ -560,7 +590,7 @@ export function App() {
     const knownHost = parsed.host ? HOST_PLATFORM[parsed.host] : undefined;
     if (parsed.host && !knownHost) {
       setNotice(
-        `Unknown host ${parsed.host}. Set the platform and endpoint in "Platform context" below, then load with the owner/repo form.`,
+        `Unknown host ${parsed.host}. Set its host and API endpoint under Advanced options → "Repository host & access tokens", then load with the owner/repo form.`,
       );
       return;
     }
@@ -570,7 +600,7 @@ export function App() {
     } else {
       if (!FETCHABLE_PLATFORMS.has(platform as RepoPlatform)) {
         setNotice(
-          `The current platform context (${platform}) can't be fetched from the browser. Choose github, gitlab, gitea or forgejo in "Platform context", or use a full URL.`,
+          `The current repository host (${platform}) can't be fetched from the browser. Choose github, gitlab, gitea or forgejo under Advanced options → "Repository host & access tokens", or use a full URL.`,
         );
         return;
       }
@@ -650,79 +680,45 @@ export function App() {
           ) : null}
         </header>
         <p className="subtitle">
-          Paste a repo config and step through what Renovate actually does with it — parsing,
-          migration, massaging, validation, preset resolution and merging, powered by
-          Renovate&apos;s own code running in your browser.
+          Understand your Renovate config by watching Renovate&apos;s own code process it, step by
+          step, right here in your browser. Nothing you paste leaves the page.
         </p>
 
-        <ConfigEditor fileName={fileName} value={content} onChange={setContent} />
-
-        <details className="advanced-settings">
-          <summary>
-            Global config (self-hosted admin)
-            <span className="advanced-hint">
-              {" "}
-              — the layer set via config.js / env / CLI
-              {globalParse.config ? " · active" : ""}
-              {globalParse.error ? " · invalid JSON" : ""}
-            </span>
-          </summary>
-          <div className="advanced-body">
-            <p className="advanced-note">
-              JSON only. Merges between the defaults and the repo config, after its own{" "}
-              <code>globalExtends</code> presets; options like <code>platform</code>,{" "}
-              <code>endpoint</code> or <code>onboarding</code> become run context instead of
-              merging. Leave empty to run without this layer.
+        {result ? null : (
+          <section className="welcome" aria-label="How it works">
+            <ol className="welcome-steps">
+              <li>
+                <strong>Bring a config.</strong> Paste your <code>renovate.json</code> below, load
+                it straight from a repository, or{" "}
+                <button
+                  type="button"
+                  className="linklike"
+                  onClick={() => setContent(EXAMPLE_CONFIG)}
+                >
+                  try an example
+                </button>
+                .
+              </li>
+              <li>
+                <strong>Run it.</strong> The same code the real bot uses resolves your{" "}
+                <Term id="preset">presets</Term>, applies{" "}
+                <Term id="migration">config migration</Term> and validates every option.
+              </li>
+              <li>
+                <strong>Explore the result.</strong> Step through each stage, hover any option for
+                its docs, and simulate which <Term id="packageRules">packageRules</Term> would apply
+                to a dependency update.
+              </li>
+            </ol>
+            <p className="welcome-footnote">
+              New to Renovate? Start with the{" "}
+              <a href="https://docs.renovatebot.com/" target="_blank" rel="noreferrer">
+                official docs ↗
+              </a>
+              . Your config and any tokens stay in this browser tab.
             </p>
-            <textarea
-              className="layer-editor"
-              placeholder='{ "globalExtends": ["config:best-practices"], "platform": "gitlab" }'
-              value={globalText}
-              onChange={(e) => setGlobalText(e.target.value)}
-              spellCheck={false}
-              rows={8}
-            />
-            {globalParse.error ? (
-              <p className="layer-editor-error">
-                Not valid JSON: {globalParse.error}. The pipeline won&apos;t run until this parses
-                or the field is cleared.
-              </p>
-            ) : null}
-          </div>
-        </details>
-
-        <details className="advanced-settings">
-          <summary>
-            Inherited config (inheritConfig)
-            <span className="advanced-hint">
-              {" "}
-              — the org-level layer between global and repo config
-              {inheritedParse.config ? " · active" : ""}
-              {inheritedParse.error ? " · invalid JSON" : ""}
-            </span>
-          </summary>
-          <div className="advanced-body">
-            <p className="advanced-note">
-              JSON only. Validated with Renovate&apos;s <code>inherit</code> rules, its presets
-              resolved, global-only options stripped — then merged between the global layer and the
-              repo config. Leave empty to run without this layer.
-            </p>
-            <textarea
-              className="layer-editor"
-              placeholder='{ "extends": ["github>my-org/renovate-config"], "automerge": false }'
-              value={inheritedText}
-              onChange={(e) => setInheritedText(e.target.value)}
-              spellCheck={false}
-              rows={8}
-            />
-            {inheritedParse.error ? (
-              <p className="layer-editor-error">
-                Not valid JSON: {inheritedParse.error}. The pipeline won&apos;t run until this
-                parses or the field is cleared.
-              </p>
-            ) : null}
-          </div>
-        </details>
+          </section>
+        )}
 
         <form
           className="repo-load"
@@ -731,17 +727,18 @@ export function App() {
             void onLoadRepo();
           }}
         >
+          <span className="repo-load-label">Load from a repository</span>
           <input
             type="text"
             className="repo-load-ref"
-            placeholder="Load from repo — owner/repo, github.com/owner/repo, or a full URL"
+            placeholder="owner/repo, github.com/owner/repo, or a full repository URL"
             value={repoInput}
             onChange={(e) => setRepoInput(e.target.value)}
           />
           <input
             type="text"
             className="repo-load-branch"
-            placeholder="ref (default branch)"
+            placeholder="branch or tag (optional)"
             value={repoRef}
             onChange={(e) => setRepoRef(e.target.value)}
           />
@@ -749,6 +746,8 @@ export function App() {
             {repoLoading ? "Loading…" : "Load"}
           </button>
         </form>
+
+        <ConfigEditor fileName={fileName} value={content} onChange={setContent} />
 
         <div className="toolbar">
           <select value={fileName} onChange={(e) => setFileName(e.target.value as typeof fileName)}>
@@ -793,8 +792,14 @@ export function App() {
             )
           ) : null}
           <span className="toolbar-spacer" />
-          <button type="button" className="primary" onClick={() => onRun()} disabled={running}>
-            {running ? "Running…" : "Run pipeline"}
+          <button
+            type="button"
+            className="primary"
+            onClick={() => onRun()}
+            disabled={running}
+            title="Process this config with Renovate's own code — it never leaves your browser"
+          >
+            {running ? "Running…" : "Run"}
           </button>
           <button
             type="button"
@@ -806,138 +811,255 @@ export function App() {
           </button>
         </div>
 
-        <details className="advanced-settings">
+        <details
+          className="advanced-zone"
+          open={advancedOpen}
+          onToggle={(e) => setAdvancedOpen(e.currentTarget.open)}
+        >
           <summary>
-            Platform context &amp; per-host tokens
+            Advanced options
             <span className="advanced-hint">
               {" "}
-              — defines `local&gt;` and bare `owner/repo` presets
+              — repository host, access tokens, self-hosted bot config
             </span>
+            {globalParse.config || inheritedParse.config ? (
+              <span className="advanced-active-chip">self-hosted config active</span>
+            ) : null}
+            {globalParse.error || inheritedParse.error ? (
+              <span className="advanced-active-chip invalid">invalid JSON</span>
+            ) : null}
           </summary>
-          <div className="advanced-body">
-            <div className="advanced-row">
-              <label>
-                Platform
-                <select value={displayPlatform} onChange={(e) => onPlatformChange(e.target.value)}>
-                  {PLATFORMS.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                  {!PLATFORMS.includes(displayPlatform) ? (
-                    <option value={displayPlatform}>{displayPlatform}</option>
+
+          <p className="advanced-intro">
+            Everything here is optional — the defaults suit a repository on github.com using the
+            hosted Renovate app.
+          </p>
+
+          <details className="advanced-settings">
+            <summary>
+              Repository host &amp; access tokens
+              <span className="advanced-hint">
+                {" "}
+                — where presets that live in other repositories are fetched from
+              </span>
+            </summary>
+            <div className="advanced-body">
+              <p className="advanced-note">
+                Some presets live in other repositories on your <Term id="platform">
+                  code host
+                </Term>{" "}
+                (referenced as{" "}
+                <Term id="localPreset">
+                  <code>local&gt;</code>
+                </Term>{" "}
+                or a bare <code>owner/repo</code>). Set the host and API endpoint they should
+                resolve against.
+              </p>
+              <div className="advanced-row">
+                <label>
+                  Platform
+                  <select
+                    value={displayPlatform}
+                    onChange={(e) => onPlatformChange(e.target.value)}
+                  >
+                    {PLATFORMS.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                    {!PLATFORMS.includes(displayPlatform) ? (
+                      <option value={displayPlatform}>{displayPlatform}</option>
+                    ) : null}
+                  </select>
+                </label>
+                <label className="grow">
+                  Endpoint
+                  <input
+                    type="text"
+                    placeholder={
+                      PLATFORM_ENDPOINTS[displayPlatform] || "not fetched in the browser"
+                    }
+                    value={displayEndpoint}
+                    onChange={(e) => onEndpointChange(e.target.value)}
+                  />
+                </label>
+              </div>
+              {reflectGlobal ? (
+                <p className="advanced-note platform-from-global">
+                  <span className="badge prov-global">from global config</span>{" "}
+                  {globalPlatform !== undefined ? (
+                    <>
+                      platform <code>{globalPlatform}</code>
+                    </>
                   ) : null}
-                </select>
-              </label>
-              <label className="grow">
-                Endpoint
-                <input
-                  type="text"
-                  placeholder={PLATFORM_ENDPOINTS[displayPlatform] || "not fetched in the browser"}
-                  value={displayEndpoint}
-                  onChange={(e) => onEndpointChange(e.target.value)}
-                />
-              </label>
+                  {globalPlatform !== undefined && globalEndpoint !== undefined ? " and " : null}
+                  {globalEndpoint !== undefined ? (
+                    <>
+                      endpoint <code>{globalEndpoint}</code>
+                    </>
+                  ) : null}{" "}
+                  come from the pasted global config — a real Renovate run would use them. Changing
+                  the control overrides them for this visualization.
+                </p>
+              ) : null}
+              {platformOverride && hasGlobalContext ? (
+                <p className="advanced-note platform-override-warning">
+                  Overriding <code>platform</code>/<code>endpoint</code> from the global config — a
+                  real Renovate run would use <code>{globalPlatform ?? displayPlatform}</code>
+                  {" / "}
+                  <code>
+                    {globalEndpoint ??
+                      (PLATFORM_ENDPOINTS[globalPlatform ?? ""] || "the platform default")}
+                  </code>
+                  .{" "}
+                  <button
+                    type="button"
+                    className="platform-override-clear"
+                    onClick={() => setPlatformOverride(false)}
+                  >
+                    use global config values
+                  </button>
+                </p>
+              ) : null}
+              {usesLocal && !(platform in PLATFORM_ENDPOINTS && PLATFORM_ENDPOINTS[platform]) ? (
+                <p className="advanced-note">
+                  <code>{platform}</code> presets are not fetched in the browser — a real Renovate
+                  run reaches them. You can still provide their content manually from a failed node
+                  below.
+                </p>
+              ) : null}
+              {oauthConfig ? (
+                <p className="advanced-note">
+                  Signing in with GitHub (top of the page) is the recommended way to reach private
+                  GitHub presets and repos. A personal access token is only a fallback — for GitHub
+                  Enterprise Server, when the app installation can&apos;t be approved, or if the
+                  sign-in service is unavailable.
+                </p>
+              ) : (
+                <p className="advanced-note">
+                  A GitHub personal access token lifts preset rate limits and reaches private
+                  repositories. It stays in this browser tab only.
+                </p>
+              )}
+              <div className="advanced-row">
+                <label className="grow">
+                  GitHub personal access token (fallback)
+                  <input
+                    type="password"
+                    placeholder="optional — stays in this browser tab"
+                    value={token}
+                    onChange={(e) => onTokenChange(e.target.value)}
+                  />
+                </label>
+                <label className="grow">
+                  GitLab token (PRIVATE-TOKEN)
+                  <input
+                    type="password"
+                    placeholder="optional — stays in this browser tab"
+                    value={gitlabToken}
+                    onChange={(e) =>
+                      makeTokenHandler(GITLAB_TOKEN_KEY, setGitlabToken)(e.target.value)
+                    }
+                  />
+                </label>
+                <label className="grow">
+                  Gitea token
+                  <input
+                    type="password"
+                    placeholder="optional — stays in this browser tab"
+                    value={giteaToken}
+                    onChange={(e) =>
+                      makeTokenHandler(GITEA_TOKEN_KEY, setGiteaToken)(e.target.value)
+                    }
+                  />
+                </label>
+                <label className="grow">
+                  Forgejo token
+                  <input
+                    type="password"
+                    placeholder="optional — stays in this browser tab"
+                    value={forgejoToken}
+                    onChange={(e) =>
+                      makeTokenHandler(FORGEJO_TOKEN_KEY, setForgejoToken)(e.target.value)
+                    }
+                  />
+                </label>
+              </div>
             </div>
-            {reflectGlobal ? (
-              <p className="advanced-note platform-from-global">
-                <span className="badge prov-global">from global config</span>{" "}
-                {globalPlatform !== undefined ? (
-                  <>
-                    platform <code>{globalPlatform}</code>
-                  </>
-                ) : null}
-                {globalPlatform !== undefined && globalEndpoint !== undefined ? " and " : null}
-                {globalEndpoint !== undefined ? (
-                  <>
-                    endpoint <code>{globalEndpoint}</code>
-                  </>
-                ) : null}{" "}
-                come from the pasted global config — a real Renovate run would use them. Changing
-                the control overrides them for this visualization.
-              </p>
-            ) : null}
-            {platformOverride && hasGlobalContext ? (
-              <p className="advanced-note platform-override-warning">
-                Overriding <code>platform</code>/<code>endpoint</code> from the global config — a
-                real Renovate run would use <code>{globalPlatform ?? displayPlatform}</code>
-                {" / "}
-                <code>
-                  {globalEndpoint ??
-                    (PLATFORM_ENDPOINTS[globalPlatform ?? ""] || "the platform default")}
-                </code>
-                .{" "}
-                <button
-                  type="button"
-                  className="platform-override-clear"
-                  onClick={() => setPlatformOverride(false)}
-                >
-                  use global config values
-                </button>
-              </p>
-            ) : null}
-            {usesLocal && !(platform in PLATFORM_ENDPOINTS && PLATFORM_ENDPOINTS[platform]) ? (
+          </details>
+
+          <details className="advanced-settings">
+            <summary>
+              Global config
+              <span className="advanced-hint">
+                {" "}
+                — bot-level settings from a self-hosted administrator
+                {globalParse.config ? " · active" : ""}
+                {globalParse.error ? " · invalid JSON" : ""}
+              </span>
+            </summary>
+            <div className="advanced-body">
               <p className="advanced-note">
-                <code>{platform}</code> presets are not fetched in the browser — a real Renovate run
-                reaches them. You can still provide their content manually from a failed node below.
+                Running your own Renovate bot? Paste its{" "}
+                <Term id="globalConfig">global config</Term> as JSON to model the full layer stack:
+                it merges between Renovate&apos;s defaults and your repo config, after its own{" "}
+                <code>globalExtends</code> presets. Options like <code>platform</code>,{" "}
+                <code>endpoint</code> or <code>onboarding</code> become run context instead of
+                merging. Leave empty to run without this layer.
               </p>
-            ) : null}
-            {oauthConfig ? (
-              <p className="advanced-note">
-                Signing in with GitHub (top of the page) is the recommended way to reach private
-                GitHub presets and repos. A personal access token is only a fallback — for GitHub
-                Enterprise Server, when the app installation can&apos;t be approved, or if the
-                sign-in service is unavailable.
-              </p>
-            ) : (
-              <p className="advanced-note">
-                A GitHub personal access token lifts preset rate limits and reaches private
-                repositories. It stays in this browser tab only.
-              </p>
-            )}
-            <div className="advanced-row">
-              <label className="grow">
-                GitHub personal access token (fallback)
-                <input
-                  type="password"
-                  placeholder="optional — stays in this browser tab"
-                  value={token}
-                  onChange={(e) => onTokenChange(e.target.value)}
-                />
-              </label>
-              <label className="grow">
-                GitLab token (PRIVATE-TOKEN)
-                <input
-                  type="password"
-                  placeholder="optional — stays in this browser tab"
-                  value={gitlabToken}
-                  onChange={(e) =>
-                    makeTokenHandler(GITLAB_TOKEN_KEY, setGitlabToken)(e.target.value)
-                  }
-                />
-              </label>
-              <label className="grow">
-                Gitea token
-                <input
-                  type="password"
-                  placeholder="optional — stays in this browser tab"
-                  value={giteaToken}
-                  onChange={(e) => makeTokenHandler(GITEA_TOKEN_KEY, setGiteaToken)(e.target.value)}
-                />
-              </label>
-              <label className="grow">
-                Forgejo token
-                <input
-                  type="password"
-                  placeholder="optional — stays in this browser tab"
-                  value={forgejoToken}
-                  onChange={(e) =>
-                    makeTokenHandler(FORGEJO_TOKEN_KEY, setForgejoToken)(e.target.value)
-                  }
-                />
-              </label>
+              <textarea
+                className="layer-editor"
+                placeholder='{ "globalExtends": ["config:best-practices"], "platform": "gitlab" }'
+                value={globalText}
+                onChange={(e) => setGlobalText(e.target.value)}
+                spellCheck={false}
+                rows={8}
+              />
+              {globalParse.error ? (
+                <p className="layer-editor-error">
+                  Not valid JSON: {globalParse.error}. The pipeline won&apos;t run until this parses
+                  or the field is cleared.
+                </p>
+              ) : null}
             </div>
-          </div>
+          </details>
+
+          <details className="advanced-settings">
+            <summary>
+              Inherited config
+              <span className="advanced-hint">
+                {" "}
+                — org-wide defaults shared across repositories
+                {inheritedParse.config ? " · active" : ""}
+                {inheritedParse.error ? " · invalid JSON" : ""}
+              </span>
+            </summary>
+            <div className="advanced-body">
+              <p className="advanced-note">
+                Defaults a self-hosted bot shares across repositories via{" "}
+                <Term id="inheritedConfig">
+                  <code>inheritConfig</code>
+                </Term>
+                . Validated with Renovate&apos;s inherit rules, its presets resolved, bot-only
+                options stripped — then merged between the global layer and the repo config. Leave
+                empty to run without this layer.
+              </p>
+              <textarea
+                className="layer-editor"
+                placeholder='{ "extends": ["github>my-org/renovate-config"], "automerge": false }'
+                value={inheritedText}
+                onChange={(e) => setInheritedText(e.target.value)}
+                spellCheck={false}
+                rows={8}
+              />
+              {inheritedParse.error ? (
+                <p className="layer-editor-error">
+                  Not valid JSON: {inheritedParse.error}. The pipeline won&apos;t run until this
+                  parses or the field is cleared.
+                </p>
+              ) : null}
+            </div>
+          </details>
         </details>
 
         {fatal ? <p style={{ color: "var(--error)" }}>{fatal}</p> : null}
@@ -963,7 +1085,8 @@ export function App() {
             <StageTimeline result={result} selected={selectedStage} onSelect={setSelectedStage} />
             <div className="card">
               <div className="card-title">
-                Stage: {selectedStage}
+                Stage: {STAGE_LABELS[selectedStage]}
+                <span className="card-title-hint"> — {STAGE_EXPLAINERS[selectedStage].plain}</span>
                 {deferredStage !== selectedStage ? (
                   <span className="rendering-note"> rendering…</span>
                 ) : null}

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -4,6 +4,7 @@ import type {
   ProvenanceStep,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
+import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { ConfigJson } from "./ConfigJson";
 
@@ -301,7 +302,9 @@ export function EffectiveConfig({
   if (provenance === null) {
     return (
       <div className="card">
-        <div className="card-title">Effective config</div>
+        <div className="card-title">
+          <Term id="effectiveConfig">Effective config</Term>
+        </div>
         <p className="empty-note">
           Per-key provenance is unavailable because preset resolution did not complete. Showing the
           effective config Renovate produced from the defaults.
@@ -317,7 +320,10 @@ export function EffectiveConfig({
 
   return (
     <div className="card">
-      <div className="card-title">Effective config — per-key provenance</div>
+      <div className="card-title">
+        <Term id="effectiveConfig">Effective config</Term>
+        <span className="card-title-hint"> — and which layer set each option</span>
+      </div>
       {provenance === undefined ? (
         <p className="empty-note">Computing provenance…</p>
       ) : (

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -5,6 +5,7 @@ import type {
   TraceEvent,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
+import { Term } from "../glossary";
 import { ConfigJson } from "./ConfigJson";
 import { type AuthState, GithubAuthHint } from "./GithubAuthHint";
 import { JsonDiff } from "./JsonDiff";
@@ -941,7 +942,8 @@ export const PresetTree = memo(function PresetTree({
   return (
     <div className="card">
       <div className="card-title">
-        Preset resolution tree ({nf.format(stats.summary.resolved)} resolved)
+        <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
+        resolved)
       </div>
       <SummaryHeader summary={stats.summary} />
       <div className="preset-controls">

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -6,6 +6,7 @@ import type {
   SimulationResult,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
+import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { ConfigJson } from "./ConfigJson";
 
@@ -380,10 +381,15 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
   if (packageRules.length === 0) {
     return (
       <div className="card">
-        <div className="card-title">packageRules simulator</div>
+        <div className="card-title">
+          Update simulator{" "}
+          <span className="sim-title-hint">
+            — test your <Term id="packageRules">packageRules</Term>
+          </span>
+        </div>
         <p className="empty-note">
-          This config has no <code>packageRules</code> — nothing to simulate. Rules added by presets
-          would appear here after a run that resolves them.
+          This config has no <Term id="packageRules">packageRules</Term> — nothing to simulate.
+          Rules added by presets would appear here after a run that resolves them.
         </p>
       </div>
     );
@@ -395,11 +401,13 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
   return (
     <div className="card">
       <div className="card-title">
-        packageRules simulator
+        Update simulator
         <span className="sim-title-hint">
           {" "}
-          — which of the {packageRules.length} rule{packageRules.length === 1 ? "" : "s"} hit a
-          hypothetical update?
+          — describe a hypothetical dependency update and see which of the {
+            packageRules.length
+          }{" "}
+          <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
         </span>
       </div>
       <div className="sim-presets">

--- a/packages/app/src/components/StageTimeline.tsx
+++ b/packages/app/src/components/StageTimeline.tsx
@@ -1,4 +1,5 @@
 import type { StageId, TraceResult } from "@renovate-config-visualizer/engine";
+import { Explained, type GlossaryEntry } from "../glossary";
 
 const STAGE_ORDER: StageId[] = [
   "global",
@@ -11,15 +12,63 @@ const STAGE_ORDER: StageId[] = [
   "merge",
 ];
 
-const STAGE_LABELS: Record<StageId, string> = {
+export const STAGE_LABELS: Record<StageId, string> = {
   global: "Global config",
-  inherit: "Inherited",
+  inherit: "Inherited config",
   parse: "Parse",
   migrate: "Migrate",
   massage: "Massage",
   validate: "Validate",
   preset: "Presets",
-  merge: "Merge defaults",
+  merge: "Merge",
+};
+
+/** Plain-language card per stage — what Renovate does there, with docs. */
+export const STAGE_EXPLAINERS: Record<StageId, GlossaryEntry> = {
+  global: {
+    name: "global config stage",
+    plain:
+      "Applies the bot-level settings a self-hosted administrator configured, including any globalExtends presets. Skipped unless you provide a global config under Advanced options.",
+    url: "https://docs.renovatebot.com/self-hosted-configuration/",
+  },
+  inherit: {
+    name: "inherited config stage",
+    plain:
+      "Applies org-level defaults shared across repositories (inheritConfig): validated, its presets resolved, and bot-only options stripped. Skipped unless you provide one under Advanced options.",
+    url: "https://docs.renovatebot.com/self-hosted-configuration/#inheritconfig",
+  },
+  parse: {
+    name: "parse stage",
+    plain: "Reads your config file text and turns it into a configuration object.",
+  },
+  migrate: {
+    name: "migrate stage",
+    plain:
+      "Rewrites deprecated options to their current names and shapes — the same rewriting Renovate applies (or proposes as a config-migration PR) on every real run.",
+    url: "https://docs.renovatebot.com/config-migration/",
+  },
+  massage: {
+    name: "massage stage",
+    plain:
+      "Normalizes allowed shorthand into the full form Renovate works with internally — for example a single string where a list is expected.",
+  },
+  validate: {
+    name: "validate stage",
+    plain:
+      "Checks every option against Renovate's schema and reports unknown names, wrong types and misplaced options.",
+    url: "https://docs.renovatebot.com/config-validation/",
+  },
+  preset: {
+    name: "presets stage",
+    plain:
+      "Downloads everything listed in extends, expands presets referenced inside presets, and merges the result in order underneath your own settings.",
+    url: "https://docs.renovatebot.com/config-presets/",
+  },
+  merge: {
+    name: "merge stage",
+    plain:
+      "Combines Renovate's built-in defaults, the resolved presets and your config — in that order — into the effective config Renovate would act on.",
+  },
 };
 
 interface Props {
@@ -32,15 +81,19 @@ export function StageTimeline({ result, selected, onSelect }: Props) {
   return (
     <div className="stage-timeline">
       {STAGE_ORDER.map((stage) => (
-        <button
-          key={stage}
-          type="button"
-          className={`stage-chip${stage === selected ? " selected" : ""}`}
-          onClick={() => onSelect(stage)}
-        >
-          <span className={`dot ${result.stageStatus[stage]}`} />
-          {STAGE_LABELS[stage]}
-        </button>
+        <Explained key={stage} entry={STAGE_EXPLAINERS[stage]}>
+          {(handlers) => (
+            <button
+              type="button"
+              className={`stage-chip${stage === selected ? " selected" : ""}`}
+              onClick={() => onSelect(stage)}
+              {...handlers}
+            >
+              <span className={`dot ${result.stageStatus[stage]}`} />
+              {STAGE_LABELS[stage]}
+            </button>
+          )}
+        </Explained>
       ))}
     </div>
   );

--- a/packages/app/src/glossary.tsx
+++ b/packages/app/src/glossary.tsx
@@ -1,0 +1,277 @@
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Plain-language explanations for Renovate concepts used in the app's own
+ * copy (the option hover docs in option-docs.tsx cover config *keys*; this
+ * covers the vocabulary around them). Each entry links to the matching
+ * docs.renovatebot.com page when one exists.
+ */
+
+export interface GlossaryEntry {
+  /** The exact Renovate name, shown as the card heading. */
+  name: string;
+  /** One or two plain sentences — what it means to a repo user. */
+  plain: string;
+  /** docs.renovatebot.com page, when there is one. */
+  url?: string;
+}
+
+export const GLOSSARY = {
+  preset: {
+    name: "presets",
+    plain:
+      "Reusable, shareable pieces of configuration that your config pulls in through the extends option. Most repos start from the config:recommended preset.",
+    url: "https://docs.renovatebot.com/config-presets/",
+  },
+  extends: {
+    name: "extends",
+    plain:
+      "The config option that lists which presets to pull in. Renovate downloads each one, expands presets referenced inside it, and merges the result under your own settings.",
+    url: "https://docs.renovatebot.com/configuration-options/#extends",
+  },
+  migration: {
+    name: "config migration",
+    plain:
+      "Renovate renames and reshapes options over time. Migration rewrites deprecated settings in your config to their current form before anything else happens.",
+    url: "https://docs.renovatebot.com/config-migration/",
+  },
+  massage: {
+    name: "massaging",
+    plain:
+      "A normalization step: shorthand you are allowed to write (like a single string where a list is expected) is expanded into the full form Renovate works with internally.",
+  },
+  validation: {
+    name: "config validation",
+    plain:
+      "Every option is checked against Renovate's schema — unknown names, wrong types and misplaced options are reported the same way renovate-config-validator would.",
+    url: "https://docs.renovatebot.com/config-validation/",
+  },
+  globalConfig: {
+    name: "global config",
+    plain:
+      "Bot-level settings a self-hosted Renovate administrator configures on the bot itself (config file, environment or CLI). Repos on the hosted GitHub App don't have one to worry about.",
+    url: "https://docs.renovatebot.com/self-hosted-configuration/",
+  },
+  inheritedConfig: {
+    name: "inherited config",
+    plain:
+      "Org-level defaults a self-hosted admin shares across repositories via the inheritConfig setting. It merges between the bot's global config and each repo's own config.",
+    url: "https://docs.renovatebot.com/self-hosted-configuration/#inheritconfig",
+  },
+  platform: {
+    name: "platform",
+    plain:
+      "Where your repositories are hosted — github, gitlab, and so on. Renovate uses it to resolve presets that live in other repositories on the same host (local> and owner/repo references).",
+    url: "https://docs.renovatebot.com/modules/platform/",
+  },
+  localPreset: {
+    name: "local> presets",
+    plain:
+      "Presets referenced as local>owner/repo (or bare owner/repo) live on the same host as the repository being processed, so resolving them needs a platform and endpoint for context.",
+    url: "https://docs.renovatebot.com/config-presets/#local-presets",
+  },
+  packageRules: {
+    name: "packageRules",
+    plain:
+      "Targeted overrides: each rule matches certain dependencies or updates (by name, manager, update type, …) and applies extra settings — grouping, automerge, labels — only to those.",
+    url: "https://docs.renovatebot.com/configuration-options/#packagerules",
+  },
+  updateType: {
+    name: "update types",
+    plain:
+      "How big a version jump an update is — major, minor, patch, pin, digest and friends. Many rules and presets branch on it.",
+    url: "https://docs.renovatebot.com/configuration-options/#matchupdatetypes",
+  },
+  manager: {
+    name: "managers",
+    plain:
+      "The modules that find dependencies in your repo — npm for package.json, gomod for go.mod, dockerfile, github-actions, and many more.",
+    url: "https://docs.renovatebot.com/modules/manager/",
+  },
+  datasource: {
+    name: "datasources",
+    plain:
+      "Where Renovate looks up available versions for a dependency — the npm registry, Docker Hub, Maven Central, GitHub releases, and so on.",
+    url: "https://docs.renovatebot.com/modules/datasource/",
+  },
+  effectiveConfig: {
+    name: "effective config",
+    plain:
+      "The final result after defaults, presets and your own settings are merged in order — the configuration Renovate actually acts on for your repository.",
+  },
+  dependencyDashboard: {
+    name: "Dependency Dashboard",
+    plain:
+      "An issue Renovate keeps open in your repo listing every pending, open and rate-limited update, with checkboxes to trigger them.",
+    url: "https://docs.renovatebot.com/key-concepts/dashboard/",
+  },
+} satisfies Record<string, GlossaryEntry>;
+
+export type TermId = keyof typeof GLOSSARY;
+
+interface CardPos {
+  left: number;
+  top: number;
+  bottom: number;
+}
+
+interface CardState {
+  entry: GlossaryEntry;
+  pos: CardPos;
+}
+
+/** Module-level singleton so only one glossary card is ever open. */
+let activeHide: (() => void) | null = null;
+
+/**
+ * Shared hover/focus behavior for an element that explains itself with a
+ * floating card. Same interaction contract as the option hover docs: a grace
+ * period lets the pointer travel into the card to click the docs link.
+ */
+function useHoverCard(entry: GlossaryEntry) {
+  const [card, setCard] = useState<CardState | null>(null);
+  const hideTimer = useRef<number | undefined>(undefined);
+
+  const hideNow = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+    setCard(null);
+  }, []);
+
+  const show = useCallback(
+    (el: Element) => {
+      if (activeHide && activeHide !== hideNow) {
+        activeHide();
+      }
+      activeHide = hideNow;
+      window.clearTimeout(hideTimer.current);
+      const rect = el.getBoundingClientRect();
+      setCard({ entry, pos: { left: rect.left, top: rect.top, bottom: rect.bottom } });
+    },
+    [entry, hideNow],
+  );
+
+  const hide = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => setCard(null), 250);
+  }, []);
+
+  const cancelHide = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+  }, []);
+
+  // Scrolling moves the anchor out from under the fixed-position card; hide
+  // rather than float a card pointing at nothing.
+  useEffect(() => {
+    if (!card) {
+      return;
+    }
+    window.addEventListener("scroll", hideNow, { passive: true });
+    return () => window.removeEventListener("scroll", hideNow);
+  }, [card, hideNow]);
+
+  return { card, show, hide, hideNow, cancelHide };
+}
+
+function GlossaryCard({
+  card,
+  onEnter,
+  onLeave,
+}: {
+  card: CardState;
+  onEnter: () => void;
+  onLeave: () => void;
+}) {
+  const { entry, pos } = card;
+  const width = 320;
+  const left = Math.max(8, Math.min(pos.left, window.innerWidth - width - 16));
+  const openUpward = pos.bottom > window.innerHeight - 200;
+  const style: React.CSSProperties = openUpward
+    ? { left, bottom: window.innerHeight - pos.top + 6, maxWidth: width }
+    : { left, top: pos.bottom + 6, maxWidth: width };
+  return (
+    <div
+      className="option-card glossary-card"
+      style={style}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
+      <div className="option-card-head">
+        <code className="option-card-name">{entry.name}</code>
+      </div>
+      <p className="option-card-desc">{entry.plain}</p>
+      {entry.url ? (
+        <p className="option-card-row">
+          <a href={entry.url} target="_blank" rel="noreferrer">
+            Renovate docs ↗
+          </a>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface TermProps {
+  id: TermId;
+  /** Visible text; defaults to the glossary entry's exact Renovate name. */
+  children?: ReactNode;
+}
+
+/**
+ * A Renovate term in running copy: dotted underline, and a hover/focus card
+ * with the plain-language explanation plus a docs link. Keyboard reachable
+ * (Tab to focus, Escape to dismiss).
+ */
+export function Term({ id, children }: TermProps) {
+  const entry = GLOSSARY[id];
+  const { card, show, hide, hideNow, cancelHide } = useHoverCard(entry);
+  return (
+    <>
+      <span
+        className="term"
+        tabIndex={0}
+        onMouseEnter={(e) => show(e.currentTarget)}
+        onMouseLeave={hide}
+        onFocus={(e) => show(e.currentTarget)}
+        onBlur={hide}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            hideNow();
+          }
+        }}
+      >
+        {children ?? entry.name}
+      </span>
+      {card ? <GlossaryCard card={card} onEnter={cancelHide} onLeave={hide} /> : null}
+    </>
+  );
+}
+
+interface ExplainedProps {
+  entry: GlossaryEntry;
+  /** Renders the anchor element; receives the hover/focus handlers to spread. */
+  children: (handlers: {
+    onMouseEnter: (e: React.MouseEvent) => void;
+    onMouseLeave: () => void;
+    onFocus: (e: React.FocusEvent) => void;
+    onBlur: () => void;
+  }) => ReactNode;
+}
+
+/**
+ * Attaches a glossary card to an arbitrary element (e.g. a stage chip that is
+ * already a button). The child render-prop spreads the handlers on its anchor.
+ */
+export function Explained({ entry, children }: ExplainedProps) {
+  const { card, show, hide, cancelHide } = useHoverCard(entry);
+  return (
+    <>
+      {children({
+        onMouseEnter: (e) => show(e.currentTarget),
+        onMouseLeave: hide,
+        onFocus: (e) => show(e.currentTarget),
+        onBlur: hide,
+      })}
+      {card ? <GlossaryCard card={card} onEnter={cancelHide} onLeave={hide} /> : null}
+    </>
+  );
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1569,3 +1569,141 @@ pre.config-view.prov-before {
   font-size: 0.85rem;
   margin-bottom: 0.4rem;
 }
+
+/* ---------- first-load guidance & glossary (UX pass) ---------- */
+
+.welcome {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin: 0 0 1rem;
+  padding: 0.9rem 1.1rem;
+}
+
+.welcome-steps {
+  counter-reset: step;
+  display: grid;
+  gap: 0.75rem 1.5rem;
+  grid-template-columns: repeat(3, 1fr);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+@media (max-width: 55rem) {
+  .welcome-steps {
+    grid-template-columns: 1fr;
+  }
+}
+
+.welcome-steps li {
+  counter-increment: step;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  padding-left: 2rem;
+  position: relative;
+}
+
+.welcome-steps li::before {
+  align-items: center;
+  background: var(--accent);
+  border-radius: 50%;
+  color: #fff;
+  content: counter(step);
+  display: inline-flex;
+  font-size: 0.8rem;
+  font-weight: 600;
+  height: 1.4rem;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0.05rem;
+  width: 1.4rem;
+}
+
+.welcome-footnote {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0.85rem 0 0;
+  padding-top: 0.6rem;
+}
+
+.linklike {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.repo-load-label {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+/* A term explained by a glossary hover card: quiet until noticed. */
+.term {
+  border-bottom: 1px dotted var(--muted);
+  cursor: help;
+}
+
+.term:hover,
+.term:focus-visible {
+  border-bottom-color: var(--accent);
+  color: var(--accent);
+}
+
+.glossary-card {
+  line-height: 1.45;
+}
+
+.card-title-hint {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+/* The one collapsed home of everything a typical repo user never touches. */
+.advanced-zone {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin: 0.5rem 0 0.75rem;
+  padding: 0.4rem 0.75rem;
+}
+
+.advanced-zone > summary {
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.advanced-zone > .advanced-settings {
+  background: var(--surface);
+}
+
+.advanced-intro {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0.6rem 0 0.2rem;
+}
+
+.advanced-active-chip {
+  background: light-dark(#ddf4ff, #121d2f);
+  border: 1px solid var(--accent);
+  border-radius: 999px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 600;
+  margin-left: 0.5rem;
+  padding: 0.05rem 0.5rem;
+  vertical-align: 0.1rem;
+}
+
+.advanced-active-chip.invalid {
+  background: light-dark(#fff1f0, #2d1516);
+  border-color: var(--error);
+  color: var(--error);
+}


### PR DESCRIPTION
Reworks the first-load experience for a **typical Renovate user** — someone with a `renovate.json` in their repo, not a self-hosted admin.

## Clean first load
- Everything an ordinary user never touches — global config, inherited config, platform context, per-host tokens — now lives in **one collapsed "Advanced options" section** below the run bar, with an intro noting the defaults suit a github.com repo on the hosted app. It auto-opens when a share link carries self-hosted layers and shows an *active / invalid JSON* chip when collapsed.
- Above the fold: title, one-line intro, a **"how it works" strip** (bring a config → run → explore, shown only before the first run) with a **Try an example** button whose starter config exercises migration, massaging, presets and the simulator, plus a "New to Renovate? official docs" pointer.
- Load-from-repo bar is now labeled and sits directly above the editor; the primary button is simply **Run**.

## Renovate names always get a hover explanation + docs link
- New `src/glossary.tsx`: `<Term>` renders a dotted-underlined concept term whose hover/focus card gives a plain-words explanation and a link to the matching docs.renovatebot.com page (presets, config migration, packageRules, inheritConfig, platform, `local>` presets, …). Keyboard-accessible (focus shows, Escape hides), and cards hide on scroll.
- Every **stage chip** in the timeline gets the same card via `<Explained>` (what the stage does + docs), and the stage panel title now carries the plain-language description instead of the internal stage id.
- Simulator ("Update simulator — describe a hypothetical dependency update…"), preset tree and effective config ("…and which layer set each option") titles reworded with terms explained.

## Verified
- Browser-tested against the dev server: first-load layout, glossary cards (welcome strip, stage chips), example config, advanced section expand/collapse, full pipeline run (light + dark).
- `lint`, `format:check`, `typecheck` and the production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ