### PR TITLE
feat(014): validation error translations + suggested quick fixes

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,5 +1,6 @@
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type {
+  ErrorFixResult,
   OptionIndex,
   RepoPlatform,
   StageId,
@@ -30,7 +31,14 @@ import {
   signOut,
   type StoredUser,
 } from "./oauth";
-import { getRenovateVersion, loadOptionIndex, loadRepoConfig, run } from "./run";
+import {
+  type ErrorTranslationLib,
+  getRenovateVersion,
+  loadErrorTranslationLib,
+  loadOptionIndex,
+  loadRepoConfig,
+  run,
+} from "./run";
 import {
   buildShareUrl,
   decodeShare,
@@ -263,6 +271,9 @@ export function App() {
   // Non-fatal notices (version drift, load-from-repo results, bad share link).
   const [notice, setNotice] = useState<string | null>(null);
   const [optionIndex, setOptionIndex] = useState<OptionIndex | null>(null);
+  // Roadmap 014: curated validator-message translations + suggested fixes,
+  // loaded lazily alongside the option index (same engine chunk).
+  const [errorLib, setErrorLib] = useState<ErrorTranslationLib | null>(null);
   // Preset-tree selection is owned here so a provenance chain (005) can select
   // a preset node in the tree. Node ids restart every run, so reset on result.
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
@@ -375,20 +386,27 @@ export function App() {
     return false;
   }
 
-  async function onRun(overrideInjected?: InjectionMap, overrideInputs?: RunInputs) {
-    const injectedPresets = overrideInjected ?? injected;
-    if (!overrideInputs && blockedByLayerErrors()) {
-      return;
-    }
-    const inputs: RunInputs = overrideInputs ?? {
+  /** The current form state as `RunInputs`, optionally with `content` swapped
+   *  out (roadmap 014's "Apply fix" re-runs against the just-edited text
+   *  before the `content` state update has committed). */
+  function buildInputs(contentOverride?: string): RunInputs {
+    return {
       fileName,
-      content,
+      content: contentOverride ?? content,
       platform,
       endpoint,
       globalConfig: globalParse.config,
       inheritedConfig: inheritedParse.config,
       platformOverride: platformOverride && hasGlobalContext,
     };
+  }
+
+  async function onRun(overrideInjected?: InjectionMap, overrideInputs?: RunInputs) {
+    const injectedPresets = overrideInjected ?? injected;
+    if (!overrideInputs && blockedByLayerErrors()) {
+      return;
+    }
+    const inputs: RunInputs = overrideInputs ?? buildInputs();
     setRunning(true);
     setFatal(null);
     try {
@@ -398,13 +416,38 @@ export function App() {
         ([, status]) => status === "error",
       );
       setSelectedStage(firstError?.[0] ?? "preset");
-      // the engine chunk is loaded now — hydrate the hover docs
+      // the engine chunk is loaded now — hydrate the hover docs and the 014
+      // error-translation library
       void loadOptionIndex().then(setOptionIndex);
+      void loadErrorTranslationLib().then(setErrorLib);
     } catch (err) {
       setFatal(err instanceof Error ? `${err.name}: ${err.message}` : String(err));
     } finally {
       setRunning(false);
     }
+  }
+
+  /**
+   * Roadmap 014: writes a curated fix's edit into the editor and re-runs —
+   * the validate stage flipping error → ok is the confirmation the user sees.
+   * Prefers a surgical text patch (comments/formatting/everything else in the
+   * document untouched); when the exact path can't be located in the raw
+   * text (e.g. an unsupported JSON5 key style), `applyFixToText` falls back
+   * to re-serializing the whole document from `fix.fixedConfig` instead —
+   * always correct, but loses comments/original formatting, so this warns
+   * about it via the existing notice banner.
+   */
+  async function applyErrorFix(fix: ErrorFixResult) {
+    const lib = errorLib ?? (await loadErrorTranslationLib());
+    const applied = lib.applyFixToText(content, fix);
+    const nextContent = applied?.text ?? JSON.stringify(fix.fixedConfig, null, 2);
+    setContent(nextContent);
+    if (applied && !applied.surgical) {
+      setNotice(
+        "Applied the fix by regenerating the whole config document — comments and custom formatting were not preserved.",
+      );
+    }
+    await onRun(undefined, buildInputs(nextContent));
   }
 
   // On mount: first complete an OAuth callback if the URL carries one (QUERY
@@ -1132,6 +1175,8 @@ export function App() {
               ruleAttribution={ruleProvenance}
               onJumpToEditor={focusEditorRepoIndex}
               onJumpToSimRule={setPendingRuleFocus}
+              errorLib={errorLib}
+              onApplyFix={applyErrorFix}
             />
             <PresetTree
               result={result}
@@ -1149,6 +1194,7 @@ export function App() {
               onJumpToEditor={focusEditorRepoIndex}
               focusRuleIndex={pendingRuleFocus}
               onRuleFocused={() => setPendingRuleFocus(null)}
+              errorLib={errorLib}
             />
           </>
         ) : null}

--- a/packages/app/src/components/ErrorTranslationView.tsx
+++ b/packages/app/src/components/ErrorTranslationView.tsx
@@ -1,0 +1,92 @@
+import type { ErrorFixResult, ValidationMessage } from "@renovate-config-visualizer/engine";
+import type { ErrorTranslationLib } from "../run";
+
+/**
+ * Roadmap 014: renders ALONGSIDE Renovate's original validator message (never
+ * instead of it — see `MessagesPanel.tsx` / `RuleSimulator.tsx`) whatever the
+ * curated translation library (`errorLib`) has to say about it: a
+ * plain-language explanation, an optional before/after snippet of a suggested
+ * edit, an "Apply fix" button, and a docs link. When nothing matches, falls
+ * back to a bare docs link if the message names a known option (003).
+ *
+ * `errorLib` is `null` until the engine chunk has loaded (same lazy-load
+ * story as the option-docs hover cards) — nothing renders until then, same
+ * as those cards degrade gracefully pre-load.
+ */
+export function ErrorTranslationView({
+  message,
+  errorLib,
+  config,
+  onApplyFix,
+}: {
+  message: ValidationMessage;
+  errorLib: ErrorTranslationLib | null;
+  /** The exact config snapshot this message was validated against (root-relative
+   *  fix paths); `null`/`undefined` when unavailable (skips fix computation) or
+   *  when this context doesn't support applying fixes (e.g. the simulator echo). */
+  config: Record<string, unknown> | null | undefined;
+  /** Omit to render explanations without an "Apply fix" button (see above). */
+  onApplyFix?: (fix: ErrorFixResult) => void;
+}) {
+  if (!errorLib) {
+    return null;
+  }
+  const translated = errorLib.translateMessage(message, config ?? null);
+  if (!translated) {
+    const doc = errorLib.findMentionedOption(message);
+    if (!doc) {
+      return null;
+    }
+    return (
+      <div className="error-translation error-translation-fallback">
+        <a href={doc.url} target="_blank" rel="noreferrer">
+          {doc.name} docs ↗
+        </a>
+      </div>
+    );
+  }
+  const { explanation, fix, docsUrl } = translated;
+  const showDiff = fix && JSON.stringify(fix.before) !== JSON.stringify(fix.after);
+  return (
+    <div className="error-translation">
+      <p className="error-translation-explain">{explanation}</p>
+      {fix ? (
+        <div className="error-translation-fix">
+          {showDiff ? (
+            <div className="error-translation-diff">
+              <code className="before">{formatSnippet(fix.before)}</code>
+              <span className="error-translation-arrow" aria-hidden="true">
+                →
+              </span>
+              <code className="after">
+                {fix.after === undefined ? "(removed)" : formatSnippet(fix.after)}
+              </code>
+            </div>
+          ) : (
+            <p className="error-translation-summary">{fix.summary}</p>
+          )}
+          {onApplyFix ? (
+            <button
+              type="button"
+              className="error-translation-apply"
+              title={fix.summary}
+              onClick={() => onApplyFix(fix)}
+            >
+              Apply fix
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+      {docsUrl ? (
+        <a className="error-translation-docs" href={docsUrl} target="_blank" rel="noreferrer">
+          docs.renovatebot.com ↗
+        </a>
+      ) : null}
+    </div>
+  );
+}
+
+function formatSnippet(value: unknown): string {
+  const text = JSON.stringify(value);
+  return text.length > 140 ? `${text.slice(0, 140)}…` : text;
+}

--- a/packages/app/src/components/MessagesPanel.tsx
+++ b/packages/app/src/components/MessagesPanel.tsx
@@ -1,4 +1,11 @@
-import type { RuleAttribution, TraceResult } from "@renovate-config-visualizer/engine";
+import type {
+  ErrorFixResult,
+  RuleAttribution,
+  TraceResult,
+} from "@renovate-config-visualizer/engine";
+import { useMemo } from "react";
+import type { ErrorTranslationLib } from "../run";
+import { ErrorTranslationView } from "./ErrorTranslationView";
 import { RuleMessage } from "./RuleMessage";
 
 export function MessagesPanel({
@@ -6,6 +13,8 @@ export function MessagesPanel({
   ruleAttribution,
   onJumpToEditor,
   onJumpToSimRule,
+  errorLib,
+  onApplyFix,
 }: {
   result: TraceResult;
   /** Roadmap 013: for cross-linking `packageRules[i]` references (repo-config
@@ -14,8 +23,24 @@ export function MessagesPanel({
   ruleAttribution?: RuleAttribution[] | null;
   onJumpToEditor?: (repoIndex: number) => void;
   onJumpToSimRule?: (mergedIndex: number) => void;
+  /** Roadmap 014: curated translations + suggested fixes, rendered alongside
+   *  (never instead of) the original message above. `undefined`/no `onApplyFix`
+   *  before the engine chunk has loaded. */
+  errorLib?: ErrorTranslationLib | null;
+  onApplyFix?: (fix: ErrorFixResult) => void;
 }) {
   const presetErrors = result.events.filter((e) => e.kind === "preset-error");
+  // The exact config `validateConfig("repo", …)` ran against (post-migrate/
+  // massage, pre-preset-merge) — matches the `packageRules[N]` indices these
+  // messages name, so a suggested fix's path resolves against the SAME
+  // snapshot the message was produced from.
+  const validatedConfig = useMemo(
+    () =>
+      (result.events.find((e) => e.stage === "massage" && e.kind === "stage-complete")?.after as
+        | Record<string, unknown>
+        | undefined) ?? null,
+    [result],
+  );
   if (result.errors.length + result.warnings.length + presetErrors.length === 0) {
     return null;
   }
@@ -33,6 +58,12 @@ export function MessagesPanel({
               onJumpToEditor={onJumpToEditor}
               onJumpToSimRule={onJumpToSimRule}
             />
+            <ErrorTranslationView
+              message={m}
+              errorLib={errorLib ?? null}
+              config={validatedConfig}
+              onApplyFix={onApplyFix}
+            />
           </li>
         ))}
         {result.warnings.map((m, i) => (
@@ -44,6 +75,12 @@ export function MessagesPanel({
               ruleAttribution={ruleAttribution}
               onJumpToEditor={onJumpToEditor}
               onJumpToSimRule={onJumpToSimRule}
+            />
+            <ErrorTranslationView
+              message={m}
+              errorLib={errorLib ?? null}
+              config={validatedConfig}
+              onApplyFix={onApplyFix}
             />
           </li>
         ))}

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -10,7 +10,9 @@ import type {
 import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { useRuleProvenance } from "../rule-provenance";
+import type { ErrorTranslationLib } from "../run";
 import { ConfigJson } from "./ConfigJson";
+import { ErrorTranslationView } from "./ErrorTranslationView";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { RuleMessage } from "./RuleMessage";
 
@@ -435,6 +437,7 @@ export function RuleSimulator({
   onJumpToEditor,
   focusRuleIndex,
   onRuleFocused,
+  errorLib,
 }: {
   result: TraceResult;
   /** Roadmap 013: a rule row's provenance chip → the contributing preset node in the tree. */
@@ -446,6 +449,13 @@ export function RuleSimulator({
   focusRuleIndex?: number | null;
   /** Called once the requested `focusRuleIndex` has been handled (found or not). */
   onRuleFocused?: () => void;
+  /** Roadmap 014: curated translations, explanation-only here — this echo
+   *  validates the MERGED packageRules array (`validateConfig("repo", {
+   *  packageRules: … })` over the simulated/flattened rules), not the editor's
+   *  own text, so there's no safe surgical "Apply fix" target from this panel.
+   *  When the same issue exists in the user's own rule, it also surfaces
+   *  (with a fix) in the top-level Errors & warnings panel. */
+  errorLib?: ErrorTranslationLib | null;
 }) {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [sim, setSim] = useState<SimulationResult | null>(null);
@@ -822,6 +832,7 @@ export function RuleSimulator({
                     onJumpToEditor={onJumpToEditor}
                     onJumpToSimRule={focusRule}
                   />
+                  <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
                 </li>
               ))}
               {sim.warnings.map((m, i) => (
@@ -834,6 +845,7 @@ export function RuleSimulator({
                     onJumpToEditor={onJumpToEditor}
                     onJumpToSimRule={focusRule}
                   />
+                  <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
                 </li>
               ))}
             </ul>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1891,3 +1891,89 @@ pre.config-view.prov-before {
   font-size: 0.78rem;
   overflow-wrap: anywhere;
 }
+
+/* ---------- validation error translations + quick fixes (014) ---------- */
+
+/* Sits directly under a message's own text (never replacing it) — a quiet
+   card, one level down from the surrounding `.messages li`. */
+.error-translation {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.85rem;
+  margin: 0.4rem 0 0.15rem;
+  padding: 0.5rem 0.65rem;
+}
+
+/* The unmatched-message fallback (003's docs link) is a single line, no card. */
+.error-translation-fallback {
+  background: none;
+  border: none;
+  padding: 0;
+}
+
+.error-translation-explain {
+  color: inherit;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.error-translation-fix {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 0.45rem;
+}
+
+.error-translation-diff {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  gap: 0.4rem;
+  overflow-wrap: anywhere;
+}
+
+.error-translation-diff .before {
+  color: var(--error);
+  text-decoration: line-through;
+}
+
+.error-translation-diff .after {
+  color: var(--ok);
+}
+
+.error-translation-arrow {
+  color: var(--muted);
+}
+
+.error-translation-summary {
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0;
+}
+
+.error-translation-apply {
+  background: color-mix(in srgb, var(--ok) 12%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--ok) 45%, var(--border));
+  border-radius: 6px;
+  color: var(--ok);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+}
+
+.error-translation-apply:hover {
+  background: color-mix(in srgb, var(--ok) 22%, var(--surface));
+}
+
+.error-translation-docs {
+  color: var(--accent);
+  display: inline-block;
+  font-size: 0.78rem;
+  margin-top: 0.35rem;
+}

--- a/packages/app/src/run.ts
+++ b/packages/app/src/run.ts
@@ -1,9 +1,14 @@
 import type {
+  AppliedTextFix,
+  ErrorFixResult,
+  OptionDoc,
   OptionIndex,
   PipelineInput,
   RepoConfigRequest,
   RepoConfigResult,
   TraceResult,
+  TranslatedMessage,
+  ValidationMessage,
 } from "@renovate-config-visualizer/engine";
 import { getValidToken } from "./oauth";
 
@@ -55,6 +60,31 @@ export async function loadOptionIndex(): Promise<OptionIndex> {
 export async function getRenovateVersion(): Promise<string> {
   const engine = await import("@renovate-config-visualizer/engine");
   return engine.renovateVersion;
+}
+
+/**
+ * Roadmap 014's curated error-translation library, loaded the same lazy way
+ * as the option index (they live in the same heavy engine chunk, already in
+ * memory by the time a validation message is on screen — a run has to
+ * complete first). Functions, not data, so callers keep calling them
+ * per-message instead of the app re-implementing a lookup.
+ */
+export interface ErrorTranslationLib {
+  translateMessage: (
+    message: ValidationMessage,
+    config: Record<string, unknown> | null,
+  ) => TranslatedMessage | null;
+  findMentionedOption: (message: ValidationMessage) => OptionDoc | undefined;
+  applyFixToText: (text: string, fix: ErrorFixResult) => AppliedTextFix | null;
+}
+
+export async function loadErrorTranslationLib(): Promise<ErrorTranslationLib> {
+  const engine = await import("@renovate-config-visualizer/engine");
+  return {
+    translateMessage: engine.translateMessage,
+    findMentionedOption: engine.findMentionedOption,
+    applyFixToText: engine.applyFixToText,
+  };
 }
 
 /** Probes a repository for its Renovate config file (roadmap 007). */

--- a/packages/engine/src/error-fix-text.ts
+++ b/packages/engine/src/error-fix-text.ts
@@ -1,0 +1,331 @@
+/**
+ * Roadmap 014 — turns an `ErrorFixResult` (see `error-translations.ts`) into
+ * an edit of the RAW config text the editor holds, so "Apply fix" preserves
+ * everything about the document that isn't the fixed value: comments,
+ * unrelated formatting, key order.
+ *
+ * This is a lightweight bracket-depth scanner in the same spirit as
+ * `packages/app/src/rule-locate.ts` (013), not a full JSON5 parser: it
+ * recognizes standard double-quoted JSON/JSON5 object keys and `//`/`/* *\/`
+ * comments, which covers the overwhelming convention (including generated
+ * `.json5` files, which mainly use JSON5 for comments/trailing commas, not
+ * unquoted or single-quoted keys). When a path segment can't be located —
+ * most commonly because the config uses that rare unquoted/single-quoted key
+ * style, or the path doesn't exist in this exact text — `applyFixToText`
+ * falls back to re-serializing the ENTIRE document from `fix.fixedConfig`
+ * (`JSON.stringify(fixedConfig, null, 2)`), which is always correct but loses
+ * comments and original formatting; the returned `surgical: false` flag lets
+ * a caller warn about that tradeoff.
+ */
+
+import type { ConfigPathSegment, ErrorFixResult } from "./error-translations";
+
+export interface AppliedTextFix {
+  text: string;
+  /** False when the path couldn't be located and the whole document was
+   *  re-serialized from `fixedConfig` instead (comments/formatting lost). */
+  surgical: boolean;
+}
+
+/** Applies `fix` to `text` (the editor's raw config content). */
+export function applyFixToText(text: string, fix: ErrorFixResult): AppliedTextFix | null {
+  const located = locateEntry(text, fix.path);
+  if (located) {
+    if (fix.remove) {
+      return { text: spliceRemove(text, located), surgical: true };
+    }
+    if (fix.renameTo) {
+      return {
+        text:
+          text.slice(0, located.keyStart) +
+          JSON.stringify(fix.renameTo) +
+          text.slice(located.keyEnd),
+        surgical: true,
+      };
+    }
+    return {
+      text:
+        text.slice(0, located.valueStart) +
+        JSON.stringify(fix.value) +
+        text.slice(located.valueEnd),
+      surgical: true,
+    };
+  }
+  try {
+    return { text: JSON.stringify(fix.fixedConfig, null, 2), surgical: false };
+  } catch {
+    return null;
+  }
+}
+
+interface EntryLocation {
+  keyStart: number;
+  keyEnd: number;
+  valueStart: number;
+  valueEnd: number;
+}
+
+/** Skips a double-quoted JSON string starting at `start`; returns the index just past it. */
+function skipString(text: string, start: number): number {
+  let i = start + 1;
+  const n = text.length;
+  while (i < n && text[i] !== '"') {
+    if (text[i] === "\\") {
+      i++;
+    }
+    i++;
+  }
+  return i + 1;
+}
+
+/** Skips a `//` or `/* *\/` comment (JSON5) starting at `start`; returns the index just past it, or null. */
+function skipComment(text: string, start: number): number | null {
+  if (text[start] !== "/") {
+    return null;
+  }
+  if (text[start + 1] === "/") {
+    let i = start + 2;
+    while (i < text.length && text[i] !== "\n") {
+      i++;
+    }
+    return i;
+  }
+  if (text[start + 1] === "*") {
+    let i = start + 2;
+    while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) {
+      i++;
+    }
+    return Math.min(i + 2, text.length);
+  }
+  return null;
+}
+
+/** Advances past whitespace and comments starting at `i`. */
+function skipTrivia(text: string, i: number): number {
+  let pos = i;
+  while (pos < text.length) {
+    if (/\s/.test(text[pos]!)) {
+      pos++;
+      continue;
+    }
+    const after = skipComment(text, pos);
+    if (after !== null) {
+      pos = after;
+      continue;
+    }
+    break;
+  }
+  return pos;
+}
+
+/** Scans one JSON value starting at `start` (first non-trivia char); returns the index just past it, or null. */
+function scanValue(text: string, start: number): number | null {
+  const c = text[start];
+  if (c === undefined) {
+    return null;
+  }
+  if (c === '"') {
+    return skipString(text, start);
+  }
+  if (c === "{" || c === "[") {
+    const open = c;
+    const close = c === "{" ? "}" : "]";
+    let depth = 1;
+    let i = start + 1;
+    while (i < text.length && depth > 0) {
+      const ch = text[i];
+      const after = skipComment(text, i);
+      if (after !== null) {
+        i = after;
+        continue;
+      }
+      if (ch === '"') {
+        i = skipString(text, i);
+        continue;
+      }
+      if (ch === open) {
+        depth++;
+        i++;
+        continue;
+      }
+      if (ch === close) {
+        depth--;
+        i++;
+        continue;
+      }
+      // A differing bracket type inside (object containing an array, etc.)
+      // also needs depth tracking so its own close doesn't unbalance ours.
+      if (ch === "{" || ch === "[") {
+        depth++;
+        i++;
+        continue;
+      }
+      if (ch === "}" || ch === "]") {
+        depth--;
+        i++;
+        continue;
+      }
+      i++;
+    }
+    return depth === 0 ? i : null;
+  }
+  // Scalar: number / true / false / null — scan up to a delimiter.
+  let i = start;
+  while (i < text.length && !/[,}\]\s]/.test(text[i]!) && skipComment(text, i) === null) {
+    i++;
+  }
+  return i > start ? i : null;
+}
+
+/** Finds `"key"` as a direct member of the object starting at `objStart` (its `{`). */
+function findKeyInObject(text: string, objStart: number, key: string): EntryLocation | null {
+  if (text[objStart] !== "{") {
+    return null;
+  }
+  let i = skipTrivia(text, objStart + 1);
+  while (i < text.length) {
+    if (text[i] === "}") {
+      return null;
+    }
+    if (text[i] !== '"') {
+      return null; // malformed / unsupported (e.g. unquoted key) — bail conservatively
+    }
+    const keyStart = i;
+    const keyEnd = skipString(text, i);
+    const keyText = text.slice(keyStart + 1, keyEnd - 1);
+    let j = skipTrivia(text, keyEnd);
+    if (text[j] !== ":") {
+      return null;
+    }
+    j = skipTrivia(text, j + 1);
+    const valueStart = j;
+    const valueEnd = scanValue(text, valueStart);
+    if (valueEnd === null) {
+      return null;
+    }
+    if (keyText === key) {
+      return { keyStart, keyEnd, valueStart, valueEnd };
+    }
+    i = skipTrivia(text, valueEnd);
+    if (text[i] === ",") {
+      i = skipTrivia(text, i + 1);
+      continue;
+    }
+    if (text[i] === "}") {
+      return null;
+    }
+    return null; // malformed
+  }
+  return null;
+}
+
+/** Finds the `index`-th top-level element of the array starting at `arrStart` (its `[`). */
+function findArrayElement(
+  text: string,
+  arrStart: number,
+  index: number,
+): { valueStart: number; valueEnd: number } | null {
+  if (text[arrStart] !== "[") {
+    return null;
+  }
+  let i = skipTrivia(text, arrStart + 1);
+  let count = 0;
+  while (i < text.length) {
+    if (text[i] === "]") {
+      return null;
+    }
+    const valueStart = i;
+    const valueEnd = scanValue(text, valueStart);
+    if (valueEnd === null) {
+      return null;
+    }
+    if (count === index) {
+      return { valueStart, valueEnd };
+    }
+    count++;
+    i = skipTrivia(text, valueEnd);
+    if (text[i] === ",") {
+      i = skipTrivia(text, i + 1);
+      continue;
+    }
+    if (text[i] === "]") {
+      return null;
+    }
+    return null;
+  }
+  return null;
+}
+
+/** Walks `path` from the document root, returning the final key's location. */
+function locateEntry(text: string, path: ConfigPathSegment[]): EntryLocation | null {
+  if (path.length === 0) {
+    return null;
+  }
+  const rootStart = skipTrivia(text, 0);
+  if (text[rootStart] !== "{") {
+    return null;
+  }
+  let containerStart = rootStart;
+  for (let i = 0; i < path.length; i++) {
+    const seg = path[i]!;
+    const isLast = i === path.length - 1;
+    if (typeof seg === "string") {
+      const found = findKeyInObject(text, containerStart, seg);
+      if (!found) {
+        return null;
+      }
+      if (isLast) {
+        return found;
+      }
+      containerStart = found.valueStart;
+    } else {
+      const found = findArrayElement(text, containerStart, seg);
+      if (!found || isLast) {
+        // Our curated fixes always end on an object key, never an array index.
+        return null;
+      }
+      containerStart = found.valueStart;
+    }
+  }
+  return null;
+}
+
+/** Removes a `"key": value` member, cleaning up the adjacent comma so the result stays valid JSON. */
+function spliceRemove(text: string, loc: EntryLocation): string {
+  // Eat back to the start of the line if only indentation precedes the key,
+  // so removal doesn't leave a blank indented line behind.
+  let lineStart = loc.keyStart;
+  while (lineStart > 0 && text[lineStart - 1] !== "\n" && /[ \t]/.test(text[lineStart - 1]!)) {
+    lineStart--;
+  }
+  const cutStart = /^[ \t]*$/.test(text.slice(lineStart, loc.keyStart)) ? lineStart : loc.keyStart;
+
+  let before = lineStart;
+  while (before > 0 && /\s/.test(text[before - 1]!)) {
+    before--;
+  }
+  const precedingComma = text[before - 1] === ",";
+
+  let after = loc.valueEnd;
+  while (after < text.length && /\s/.test(text[after]!)) {
+    after++;
+  }
+  const followingComma = text[after] === ",";
+
+  if (followingComma) {
+    let cutEnd = after + 1;
+    while (text[cutEnd] === " " || text[cutEnd] === "\t") {
+      cutEnd++;
+    }
+    if (text[cutEnd] === "\n") {
+      cutEnd++;
+    } else if (text[cutEnd] === "\r" && text[cutEnd + 1] === "\n") {
+      cutEnd += 2;
+    }
+    return text.slice(0, cutStart) + text.slice(cutEnd);
+  }
+  if (precedingComma) {
+    return text.slice(0, before - 1) + text.slice(loc.valueEnd);
+  }
+  return text.slice(0, cutStart) + text.slice(loc.valueEnd);
+}

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -1,0 +1,395 @@
+/**
+ * Roadmap 014 — a small curated library that translates a handful of
+ * recurring Renovate validator messages into plain language plus a concrete,
+ * conservative suggested edit. Renders ALONGSIDE the original message (see
+ * `packages/app/src/components/MessagesPanel.tsx` /
+ * `packages/app/src/components/RuleSimulator.tsx`), never instead of it.
+ *
+ * Every matcher parses the EXACT message text Renovate's own validator
+ * produces (see upstream's `config/validation.js` and
+ * `validation-helpers/regex-glob-matchers.js`, under renovate's package
+ * `dist/`) — a change to those strings upstream simply stops the pattern
+ * matching, falling back to today's plain rendering; it never mis-fires.
+ *
+ * Deliberately conservative: a `suggestFix` only returns a result when it can
+ * locate the exact value the message is about in the given config snapshot
+ * (usually because Renovate's own message embeds the config path, e.g.
+ * `packageRules[1].matchPackageNames: ...`) and the edit is unambiguous. When
+ * it can't, it returns `null` and the UI shows the explanation without an
+ * "Apply fix" button.
+ */
+
+import { snapshot } from "./trace/delta";
+import type { ValidationMessage } from "./trace/model";
+import { getOptionIndex, type OptionDoc } from "./option-docs";
+
+/** One step of a JSON path: an object key, or an array index. */
+export type ConfigPathSegment = string | number;
+
+export interface ErrorFixResult {
+  /** Path (root-relative) to the value this fix changes. */
+  path: ConfigPathSegment[];
+  /** Value-replace fixes: the new value to set at `path`. */
+  value?: unknown;
+  /** Rename fixes: the new key name; `path`'s last segment is the old key. */
+  renameTo?: string;
+  /** Remove fixes: delete the key/index `path` points at. */
+  remove?: true;
+  /** The value at `path` before the fix (for a before/after snippet). */
+  before: unknown;
+  /** The value at `path` after the fix; `undefined` for a `remove` fix. */
+  after: unknown;
+  /** One-line human summary of the edit, e.g. "Remove `*` from `matchPackageNames`". */
+  summary: string;
+  /** The whole config with the fix applied — the plain "parsed config → fixed config" function roadmap 014 asks for. */
+  fixedConfig: Record<string, unknown>;
+}
+
+export interface ErrorTranslation {
+  id: string;
+  matches(message: ValidationMessage): boolean;
+  explain(message: ValidationMessage): string;
+  /** Renovate option name(s) the message concerns, for a 003 docs-link. */
+  optionNames(message: ValidationMessage): string[];
+  /** `config` is the exact snapshot the message was validated against. */
+  suggestFix?(message: ValidationMessage, config: Record<string, unknown>): ErrorFixResult | null;
+}
+
+export interface TranslatedMessage {
+  id: string;
+  explanation: string;
+  fix: ErrorFixResult | null;
+  docsUrl?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/** Parses a Renovate `currentPath` string, e.g. `packageRules[1].matchPackageNames`
+ *  or a bare top-level key, into path segments. */
+export function parseConfigPath(pathStr: string): ConfigPathSegment[] {
+  const segments: ConfigPathSegment[] = [];
+  const re = /([^.[\]]+)|\[(\d+)\]/g;
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = re.exec(pathStr))) {
+    segments.push(m[2] !== undefined ? Number(m[2]) : m[1]!);
+  }
+  return segments;
+}
+
+function getAtPath(obj: unknown, path: ConfigPathSegment[]): unknown {
+  let cur: unknown = obj;
+  for (const seg of path) {
+    if (cur === null || typeof cur !== "object") {
+      return undefined;
+    }
+    cur = (cur as Record<PropertyKey, unknown>)[seg];
+  }
+  return cur;
+}
+
+function withValueAtPath(
+  config: Record<string, unknown>,
+  path: ConfigPathSegment[],
+  value: unknown,
+): Record<string, unknown> {
+  const clone = snapshot(config);
+  let cur = clone as Record<PropertyKey, unknown>;
+  for (let i = 0; i < path.length - 1; i++) {
+    cur = cur[path[i]!] as Record<PropertyKey, unknown>;
+  }
+  cur[path[path.length - 1]!] = value;
+  return clone;
+}
+
+function withKeyRemoved(
+  config: Record<string, unknown>,
+  path: ConfigPathSegment[],
+): Record<string, unknown> {
+  const clone = snapshot(config);
+  let cur = clone as Record<PropertyKey, unknown>;
+  for (let i = 0; i < path.length - 1; i++) {
+    cur = cur[path[i]!] as Record<PropertyKey, unknown>;
+  }
+  const last = path[path.length - 1]!;
+  if (Array.isArray(cur) && typeof last === "number") {
+    cur.splice(last, 1);
+  } else {
+    delete cur[last];
+  }
+  return clone;
+}
+
+function withKeyRenamed(
+  config: Record<string, unknown>,
+  path: ConfigPathSegment[],
+  newKey: string,
+): Record<string, unknown> {
+  const clone = snapshot(config);
+  let cur = clone as Record<PropertyKey, unknown>;
+  for (let i = 0; i < path.length - 1; i++) {
+    cur = cur[path[i]!] as Record<PropertyKey, unknown>;
+  }
+  const last = path[path.length - 1]!;
+  const value = cur[last];
+  delete cur[last];
+  cur[newKey] = value;
+  return clone;
+}
+
+/** Unique `` `identifier` `` tokens mentioned in a free-text message. */
+function backtickedTokens(text: string): string[] {
+  const seen = new Set<string>();
+  for (const m of text.matchAll(/`([A-Za-z][\w]*)`/g)) {
+    seen.add(m[1]!);
+  }
+  return [...seen];
+}
+
+// ---------------------------------------------------------------------------
+// 1. Redundant `*`/`**` alongside other patterns
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation-helpers/regex-glob-matchers.js):
+// `${currentPath}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`
+
+const REDUNDANT_GLOB_RE =
+  /^(.+?): Your input contains \* or \*\* along with other patterns\. Please remove them, as \* or \*\* matches all patterns\.$/;
+
+const redundantGlobStar: ErrorTranslation = {
+  id: "redundant-glob-star",
+  matches: (m) => REDUNDANT_GLOB_RE.test(m.message),
+
+  explain: (m) => {
+    const match = REDUNDANT_GLOB_RE.exec(m.message);
+    const path = match?.[1] ?? "this list";
+    return (
+      `\`*\`/\`**\` already matches everything, so listing it alongside other patterns in ` +
+      `\`${path}\` is redundant — newer Renovate rejects the combination outright. Removing the ` +
+      `\`*\`/\`**\` entry and keeping the rest is the same behavior (the other patterns already ` +
+      `covered every case \`*\` did).`
+    );
+  },
+
+  optionNames: (m) => {
+    const match = REDUNDANT_GLOB_RE.exec(m.message);
+    if (!match) {
+      return [];
+    }
+    const segments = parseConfigPath(match[1]!);
+    const last = segments[segments.length - 1];
+    return typeof last === "string" ? [last] : [];
+  },
+
+  suggestFix: (m, config) => {
+    const match = REDUNDANT_GLOB_RE.exec(m.message);
+    if (!match) {
+      return null;
+    }
+    const path = parseConfigPath(match[1]!);
+    if (path.length === 0) {
+      return null;
+    }
+    const arr = getAtPath(config, path);
+    if (!Array.isArray(arr) || !arr.every((v) => typeof v === "string")) {
+      return null;
+    }
+    const removed = arr.filter((v) => v === "*" || v === "**");
+    const filtered = arr.filter((v) => v !== "*" && v !== "**");
+    // Conservative: nothing to remove, or removing it would leave nothing
+    // (the message's own precondition is "along with OTHER patterns", so this
+    // shouldn't happen against a config the message was actually produced
+    // from — bail rather than guess if it does).
+    if (removed.length === 0 || filtered.length === 0) {
+      return null;
+    }
+    return {
+      path,
+      value: filtered,
+      before: arr,
+      after: filtered,
+      summary: `Remove ${removed.map((v) => `\`${v}\``).join(" and ")} from \`${match[1]}\``,
+      fixedConfig: withValueAtPath(config, path, filtered),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 2. Deprecated option (that the migrate stage doesn't rename automatically)
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js `getDeprecationMessage`):
+// `The '${option}' option is deprecated: ${deprecationMsg}`
+// By the time `validate` runs, `migrate` (004) has already applied every
+// automatic rename (`RenamePropertyMigration`), so a key surviving to this
+// warning has NO automatic replacement in the general case — the fix below
+// only fires for the rare case where the deprecation text itself names
+// exactly one other real option to switch to.
+
+const DEPRECATED_RE = /^The '([^']+)' option is deprecated: (.+)$/;
+
+const deprecatedOption: ErrorTranslation = {
+  id: "deprecated-option",
+  matches: (m) => m.topic === "Deprecation Warning" && DEPRECATED_RE.test(m.message),
+
+  explain: (m) => {
+    const match = DEPRECATED_RE.exec(m.message);
+    const key = match?.[1] ?? "This option";
+    const detail = match?.[2] ?? "";
+    return (
+      `\`${key}\` is deprecated${detail ? `: ${detail}` : "."} The app's migration step ` +
+      `(roadmap 004 — see the Migrations panel) already renames options where Renovate provides a ` +
+      `direct automatic replacement; \`${key}\` reaching validation means Renovate has no single ` +
+      `automatic mapping for it, so it needs a manual look.`
+    );
+  },
+
+  optionNames: (m) => {
+    const match = DEPRECATED_RE.exec(m.message);
+    return match ? [match[1]!] : [];
+  },
+
+  suggestFix: (m, config) => {
+    const match = DEPRECATED_RE.exec(m.message);
+    if (!match) {
+      return null;
+    }
+    const key = match[1]!;
+    const detail = match[2]!;
+    if (!(key in config)) {
+      // Not present at the root of this snapshot — can't confidently locate
+      // it (e.g. it's nested), so no auto-fix.
+      return null;
+    }
+    const knownOptions = getOptionIndex().options;
+    const candidates = backtickedTokens(detail).filter((c) => c !== key && knownOptions.has(c));
+    if (candidates.length !== 1) {
+      // Zero or ambiguous (more than one) alternative named — be conservative.
+      return null;
+    }
+    const newKey = candidates[0]!;
+    if (newKey in config) {
+      // Don't clobber an existing value under the new name.
+      return null;
+    }
+    const value = config[key];
+    return {
+      path: [key],
+      renameTo: newKey,
+      before: value,
+      after: value,
+      summary: `Rename \`${key}\` to \`${newKey}\``,
+      fixedConfig: withKeyRenamed(config, [key], newKey),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 3. Global-only option set in repo config (008's boundary warning)
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js):
+// `The "${key}" option is a global option reserved only for Renovate's global
+// configuration and cannot be configured within a repository's config file.`
+
+const GLOBAL_ONLY_RE =
+  /^The "([^"]+)" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file\.$/;
+
+const globalOnlyOption: ErrorTranslation = {
+  id: "global-only-option",
+  matches: (m) => GLOBAL_ONLY_RE.test(m.message),
+
+  explain: (m) => {
+    const match = GLOBAL_ONLY_RE.exec(m.message);
+    const key = match?.[1] ?? "This option";
+    return (
+      `\`${key}\` only works in Renovate's global/self-hosted config (roadmap 008's global config ` +
+      `layer) — a repository's own config file can't set it, so as written it has no effect at all. ` +
+      `Move it to the self-hosted config, or remove it here.`
+    );
+  },
+
+  optionNames: (m) => {
+    const match = GLOBAL_ONLY_RE.exec(m.message);
+    return match ? [match[1]!] : [];
+  },
+
+  suggestFix: (m, config) => {
+    const match = GLOBAL_ONLY_RE.exec(m.message);
+    if (!match) {
+      return null;
+    }
+    const key = match[1]!;
+    // Conservative: only offer removal when the key is at the root of this
+    // snapshot (the overwhelming common case for global-only options, which
+    // have no `parents` restricting them elsewhere) — a nested occurrence is
+    // left alone rather than guessed at.
+    if (!(key in config)) {
+      return null;
+    }
+    const value = config[key];
+    return {
+      path: [key],
+      remove: true,
+      before: value,
+      after: undefined,
+      summary: `Remove \`${key}\` from the repository config`,
+      fixedConfig: withKeyRemoved(config, [key]),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const ERROR_TRANSLATIONS: ErrorTranslation[] = [
+  redundantGlobStar,
+  deprecatedOption,
+  globalOnlyOption,
+];
+
+/**
+ * Matches `message` against the curated library. `config` should be the exact
+ * config snapshot the message was validated against (e.g. the pipeline's
+ * post-massage, pre-preset-merge snapshot for a top-level `validate` message);
+ * pass `null` when no such snapshot is available to skip fix computation.
+ */
+export function translateMessage(
+  message: ValidationMessage,
+  config: Record<string, unknown> | null,
+): TranslatedMessage | null {
+  const translation = ERROR_TRANSLATIONS.find((t) => t.matches(message));
+  if (!translation) {
+    return null;
+  }
+  const fix = config && translation.suggestFix ? translation.suggestFix(message, config) : null;
+  const doc = translation
+    .optionNames(message)
+    .map((name) => getOptionIndex().options.get(name))
+    .find((d): d is OptionDoc => Boolean(d));
+  return {
+    id: translation.id,
+    explanation: translation.explain(message),
+    fix,
+    docsUrl: doc?.url,
+  };
+}
+
+/**
+ * Fallback for messages the curated library doesn't recognize (the common
+ * case): if the raw text mentions a real option name — quoted with backticks,
+ * single, or double quotes, Renovate's validator uses all three — surface a
+ * docs link for it (roadmap 003's option index), same as the option hover
+ * cards do.
+ */
+export function findMentionedOption(message: ValidationMessage): OptionDoc | undefined {
+  const index = getOptionIndex();
+  const tokens = message.message.matchAll(/[`'"]([A-Za-z][\w]*)[`'"]/g);
+  for (const m of tokens) {
+    const doc = index.options.get(m[1]!);
+    if (doc) {
+      return doc;
+    }
+  }
+  return undefined;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -16,6 +16,16 @@ export { renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
 export {
+  type ConfigPathSegment,
+  ERROR_TRANSLATIONS,
+  type ErrorFixResult,
+  type ErrorTranslation,
+  findMentionedOption,
+  translateMessage,
+  type TranslatedMessage,
+} from "./error-translations";
+export { applyFixToText, type AppliedTextFix } from "./error-fix-text";
+export {
   computeProvenance,
   computeRuleProvenance,
   type KeyProvenance,

--- a/packages/engine/test/error-fix-text.node.test.ts
+++ b/packages/engine/test/error-fix-text.node.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { applyFixToText } from "../src/error-fix-text";
+import type { ErrorFixResult } from "../src/error-translations";
+
+function valueFix(overrides: Partial<ErrorFixResult>): ErrorFixResult {
+  return {
+    path: [],
+    before: undefined,
+    after: undefined,
+    summary: "test fix",
+    fixedConfig: {},
+    ...overrides,
+  };
+}
+
+describe("applyFixToText — value replace (pattern 1: redundant */**)", () => {
+  it("replaces a nested packageRules array in place, leaving the rest of the document untouched", () => {
+    const text = [
+      "{",
+      '  "extends": ["config:recommended"],',
+      '  "packageRules": [',
+      '    { "matchDepTypes": ["devDependencies"] },',
+      '    { "matchPackageNames": ["*", "!gradle"] }',
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const fix = valueFix({
+      path: ["packageRules", 1, "matchPackageNames"],
+      value: ["!gradle"],
+      fixedConfig: {},
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(true);
+    expect(result?.text).toContain('"matchPackageNames": ["!gradle"]');
+    // untouched surroundings
+    expect(result?.text).toContain('"extends": ["config:recommended"]');
+    expect(result?.text).toContain('"matchDepTypes": ["devDependencies"]');
+    expect(JSON.parse(result!.text)).toEqual({
+      extends: ["config:recommended"],
+      packageRules: [{ matchDepTypes: ["devDependencies"] }, { matchPackageNames: ["!gradle"] }],
+    });
+  });
+
+  it("replaces a root-level array", () => {
+    const text = '{\n  "matchPackageNames": ["**", "!gradle"]\n}\n';
+    const fix = valueFix({
+      path: ["matchPackageNames"],
+      value: ["!gradle"],
+      fixedConfig: {},
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(true);
+    expect(JSON.parse(result!.text)).toEqual({ matchPackageNames: ["!gradle"] });
+  });
+
+  it("tolerates // and /* */ comments (json5) while locating the path", () => {
+    const text = [
+      "{",
+      "  // top comment",
+      '  "packageRules": [',
+      "    /* rule 0 */",
+      '    { "matchPackageNames": ["*", "!gradle"] } // trailing',
+      "  ]",
+      "}",
+    ].join("\n");
+    const fix = valueFix({
+      path: ["packageRules", 0, "matchPackageNames"],
+      value: ["!gradle"],
+      fixedConfig: {},
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(true);
+    expect(result?.text).toContain('"matchPackageNames": ["!gradle"]');
+    expect(result?.text).toContain("// top comment");
+  });
+});
+
+describe("applyFixToText — rename (pattern 2: deprecated option)", () => {
+  it("renames only the key token, keeping the value and formatting", () => {
+    const text = '{\n  "versionScheme": "semver",\n  "rangeStrategy": "auto"\n}\n';
+    const fix = valueFix({
+      path: ["versionScheme"],
+      renameTo: "versioning",
+      fixedConfig: {},
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(true);
+    expect(JSON.parse(result!.text)).toEqual({ versioning: "semver", rangeStrategy: "auto" });
+  });
+});
+
+describe("applyFixToText — remove (pattern 3: global-only option)", () => {
+  it("removes the sole property in an object", () => {
+    const text = '{\n  "token": "abc"\n}\n';
+    const fix = valueFix({ path: ["token"], remove: true, fixedConfig: {} });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(true);
+    expect(JSON.parse(result!.text)).toEqual({});
+  });
+
+  it("removes the first of several properties, keeping the rest valid", () => {
+    const text = '{\n  "token": "abc",\n  "extends": ["config:recommended"]\n}\n';
+    const fix = valueFix({ path: ["token"], remove: true, fixedConfig: {} });
+    const result = applyFixToText(text, fix);
+    expect(JSON.parse(result!.text)).toEqual({ extends: ["config:recommended"] });
+  });
+
+  it("removes the last of several properties without leaving a dangling comma", () => {
+    const text = '{\n  "extends": ["config:recommended"],\n  "token": "abc"\n}\n';
+    const fix = valueFix({ path: ["token"], remove: true, fixedConfig: {} });
+    const result = applyFixToText(text, fix);
+    expect(JSON.parse(result!.text)).toEqual({ extends: ["config:recommended"] });
+  });
+
+  it("removes a middle property", () => {
+    const text = '{\n  "a": 1,\n  "token": "abc",\n  "b": 2\n}\n';
+    const fix = valueFix({ path: ["token"], remove: true, fixedConfig: {} });
+    const result = applyFixToText(text, fix);
+    expect(JSON.parse(result!.text)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("removes a compact single-line object member", () => {
+    const text = '{ "a": 1, "token": "abc", "b": 2 }';
+    const fix = valueFix({ path: ["token"], remove: true, fixedConfig: {} });
+    const result = applyFixToText(text, fix);
+    expect(JSON.parse(result!.text)).toEqual({ a: 1, b: 2 });
+  });
+});
+
+describe("applyFixToText — fallback when the path can't be located", () => {
+  it("falls back to re-serializing fixedConfig when the key uses an unsupported style (single-quoted)", () => {
+    const text = "{ 'token': 'abc' }"; // valid JSON5, not the supported double-quoted-key convention
+    const fix = valueFix({
+      path: ["token"],
+      remove: true,
+      fixedConfig: { other: true },
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(false);
+    expect(JSON.parse(result!.text)).toEqual({ other: true });
+  });
+
+  it("falls back when the path segment doesn't exist in this text at all", () => {
+    const text = '{\n  "extends": ["config:recommended"]\n}\n';
+    const fix = valueFix({
+      path: ["packageRules", 0, "matchPackageNames"],
+      value: ["!gradle"],
+      fixedConfig: { extends: ["config:recommended"] },
+    });
+    const result = applyFixToText(text, fix);
+    expect(result?.surgical).toBe(false);
+    expect(JSON.parse(result!.text)).toEqual({ extends: ["config:recommended"] });
+  });
+});

--- a/packages/engine/test/error-translations.node.test.ts
+++ b/packages/engine/test/error-translations.node.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+import {
+  ERROR_TRANSLATIONS,
+  findMentionedOption,
+  parseConfigPath,
+  translateMessage,
+} from "../src/error-translations";
+import type { ValidationMessage } from "../src/trace/model";
+
+describe("parseConfigPath", () => {
+  it("parses a bare top-level key", () => {
+    expect(parseConfigPath("matchPackageNames")).toEqual(["matchPackageNames"]);
+  });
+
+  it("parses a nested packageRules path", () => {
+    expect(parseConfigPath("packageRules[1].matchPackageNames")).toEqual([
+      "packageRules",
+      1,
+      "matchPackageNames",
+    ]);
+  });
+
+  it("parses multiple array indices", () => {
+    expect(parseConfigPath("packageRules[0].packageRules[2].matchDepTypes")).toEqual([
+      "packageRules",
+      0,
+      "packageRules",
+      2,
+      "matchDepTypes",
+    ]);
+  });
+});
+
+function redundantGlobMessage(path: string): ValidationMessage {
+  return {
+    topic: "Configuration Error",
+    message: `${path}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`,
+  };
+}
+
+describe("redundant-glob-star translation (P2 study case)", () => {
+  const message = redundantGlobMessage;
+
+  it("matches the exact upstream message shape", () => {
+    const translation = ERROR_TRANSLATIONS.find((t) => t.id === "redundant-glob-star")!;
+    expect(translation.matches(message("packageRules[1].matchPackageNames"))).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains the redundancy in plain language, naming the path", () => {
+    const translated = translateMessage(message("packageRules[1].matchPackageNames"), null);
+    expect(translated).not.toBeNull();
+    expect(translated!.explanation).toMatch(/redundant/);
+    expect(translated!.explanation).toContain("packageRules[1].matchPackageNames");
+    // no config snapshot given -> no fix computed
+    expect(translated!.fix).toBeNull();
+  });
+
+  it("suggests removing exactly the * / ** entries from the named array (study's ['*','!gradle'] case)", () => {
+    const config = {
+      packageRules: [
+        { matchDepTypes: ["devDependencies"] },
+        { matchPackageNames: ["*", "!gradle"] },
+      ],
+    };
+    const translated = translateMessage(message("packageRules[1].matchPackageNames"), config);
+    expect(translated!.fix).not.toBeNull();
+    const fix = translated!.fix!;
+    expect(fix.path).toEqual(["packageRules", 1, "matchPackageNames"]);
+    expect(fix.before).toEqual(["*", "!gradle"]);
+    expect(fix.after).toEqual(["!gradle"]);
+    expect(fix.value).toEqual(["!gradle"]);
+    expect(fix.summary).toContain("`*`");
+    // the fixed config is otherwise untouched
+    expect(fix.fixedConfig.packageRules).toEqual([
+      { matchDepTypes: ["devDependencies"] },
+      { matchPackageNames: ["!gradle"] },
+    ]);
+    expect(config.packageRules[1]!.matchPackageNames).toEqual(["*", "!gradle"]); // original untouched
+  });
+
+  it("handles a root-level (non-nested) array", () => {
+    const config = { matchPackageNames: ["**", "!gradle", "!npm"] };
+    const translated = translateMessage(message("matchPackageNames"), config);
+    expect(translated!.fix!.after).toEqual(["!gradle", "!npm"]);
+  });
+
+  it("gives up when the named path isn't an array of strings in this config", () => {
+    const config = { packageRules: [{ matchPackageNames: "not-an-array" }] };
+    const translated = translateMessage(message("packageRules[0].matchPackageNames"), config);
+    expect(translated!.fix).toBeNull();
+  });
+
+  it("gives up when the path can't be found at all (stale message vs. edited config)", () => {
+    const config = { packageRules: [] as unknown[] };
+    const translated = translateMessage(message("packageRules[0].matchPackageNames"), config);
+    expect(translated!.fix).toBeNull();
+  });
+
+  it("attaches a docs link for the named matcher option", () => {
+    const translated = translateMessage(message("matchPackageNames"), null);
+    expect(translated!.docsUrl).toBe(
+      "https://docs.renovatebot.com/configuration-options/#matchpackagenames",
+    );
+  });
+});
+
+describe("deprecated-option translation", () => {
+  it("matches only Deprecation Warning messages with the exact upstream shape", () => {
+    const translation = ERROR_TRANSLATIONS.find((t) => t.id === "deprecated-option")!;
+    expect(
+      translation.matches({
+        topic: "Deprecation Warning",
+        message:
+          "The 'dnsCache' option is deprecated: This option is deprecated and will be removed.",
+      }),
+    ).toBe(true);
+    expect(
+      translation.matches({
+        topic: "Configuration Error",
+        message: "The 'dnsCache' option is deprecated: x",
+      }),
+    ).toBe(false);
+  });
+
+  it("explains and points at the migration step-through", () => {
+    const translated = translateMessage(
+      {
+        topic: "Deprecation Warning",
+        message:
+          "The 'dnsCache' option is deprecated: This option is deprecated and will be removed.",
+      },
+      null,
+    );
+    expect(translated).not.toBeNull();
+    expect(translated!.explanation).toMatch(/migration/i);
+    expect(translated!.explanation).toContain("dnsCache");
+  });
+
+  it("offers no auto-fix for a real deprecated option with no single named replacement (dnsCache)", () => {
+    const translated = translateMessage(
+      {
+        topic: "Deprecation Warning",
+        message:
+          "The 'dnsCache' option is deprecated: This option is deprecated and will be removed.",
+      },
+      { dnsCache: true },
+    );
+    expect(translated!.fix).toBeNull();
+  });
+
+  it("renames unambiguously when the deprecation text names exactly one known replacement option", () => {
+    const translated = translateMessage(
+      {
+        topic: "Deprecation Warning",
+        message: "The 'versionScheme' option is deprecated: Renamed to `versioning`.",
+      },
+      { versionScheme: "semver" },
+    );
+    const fix = translated!.fix!;
+    expect(fix.renameTo).toBe("versioning");
+    expect(fix.before).toBe("semver");
+    expect(fix.after).toBe("semver");
+    expect(fix.fixedConfig).toEqual({ versioning: "semver" });
+  });
+
+  it("declines to clobber an existing value under the replacement name", () => {
+    const translated = translateMessage(
+      {
+        topic: "Deprecation Warning",
+        message: "The 'versionScheme' option is deprecated: Renamed to `versioning`.",
+      },
+      { versionScheme: "semver", versioning: "npm" },
+    );
+    expect(translated!.fix).toBeNull();
+  });
+
+  it("declines when two or more candidate replacements are named (ambiguous)", () => {
+    const translated = translateMessage(
+      {
+        topic: "Deprecation Warning",
+        message:
+          "The 'branchName' option is deprecated: Please edit `branchPrefix`, `additionalBranchPrefix`, or `branchTopic` instead.",
+      },
+      { branchName: "renovate/{{depName}}" },
+    );
+    expect(translated!.fix).toBeNull();
+  });
+});
+
+describe("global-only-option translation (008 boundary warning)", () => {
+  const message: ValidationMessage = {
+    topic: "Configuration Error",
+    message:
+      "The \"token\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.",
+  };
+
+  it("matches the exact upstream boundary-warning shape", () => {
+    const translation = ERROR_TRANSLATIONS.find((t) => t.id === "global-only-option")!;
+    expect(translation.matches(message)).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains that the option only works in global config", () => {
+    const translated = translateMessage(message, null);
+    expect(translated!.explanation).toMatch(/global/i);
+    expect(translated!.explanation).toContain("token");
+  });
+
+  it("suggests removing the option when it's present at the config root", () => {
+    const translated = translateMessage(message, { token: "abc", extends: ["config:recommended"] });
+    const fix = translated!.fix!;
+    expect(fix.remove).toBe(true);
+    expect(fix.path).toEqual(["token"]);
+    expect(fix.before).toBe("abc");
+    expect(fix.after).toBeUndefined();
+    expect(fix.fixedConfig).toEqual({ extends: ["config:recommended"] });
+  });
+
+  it("declines when the option isn't present at the root of this snapshot (can't confidently locate it)", () => {
+    const translated = translateMessage(message, { packageRules: [{ token: "abc" }] });
+    expect(translated!.fix).toBeNull();
+  });
+});
+
+describe("translateMessage", () => {
+  it("returns null for a message no curated pattern recognizes", () => {
+    expect(
+      translateMessage({ topic: "Configuration Error", message: "Something else entirely" }, null),
+    ).toBeNull();
+  });
+});
+
+describe("findMentionedOption (fallback docs link for unmatched messages)", () => {
+  it("finds a backtick-quoted option name", () => {
+    const doc = findMentionedOption({
+      topic: "x",
+      message: "Setting `registryUrls` at the top level applies it everywhere.",
+    });
+    expect(doc?.name).toBe("registryUrls");
+  });
+
+  it("finds a single-quoted option name", () => {
+    const doc = findMentionedOption({
+      topic: "x",
+      message: "The 'rangeStrategy' option is odd here.",
+    });
+    expect(doc?.name).toBe("rangeStrategy");
+  });
+
+  it("returns undefined when nothing quoted is a real option", () => {
+    const doc = findMentionedOption({
+      topic: "x",
+      message: "The 'notARealOption' thing is wrong.",
+    });
+    expect(doc).toBeUndefined();
+  });
+});

--- a/roadmap/014-validation-translations-and-quick-fixes.md
+++ b/roadmap/014-validation-translations-and-quick-fixes.md
@@ -1,6 +1,54 @@
 # 014 — Validation error translations + suggested fixes
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified, scoped to three curated patterns (redundant
+> `*`/`**`, deprecated options the migrate stage doesn't auto-rename, 008's
+> global-only boundary warning) plus a docs-link fallback for anything else —
+> a change to Renovate's own message wording simply stops a pattern matching
+> rather than mis-firing. `packages/engine/src/error-translations.ts` matches
+> `ValidationMessage`s and computes a structured `ErrorFixResult` (a JSON path
+> plus before/after values, and also the fully fixed config, satisfying both
+> the "function from parsed config to fixed config" the spec asked for and a
+> surgical text-patch target) against the EXACT config snapshot
+> `validateConfig("repo", …)` ran on (the pipeline's post-massage,
+> pre-preset-merge trace snapshot). Renovate's own message already embeds the
+> offending path (`packageRules[1].matchPackageNames: …`), so locating "the
+> one array" is exact, not a search. Conservative by construction: a fix is
+> only returned when the path resolves in that exact config and the edit is
+> unambiguous (nothing to remove, an already-taken rename target, more than
+> one candidate replacement named, etc. all decline rather than guess). Both
+> this module and its text-patch counterpart
+> (`packages/engine/src/error-fix-text.ts`) live in the ENGINE rather than the
+> app: the app package has no test setup, and both are pure (no DOM, no
+> renovate/dist imports; option-name lookups go through `option-docs.ts`'s
+> re-export), so this is where they could actually be unit-tested. `run.ts`
+> loads them through the same lazy dynamic import as the option index so the
+> heavy engine chunk stays out of the initial bundle (verified: the pattern
+> text is absent from the main chunk, present only in the lazily-loaded one).
+> `error-fix-text.ts` applies a fix as a surgical text splice (bracket-depth
+> scan in the spirit of 013's `rule-locate.ts`, not a full JSON5 parser: it
+> recognizes double-quoted keys and `//`/`/* */` comments, the overwhelming
+> convention), so everything about the document except the fixed value —
+> comments, formatting, key order — survives. When a path segment can't be
+> located (e.g. a single-quoted key, or the config was hand-edited since the
+> message was produced) it falls back to re-serializing `fixedConfig` for the
+> whole document instead, flagged `surgical: false` so the app can warn that
+> formatting/comments were lost: a documented tradeoff, not a silent partial
+> edit. UI: a new `ErrorTranslationView` renders under every message in both
+> `MessagesPanel` (the top-level `validate` errors/warnings, where "Apply fix"
+> is offered, since these index the repo's own editor text) and
+> `RuleSimulator`'s validation echo (explanation + docs link only — that echo
+> validates the merged/simulated `packageRules`, not the editor's text, so
+> there's no safe surgical target there; the same issue in the user's own rule
+> also surfaces with a fix in the main panel). "Apply fix" writes the patched
+> text into the editor and re-runs immediately, without waiting on the
+> `content` state commit — the validate stage flipping error to ok is the
+> confirmation. Unmatched messages get `findMentionedOption`'s docs-link
+> fallback (quoted-token scan against 003's option index) instead of a
+> translation card. 013's `packageRules[i]` cross-links are unaffected: the
+> translation renders as an additional block below `RuleMessage`, never
+> replacing it.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -18,7 +18,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
 | [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
 | [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
-| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | planned |
+| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | planned |
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | planned |
 | [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | planned |


### PR DESCRIPTION
Implements roadmap item 014 (M5, from the 2026-07 persona UX study).

- Curated pattern library (`packages/engine/src/error-translations.ts`, pure + 34 unit tests): redundant `*`/`**` alongside other patterns (the study's case), deprecated-option renames (only with exactly one known replacement), global-only options in repo config. Explanations render **alongside** Renovate's original message, never instead of it; unmatched messages get a docs link when they name a known option (003 index).
- **Apply fix**: surgical text patch of the editor content (value replace / key rename / member removal with comma cleanup — comments and formatting preserved; whole-document re-serialize fallback with a visible notice), then an automatic re-run: validate flipping 1 error → 0 is the confirmation.
- Simulator's validation echo gets explanation + docs link only (its index space differs from the editor; the same user-rule issue surfaces with a fix in the main messages panel).
- Translation library stays in the lazily-loaded engine chunk (verified not in the eager bundle).

Validated: lint, format, typecheck, golden (49) + shimmed (70) tests, production build, CI import-boundary grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ