### PR TITLE
Roadmap: M5/M6 items from the persona UX study

### DIFF
--- a/roadmap/012-simulator-verdict-first-results.md
+++ b/roadmap/012-simulator-verdict-first-results.md
@@ -1,0 +1,46 @@
+# 012 — Simulator: verdict-first results + update-type flattening
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+The 2026-07 persona study ([study report](2026-07-persona-ux-study.md)) found
+the simulator's _evidence_ is excellent but its _answer_ is missing or buried:
+it never applies Renovate's update-type flattening (so "will this update
+automerge?" is unanswerable — a minor update still shows top-level
+`automerge: false` with `minor: {automerge: true}` unmerged), and the verdict
+sits below ~710 "no match" rows. All 9 personas hit the second problem; the
+expert failed a goal on the first.
+
+## User story
+
+As a user simulating an update, I want the simulator to open with the answer —
+"this major update WOULD get labels `[deploy_pr]` and auto-approval, but would
+NOT automerge (automerge is scoped to minor/patch)" — and show me only the
+rules that matched, instead of making me scroll 700 rows to assemble the
+conclusion myself.
+
+## Scope
+
+- Engine: after the packageRules merge tail, apply the update-type flattening
+  step (`mergeChildConfig(config, config[updateType])`, as upstream
+  `flattenUpdates` does) so the resolved per-dependency config reflects the
+  update's type. Oracle-parity test against upstream, like the rest of 006.
+- A verdict block pinned directly under the Simulate button: matched-rule
+  count, the changed keys **with their final values** (not key names only),
+  and a plain-language outcome sentence covering the high-signal options
+  (automerge, labels, grouping, enabled/disabled + skipReason, schedule).
+- Results list defaults to **matched rules only**, with a "show all N" toggle;
+  "3 of 713 rules matched" becomes a jump link to the matches.
+- Keep per-clause evidence rows exactly as they are — every persona praised
+  them ("the money shot").
+
+## Out of scope
+
+- Rule provenance chips and rule-numbering cross-links (013).
+- Input-form ergonomics (015).
+- A/B comparison of two simulation runs (018).
+
+## Dependencies
+
+- 006 (simulator engine + oracle tests).

--- a/roadmap/013-rule-identity-and-provenance.md
+++ b/roadmap/013-rule-identity-and-provenance.md
@@ -1,0 +1,44 @@
+# 013 — Rule identity: one numbering, provenance chips, cross-links
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+The same packageRule appears under three unrelated numbers: validation says
+`packageRules[1]` (repo-config index), the simulator's validation echo says
+`packageRules[713]` (post-preset-merge index), and the results list says
+`#714` (1-based row). Nothing connects them, and nothing marks which rules
+came from the user's own config versus a preset. Every skill level in the
+persona study stumbled on this; the expert called it the thing "a
+non-maintainer will think are two different errors."
+
+## User story
+
+As a user reading a validation error or a simulator result, I want to click
+`packageRules[1]` and land on that rule — in my editor and in the merged rule
+list — and I want my own rules visually distinct from the 711 rules
+`config:recommended` injected, so "where is MY rule?" is never a scroll hunt.
+
+## Scope
+
+- One canonical rule presentation; wherever another indexing scheme must
+  appear (upstream validator messages), annotate it: "repo-config index 1 =
+  merged rule 713".
+- Provenance chip on every simulator rule row and on the effective config's
+  `packageRules` entries: `repo config`, `global config`, `inherited config`,
+  or the contributing preset's name (the Effective config panel already has
+  these chips — reuse them).
+- Clickable cross-links: validation error → editor line (repo config) and →
+  merged rule row; simulator rule row → contributing preset node in the tree.
+- Rule captions list **all** matcher clauses and name the failing one
+  (`#7 matchSourceUrls + matchUpdateTypes — failed on matchSourceUrls`);
+  today a row captioned with a passing matcher plus "no match" looks broken.
+
+## Out of scope
+
+- Verdict block / matched-only filter (012).
+- Fixing upstream validator message indices.
+
+## Dependencies
+
+- 005 (provenance layers), 006, 012 (results-list rework lands first).

--- a/roadmap/014-validation-translations-and-quick-fixes.md
+++ b/roadmap/014-validation-translations-and-quick-fixes.md
@@ -1,0 +1,44 @@
+# 014 — Validation error translations + suggested fixes
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+The app reproduces Renovate's validator messages verbatim — authentic, but
+raw. In the persona study, the real-world message _"Your input contains \* or
+\*\* along with other patterns. Please remove them, as \* or \*\* matches all
+patterns"_ left even the advanced user unsure what "them" refers to. The
+advanced persona then spent ~10 minutes manually proving the fix was
+behavior-preserving — a proof the tool has all the pieces to run itself.
+
+## User story
+
+As a user whose config was flagged, I want the error translated into plain
+words with a concrete suggested edit — "`*` is redundant next to `!gradle`
+and newer Renovate rejects it. Change `["*", "!gradle"]` → `["!gradle"]`
+(same behavior)" — and ideally a one-click way to apply it and see the
+before/after proof.
+
+## Scope
+
+- A small curated library of known validator-error patterns → plain-language
+  explanation + suggested edit. Start with the messages that recur on the
+  discussion board (redundant `*`/`**`, deprecated option names the migrate
+  stage already handles, misplaced global-only options — 008 already surfaces
+  the boundary warning).
+- Render the translation alongside (never instead of) Renovate's original
+  message.
+- "Apply fix" writes the edit into the editor and re-runs; the validate stage
+  flipping 1 error → 0 errors is the confirmation signal personas already
+  found compelling.
+- Unmatched errors fall back to today's behavior, plus a docs link when the
+  message names an option (003's option index has the URL).
+
+## Out of scope
+
+- Automatic behavioral-equivalence proof via A/B simulation (018 stretch).
+- Translating every possible validator message; this is a curated list.
+
+## Dependencies
+
+- 001 (validate stage), 003 (option docs/urls).

--- a/roadmap/015-simulator-input-ergonomics.md
+++ b/roadmap/015-simulator-input-ergonomics.md
@@ -1,0 +1,44 @@
+# 015 — Simulator input ergonomics
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+The persona study showed the simulator's inputs undermine its (excellent)
+evaluation: `sourceUrl` — the decisive matcher in two of the three real-world
+problems studied — is hidden behind "More fields"; the adjacent `repository`
+field invites the wrong guess for a repo URL (guessing wrong flips the
+conclusion); `updateType` is not derived from the versions (a quick-fill's
+`patch` silently survived a 18.2.0 → 19.2.0 edit); an empty-form Simulate
+reports "0 of 714 rules matched" with no hint (one persona read it as "my
+broken rule disabled everything").
+
+## User story
+
+As a user copying facts out of a bot PR (package, versions, repo URL), I want
+the form to accept them where I'd expect, infer what it can, and stop me from
+running a meaningless simulation — so a wrong conclusion can't come from a
+misplaced input.
+
+## Scope
+
+- Promote `sourceUrl` to the primary fields; disambiguate it from
+  `repository` with examples in the placeholders/hover docs.
+- Derive `updateType` from currentValue/newValue via the selected versioning
+  scheme (manual override wins; show "major (derived)").
+- Empty-form guard: Simulate with no meaningful input prompts "pick an
+  example or fill in a package first" instead of rendering 714 no-matches.
+- Stale results: grey out the previous result list when inputs change (the
+  small orange hint alone was skimmed past twice in the study).
+- Add a `nuget` quick-fill chip (Azure DevOps users); fix the `updateType`
+  select ignoring arrow keys.
+
+## Out of scope
+
+- Looking up a package's real sourceUrl from its registry (needs datasource
+  network calls; possible follow-up for npm only).
+- Verdict/results-list rework (012).
+
+## Dependencies
+
+- 006 (simulator).

--- a/roadmap/016-scale-framing-and-page-ergonomics.md
+++ b/roadmap/016-scale-framing-and-page-ergonomics.md
@@ -1,0 +1,45 @@
+# 016 — Scale framing, badge glossary, page & editor ergonomics
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+Cross-cutting legibility items from the persona study. Big numbers appear
+without framing ("Resolved 1076 preset(s)", "packageRules [ 714 items ]") and
+read as "did I break something?" to newcomers whose config is 10 lines. Badge
+vocabulary (`2 opts`, `duplicate ×2`, `nested`, `internal`, `overridden`) has
+no inline explanation — and `overridden` on an _appended_ array like
+`packageRules` is actively misleading. Long pages fight the user: `End` lands
+on a blank over-scrolled viewport, there's no back-to-top, re-simulating
+resets scroll position, and in-editor edits are hazardous (stale-coordinate
+clicks silently replace the wrong line; no visible undo affordance).
+
+## User story
+
+As a user with a small config, I want every large number to carry its origin
+("713 rules — 2 from your config, 711 pulled in by `config:recommended`"),
+every badge to explain itself on hover like the stage pills already do, and
+the page to stay navigable while I bounce between editor, results and
+verdicts.
+
+## Scope
+
+- Framing phrase wherever a large count first appears (preset tree header,
+  effective config `packageRules` row, simulator heading).
+- Hover cards for tree/row badges, reusing the glossary card mechanism from
+  the first-load UX pass; reconcile inconsistent counts (712 vs 713 vs 714,
+  "1 duplicates" vs "duplicate ×2").
+- Replace/augment `overridden` on concatenated arrays with an accurate badge
+  (e.g. `appended`).
+- Keyboard + scroll: End/Home work; sticky mini-bar (stage pills + Run) or a
+  back-to-top affordance; preserve scroll position across re-simulations.
+- Editor safety: visible undo/redo hint and a "revert to loaded config"
+  button.
+
+## Out of scope
+
+- Simulator results filtering (012) and rule provenance (013).
+
+## Dependencies
+
+- 011 (tree summary header), the first-load UX pass (glossary cards).

--- a/roadmap/017-share-links-in-a-running-app.md
+++ b/roadmap/017-share-links-in-a-running-app.md
@@ -1,0 +1,38 @@
+# 017 — Share links opened in a running app (hashchange)
+
+Milestone: M5 · Status: planned
+
+## Summary
+
+Bug found while preparing the persona study: the share-link decode effect
+runs only on mount. Navigating from the already-open app to a share URL is a
+hash-only navigation — nothing reloads, so **nothing happens**: no config
+load, no run, no error. A user clicking a colleague's link while the app is
+open silently keeps looking at their old state, which can misattribute
+results to the wrong config.
+
+## User story
+
+As a user with the visualizer already open, I want clicking a share link to
+load and run that shared analysis — or ask me first if I have unsaved work —
+exactly like opening it in a fresh tab would.
+
+## Scope
+
+- Listen for `hashchange`; on a new `#config=` token, run the same
+  decode-populate-run path as the mount effect.
+- Guard against clobbering: if the current editor content differs from the
+  last loaded/run state, confirm before overwriting ("Load shared config?
+  Your current edits will be replaced.").
+- Ignore the hash mutations the app itself makes (Copy link mirrors the
+  token into the address bar — must not re-trigger a run).
+- Covered by an e2e test (020) — this exact regression is its motivating
+  case.
+
+## Out of scope
+
+- Encoding simulator inputs in share links (018).
+
+## Dependencies
+
+- 007 (share codec).

--- a/roadmap/018-evidence-export-and-expert-precision.md
+++ b/roadmap/018-evidence-export-and-expert-precision.md
@@ -1,0 +1,43 @@
+# 018 — Evidence export + expert-grade precision
+
+Milestone: M6 · Status: planned
+
+## Summary
+
+The expert personas judged the tool "citable with caveats" for
+discussion-board answers. What's missing to make it a self-contained
+authority: exportable evidence, reproducible simulator links, comparable
+runs, and matcher verdicts as precise as the code
+(`false` fail-closed vs `null` not-applicable both render as "no match";
+"no match against no input value set" is also mangled English).
+
+## User story
+
+As an experienced user answering someone's config question, I want to hand
+back one link that reproduces my exact demonstration — simulator inputs
+included — plus copy-paste-ready evidence (a preset's resolved body, a
+rule's applied diff), and an explicit "no behavioral change" verdict when I
+compare a fix against the original.
+
+## Scope
+
+- Share links optionally encode simulator inputs; opening one lands with the
+  form pre-filled and (explicit flag) auto-simulated.
+- Copy-as-markdown on the preset inspector (fetched/resolved body) and on a
+  rule's applied-diff panel.
+- A/B runs: pin a simulation result, edit the config, re-simulate, get a
+  structured diff of matched-rule set + final per-dependency config, with an
+  explicit "no behavioral change" verdict when equal (pairs with 014's
+  suggested fixes).
+- Matcher verdict precision: distinguish "returned false (input present,
+  no match)" from "returned null (not applicable, skipped)" in the clause
+  rows, and fix the "no input value set" phrasing to name the missing field.
+
+## Out of scope
+
+- Diffing a preset across Renovate versions (would need multiple pinned
+  renovate builds — revisit as its own item if demand shows up).
+
+## Dependencies
+
+- 006, 007, 012 (verdict block is where A/B output renders), 014.

--- a/roadmap/019-persona-replay-skill.md
+++ b/roadmap/019-persona-replay-skill.md
@@ -1,0 +1,46 @@
+# 019 — Persona usability-test replay skill
+
+Milestone: M6 · Status: planned
+
+## Summary
+
+The 2026-07 persona study ([study report](2026-07-persona-ux-study.md)) —
+3 real discussion-board problems × entry/advanced/expert personas, each
+role-played by an agent driving the live app in a browser — produced the
+highest-signal UX feedback this project has had. Make it repeatable: a
+committed agent skill that replays the study (or a subset) on demand, so any
+UX change can be evaluated against the same benchmark scenarios.
+
+## User story
+
+As a maintainer who just changed the UI, I want to run
+`/persona-test simulator` (or all scenarios) and get the same structured
+persona reports — first impression, step log, outcome + confidence, friction
+points, wishes — so I can see whether the change actually helped the users it
+targeted, without hand-writing nine subagent prompts each time.
+
+## Scope
+
+- A skill under `.claude/skills/persona-test/` encoding the proven procedure:
+  build + `vite preview` (NOT `vite dev` — see the study's infra notes),
+  generate share links for scenario configs with the share codec, spawn
+  persona subagents **serially** (one browser), each browser-only with an
+  action budget, collect reports, synthesize a comparison against the
+  previous run's findings.
+- A scenario library file per problem: config, symptom framing per skill
+  level (entry framing must avoid Renovate vocabulary), the facts each level
+  is allowed to know, and the ground-truth answer for grading (never shown to
+  personas).
+- The three studied scenarios (renovate discussions #44772, #43936, #44006)
+  as the initial library; adding a scenario = adding one file.
+- Persona definitions (entry / advanced / expert) as reusable prompt blocks.
+
+## Out of scope
+
+- Fully automated pass/fail scoring — the output is reports for a human;
+  grading against ground truth stays a judgment call.
+- Running personas in parallel (single shared browser).
+
+## Dependencies
+
+- 007 (share codec for scenario links). Complements, not replaces, 020.

--- a/roadmap/020-browser-e2e-tests.md
+++ b/roadmap/020-browser-e2e-tests.md
@@ -1,0 +1,48 @@
+# 020 — Browser end-to-end test suite
+
+Milestone: M6 · Status: planned
+
+## Summary
+
+The persona-study setup surfaced a class of defects no current check can
+catch: real-browser, whole-app behavior. The concrete motivating case: share
+links opened in a running app do nothing (017) — invisible to unit tests,
+the golden/shimmed suites, the production build, and the dev-graph guard
+alike, because it only exists in a live browser session with navigation
+history. A stuck "Running…" state (also observed during setup) is the same
+class.
+
+## User story
+
+As a maintainer, I want CI to drive the built app in a real browser through
+the core user journeys, so regressions like "the share link silently does
+nothing" or "the pipeline never finishes" fail a PR instead of a user.
+
+## Scope
+
+- Playwright against the production build served by `vite preview` (the
+  study showed `vite dev` cold-starts are not representative and can wedge
+  the first engine import — test what users get).
+- Journeys, each with a hard timeout so hangs fail rather than stall:
+  1. Cold share link: opens, decodes, auto-runs, timeline + version badge
+     appear (guards the whole engine-in-browser path).
+  2. Share link into a running app: navigate within the app, then to a share
+     URL — the shared config must load and run (regression for 017).
+  3. Paste → Run → validate error shown → edit config → re-run → error gone.
+  4. Simulator: fill descriptor, Simulate, assert a matched rule row and its
+     applied diff.
+  5. First-load smoke: welcome strip, advanced options collapsed, glossary
+     hover card renders with a docs link.
+- CI step after the existing checks; keep total runtime in low minutes
+  (single browser, chromium only).
+- Share-link fixtures generated with the real codec (reuse 019's generator).
+
+## Out of scope
+
+- Cross-browser matrix, visual regression screenshots, and network-dependent
+  journeys (preset fetching from live hosts stays covered by engine tests).
+
+## Dependencies
+
+- 001–007 features under test; pairs with 017 (its regression test lands
+  here) and 019 (shared scenario/link tooling).

--- a/roadmap/2026-07-persona-ux-study.md
+++ b/roadmap/2026-07-persona-ux-study.md
@@ -1,0 +1,214 @@
+# Persona UX Study — Renovate Config Visualizer
+
+**Method.** Three real, answered configuration problems were taken from the
+[renovatebot/renovate discussion board](https://github.com/renovatebot/renovate/discussions).
+For each problem, three subagents role-played a user at a different skill level —
+**Entry** (zero Renovate knowledge), **Advanced** (2 years of config maintenance),
+**Expert** (maintainer-level intrinsic knowledge) — and drove the **live app in a real
+Chrome session** (production build of PR #21, Renovate v43.275.0), one session at a
+time, browser-only, ~30 actions budget each. Each persona received the problem as a
+pre-loaded share link plus only the facts their skill level would plausibly know, and
+never the answer. 9 sessions total.
+
+## The three problems (and ground truth)
+
+| #   | Discussion                                                                                                                            | Scenario given to personas                                                                                                | Ground truth (from the accepted answer)                                                                                                           |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P1  | [#44772 "monorepo:react preset not working"](https://github.com/renovatebot/renovate/discussions/44772)                               | `packageRules: [{extends: ["monorepo:react"], enabled: false}]`, yet react 18.2.0→19.2.0 PRs keep appearing               | The bundled preset matches `matchSourceUrls: ["https://github.com/facebook/react"]`; react's repo moved to `react/react`, so the rule never fires |
+| P2  | [#43936 "Invalid configuration reported, but configuration seems correct"](https://github.com/renovatebot/renovate/discussions/43936) | `matchPackageNames: ["*", "!gradle"]` newly flagged: _"Your input contains \* or \*\* along with other patterns…"_        | Validator tightened; `*` is redundant next to `!gradle` — remove it, behavior unchanged                                                           |
+| P3  | [#44006 ":automergeMinor merge behavior"](https://github.com/renovatebot/renovate/discussions/44006)                                  | Rule extends `:automergeMinor` + `:label(deploy_pr)` + `autoApprove: true`; a **major** update got the label and approval | The preset only nests `automerge` under update-type keys; `labels`/`autoApprove` are rule-level and apply to _every_ matched update               |
+
+## Outcome matrix
+
+Every persona reached (or independently confirmed) the correct diagnosis — the tool
+_works_. The findings below are therefore about **speed, confidence, and one real
+capability gap**, not about fundamental failure.
+
+|                        | Entry (no knowledge)                                                                                | Advanced                                                       | Expert                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **P1 react preset**    | ✅ Solved, 85% conf. — full 30-action budget; survived only thanks to the simulator's example chips | ✅ Confirmed in **4 actions / ~2 min** via preset tree, 95%    | ✅ Both goals < 5 min, 97%; couldn't see matcher `false` vs `null`     |
+| **P2 validation**      | ✅ Solved **and fixed and re-verified in-app**, 85%                                                 | ✅ All 3 goals (real error? what? minimal fix + proof), 90–95% | ✅ All 3 goals, 92%; "citable with caveats" for a discussion answer    |
+| **P3 automerge scope** | ✅ Solved, 90% — assembled the verdict manually from diffs                                          | ✅ All goals; tool **corrected their mental model**, 95–100%   | ⚠️ 2 of 3 goals — the minor-update contrast **failed** (see Finding 1) |
+
+What consistently carried users to the answer, across all levels:
+
+- the **per-rule clause evidence** in the simulator — `matchSourceUrls: [...] — no match against sourceUrl = "https://github.com/react/react"` was called "the money shot" / "the single most convincing screen" in five separate reports;
+- the **preset inspector** ("Fetched content" + the nested-resolution footnote) — one click to a preset's literal body;
+- the pinned **Renovate version badge** — settled "regression vs. real" instantly;
+- **share links + auto-run** — zero-click reproduction;
+- the **example chips** in the simulator — the entry personas said they could never have filled the form from scratch.
+
+---
+
+## Findings, ranked
+
+### 1. The simulator never applies update-type flattening — its biggest capability gap ⚠️ (P3-expert, correctness-adjacent)
+
+After packageRules are applied, real Renovate merges `minor: {automerge: true}` up
+into the config when the update _is_ minor (`flattenUpdates` /
+`mergeChildConfig(config, config[updateType])`). The simulator stops before this
+step: a **minor** simulation of the P3 config still shows top-level
+`automerge: false` with `minor: {"automerge": true}` sitting unmerged — visually
+identical to the major run. The expert could not produce the "minor ⇒ automerge
+true" contrast at all, and warned:
+
+> "A non-expert would read the minor run as 'automerge is false' and be _more_
+> confused."
+
+The single most common question the simulator could answer — _"will this update
+automerge?"_ — is left as an exercise. **Recommendation:** run the flattening step
+and print a verdict block (see Finding 2). This is engine work, not just UI.
+
+### 2. The simulator's answer is buried under ~710 "no match" rows (all 9 sessions)
+
+The unanimous complaint. "3 of 713 rules matched" renders **all 713 rules**, almost
+all "no match"; the user's own rule is always last (repo rules append after preset
+rules); the FINAL PER-DEPENDENCY CONFIG verdict sits below the entire list; `End`
+lands on a blank over-scrolled viewport; re-simulating resets scroll position.
+
+**Recommendations (highest leverage in the whole study):**
+
+- Default to **matched rules only**, with a "show all N" toggle; make the "3 of 713
+  rules matched" text a jump-link.
+- Pin the **final per-dependency config summary directly under the Simulate button**,
+  and open it with a plain-language verdict sentence, e.g. _"This major update WOULD
+  get labels [deploy_pr] and auto-approval, but would NOT automerge (automerge is
+  scoped to minor/patch)."_ Three personas independently asked for exactly this
+  sentence.
+- Add a **provenance chip on every rule row** (`repo config` / preset name — the
+  Effective config panel already has these chips) and highlight the user's own rules.
+- Rule captions should list **all matchers with the failing one named**
+  (`#7 matchSourceUrls+matchUpdateTypes — failed on matchSourceUrls`); today rows
+  like `#712 matchUpdateTypes: ["major","minor","patch"] — no match` on a major
+  update look flatly wrong until expanded ("exactly the kind of thing a confused
+  discussion poster screenshots as 'the tool is broken'").
+
+### 3. Three numbering schemes for the same rule, with no cross-links (P2 all levels, P3)
+
+The validator says `packageRules[1]` (repo-config index), the simulator error says
+`packageRules[713]` (post-merge index), the results list says `#714` (1-based). The
+entry user "made sure they were the same thing" only by luck; the expert called it
+the thing "a non-maintainer will think are two different errors."
+
+**Recommendation:** one canonical presentation plus cross-references — wherever an
+error cites `packageRules[N]`, hyperlink it to the editor line (repo config) and/or
+the merged rule row, annotated "repo-config index 1 = merged index 713 = row #714."
+
+### 4. Validation errors are re-printed raw, with no translation or fix (P2 all levels)
+
+The app reproduces Renovate's message verbatim — great for authenticity, but the
+message itself is ambiguous ("Please remove **them**" — the stars or the other
+patterns?). Entry and advanced both wished for a plain-language explanation with a
+one-click suggested fix, and noted the tool has everything needed to _prove_ the
+fix is behavior-preserving (the advanced persona did that proof manually in ~10
+minutes; an A/B simulation diff could do it automatically).
+
+**Recommendation:** a small library of known-validator-error translations
+("`*` is redundant next to other patterns — newer Renovate rejects it. Suggested
+change: `["*", "!gradle"]` → `["!gradle"]` (same behavior)"), each with an "apply
+fix" affordance. Longer-term: pin a simulation, edit, re-simulate, and show a
+structured diff with an explicit "no behavioral change" verdict (expert wish, P2).
+
+### 5. Simulator input UX undermines the tool's best feature (P1/P3, all levels)
+
+- `sourceUrl` — the _only_ matcher in two of the three real-world problems — is
+  hidden behind "More fields — versioning, lock files, URLs, categories, age…".
+- The nearby `repository` field invites the wrong guess for a repo URL; the P3 entry
+  persona nearly put the URL there, which "would have given me the opposite conclusion."
+- `updateType` is not derived from currentValue/newValue (18.2.0→19.2.0 left "patch"
+  from a quick-fill chip); a silently wrong updateType invalidates a simulation.
+- Simulate with an empty form yields "0 of 714 rules matched" with no hint — the P2
+  entry persona briefly concluded the broken rule "had disabled ALL 714 rules."
+- The `updateType` dropdown ignored arrow keys (typeahead only) in one session.
+- Quick-fill chips lack a nuget example (Azure DevOps users).
+
+**Recommendations:** promote `sourceUrl` to the primary fields; derive `updateType`
+from the versions with manual override; guard the empty form ("pick an example or
+fill in a package first"); fix select keyboard handling; add a nuget chip; make the
+stale-results state grey out the old list, not just show the small orange hint.
+
+### 6. Scale shock: unexplained big numbers frighten exactly the users the app courts (all entry sessions, advanced too)
+
+"Resolved 1076 preset(s)", "packageRules [ 714 items ]", "712 rules", the seven-counter
+summary strip, and a 10,000-line default diff all triggered "did I break something?" /
+"I wrote 2 rules" reactions. The preset-tree summary header exists, but the numbers
+appear in many places without the framing sentence.
+
+**Recommendation:** attach one framing phrase wherever a big count first appears —
+e.g. "713 rules (2 from your config, 711 pulled in by `config:recommended`)" — and
+give the counter strip and badges (`2 opts`, `duplicate ×2`, `nested`, `internal`,
+`overridden`) the same hover-card treatment the stage pills got in PR #21. Note:
+`overridden` on an _appended_ array (`packageRules`) was called actively misleading
+by the expert.
+
+### 7. Navigation and keyboard ergonomics (7 of 9 sessions)
+
+`End` key lands on a blank viewport below the content; no back-to-top affordance;
+after Run the viewport jumps somewhere unrelated; long pages must be re-scrolled
+after every re-simulate. **Recommendation:** fix End/Home scrolling, add a sticky
+mini-toolbar (stage pills + Run) or back-to-top button, and preserve scroll position
+across re-simulations.
+
+### 8. In-app config editing is hazardous (P2/P3 advanced)
+
+Stale-coordinate clicks silently replaced the wrong line; triple-click selection ate
+newlines; typed edits vanished without feedback when focus was elsewhere; no visible
+undo affordance (Cmd+Z works but nothing says so). For the edit → re-run → re-verify
+loop that P2 proved so valuable, **recommendation:** a visible undo/redo hint or
+toolbar, and possibly a "revert to loaded config" button.
+
+### 9. Expert-grade evidence gaps (all expert sessions)
+
+- Matcher verdicts don't distinguish **`false` (fail-closed) vs `null` (not
+  applicable)** — both render as "no match"; the prose hints at it ("no match against
+  no input value set" — also flagged as mangled grammar by two personas).
+- No **copy/export**: preset body and applied-diff as markdown, for pasting into a
+  discussion answer.
+- Share links don't encode **simulator inputs**, so "open this link and press
+  Simulate" can't reproduce a demonstration.
+- No **preset diff across Renovate versions** ("did upstream already add
+  react/react?") — heavy to build; long-term idea.
+
+### 10. Bug found during study setup: share links are ignored in an open app
+
+Navigating from the already-open app to a share URL is a hash-only navigation — the
+decode effect runs only on mount, so **nothing happens** (no config load, no run, no
+error). A user clicking a colleague's link while the app is open sees their old state
+and may not notice. **Recommendation:** listen for `hashchange` and run the same
+decode-and-run path (with an "overwrite current work?" guard).
+Also observed (dev-only, not user-facing): a cold `vite dev` server can wedge the
+first engine import after `--force` re-optimization; the production build is fine.
+
+---
+
+## Suggested priority order
+
+| Priority | Item                                                                                                  | Findings | Effort                              |
+| -------- | ----------------------------------------------------------------------------------------------------- | -------- | ----------------------------------- |
+| P0       | Simulator: matched-only default + pinned verdict block with plain-language sentence                   | 1, 2     | M (UI) + engine work for flattening |
+| P0       | `hashchange` handling for share links                                                                 | 10       | S                                   |
+| P1       | Rule provenance chips + unified/cross-linked rule numbering                                           | 2, 3     | M                                   |
+| P1       | Simulator inputs: promote sourceUrl, derive updateType, empty-form guard, nuget chip, select keyboard | 5        | S–M                                 |
+| P1       | Known-error translations with suggested fixes                                                         | 4        | M                                   |
+| P2       | Count framing ("2 yours, 711 from config:recommended") + badge hover cards                            | 6        | S                                   |
+| P2       | End/Home + sticky nav + scroll preservation                                                           | 7        | S                                   |
+| P2       | Editor undo affordance / revert button                                                                | 8        | S                                   |
+| P3       | Matcher false-vs-null verdicts; full matcher list in captions                                         | 9, 2     | M                                   |
+| P3       | Evidence export (copy-as-markdown, simulator inputs in share links, A/B diff)                         | 9, 4     | M–L                                 |
+| P3       | Cross-version preset diff                                                                             | 9        | L                                   |
+
+## What to keep (validated by the study)
+
+The per-clause match evidence, the preset inspector with its nested-resolution
+footnote, version pinning, share-link auto-run, simulator example chips, the
+red→green stage dots as before/after proof, input preservation across re-runs, and
+the stage-pill hover cards — each was explicitly credited in multiple reports.
+Notably, several are recent PR #21 additions (hover cards, plain-language stage
+descriptions, "try an example"), and the entry personas — the audience PR #21
+targeted — all reached correct diagnoses.
+
+---
+
+_Study run 2026-07-23 against the production build of branch `feature/ux-first-load`
+(PR #21), Renovate v43.275.0. Full persona transcripts live in the
+originating Claude Code session._

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,16 +3,29 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.agents/spec/renovate-config-visualizer.md).
 
-| #                                             | Feature                                   | Milestone            | Status |
-| --------------------------------------------- | ----------------------------------------- | -------------------- | ------ |
-| [001](001-engine-and-config-input.md)         | Trace engine + config input               | M0/M1                | done   |
-| [002](002-preset-resolution-tree.md)          | Preset resolution tree                    | M1 (MVP centerpiece) | done   |
-| [003](003-inline-option-docs.md)              | Inline option documentation               | M1                   | done   |
-| [004](004-migration-step-through.md)          | Migration step-through                    | M2                   | done   |
-| [005](005-merge-provenance-view.md)           | Merge provenance view                     | M2                   | done   |
-| [006](006-package-rules-simulator.md)         | packageRules simulator                    | M3                   | done   |
-| [007](007-shareable-links-and-repo-fetch.md)  | Shareable links + fetch config from repo  | M4                   | done   |
-| [008](008-global-and-inherited-config.md)     | Global + inherited config layers          | M3                   | done   |
-| [009](009-github-oauth-sign-in.md)            | "Sign in with GitHub" (replace PAT field) | M4                   | done   |
-| [010](010-preset-hosting-coverage.md)         | Preset hosting coverage + `local>`        | M2                   | done   |
-| [011](011-preset-tree-legibility-at-scale.md) | Preset tree legibility at scale           | M2                   | done   |
+| #                                                     | Feature                                                   | Milestone            | Status  |
+| ----------------------------------------------------- | --------------------------------------------------------- | -------------------- | ------- |
+| [001](001-engine-and-config-input.md)                 | Trace engine + config input                               | M0/M1                | done    |
+| [002](002-preset-resolution-tree.md)                  | Preset resolution tree                                    | M1 (MVP centerpiece) | done    |
+| [003](003-inline-option-docs.md)                      | Inline option documentation                               | M1                   | done    |
+| [004](004-migration-step-through.md)                  | Migration step-through                                    | M2                   | done    |
+| [005](005-merge-provenance-view.md)                   | Merge provenance view                                     | M2                   | done    |
+| [006](006-package-rules-simulator.md)                 | packageRules simulator                                    | M3                   | done    |
+| [007](007-shareable-links-and-repo-fetch.md)          | Shareable links + fetch config from repo                  | M4                   | done    |
+| [008](008-global-and-inherited-config.md)             | Global + inherited config layers                          | M3                   | done    |
+| [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done    |
+| [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done    |
+| [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
+| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | planned |
+| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | planned |
+| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | planned |
+| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | planned |
+| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | planned |
+| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | planned |
+| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | planned |
+| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | planned |
+| [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | planned |
+
+M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
+three real discussion-board configuration problems, each replayed against the live
+app by entry-, advanced- and expert-level user personas.


### PR DESCRIPTION
Adds nine planned roadmap items (012–020) derived from the 2026-07 persona UX study — three real discussion-board configuration problems ([#44772](https://github.com/renovatebot/renovate/discussions/44772), [#43936](https://github.com/renovatebot/renovate/discussions/43936), [#44006](https://github.com/renovatebot/renovate/discussions/44006)), each replayed against the live app by entry/advanced/expert user personas in real browser sessions. The full study report is committed as `roadmap/2026-07-persona-ux-study.md`.

**M5 (product UX):**
- **012** Simulator: verdict-first results + the missing update-type flattening (the study's biggest capability gap — "will this update automerge?" is currently unanswerable)
- **013** Rule identity: one numbering, provenance chips, cross-links (`packageRules[1]` vs `[713]` vs `#714`)
- **014** Validation error translations + suggested fixes
- **015** Simulator input ergonomics (promote sourceUrl, derive updateType, empty-form guard)
- **016** Scale framing, badge glossary, page & editor ergonomics
- **017** Share links opened in a running app — hashchange bug found during study setup

**M6 (tooling/testing):**
- **018** Evidence export + expert-grade precision (citable answers, A/B run diff, false-vs-null verdicts)
- **019** Persona usability-test replay skill — a committed agent skill that re-runs this study's scenarios on demand
- **020** Browser e2e test suite — Playwright against the production build; motivating regression is the 017 setup bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ