### PR TITLE
feat(012): simulator verdict-first results + update-type flattening

### DIFF
--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ClauseEvaluation,
   DependencyDescriptor,
@@ -211,6 +211,95 @@ const VERDICT_LABEL: Record<RuleEvaluation["verdict"], string> = {
   "not-simulated": "not simulated",
 };
 
+/** A config value in a plain-language sentence: `[a, b]`, `"x"`, `42`. */
+function plainValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => (typeof v === "string" ? v : JSON.stringify(v))).join(", ")}]`;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+/** Oxford-comma join for the verdict sentence's clause lists. */
+function joinClauses(items: string[]): string {
+  if (items.length <= 1) {
+    return items.join("");
+  }
+  if (items.length === 2) {
+    return `${items[0]} and ${items[1]}`;
+  }
+  return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
+}
+
+/**
+ * The plain-language outcome sentence (roadmap 012). Covers the high-signal
+ * options — enabled/skipReason, automerge (with update-type scoping),
+ * labels, grouping, schedule — splitting them into what the update WOULD and
+ * would NOT get, e.g. "This major update WOULD get labels [deploy_pr] and
+ * auto-approval, but would NOT automerge (automerge is scoped to minor/patch)".
+ */
+function buildVerdictSentence(
+  sim: SimulationResult,
+  updateType: string | undefined,
+  changedKeys: string[],
+): string {
+  const c = sim.finalDependencyConfig;
+  const subject = `This ${updateType ? `${updateType} ` : ""}update`;
+  const changed = new Set(changedKeys);
+  const positives: string[] = [];
+  const negatives: string[] = [];
+
+  // Strongest signal first: will the PR even be raised?
+  const skipReason = typeof c.skipReason === "string" ? c.skipReason : undefined;
+  if (c.enabled === false || skipReason !== undefined) {
+    negatives.push(
+      skipReason ? `be raised at all (skipReason: ${skipReason})` : "be raised (disabled)",
+    );
+  }
+
+  // automerge, aware of update-type scoping (the flattened blocks).
+  const scopedAutomerge = Object.entries(sim.flattened.blocks)
+    .filter(([, block]) => block?.automerge === true)
+    .map(([type]) => type);
+  if (c.automerge === true) {
+    positives.push("automerge");
+  } else if (scopedAutomerge.length > 0) {
+    negatives.push(`automerge (automerge is scoped to ${scopedAutomerge.join("/")})`);
+  } else if (c.automerge === false && changed.has("automerge")) {
+    negatives.push("automerge");
+  }
+
+  if (Array.isArray(c.labels)) {
+    positives.push(`get labels ${plainValue(c.labels)}`);
+  }
+  if (Array.isArray(c.addLabels)) {
+    positives.push(`add labels ${plainValue(c.addLabels)}`);
+  }
+  if (c.autoApprove === true) {
+    positives.push("auto-approval");
+  }
+  if (typeof c.groupName === "string") {
+    positives.push(`be grouped as "${c.groupName}"`);
+  }
+  if (Array.isArray(c.schedule) && c.schedule.length > 0) {
+    positives.push(`only run on schedule ${plainValue(c.schedule)}`);
+  }
+
+  const parts: string[] = [];
+  if (positives.length > 0) {
+    parts.push(`WOULD ${joinClauses(positives)}`);
+  }
+  if (negatives.length > 0) {
+    parts.push(`would NOT ${joinClauses(negatives)}`);
+  }
+  if (parts.length === 0) {
+    return `${subject} gets no special handling from your matched rules — the defaults apply.`;
+  }
+  return `${subject} ${parts.join(", but ")}.`;
+}
+
 /** Short label: the rule's first present selector clause + value preview. */
 function ruleLabel(rule: RuleEvaluation): string {
   const first = rule.clauses[0];
@@ -319,12 +408,15 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
   const [ranKey, setRanKey] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [showAll, setShowAll] = useState(false);
+  const rulesRef = useRef<HTMLDivElement>(null);
 
   // A new run invalidates any previous simulation (the rules may differ).
   useEffect(() => {
     setSim(null);
     setRanKey(null);
     setError(null);
+    setShowAll(false);
   }, [result]);
 
   const finalConfig = result.finalConfig;
@@ -365,6 +457,7 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
       });
       setSim(simResult);
       setRanKey(JSON.stringify(nextForm));
+      setShowAll(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -397,6 +490,23 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
 
   const stale = sim !== null && ranKey !== JSON.stringify(form);
   const matchedCount = sim?.rules.filter((r) => r.verdict === "matched").length ?? 0;
+  // Default the results list to the rules that actually did something (matched
+  // or unresolved), hiding the sea of "no match" rows behind a toggle.
+  const notableRules = sim ? sim.rules.filter((r) => r.verdict !== "no-match") : [];
+  const hiddenCount = sim ? sim.rules.length - notableRules.length : 0;
+  const shownRules = showAll ? (sim?.rules ?? []) : notableRules;
+  const verdictSentence = sim
+    ? buildVerdictSentence(sim, sim.flattened.updateType, changedKeys)
+    : "";
+  const changedWithValues = changedKeys.map((key) => ({
+    key,
+    value: sim?.finalDependencyConfig[key],
+    present: sim ? key in sim.finalDependencyConfig : false,
+  }));
+
+  function jumpToRules() {
+    rulesRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
 
   return (
     <div className="card">
@@ -565,6 +675,44 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
 
       {sim ? (
         <div className="sim-results">
+          {/* Roadmap 012: the answer first — a pinned verdict directly under
+              the Simulate button, before the rule list. */}
+          <div className={`sim-verdict-block${matchedCount === 0 ? " none" : ""}`}>
+            <p className="sim-verdict-sentence">{verdictSentence}</p>
+            {changedWithValues.length > 0 ? (
+              <ul className="sim-verdict-keys">
+                {changedWithValues.map(({ key, value, present }) => (
+                  <li key={key}>
+                    <code>
+                      <OptionKey name={key} flagUnknown />
+                    </code>
+                    {present ? (
+                      <>
+                        {" = "}
+                        <span className="sim-verdict-value">{previewValue(value, 80)}</span>
+                        {sim.flattened.merged.some((m) => m.key === key) ? (
+                          <span className="sim-verdict-from">
+                            {" "}
+                            from the <Term id="updateType">{sim.flattened.updateType}</Term> block
+                          </span>
+                        ) : null}
+                      </>
+                    ) : (
+                      <span className="sim-verdict-value removed"> removed</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="sim-verdict-none">
+                No rule changed anything for this dependency — the defaults apply.
+              </p>
+            )}
+            <button type="button" className="sim-jump" onClick={jumpToRules}>
+              {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched →
+            </button>
+          </div>
+
           {[...sim.errors, ...sim.warnings].length > 0 ? (
             <ul className="messages sim-messages">
               {sim.errors.map((m, i) => (
@@ -584,14 +732,38 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
               {note}
             </p>
           ))}
-          <div className="sim-summary">
-            {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched
+          <div className="sim-rules-head" ref={rulesRef}>
+            <span className="sim-summary">
+              {showAll
+                ? `all ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"}`
+                : `${notableRules.length} of ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"} shown`}
+            </span>
+            {hiddenCount > 0 ? (
+              <button type="button" className="sim-toggle" onClick={() => setShowAll(!showAll)}>
+                {showAll ? "show matched only" : `show all ${sim.rules.length}`}
+              </button>
+            ) : null}
           </div>
-          <div className="sim-rules">
-            {sim.rules.map((rule) => (
-              <RuleRow key={rule.index} rule={rule} />
-            ))}
-          </div>
+          {shownRules.length > 0 ? (
+            <div className="sim-rules">
+              {shownRules.map((rule) => (
+                <RuleRow key={rule.index} rule={rule} />
+              ))}
+            </div>
+          ) : (
+            <p className="empty-note">
+              No rule matched this dependency.{" "}
+              {hiddenCount > 0 ? (
+                <button
+                  type="button"
+                  className="sim-toggle inline"
+                  onClick={() => setShowAll(true)}
+                >
+                  Show all {sim.rules.length} anyway.
+                </button>
+              ) : null}
+            </p>
+          )}
           <div className="sim-final">
             <div className="sim-merged-title">Final per-dependency config</div>
             {changedKeys.length > 0 ? (

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1570,6 +1570,105 @@ pre.config-view.prov-before {
   margin-bottom: 0.4rem;
 }
 
+/* ---------- verdict block + matched-only results (012) ---------- */
+
+.sim-verdict-block {
+  background: color-mix(in srgb, var(--ok) 8%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--ok) 35%, var(--border));
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.sim-verdict-block.none {
+  background: var(--surface);
+  border-color: var(--border);
+}
+
+.sim-verdict-sentence {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.sim-verdict-keys {
+  list-style: none;
+  margin: 0.55rem 0 0;
+  padding: 0;
+}
+
+.sim-verdict-keys li {
+  font-size: 0.83rem;
+  overflow-wrap: anywhere;
+  padding: 0.1rem 0;
+}
+
+.sim-verdict-value {
+  color: var(--ok);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+}
+
+.sim-verdict-value.removed {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.sim-verdict-from {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.sim-verdict-none {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 0.5rem 0 0;
+}
+
+.sim-jump {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  display: inline-block;
+  font: inherit;
+  font-size: 0.82rem;
+  margin-top: 0.55rem;
+  padding: 0;
+}
+
+.sim-jump:hover {
+  text-decoration: underline;
+}
+
+.sim-rules-head {
+  align-items: baseline;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  margin: 0.25rem 0 0.5rem;
+  scroll-margin-top: 0.5rem;
+}
+
+.sim-toggle {
+  background: transparent;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.82rem;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.sim-toggle:hover {
+  text-decoration: underline;
+}
+
+.sim-toggle.inline {
+  font-size: inherit;
+}
+
 /* ---------- first-load guidance & glossary (UX pass) ---------- */
 
 .welcome {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@ export {
   type ClauseEvaluation,
   type ClauseState,
   type DependencyDescriptor,
+  type FlattenResult,
   type MergedKey,
   type RuleEvaluation,
   type RuleVerdict,

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -17,6 +17,13 @@ import type { ValidationMessage } from "./trace/model";
  * (removeMatchers + mergeChildConfig, cumulative and in order) so the final
  * per-dependency config matches what Renovate would compute.
  *
+ * Roadmap 012: after the merge tail, the simulator also replicates Renovate's
+ * update-type flattening (upstream `flattenUpdates`:
+ * `mergeChildConfig(config, config[updateType])` followed by deleting every
+ * update-type block) so that e.g. `minor: { automerge: true }` resolves to
+ * `automerge: true` for a minor update. What the flattening changed, and which
+ * update-type blocks were present, is recorded on `result.flattened`.
+ *
  * The one deliberate gap: `matchConfidence` needs a Merge Confidence API
  * token and upstream THROWS without one, so rules containing it are reported
  * as "not-simulated" instead of being decided — mirroring that a real run
@@ -81,6 +88,25 @@ export interface MergedKey {
   after?: unknown;
 }
 
+/**
+ * The update-type flattening step (roadmap 012), replicating upstream
+ * `flattenUpdates`: after packageRules merge, `config[updateType]` is merged
+ * up into the config and every update-type block is dropped.
+ */
+export interface FlattenResult {
+  /** The update's type whose block was merged, e.g. `minor` (if any was set). */
+  updateType?: string;
+  /** Keys the update-type block set/changed on the final config (may be empty). */
+  merged: MergedKey[];
+  /**
+   * Every standard update-type block present on the resolved config *before*
+   * flattening (`major`/`minor`/`patch`/`pin`/`digest`/`lockFileMaintenance`/
+   * `replacement`), so the UI can explain when a setting is scoped to update
+   * types other than the current one.
+   */
+  blocks: Record<string, Record<string, unknown>>;
+}
+
 export interface RuleEvaluation {
   /** Position in `packageRules`. */
   index: number;
@@ -98,10 +124,13 @@ export interface SimulationResult {
   /** Exactly what `applyPackageRules` would return (dep fields included). */
   rawFinalConfig: Record<string, unknown>;
   /**
-   * `rawFinalConfig` without `packageRules` and without synthetic descriptor
-   * fields that no rule changed — the per-dependency config for display.
+   * `rawFinalConfig` after update-type flattening, without `packageRules` and
+   * without synthetic descriptor fields that no rule changed — the
+   * per-dependency config for display.
    */
   finalDependencyConfig: Record<string, unknown>;
+  /** What Renovate's update-type flattening changed (roadmap 012). */
+  flattened: FlattenResult;
   /** `validateConfig("repo", { packageRules })` output for the rules block. */
   errors: ValidationMessage[];
   warnings: ValidationMessage[];
@@ -146,6 +175,21 @@ const MATCHER_TABLE: readonly MatcherDescriptor[] = [
 ];
 
 const KNOWN_SELECTORS = new Set(MATCHER_TABLE.map((entry) => entry.key));
+
+/**
+ * The update-type config blocks Renovate flattens and then deletes, in the
+ * exact set and order of upstream `flattenUpdates`. `rollback`/`bump` are NOT
+ * flattenable blocks upstream and are intentionally absent.
+ */
+const UPDATE_TYPE_KEYS = [
+  "major",
+  "minor",
+  "patch",
+  "pin",
+  "digest",
+  "lockFileMaintenance",
+  "replacement",
+] as const;
 
 const NOT_SIMULATED_NOTE =
   "not simulated — matchConfidence requires a Merge Confidence API token; " +
@@ -436,7 +480,40 @@ async function execute(input: SimulationInput): Promise<SimulationResult> {
       );
     }
 
-    const finalDependencyConfig = { ...config };
+    // ---- upstream flattenUpdates update-type flattening, replicated ----
+    // After the packageRules merge, Renovate merges `config[updateType]` up
+    // into the config (so `minor: { automerge: true }` becomes
+    // `automerge: true` for a minor update) and then drops every update-type
+    // block. `rawFinalConfig` keeps the pre-flatten value (006 oracle parity);
+    // the display config below reflects the flattening.
+    const updateType = typeof config.updateType === "string" ? config.updateType : undefined;
+    const blocks: Record<string, Record<string, unknown>> = {};
+    for (const key of UPDATE_TYPE_KEYS) {
+      if (isPlainObject(config[key])) {
+        blocks[key] = config[key] as Record<string, unknown>;
+      }
+    }
+    const preFlatten: Record<string, unknown> = { ...config };
+    for (const key of UPDATE_TYPE_KEYS) {
+      delete preFlatten[key];
+    }
+    let flattenedConfig: Record<string, unknown> = { ...config };
+    const updateBlock = updateType !== undefined ? config[updateType] : undefined;
+    if (isPlainObject(updateBlock)) {
+      flattenedConfig = mergeChildConfig(flattenedConfig, updateBlock) as Record<string, unknown>;
+    }
+    for (const key of UPDATE_TYPE_KEYS) {
+      delete flattenedConfig[key];
+    }
+    const flattenMerged = diffKeys(preFlatten, flattenedConfig);
+    if (flattenMerged.length > 0 && updateType) {
+      notes.push(
+        `update-type flattening merged the \`${updateType}\` block up into the config: ` +
+          `${flattenMerged.map((m) => `\`${m.key}\``).join(", ")}`,
+      );
+    }
+
+    const finalDependencyConfig = { ...flattenedConfig };
     delete finalDependencyConfig.packageRules;
     for (const [key, value] of Object.entries(depFields)) {
       if (key in finalDependencyConfig && jsonEqual(finalDependencyConfig[key], value)) {
@@ -448,6 +525,7 @@ async function execute(input: SimulationInput): Promise<SimulationResult> {
       rules,
       rawFinalConfig: config,
       finalDependencyConfig,
+      flattened: { updateType, merged: flattenMerged, blocks },
       errors,
       warnings,
       notes,

--- a/packages/engine/test/simulate-package-rules.node.test.ts
+++ b/packages/engine/test/simulate-package-rules.node.test.ts
@@ -4,10 +4,35 @@
  * renovate modules (no shims) — proving the simulator replicates upstream
  * behavior, not an artifact of the browser module graph.
  */
+import { mergeChildConfig } from "renovate/dist/config/utils.js";
 import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
 import { describe, expect, it } from "vitest";
 import type { DependencyDescriptor } from "../src/index";
 import { simulatePackageRules } from "../src/index";
+
+const UPDATE_TYPE_KEYS = [
+  "major",
+  "minor",
+  "patch",
+  "pin",
+  "digest",
+  "lockFileMaintenance",
+  "replacement",
+];
+
+/** Upstream flattenUpdates' update-type merge + block deletion (roadmap 012). */
+function oracleFlatten(raw: Record<string, unknown>): Record<string, unknown> {
+  const updateType = typeof raw.updateType === "string" ? raw.updateType : undefined;
+  const block = updateType !== undefined ? raw[updateType] : undefined;
+  const out =
+    block && typeof block === "object"
+      ? (mergeChildConfig(raw, block as Record<string, unknown>) as Record<string, unknown>)
+      : { ...raw };
+  for (const key of UPDATE_TYPE_KEYS) {
+    delete out[key];
+  }
+  return out;
+}
 
 const npmDep: DependencyDescriptor = {
   manager: "npm",
@@ -51,6 +76,36 @@ describe("simulatePackageRules (golden)", () => {
     expect(oracle.datasource).toBe("github-tags");
     expect(oracle.skipReason).toBe("package-rules");
     expect(oracle.addLabels).toEqual(["all-but-react", "via-jsonata"]);
+  });
+
+  it("flattens config[updateType] up, matching upstream (oracle parity)", async () => {
+    const config = {
+      packageRules: [
+        {
+          matchPackageNames: ["lodash"],
+          automerge: false,
+          minor: { automerge: true, addLabels: ["auto"] },
+        },
+      ],
+    };
+    const dep: DependencyDescriptor = { ...npmDep, updateType: "minor" };
+    const simulated = await simulatePackageRules({ config, dep });
+    const oracle = oracleFlatten(
+      await applyPackageRules({ ...config, ...dep, depName: dep.packageName }),
+    );
+    // the update-type block merged up exactly as Renovate computes it
+    expect(oracle.automerge).toBe(true);
+    expect(oracle.addLabels).toEqual(["auto"]);
+    expect(oracle).not.toHaveProperty("minor");
+    // and the simulator's flattened result agrees
+    expect(simulated.finalDependencyConfig.automerge).toBe(oracle.automerge);
+    expect(simulated.finalDependencyConfig.addLabels).toEqual(oracle.addLabels);
+    expect(simulated.finalDependencyConfig).not.toHaveProperty("minor");
+    expect(simulated.flattened.updateType).toBe("minor");
+    expect(simulated.flattened.merged.map((m) => m.key).toSorted()).toEqual([
+      "addLabels",
+      "automerge",
+    ]);
   });
 
   it("agrees with upstream on exclusion patterns and rule order", async () => {

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -6,10 +6,56 @@
  * shimmed module graph). A golden twin (simulate-package-rules.node.test.ts)
  * asserts the same parity unshimmed.
  */
+import { mergeChildConfig } from "renovate/dist/config/utils.js";
 import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
 import { describe, expect, it } from "vitest";
 import type { DependencyDescriptor } from "../src/index";
 import { simulatePackageRules } from "../src/index";
+
+/** The update-type blocks upstream `flattenUpdates` merges up and then drops. */
+const UPDATE_TYPE_KEYS = [
+  "major",
+  "minor",
+  "patch",
+  "pin",
+  "digest",
+  "lockFileMaintenance",
+  "replacement",
+];
+
+/**
+ * The oracle for the 012 update-type flattening step: exactly upstream's two
+ * lines in `flattenUpdates` after `applyPackageRules` — merge `config[updateType]`
+ * up, then delete every update-type block.
+ */
+function oracleFlatten(raw: Record<string, unknown>): Record<string, unknown> {
+  const updateType = typeof raw.updateType === "string" ? raw.updateType : undefined;
+  const block = updateType !== undefined ? raw[updateType] : undefined;
+  const out =
+    block && typeof block === "object"
+      ? (mergeChildConfig(raw, block as Record<string, unknown>) as Record<string, unknown>)
+      : { ...raw };
+  for (const key of UPDATE_TYPE_KEYS) {
+    delete out[key];
+  }
+  return out;
+}
+
+/** Strip a raw config to the display config exactly as the simulator does. */
+function toDisplay(
+  raw: Record<string, unknown>,
+  dep: DependencyDescriptor,
+): Record<string, unknown> {
+  const depFields: Record<string, unknown> = { ...dep, depName: dep.depName ?? dep.packageName };
+  const out = { ...raw };
+  delete out.packageRules;
+  for (const [key, value] of Object.entries(depFields)) {
+    if (value !== undefined && key in out && JSON.stringify(out[key]) === JSON.stringify(value)) {
+      delete out[key];
+    }
+  }
+  return out;
+}
 
 const npmDep: DependencyDescriptor = {
   manager: "npm",
@@ -218,6 +264,51 @@ describe("simulatePackageRules", () => {
     expect(oracle.datasource).toBe("github-tags");
     expect(oracle.skipReason).toBe("package-rules");
     expect(oracle.prPriority).toBe(5);
+  });
+
+  it("flattens the update-type block, matching upstream flattenUpdates (oracle parity)", async () => {
+    const config = {
+      packageRules: [
+        {
+          matchPackageNames: ["lodash"],
+          addLabels: ["deploy_pr"],
+          autoApprove: true,
+          automerge: false,
+          minor: { automerge: true },
+          patch: { automerge: true },
+        },
+      ],
+    };
+
+    // minor update: automerge is scoped to minor/patch, so it flattens to true.
+    const minorDep: DependencyDescriptor = { ...npmDep, updateType: "minor" };
+    const minor = await simulatePackageRules({ config, dep: minorDep });
+    const minorOracle = oracleFlatten(await applyPackageRules(oracleInput(config, minorDep)));
+    expect(minor.finalDependencyConfig).toEqual(toDisplay(minorOracle, minorDep));
+    expect(minor.finalDependencyConfig.automerge).toBe(true);
+    // the flattening is recorded for the UI
+    expect(minor.flattened.updateType).toBe("minor");
+    expect(minor.flattened.merged).toContainEqual({
+      key: "automerge",
+      before: false,
+      after: true,
+    });
+    expect(Object.keys(minor.flattened.blocks).toSorted()).toEqual(["minor", "patch"]);
+    // update-type blocks are dropped from the display config, like upstream
+    expect(minor.finalDependencyConfig).not.toHaveProperty("minor");
+    expect(minor.finalDependencyConfig).not.toHaveProperty("patch");
+
+    // major update: no major block, so automerge stays false — the contrast
+    // the persona study found impossible before flattening.
+    const majorDep: DependencyDescriptor = { ...npmDep, updateType: "major" };
+    const major = await simulatePackageRules({ config, dep: majorDep });
+    const majorOracle = oracleFlatten(await applyPackageRules(oracleInput(config, majorDep)));
+    expect(major.finalDependencyConfig).toEqual(toDisplay(majorOracle, majorDep));
+    expect(major.finalDependencyConfig.automerge).toBe(false);
+    expect(major.flattened.merged).toEqual([]);
+    // rule-level (non-scoped) settings still apply to the major update
+    expect(major.finalDependencyConfig.addLabels).toEqual(["deploy_pr"]);
+    expect(major.finalDependencyConfig.autoApprove).toBe(true);
   });
 
   it("surfaces validateConfig messages for a bogus matcher key", async () => {

--- a/roadmap/012-simulator-verdict-first-results.md
+++ b/roadmap/012-simulator-verdict-first-results.md
@@ -1,6 +1,25 @@
 # 012 — Simulator: verdict-first results + update-type flattening
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified. Engine: `simulatePackageRules` now replicates
+> Renovate's update-type flattening after the packageRules merge tail —
+> `mergeChildConfig(config, config[updateType])` followed by dropping every
+> update-type block (`major`/`minor`/`patch`/`pin`/`digest`/
+> `lockFileMaintenance`/`replacement`), exactly as upstream `flattenUpdates`
+> does. `rawFinalConfig` keeps its pre-flatten value (006 oracle parity);
+> `finalDependencyConfig` reflects the flattening; a new `flattened`
+> ({ updateType, merged, blocks }) records what the update-type block changed
+> and which blocks were present, so the UI can explain update-type scoping.
+> Golden + shimmed oracle tests assert parity against upstream's real
+> `applyPackageRules` + `mergeChildConfig`. UI: a verdict block is pinned
+> directly under the Simulate button with matched-rule count, the changed keys
+> and their final values (flagging which came from the update-type block), and
+> a plain-language outcome sentence covering enabled/skipReason, automerge
+> (with update-type scoping), labels, grouping and schedule. The results list
+> defaults to matched-and-unresolved rules with a "show all N" toggle, and the
+> "N of M rules matched" line is a jump link to the list; per-clause evidence
+> rows are unchanged.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -16,7 +16,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done    |
 | [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
-| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | planned |
+| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
 | [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | planned |
 | [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | planned |
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | planned |


### PR DESCRIPTION
Implements roadmap item 012 (M5, from the 2026-07 persona UX study).

## Engine
- After the packageRules merge tail, replicate upstream `flattenUpdates`: `mergeChildConfig(config, config[updateType])` then drop every update-type block (`major`/`minor`/`patch`/`pin`/`digest`/`lockFileMaintenance`/`replacement`), so `minor: {automerge: true}` resolves to `automerge: true` for a minor update.
- New `flattened` field on `SimulationResult` records the update type, what the block merged, and every update-type block present pre-flatten.
- Oracle-parity tests in both suites build the expected value by running renovate's own `applyPackageRules` + `mergeChildConfig`, including the minor-vs-major automerge contrast the persona study found unanswerable.

## App
- Verdict block pinned directly under Simulate: matched-rule count (jump link to the list), changed keys **with final values**, and a plain-language outcome sentence — e.g. "This major update WOULD add labels [deploy_pr] and auto-approval, but would NOT automerge (automerge is scoped to minor/patch)."
- Results list defaults to matched rules only, with a "show all N" toggle. Per-clause evidence rows unchanged.

Validated: lint, format, typecheck, golden (14) + shimmed (65) tests, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ