### PR TITLE
CI: gate the Pages deploy behind a DEPLOY_PAGES variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,13 +57,17 @@ jobs:
           VITE_GITHUB_APP_SLUG: ${{ vars.VITE_GITHUB_APP_SLUG }}
         run: pnpm --filter @renovate-config-visualizer/app build
 
+      # Pages deployment is opt-in: the repo is private and GitHub Pages for
+      # private repos needs a paid plan, so the deploy job would always fail.
+      # To publish the site, enable Pages (build type "GitHub Actions") in the
+      # repo settings and set the repository Actions variable DEPLOY_PAGES=true.
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && vars.DEPLOY_PAGES == 'true'
         with:
           path: packages/app/dist
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && vars.DEPLOY_PAGES == 'true'
     needs: checks
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The deploy job has failed on every push to main since the workflow was added: the repo is private, and GitHub Pages for private repositories requires a paid plan, so `actions/deploy-pages` 404s with "Ensure GitHub Pages has been enabled".

This gates the `upload-pages-artifact` step and the `deploy` job behind the repository Actions variable `DEPLOY_PAGES == 'true'`, so main CI is green while the repo stays private. To publish the site later: make the repo public (or upgrade the plan), enable Pages with build type "GitHub Actions" in the repo settings, and set the `DEPLOY_PAGES` variable to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ