### PR TITLE
feat(013): rule identity — canonical numbering, provenance chips, cross-links

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -5,7 +5,7 @@ import type {
   StageId,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
-import { ConfigEditor } from "./components/ConfigEditor";
+import { ConfigEditor, type ConfigEditorHandle } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
 import { type AuthState, GithubAuthHint } from "./components/GithubAuthHint";
 import { MessagesPanel } from "./components/MessagesPanel";
@@ -16,6 +16,8 @@ import { StageDiff } from "./components/StageDiff";
 import { STAGE_EXPLAINERS, STAGE_LABELS, StageTimeline } from "./components/StageTimeline";
 import { Term } from "./glossary";
 import { OptionDocsProvider } from "./option-docs";
+import { findPackageRuleOffsets } from "./rule-locate";
+import { useRuleProvenance } from "./rule-provenance";
 import {
   beginSignIn,
   completeCallback,
@@ -279,6 +281,24 @@ export function App() {
   // When a GitHub load fails with a not-found/auth/rate-limit error, offer the
   // sign-in / install hint next to the failure (009). null = no hint.
   const [repoAuthHint, setRepoAuthHint] = useState<{ rateLimited: boolean } | null>(null);
+  // Roadmap 013: rule identity cross-links. The editor is an imperative jump
+  // target (CodeMirror has no declarative "scroll to offset X" prop); the
+  // simulator's target rule is prop-driven since it is a sibling component.
+  const configEditorRef = useRef<ConfigEditorHandle>(null);
+  const [pendingRuleFocus, setPendingRuleFocus] = useState<number | null>(null);
+  const ruleProvenance = useRuleProvenance(result);
+  // The raw text is re-scanned only when it changes, not on every keystroke's
+  // render of something unrelated — this is a plain bracket-depth scan, not a
+  // full parse, so it stays cheap even for large configs.
+  const packageRuleOffsets = useMemo(() => findPackageRuleOffsets(content), [content]);
+
+  /** A validation message's REPO-config `packageRules[repoIndex]` → the editor line. */
+  function focusEditorRepoIndex(repoIndex: number) {
+    const offset = packageRuleOffsets?.[repoIndex];
+    if (offset !== undefined) {
+      configEditorRef.current?.highlightOffset(offset);
+    }
+  }
 
   useEffect(() => {
     setSelectedNodeId(null);
@@ -747,7 +767,12 @@ export function App() {
           </button>
         </form>
 
-        <ConfigEditor fileName={fileName} value={content} onChange={setContent} />
+        <ConfigEditor
+          ref={configEditorRef}
+          fileName={fileName}
+          value={content}
+          onChange={setContent}
+        />
 
         <div className="toolbar">
           <select value={fileName} onChange={(e) => setFileName(e.target.value as typeof fileName)}>
@@ -1102,7 +1127,12 @@ export function App() {
                 <StageDiff result={result} stage={deferredStage} />
               )}
             </div>
-            <MessagesPanel result={result} />
+            <MessagesPanel
+              result={result}
+              ruleAttribution={ruleProvenance}
+              onJumpToEditor={focusEditorRepoIndex}
+              onJumpToSimRule={setPendingRuleFocus}
+            />
             <PresetTree
               result={result}
               onInject={onInject}
@@ -1113,7 +1143,13 @@ export function App() {
               installUrl={installUrl()}
             />
             <EffectiveConfig result={result} onSelectPreset={setSelectedNodeId} />
-            <RuleSimulator result={result} />
+            <RuleSimulator
+              result={result}
+              onSelectPreset={setSelectedNodeId}
+              onJumpToEditor={focusEditorRepoIndex}
+              focusRuleIndex={pendingRuleFocus}
+              onRuleFocused={() => setPendingRuleFocus(null)}
+            />
           </>
         ) : null}
       </main>

--- a/packages/app/src/components/ConfigEditor.tsx
+++ b/packages/app/src/components/ConfigEditor.tsx
@@ -1,8 +1,8 @@
-import CodeMirror from "@uiw/react-codemirror";
+import CodeMirror, { EditorView, type ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import { jsonSchema } from "codemirror-json-schema";
 import { json5Schema } from "codemirror-json-schema/json5";
 import { renovateSchema } from "@renovate-config-visualizer/engine/schema";
-import { useMemo } from "react";
+import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 
 interface Props {
   fileName: string;
@@ -10,10 +10,52 @@ interface Props {
   onChange: (value: string) => void;
 }
 
-export function ConfigEditor({ fileName, value, onChange }: Props) {
+/**
+ * Roadmap 013: imperative cross-link target. A validation error naming a
+ * repo-config `packageRules[i]` index resolves to a character offset (via
+ * `rule-locate.ts`) and calls `highlightOffset` to jump the editor there.
+ */
+export interface ConfigEditorHandle {
+  /** Scrolls the line at `offset` into view, selects it, and flashes it briefly. */
+  highlightOffset(offset: number): void;
+}
+
+export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function ConfigEditor(
+  { fileName, value, onChange },
+  ref,
+) {
   const extensions = useMemo(
     () => [fileName.endsWith(".json5") ? json5Schema(renovateSchema) : jsonSchema(renovateSchema)],
     [fileName],
+  );
+  const cmRef = useRef<ReactCodeMirrorRef>(null);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      highlightOffset(offset: number) {
+        const view = cmRef.current?.view;
+        if (!view) {
+          return;
+        }
+        const pos = Math.max(0, Math.min(offset, view.state.doc.length));
+        const line = view.state.doc.lineAt(pos);
+        view.dispatch({
+          selection: { anchor: line.from, head: line.to },
+          effects: EditorView.scrollIntoView(line.from, { y: "center" }),
+        });
+        view.focus();
+        const dom = view.domAtPos(line.from).node;
+        const lineEl = (
+          dom.nodeType === Node.TEXT_NODE ? dom.parentElement : (dom as Element)
+        )?.closest(".cm-line");
+        if (lineEl) {
+          lineEl.classList.add("rcv-flash");
+          window.setTimeout(() => lineEl.classList.remove("rcv-flash"), 1600);
+        }
+      },
+    }),
+    [],
   );
 
   const dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
@@ -22,6 +64,7 @@ export function ConfigEditor({ fileName, value, onChange }: Props) {
     <div className="card">
       <div className="card-title">{fileName}</div>
       <CodeMirror
+        ref={cmRef}
         value={value}
         onChange={onChange}
         extensions={extensions}
@@ -31,4 +74,4 @@ export function ConfigEditor({ fileName, value, onChange }: Props) {
       />
     </div>
   );
-}
+});

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -2,11 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import type {
   KeyProvenance,
   ProvenanceStep,
+  RuleAttribution,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
 import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { ConfigJson } from "./ConfigJson";
+import { layerId, layerLabel, type LayerId, ProvenanceChip } from "./ProvenanceChip";
+import { useRuleProvenance } from "../rule-provenance";
 
 /**
  * Roadmap 005: the effective config as a provenance view. Every top-level key
@@ -36,33 +39,6 @@ function useProvenance(result: TraceResult): Provenance | null | undefined {
     };
   }, [result]);
   return state;
-}
-
-type LayerId = string;
-
-/** Stable id for a layer, used by the dropdown filter + winning-badge classes. */
-function layerId(layer: ProvenanceStep["layer"]): LayerId {
-  return layer.kind === "preset" ? `preset:${layer.name}` : layer.kind;
-}
-
-function layerLabel(layer: ProvenanceStep["layer"]): string {
-  if (layer.kind === "defaults") {
-    return "default";
-  }
-  if (layer.kind === "global") {
-    return "global config";
-  }
-  if (layer.kind === "inherited") {
-    return "inherited config";
-  }
-  if (layer.kind === "repo") {
-    return "repo config";
-  }
-  return layer.name;
-}
-
-function layerClass(layer: ProvenanceStep["layer"]): string {
-  return `prov-${layer.kind}`;
 }
 
 const VERBS: Record<ProvenanceStep["action"], string> = {
@@ -116,43 +92,6 @@ function preview(value: unknown): string {
   return truncate(JSON.stringify(value) ?? String(value), 80);
 }
 
-function LayerBadge({
-  layer,
-  onSelectPreset,
-}: {
-  layer: ProvenanceStep["layer"];
-  onSelectPreset?: (nodeId: string) => void;
-}) {
-  const clickable = layer.kind === "preset" && onSelectPreset;
-  const className = `badge prov-layer ${layerClass(layer)}`;
-  if (clickable) {
-    // Not a <button>: KeyRow renders this inside its row-toggle button, and
-    // buttons cannot nest. stopPropagation keeps the row from toggling too.
-    return (
-      <span
-        role="button"
-        tabIndex={0}
-        className={className}
-        title="Show this preset in the resolution tree"
-        onClick={(e) => {
-          e.stopPropagation();
-          onSelectPreset(layer.nodeId);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            e.stopPropagation();
-            onSelectPreset(layer.nodeId);
-          }
-        }}
-      >
-        {layerLabel(layer)}
-      </span>
-    );
-  }
-  return <span className={className}>{layerLabel(layer)}</span>;
-}
-
 function Step({
   step,
   onSelectPreset,
@@ -165,7 +104,7 @@ function Step({
   return (
     <div className={`prov-step action-${step.action}`}>
       <div className="prov-step-head">
-        <LayerBadge layer={step.layer} onSelectPreset={onSelectPreset} />
+        <ProvenanceChip layer={step.layer} onSelectPreset={onSelectPreset} />
         <span className="prov-step-verb">{VERBS[step.action]}</span>
         {step.expandedNested ? (
           <span
@@ -188,19 +127,75 @@ function Step({
   );
 }
 
+/** First matcher-clause key list, for a one-line rule summary (mirrors the
+ *  simulator's ruleLabel — all clauses, no "which one matters" judgment
+ *  since this view has no dependency to evaluate against). */
+function summarizeRuleSelectors(rule: unknown): string {
+  if (typeof rule !== "object" || rule === null) {
+    return "(not an object)";
+  }
+  const keys = Object.keys(rule as Record<string, unknown>).filter(
+    (k) => k.startsWith("match") || k.startsWith("exclude"),
+  );
+  return keys.length > 0 ? keys.join(" + ") : "(no match*/exclude* selectors)";
+}
+
+/** Roadmap 013: per-entry provenance for `packageRules` — which layer (repo /
+ *  global / inherited / preset) contributed each merged rule, reusing the
+ *  same chip the effective config's top-level keys already show. */
+function PackageRulesProvenance({
+  rules,
+  attribution,
+  onSelectPreset,
+}: {
+  rules: unknown[];
+  attribution: RuleAttribution[];
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const byIndex = useMemo(() => new Map(attribution.map((a) => [a.index, a])), [attribution]);
+  return (
+    <div className="prov-rules">
+      <div className="prov-rules-title">
+        Per-rule provenance ({rules.length} rule{rules.length === 1 ? "" : "s"})
+      </div>
+      <ul className="prov-rules-list">
+        {rules.map((rule, i) => {
+          const attr = byIndex.get(i);
+          return (
+            <li key={i}>
+              <span className="prov-rule-index">#{i + 1}</span>
+              {attr ? (
+                <ProvenanceChip layer={attr.layer} onSelectPreset={onSelectPreset} />
+              ) : (
+                <span className="badge prov-layer">source unknown</span>
+              )}
+              <span className="prov-rule-preview">{summarizeRuleSelectors(rule)}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 function KeyRow({
   entry,
   expanded,
   onToggle,
   onSelectPreset,
+  ruleAttribution,
 }: {
   entry: KeyProvenance;
   expanded: boolean;
   onToggle: () => void;
   onSelectPreset?: (nodeId: string) => void;
+  /** Only meaningful for the `packageRules` row; undefined/unavailable elsewhere. */
+  ruleAttribution?: RuleAttribution[] | null;
 }) {
   const winner = winningStep(entry);
   const visibleSteps = entry.chain.filter((s) => !s.noop);
+  const rules =
+    entry.key === "packageRules" && Array.isArray(entry.finalValue) ? entry.finalValue : null;
   return (
     <div className={`prov-row${expanded ? " expanded" : ""}`}>
       <button type="button" className="prov-row-head" onClick={onToggle} aria-expanded={expanded}>
@@ -214,7 +209,7 @@ function KeyRow({
             overridden
           </span>
         ) : null}
-        <LayerBadge layer={winner.layer} onSelectPreset={onSelectPreset} />
+        <ProvenanceChip layer={winner.layer} onSelectPreset={onSelectPreset} />
       </button>
       {expanded ? (
         <div className="prov-detail">
@@ -224,6 +219,16 @@ function KeyRow({
               <ConfigJson value={entry.finalValue} />
             </pre>
           </div>
+          {rules &&
+          rules.length > 0 &&
+          ruleAttribution &&
+          ruleAttribution.length === rules.length ? (
+            <PackageRulesProvenance
+              rules={rules}
+              attribution={ruleAttribution}
+              onSelectPreset={onSelectPreset}
+            />
+          ) : null}
           <div className="prov-chain-title">
             Override chain ({visibleSteps.length} step{visibleSteps.length === 1 ? "" : "s"})
           </div>
@@ -244,6 +249,7 @@ export function EffectiveConfig({
   onSelectPreset?: (nodeId: string) => void;
 }) {
   const provenance = useProvenance(result);
+  const ruleAttribution = useRuleProvenance(result);
   const [query, setQuery] = useState("");
   const [layerFilter, setLayerFilter] = useState<LayerId | "all">("all");
   const [onlyOverridden, setOnlyOverridden] = useState(false);
@@ -374,6 +380,7 @@ export function EffectiveConfig({
                 <KeyRow
                   key={entry.key}
                   entry={entry}
+                  ruleAttribution={entry.key === "packageRules" ? ruleAttribution : undefined}
                   expanded={expanded.has(entry.key)}
                   onToggle={() =>
                     setExpanded((prev) => {

--- a/packages/app/src/components/MessagesPanel.tsx
+++ b/packages/app/src/components/MessagesPanel.tsx
@@ -1,6 +1,20 @@
-import type { TraceResult } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution, TraceResult } from "@renovate-config-visualizer/engine";
+import { RuleMessage } from "./RuleMessage";
 
-export function MessagesPanel({ result }: { result: TraceResult }) {
+export function MessagesPanel({
+  result,
+  ruleAttribution,
+  onJumpToEditor,
+  onJumpToSimRule,
+}: {
+  result: TraceResult;
+  /** Roadmap 013: for cross-linking `packageRules[i]` references (repo-config
+   *  index, since these messages come from validating the repo's own config
+   *  before any preset merge) to the editor line and the simulator's rule row. */
+  ruleAttribution?: RuleAttribution[] | null;
+  onJumpToEditor?: (repoIndex: number) => void;
+  onJumpToSimRule?: (mergedIndex: number) => void;
+}) {
   const presetErrors = result.events.filter((e) => e.kind === "preset-error");
   if (result.errors.length + result.warnings.length + presetErrors.length === 0) {
     return null;
@@ -11,12 +25,26 @@ export function MessagesPanel({ result }: { result: TraceResult }) {
       <ul className="messages">
         {result.errors.map((m, i) => (
           <li key={`e${i}`} className="error">
-            <strong>{m.topic}:</strong> {m.message}
+            <strong>{m.topic}:</strong>{" "}
+            <RuleMessage
+              message={m}
+              indexKind="repo"
+              ruleAttribution={ruleAttribution}
+              onJumpToEditor={onJumpToEditor}
+              onJumpToSimRule={onJumpToSimRule}
+            />
           </li>
         ))}
         {result.warnings.map((m, i) => (
           <li key={`w${i}`} className="warn">
-            <strong>{m.topic}:</strong> {m.message}
+            <strong>{m.topic}:</strong>{" "}
+            <RuleMessage
+              message={m}
+              indexKind="repo"
+              ruleAttribution={ruleAttribution}
+              onJumpToEditor={onJumpToEditor}
+              onJumpToSimRule={onJumpToSimRule}
+            />
           </li>
         ))}
         {presetErrors.map((e) => (

--- a/packages/app/src/components/ProvenanceChip.tsx
+++ b/packages/app/src/components/ProvenanceChip.tsx
@@ -1,0 +1,75 @@
+import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
+
+/**
+ * Roadmap 013: the layer-provenance chip introduced by the effective config
+ * panel (005) — `repo config` / `global config` / `inherited config` / a
+ * preset name, color-coded, clickable to select the contributing preset node
+ * in the resolution tree. Factored out so the simulator's rule rows and
+ * `packageRules` entries (013) can show the exact same chip instead of a
+ * near-duplicate.
+ */
+
+export type LayerId = string;
+
+/** Stable id for a layer, used by dropdown filters + winning-badge classes. */
+export function layerId(layer: ProvenanceLayer): LayerId {
+  return layer.kind === "preset" ? `preset:${layer.name}` : layer.kind;
+}
+
+export function layerLabel(layer: ProvenanceLayer): string {
+  if (layer.kind === "defaults") {
+    return "default";
+  }
+  if (layer.kind === "global") {
+    return "global config";
+  }
+  if (layer.kind === "inherited") {
+    return "inherited config";
+  }
+  if (layer.kind === "repo") {
+    return "repo config";
+  }
+  return layer.name;
+}
+
+export function layerClass(layer: ProvenanceLayer): string {
+  return `prov-${layer.kind}`;
+}
+
+export function ProvenanceChip({
+  layer,
+  onSelectPreset,
+}: {
+  layer: ProvenanceLayer;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const clickable = layer.kind === "preset" && onSelectPreset;
+  const className = `badge prov-layer ${layerClass(layer)}`;
+  if (clickable) {
+    // Not necessarily a <button>: callers may render this inside their own
+    // row-toggle button, and buttons cannot nest — stopPropagation keeps the
+    // row from toggling too.
+    return (
+      <span
+        role="button"
+        tabIndex={0}
+        className={className}
+        title="Show this preset in the resolution tree"
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelectPreset(layer.nodeId);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            e.stopPropagation();
+            onSelectPreset(layer.nodeId);
+          }
+        }}
+      >
+        {layerLabel(layer)}
+      </span>
+    );
+  }
+  return <span className={className}>{layerLabel(layer)}</span>;
+}

--- a/packages/app/src/components/RuleMessage.tsx
+++ b/packages/app/src/components/RuleMessage.tsx
@@ -1,0 +1,102 @@
+import type { RuleAttribution, ValidationMessage } from "@renovate-config-visualizer/engine";
+
+/**
+ * Roadmap 013: one canonical rule presentation + cross-links. A validation
+ * message from Renovate's own validator embeds an index the app cannot
+ * change (`packageRules[N]`) — this component makes that reference clickable
+ * (jumping to the editor line or the simulator row, depending which index
+ * scheme the message uses) and, when the mapping is determinable via
+ * `computeRuleProvenance`, appends the OTHER index as a second clickable
+ * annotation: "repo-config index 1 = merged rule 713".
+ */
+
+const RULE_INDEX_RE = /packageRules\[(\d+)\]/;
+
+/**
+ * `"repo"` = the message came from validating the repo's own directly-authored
+ * config (pre-preset-merge) — e.g. the top-level validate stage.
+ * `"merged"` = the message came from validating the fully-merged
+ * `finalConfig.packageRules` — e.g. the simulator's own validateConfig echo.
+ */
+export type RuleMessageIndexKind = "repo" | "merged";
+
+/** The other index for a given one, only when it is attributable to the repo layer
+ *  (a preset-sourced rule has no repo-config index to annotate with). */
+function crossIndex(
+  indexKind: RuleMessageIndexKind,
+  index: number,
+  ruleAttribution: RuleAttribution[] | null | undefined,
+): number | undefined {
+  if (!ruleAttribution) {
+    return undefined;
+  }
+  if (indexKind === "repo") {
+    return ruleAttribution.find((a) => a.layer.kind === "repo" && a.sourceIndex === index)?.index;
+  }
+  const entry = ruleAttribution.find((a) => a.index === index);
+  return entry?.layer.kind === "repo" ? entry.sourceIndex : undefined;
+}
+
+export function RuleMessage({
+  message,
+  indexKind,
+  ruleAttribution,
+  onJumpToEditor,
+  onJumpToSimRule,
+}: {
+  message: ValidationMessage;
+  indexKind: RuleMessageIndexKind;
+  ruleAttribution: RuleAttribution[] | null | undefined;
+  /** Jumps the config editor to the repo-config `packageRules[repoIndex]` line. */
+  onJumpToEditor?: (repoIndex: number) => void;
+  /** Scrolls to / highlights the simulator's merged-index rule row. */
+  onJumpToSimRule?: (mergedIndex: number) => void;
+}) {
+  const match = RULE_INDEX_RE.exec(message.message);
+  if (!match || match.index === undefined) {
+    return <>{message.message}</>;
+  }
+  const index = Number(match[1]);
+  const start = match.index;
+  const end = start + match[0].length;
+  const before = message.message.slice(0, start);
+  const after = message.message.slice(end);
+  const cross = crossIndex(indexKind, index, ruleAttribution);
+
+  return (
+    <>
+      {before}
+      <button
+        type="button"
+        className="rule-ref-link"
+        onClick={() => (indexKind === "repo" ? onJumpToEditor?.(index) : onJumpToSimRule?.(index))}
+        title={
+          indexKind === "repo"
+            ? "Jump to this rule in the editor"
+            : "Jump to this rule in the simulator's rule list"
+        }
+      >
+        {match[0]}
+      </button>
+      {after}
+      {cross !== undefined ? (
+        <button
+          type="button"
+          className="rule-ref-link rule-ref-cross"
+          onClick={() =>
+            indexKind === "repo" ? onJumpToSimRule?.(cross) : onJumpToEditor?.(cross)
+          }
+          title={
+            indexKind === "repo"
+              ? "Jump to this rule in the simulator's rule list"
+              : "Jump to this rule in the editor"
+          }
+        >
+          {indexKind === "repo"
+            ? ` (= merged rule packageRules[${cross}] in the simulator)`
+            : ` (repo-config index ${cross})`}
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -2,13 +2,17 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ClauseEvaluation,
   DependencyDescriptor,
+  ProvenanceLayer,
   RuleEvaluation,
   SimulationResult,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
 import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
+import { useRuleProvenance } from "../rule-provenance";
 import { ConfigJson } from "./ConfigJson";
+import { ProvenanceChip } from "./ProvenanceChip";
+import { RuleMessage } from "./RuleMessage";
 
 /**
  * Roadmap 006: the packageRules simulator. Describe a hypothetical dependency
@@ -300,19 +304,34 @@ function buildVerdictSentence(
   return `${subject} ${parts.join(", but ")}.`;
 }
 
-/** Short label: the rule's first present selector clause + value preview. */
+/**
+ * Roadmap 013: label lists EVERY `match*` / `exclude*` clause the rule
+ * carries, and names the one that decided a no-match verdict — e.g.
+ * `matchSourceUrls + matchUpdateTypes — failed on matchSourceUrls`. A caption
+ * with only the first clause plus a bare "no match" reads as broken when that
+ * first clause actually matched and a LATER one is what failed it.
+ */
 function ruleLabel(rule: RuleEvaluation): string {
-  const first = rule.clauses[0];
-  if (!first) {
+  if (rule.clauses.length === 0) {
     return "no match* selectors";
   }
-  return `${first.key}: ${previewValue(first.value, 48)}`;
+  const joined = rule.clauses.map((c) => c.key).join(" + ");
+  const failing = rule.clauses.find((c) => c.state === "no-match" || c.state === "error");
+  return failing ? `${joined} — failed on ${failing.key}` : joined;
 }
 
-function RuleRow({ rule }: { rule: RuleEvaluation }) {
+function RuleRow({
+  rule,
+  layer,
+  onSelectPreset,
+}: {
+  rule: RuleEvaluation;
+  layer?: ProvenanceLayer;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
   const [expanded, setExpanded] = useState(false);
   return (
-    <div className={`sim-rule${expanded ? " expanded" : ""}`}>
+    <div id={`sim-rule-${rule.index}`} className={`sim-rule${expanded ? " expanded" : ""}`}>
       <button
         type="button"
         className="sim-rule-head"
@@ -320,11 +339,19 @@ function RuleRow({ rule }: { rule: RuleEvaluation }) {
         aria-expanded={expanded}
       >
         <span className="caret">{expanded ? "▾" : "▸"}</span>
-        <span className="sim-rule-index">#{rule.index + 1}</span>
+        {/* Roadmap 013: canonical form — the SAME text a validator message and
+            the editor cross-link use, so this row is unmistakably the same
+            rule as "packageRules[N]" elsewhere on the page. */}
+        <span className="sim-rule-index">packageRules[{rule.index}]</span>
         <span className="sim-rule-label">{ruleLabel(rule)}</span>
         <span className={`badge sim-verdict verdict-${rule.verdict}`}>
           {VERDICT_LABEL[rule.verdict]}
         </span>
+        {layer ? (
+          <span className="sim-rule-provenance">
+            <ProvenanceChip layer={layer} onSelectPreset={onSelectPreset} />
+          </span>
+        ) : null}
       </button>
       {expanded ? (
         <div className="sim-rule-detail">
@@ -402,7 +429,24 @@ function Field({
   );
 }
 
-export function RuleSimulator({ result }: { result: TraceResult }) {
+export function RuleSimulator({
+  result,
+  onSelectPreset,
+  onJumpToEditor,
+  focusRuleIndex,
+  onRuleFocused,
+}: {
+  result: TraceResult;
+  /** Roadmap 013: a rule row's provenance chip → the contributing preset node in the tree. */
+  onSelectPreset?: (nodeId: string) => void;
+  /** Roadmap 013: a merged-index validation message → the repo-config editor line. */
+  onJumpToEditor?: (repoIndex: number) => void;
+  /** Roadmap 013: a merged rule index to scroll to/highlight (from a validation
+   *  message elsewhere on the page naming this rule's repo-config index). */
+  focusRuleIndex?: number | null;
+  /** Called once the requested `focusRuleIndex` has been handled (found or not). */
+  onRuleFocused?: () => void;
+}) {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [sim, setSim] = useState<SimulationResult | null>(null);
   const [ranKey, setRanKey] = useState<string | null>(null);
@@ -410,6 +454,11 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
   const [error, setError] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
   const rulesRef = useRef<HTMLDivElement>(null);
+  const ruleAttribution = useRuleProvenance(result);
+  // Roadmap 013: the merged index awaiting a scroll+flash — set either from the
+  // external `focusRuleIndex` prop or a click on this component's own
+  // packageRules[N]-in-message links (`focusRule`, defined below).
+  const [scrollTarget, setScrollTarget] = useState<number | null>(null);
 
   // A new run invalidates any previous simulation (the rules may differ).
   useEffect(() => {
@@ -419,11 +468,59 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
     setShowAll(false);
   }, [result]);
 
+  useEffect(() => {
+    if (focusRuleIndex != null) {
+      setScrollTarget(focusRuleIndex);
+    }
+  }, [focusRuleIndex]);
+
+  // Performs the actual scroll+flash once the target row is guaranteed to be
+  // in the DOM: if it is currently hidden behind the matched-only filter,
+  // reveal it first and let the effect re-run on the next render (kept out of
+  // the packageRules-empty early return below, since hooks can't be
+  // conditional — checked against `sim` directly instead of `notableRules`).
+  useEffect(() => {
+    if (scrollTarget == null || !sim) {
+      return;
+    }
+    const rule = sim.rules.find((r) => r.index === scrollTarget);
+    if (!rule) {
+      setScrollTarget(null);
+      onRuleFocused?.();
+      return;
+    }
+    const visible = showAll || rule.verdict !== "no-match";
+    if (!visible) {
+      setShowAll(true);
+      return;
+    }
+    const el = document.getElementById(`sim-rule-${scrollTarget}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("rcv-flash");
+      window.setTimeout(() => el.classList.remove("rcv-flash"), 1600);
+    }
+    setScrollTarget(null);
+    onRuleFocused?.();
+  }, [scrollTarget, sim, showAll, onRuleFocused]);
+
+  /** A merged rule index a click on a `packageRules[N]` message link asked to see. */
+  function focusRule(mergedIndex: number) {
+    setScrollTarget(mergedIndex);
+  }
+
   const finalConfig = result.finalConfig;
   const packageRules = useMemo(
     () => (Array.isArray(finalConfig?.packageRules) ? finalConfig.packageRules : []),
     [finalConfig],
   );
+  const layerByIndex = useMemo(() => {
+    const map = new Map<number, ProvenanceLayer>();
+    for (const attr of ruleAttribution ?? []) {
+      map.set(attr.index, attr.layer);
+    }
+    return map;
+  }, [ruleAttribution]);
 
   // Keys the rules changed vs. the pre-rules effective config, for the final
   // section's summary chips.
@@ -717,12 +814,26 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
             <ul className="messages sim-messages">
               {sim.errors.map((m, i) => (
                 <li key={`e${i}`} className="error">
-                  <strong>{m.topic}</strong>: {m.message}
+                  <strong>{m.topic}</strong>:{" "}
+                  <RuleMessage
+                    message={m}
+                    indexKind="merged"
+                    ruleAttribution={ruleAttribution}
+                    onJumpToEditor={onJumpToEditor}
+                    onJumpToSimRule={focusRule}
+                  />
                 </li>
               ))}
               {sim.warnings.map((m, i) => (
                 <li key={`w${i}`} className="warn">
-                  <strong>{m.topic}</strong>: {m.message}
+                  <strong>{m.topic}</strong>:{" "}
+                  <RuleMessage
+                    message={m}
+                    indexKind="merged"
+                    ruleAttribution={ruleAttribution}
+                    onJumpToEditor={onJumpToEditor}
+                    onJumpToSimRule={focusRule}
+                  />
                 </li>
               ))}
             </ul>
@@ -747,7 +858,12 @@ export function RuleSimulator({ result }: { result: TraceResult }) {
           {shownRules.length > 0 ? (
             <div className="sim-rules">
               {shownRules.map((rule) => (
-                <RuleRow key={rule.index} rule={rule} />
+                <RuleRow
+                  key={rule.index}
+                  rule={rule}
+                  layer={layerByIndex.get(rule.index)}
+                  onSelectPreset={onSelectPreset}
+                />
               ))}
             </div>
           ) : (

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1442,7 +1442,10 @@ pre.config-view.prov-before {
 
 .sim-rule-index {
   color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .sim-rule-label {
@@ -1805,4 +1808,86 @@ pre.config-view.prov-before {
   background: light-dark(#fff1f0, #2d1516);
   border-color: var(--error);
   color: var(--error);
+}
+
+/* ---------- rule identity & provenance (013) ---------- */
+
+/* A packageRules[N] reference inside a validator message: the primary link
+   jumps to that index's own scheme (repo → editor, merged → simulator row);
+   the muted cross-link (rule-ref-cross) names the other scheme's index. */
+.rule-ref-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline dotted;
+}
+
+.rule-ref-link:hover {
+  text-decoration-style: solid;
+}
+
+.rule-ref-cross {
+  color: var(--muted);
+  font-size: 0.85em;
+}
+
+/* Transient "you are here" flash for a cross-link's target: a CodeMirror
+   line, or a simulator rule row. Timed to match the callers' ~1.6s timeout. */
+@keyframes rcv-flash {
+  from {
+    background: color-mix(in srgb, var(--accent) 35%, transparent);
+  }
+  to {
+    background: transparent;
+  }
+}
+
+.rcv-flash {
+  animation: rcv-flash 1.6s ease-out;
+}
+
+.sim-rule-provenance {
+  flex: none;
+}
+
+/* Per-entry provenance list inside the effective config's packageRules row. */
+.prov-rules {
+  margin-top: 0.5rem;
+}
+
+.prov-rules-title {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0.5rem 0 0.3rem;
+  text-transform: uppercase;
+}
+
+.prov-rules-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.prov-rules-list li {
+  align-items: center;
+  display: flex;
+  font-size: 0.82rem;
+  gap: 0.45rem;
+  padding: 0.2rem 0;
+}
+
+.prov-rule-index {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  min-width: 2rem;
+}
+
+.prov-rule-preview {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
 }

--- a/packages/app/src/rule-locate.ts
+++ b/packages/app/src/rule-locate.ts
@@ -1,0 +1,143 @@
+/**
+ * Roadmap 013: locates the character offset of each entry of the TOP-LEVEL
+ * `packageRules` array in the raw config text, so a validator message naming
+ * a repo-config index (`packageRules[1]`, produced by the validate stage
+ * against the repo's own directly-authored array, before any preset merge)
+ * can jump to the right editor line.
+ *
+ * This is a lightweight bracket-depth scanner, not a full JSON5 parser: it
+ * only recognizes a top-level key written as a double-quoted string (the
+ * overwhelming convention even in `.json5` files, which mainly use JSON5 for
+ * comments/trailing commas) followed by `:` and an array. An unquoted or
+ * single-quoted `packageRules` key — valid JSON5, rare in practice — is not
+ * recognized and the function returns `null`, same as "no packageRules key
+ * found" (the caller then just skips the editor cross-link).
+ */
+
+/** Returns the offset of each top-level `packageRules[i]` object's `{`, or `null`. */
+export function findPackageRuleOffsets(text: string): number[] | null {
+  const arrayStart = findTopLevelArrayStart(text, "packageRules");
+  if (arrayStart === null) {
+    return null;
+  }
+  return collectObjectStarts(text, arrayStart);
+}
+
+/** Skips a double-quoted JSON string starting at `start`; returns the index just past it. */
+function skipString(text: string, start: number): number {
+  let i = start + 1;
+  const n = text.length;
+  while (i < n && text[i] !== '"') {
+    if (text[i] === "\\") {
+      i++;
+    }
+    i++;
+  }
+  return i + 1;
+}
+
+/** Skips a `//` or `/* *\/` comment (JSON5) starting at `start`; returns the index just past it. */
+function skipComment(text: string, start: number): number | null {
+  if (text[start] !== "/") {
+    return null;
+  }
+  if (text[start + 1] === "/") {
+    let i = start + 2;
+    while (i < text.length && text[i] !== "\n") {
+      i++;
+    }
+    return i;
+  }
+  if (text[start + 1] === "*") {
+    let i = start + 2;
+    while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) {
+      i++;
+    }
+    return Math.min(i + 2, text.length);
+  }
+  return null;
+}
+
+/** Finds the `[` of the top-level `key`'s array value (directly inside the root `{}`), or `null`. */
+function findTopLevelArrayStart(text: string, key: string): number | null {
+  const n = text.length;
+  const stack: string[] = [];
+  let i = 0;
+  while (i < n) {
+    const c = text[i];
+    const afterComment = skipComment(text, i);
+    if (afterComment !== null) {
+      i = afterComment;
+      continue;
+    }
+    if (c === '"') {
+      const strEnd = skipString(text, i);
+      const str = text.slice(i + 1, strEnd - 1);
+      let j = strEnd;
+      while (j < n && /\s/.test(text[j]!)) {
+        j++;
+      }
+      if (text[j] === ":" && stack.length === 1 && stack[0] === "{" && str === key) {
+        let k = j + 1;
+        while (k < n && /\s/.test(text[k]!)) {
+          k++;
+        }
+        return text[k] === "[" ? k : null;
+      }
+      i = strEnd;
+      continue;
+    }
+    if (c === "{" || c === "[") {
+      stack.push(c);
+      i++;
+      continue;
+    }
+    if (c === "}" || c === "]") {
+      stack.pop();
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return null;
+}
+
+/** Enumerates the `{` offsets of every object directly inside the array starting at `arrayStart`. */
+function collectObjectStarts(text: string, arrayStart: number): number[] {
+  const n = text.length;
+  const offsets: number[] = [];
+  let i = arrayStart + 1;
+  let depth = 1;
+  while (i < n && depth > 0) {
+    const c = text[i];
+    const afterComment = skipComment(text, i);
+    if (afterComment !== null) {
+      i = afterComment;
+      continue;
+    }
+    if (c === '"') {
+      i = skipString(text, i);
+      continue;
+    }
+    if (c === "{") {
+      if (depth === 1) {
+        offsets.push(i);
+      }
+      depth++;
+      i++;
+      continue;
+    }
+    if (c === "[") {
+      depth++;
+      i++;
+      continue;
+    }
+    if (c === "}" || c === "]") {
+      depth--;
+      i++;
+      continue;
+    }
+    i++;
+  }
+  return offsets;
+}

--- a/packages/app/src/rule-provenance.ts
+++ b/packages/app/src/rule-provenance.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import type { RuleAttribution, TraceResult } from "@renovate-config-visualizer/engine";
+
+/**
+ * Roadmap 013: loads + computes per-`packageRules`-entry provenance for a
+ * result, once the engine chunk is present — shared by the effective config's
+ * `packageRules` row, the simulator's rule rows, and the validation-message
+ * cross-links (App). Mirrors EffectiveConfig's `useProvenance` hook shape:
+ * `undefined` = loading/no result yet, `null` = unavailable (e.g. preset
+ * resolution failed, or the replayed layer lengths didn't add up).
+ */
+export function useRuleProvenance(
+  result: TraceResult | null | undefined,
+): RuleAttribution[] | null | undefined {
+  const [state, setState] = useState<RuleAttribution[] | null | undefined>(undefined);
+  useEffect(() => {
+    if (!result) {
+      setState(undefined);
+      return;
+    }
+    let live = true;
+    setState(undefined);
+    void import("@renovate-config-visualizer/engine").then((engine) => {
+      if (live) {
+        setState(engine.computeRuleProvenance(result) ?? null);
+      }
+    });
+    return () => {
+      live = false;
+    };
+  }, [result]);
+  return state;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -17,10 +17,12 @@ export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
 export {
   computeProvenance,
+  computeRuleProvenance,
   type KeyProvenance,
   type ProvenanceAction,
   type ProvenanceLayer,
   type ProvenanceStep,
+  type RuleAttribution,
 } from "./trace/provenance";
 export {
   parseInjectedPreset,

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -269,3 +269,68 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
   }
   return provenance;
 }
+
+/**
+ * Roadmap 013: per-rule provenance for `packageRules`. `packageRules` is a
+ * concatenating array key (`ProvenanceAction.concat`), so — unlike scalar
+ * keys — a single `KeyProvenance` chain cannot say which merged INDEX came
+ * from which layer, only which layers contributed *an* entry. Renovate's
+ * `mergeChildConfig` concatenates arrays in encounter order and is
+ * associative (`(a++b)++c === a++(b++c)`), so replaying the same layer order
+ * `buildLayers` already establishes — but reading each layer's OWN
+ * `packageRules` length instead of merging — reproduces exactly which
+ * contiguous slice of the final merged array came from which layer, with no
+ * merge needed at all.
+ */
+export interface RuleAttribution {
+  /** 0-based index into the final merged `packageRules` array (the canonical index). */
+  index: number;
+  /** The layer (global/inherited/preset/repo/defaults) that contributed this entry. */
+  layer: ProvenanceLayer;
+  /** 0-based index of this entry within that layer's OWN `packageRules` array — e.g. the
+   *  repo-config index a validator message like `packageRules[1]` refers to, when `layer.kind === "repo"`. */
+  sourceIndex: number;
+}
+
+function ownRuleCount(config: Obj): number {
+  return Array.isArray(config.packageRules) ? config.packageRules.length : 0;
+}
+
+/**
+ * Attributes every entry of a completed run's `finalConfig.packageRules` to
+ * its contributing layer, or `undefined` when the run lacks the data it needs
+ * (mirrors `computeProvenance`'s availability). Returns `undefined` — rather
+ * than a partial/incorrect attribution — when the replayed layer lengths
+ * don't add up to the ground-truth array length (e.g. a packageRules[n].extends
+ * whose nested preset itself unexpectedly reshapes the array), since a wrong
+ * cross-link is worse than none.
+ */
+export function computeRuleProvenance(result: TraceResult): RuleAttribution[] | undefined {
+  const { finalConfig } = result;
+  const root = result.presetTree;
+  if (!finalConfig || !root || root.resolved === undefined || root.input === undefined) {
+    return undefined;
+  }
+  const rules = Array.isArray(finalConfig.packageRules) ? finalConfig.packageRules : [];
+  if (rules.length === 0) {
+    return [];
+  }
+
+  const defaults = getDefaultConfig() as Obj;
+  const layers: Layer[] = [];
+  if (ownRuleCount(defaults) > 0) {
+    layers.push({ layer: { kind: "defaults" }, config: defaults });
+  }
+  layers.push(...buildLayers(root, result.layerConfigs));
+
+  const attribution: RuleAttribution[] = [];
+  let offset = 0;
+  for (const { layer, config } of layers) {
+    const count = ownRuleCount(config);
+    for (let sourceIndex = 0; sourceIndex < count; sourceIndex++) {
+      attribution.push({ index: offset + sourceIndex, layer, sourceIndex });
+    }
+    offset += count;
+  }
+  return offset === rules.length ? attribution : undefined;
+}

--- a/packages/engine/test/provenance.shimmed.test.ts
+++ b/packages/engine/test/provenance.shimmed.test.ts
@@ -9,9 +9,12 @@
 import { describe, expect, it } from "vitest";
 import {
   computeProvenance,
+  computeRuleProvenance,
   type KeyProvenance,
   presetInjectionKey,
+  type RuleAttribution,
   runPipeline,
+  type TraceResult,
 } from "../src/index";
 
 const injectedPresets = {
@@ -36,13 +39,18 @@ const repoConfig = JSON.stringify({
   packageRules: [{ matchDepTypes: ["devDependencies"], extends: ["github>test-org/nested-rule"] }],
 });
 
-async function provenance(): Promise<Map<string, KeyProvenance>> {
+async function runResult(): Promise<TraceResult> {
   const result = await runPipeline({
     fileName: "renovate.json",
     content: repoConfig,
     injectedPresets,
   });
   expect(result.stageStatus.preset).toBe("ok");
+  return result;
+}
+
+async function provenance(): Promise<Map<string, KeyProvenance>> {
+  const result = await runResult();
   const prov = computeProvenance(result);
   expect(prov).toBeDefined();
   return prov as Map<string, KeyProvenance>;
@@ -147,5 +155,73 @@ describe("computeProvenance", () => {
     // has no resolved payload
     expect(result.stageStatus.preset).toBe("error");
     expect(computeProvenance(result)).toBeUndefined();
+  });
+});
+
+/** Layer label for an attribution, for terse assertions (mirrors `layerName` above). */
+function attrLayerName(attr: RuleAttribution): string {
+  return attr.layer.kind === "preset" ? attr.layer.name : attr.layer.kind;
+}
+
+describe("computeRuleProvenance (013)", () => {
+  it("attributes each merged packageRules index to its contributing layer + the index within that layer's own array", async () => {
+    const result = await runResult();
+    const attribution = computeRuleProvenance(result);
+    expect(attribution).toBeDefined();
+    const rules = attribution as RuleAttribution[];
+    // merged order: preset-a's own rule first (it extends before the repo's
+    // own packageRules), then the repo's own rule — matching (b) above.
+    expect(rules.map((a) => [a.index, attrLayerName(a), a.sourceIndex])).toEqual([
+      [0, "github>test-org/preset-a", 0],
+      [1, "repo", 0],
+    ]);
+  });
+
+  it("agrees with the final merged config's length and the nested-extends-corrected rule content", async () => {
+    const result = await runResult();
+    const attribution = computeRuleProvenance(result) as RuleAttribution[];
+    const finalRules = result.finalConfig?.packageRules as Record<string, unknown>[];
+    expect(attribution).toHaveLength(finalRules.length);
+    // the repo-attributed entry is the nested-extends-expanded rule (enabled:false
+    // merged in from the injected nested preset, per provenance test (e) above).
+    const repoEntry = attribution.find((a) => a.layer.kind === "repo");
+    expect(repoEntry).toBeDefined();
+    expect(finalRules[repoEntry!.index]).toMatchObject({
+      matchDepTypes: ["devDependencies"],
+      enabled: false,
+    });
+  });
+
+  it("a repo-config index round-trips to the same rule a validator message about it would name", async () => {
+    // Validation runs BEFORE preset merge, against the repo's own directly-authored
+    // packageRules array — so a message like `packageRules[0]` names sourceIndex 0
+    // of the "repo" layer, i.e. the same array JSON.parse(repoConfig).packageRules is.
+    const repoOwnRules = (JSON.parse(repoConfig) as { packageRules: unknown[] }).packageRules;
+    const result = await runResult();
+    const attribution = computeRuleProvenance(result) as RuleAttribution[];
+    for (const [sourceIndex] of repoOwnRules.entries()) {
+      const entry = attribution.find(
+        (a) => a.layer.kind === "repo" && a.sourceIndex === sourceIndex,
+      );
+      expect(entry, `no attribution for repo-config index ${sourceIndex}`).toBeDefined();
+    }
+  });
+
+  it("returns an empty array when the merged config has no packageRules", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify({ automerge: true }),
+    });
+    expect(result.stageStatus.preset).toBe("ok");
+    expect(computeRuleProvenance(result)).toEqual([]);
+  });
+
+  it("returns undefined when preset resolution did not complete", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify({ extends: ["github>test-org/does-not-resolve"] }),
+    });
+    expect(result.stageStatus.preset).toBe("error");
+    expect(computeRuleProvenance(result)).toBeUndefined();
   });
 });

--- a/roadmap/013-rule-identity-and-provenance.md
+++ b/roadmap/013-rule-identity-and-provenance.md
@@ -1,6 +1,40 @@
 # 013 — Rule identity: one numbering, provenance chips, cross-links
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified. Engine: `computeRuleProvenance` (013) attributes
+> every entry of the merged `finalConfig.packageRules` to its contributing
+> layer (repo / global / inherited / preset) and the index within that
+> layer's OWN `packageRules` array — the repo-config index a validator
+> message like `packageRules[1]` names. It needs no merge replay: since
+> `packageRules` only concatenates and `mergeChildConfig` concatenates arrays
+> associatively in encounter order, reading each layer's own array length off
+> the same ordered layer list `computeProvenance` (005) already builds gives
+> the exact contiguous slice of the final array each layer contributed;
+> returns `undefined` (not a guess) when the replayed lengths don't add up to
+> the ground-truth array. UI: the simulator's rule rows now read
+> `packageRules[N]` (0-based) instead of a separate `#N+1` row count — the
+> same text a validator message uses — with a provenance chip reusing the
+> effective config's exact chip component (extracted to `ProvenanceChip.tsx`);
+> the same chip + per-rule list now also appears under the effective config's
+> `packageRules` entry. Rule captions list every `match*`/`exclude*` clause
+> and name the one that decided a no-match verdict. Validation messages
+> (`packageRules[N]`) are rendered through a shared `RuleMessage` component
+> that makes the index a clickable jump (repo-config messages → the editor
+> line, via a lightweight bracket-depth scan of the raw text, no full JSON5
+> parser; merged-index messages, e.g. the simulator's own validateConfig echo,
+> → the rule row) and appends the other index as a second link when the
+> mapping is determinable ("repo-config index 1" / "merged rule
+> packageRules[713]"). A simulator rule row's provenance chip reuses the
+> existing preset-tree selection wiring (`onSelectPreset`/`selectedId`) rather
+> than new plumbing. All cross-links use `scrollIntoView` + a transient
+> `rcv-flash` CSS class; the editor jump uses CodeMirror's own
+> transaction/selection API (no new dependency — `@uiw/react-codemirror`
+> re-exports `EditorView`). Known gap: the editor-line locator only recognizes
+> a double-quoted top-level `packageRules` key (the overwhelming convention,
+> including in `.json5` files); an unquoted or single-quoted key is not
+> recognized and the editor cross-link is silently skipped for that config
+> (the simulator/preset-tree cross-links are unaffected).
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -17,7 +17,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done    |
 | [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
 | [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
-| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | planned |
+| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
 | [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | planned |
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | planned |
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | planned |


### PR DESCRIPTION
Implements roadmap item 013 (M5, from the 2026-07 persona UX study).

- One canonical rule number: simulator rows now read `packageRules[N]` (merged 0-based) — the same text validator messages use; where a message's own index differs (repo-config index), the mapping is annotated and linked.
- `computeRuleProvenance` (engine): attributes each merged `packageRules` entry to defaults / global / inherited / preset name / repo config + its index in that layer's own array. Fail-closed (`undefined`) when lengths don't reconcile.
- Provenance chips (reusing the Effective-config chip) on every simulator rule row and per-entry under the effective config's `packageRules` row; clicking selects the contributing preset in the tree.
- Validation messages: `packageRules[i]` becomes a clickable cross-link — repo index jumps to the editor line (CodeMirror highlight), merged index jumps to the rule row.
- Rule captions list **all** matcher clauses and name the failing one (`matchSourceUrls + matchUpdateTypes — failed on matchSourceUrls`).

Validated: lint, format, typecheck, golden (14) + shimmed (70) tests, production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ