### PR TITLE
feat(015): simulator input ergonomics

### DIFF
--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import type {
   ClauseEvaluation,
   DependencyDescriptor,
@@ -134,6 +134,21 @@ const QUICK_FILLS: { label: string; fill: Partial<FormState> }[] = [
       updateType: "minor",
     },
   },
+  {
+    // Roadmap 015: Azure DevOps / .NET users had no chip that matched their
+    // stack.
+    label: "nuget",
+    fill: {
+      manager: "nuget",
+      datasource: "nuget",
+      packageFile: "src/App.csproj",
+      packageName: "Newtonsoft.Json",
+      currentValue: "13.0.1",
+      newValue: "13.0.3",
+      updateType: "patch",
+      versioning: "nuget",
+    },
+  },
 ];
 
 function trimmed(value: string): string | undefined {
@@ -149,10 +164,16 @@ function list(value: string): string[] | undefined {
   return items.length > 0 ? items : undefined;
 }
 
-function toDescriptor(form: FormState): DependencyDescriptor {
+/**
+ * @param effectiveUpdateType Roadmap 015: the updateType to actually send —
+ * the derived value when the user hasn't manually overridden the select,
+ * `form.updateType` otherwise. Defaults to `form.updateType` so callers that
+ * only need e.g. the empty-form check don't have to compute derivation.
+ */
+function toDescriptor(form: FormState, effectiveUpdateType?: string): DependencyDescriptor {
   // "bump" is a real Renovate updateType, but matchUpdateTypes only sees it
   // via the isBump flag on in-range updates — set both.
-  const updateType = trimmed(form.updateType);
+  const updateType = trimmed(effectiveUpdateType ?? form.updateType);
   return {
     manager: trimmed(form.manager),
     datasource: trimmed(form.datasource),
@@ -175,6 +196,15 @@ function toDescriptor(form: FormState): DependencyDescriptor {
     baseBranch: trimmed(form.baseBranch),
     currentVersionTimestamp: trimmed(form.currentVersionTimestamp),
   };
+}
+
+/**
+ * Roadmap 015: an empty-form guard. True once ANY descriptor field carries a
+ * value — a form with nothing filled in is guaranteed to match nothing, and
+ * running it just renders hundreds of "no match" rows with no explanation.
+ */
+function hasMeaningfulInput(form: FormState): boolean {
+  return Object.values(toDescriptor(form)).some((v) => v !== undefined);
 }
 
 function previewValue(value: unknown, max = 60): string {
@@ -412,7 +442,7 @@ function Field({
   onChange,
   placeholder,
 }: {
-  label: string;
+  label: ReactNode;
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
@@ -463,8 +493,35 @@ export function RuleSimulator({
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
+  // Roadmap 015: updateType derivation. `engineModule` is loaded once, up
+  // front — by the time this component can render, a run has already pulled
+  // the engine chunk in (see `simulate` below), so this is a cache hit, not
+  // a second network fetch. `updateTypeTouched` tracks whether the user
+  // picked the select THEMSELVES: while false, the effective updateType
+  // tracks currentValue/newValue live; the moment they touch the select (or
+  // a quick-fill runs, which resets it) their choice wins outright, even if
+  // they go on to edit the versions afterward.
+  const [engineModule, setEngineModule] = useState<
+    typeof import("@renovate-config-visualizer/engine") | null
+  >(null);
+  const [updateTypeTouched, setUpdateTypeTouched] = useState(false);
+  // Roadmap 015: set when Simulate is clicked on a form with no identifying
+  // input; cleared reactively the moment the form has ANY meaningful field.
+  const [emptyGuardTriggered, setEmptyGuardTriggered] = useState(false);
   const rulesRef = useRef<HTMLDivElement>(null);
   const ruleAttribution = useRuleProvenance(result);
+
+  useEffect(() => {
+    let cancelled = false;
+    import("@renovate-config-visualizer/engine").then((m) => {
+      if (!cancelled) {
+        setEngineModule(m);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
   // Roadmap 013: the merged index awaiting a scroll+flash — set either from the
   // external `focusRuleIndex` prop or a click on this component's own
   // packageRules[N]-in-message links (`focusRule`, defined below).
@@ -476,6 +533,7 @@ export function RuleSimulator({
     setRanKey(null);
     setError(null);
     setShowAll(false);
+    setEmptyGuardTriggered(false);
   }, [result]);
 
   useEffect(() => {
@@ -532,6 +590,16 @@ export function RuleSimulator({
     return map;
   }, [ruleAttribution]);
 
+  // Roadmap 015: recomputed live as currentValue/newValue/versioning change —
+  // undefined until the engine chunk resolves, or when the pair can't be
+  // derived (blank, a range, an unparseable value, …).
+  const derivedUpdateType = useMemo(
+    () => engineModule?.deriveUpdateType(form.currentValue, form.newValue, form.versioning),
+    [engineModule, form.currentValue, form.newValue, form.versioning],
+  );
+  const effectiveUpdateType =
+    updateTypeTouched || derivedUpdateType === undefined ? form.updateType : derivedUpdateType;
+
   // Keys the rules changed vs. the pre-rules effective config, for the final
   // section's summary chips.
   const changedKeys = useMemo(() => {
@@ -550,17 +618,39 @@ export function RuleSimulator({
     return null;
   }
 
-  async function simulate(nextForm: FormState) {
+  /**
+   * @param touched Roadmap 015: whether the CALLER's updateType is a manual
+   * override (Simulate button click — pass the current `updateTypeTouched`
+   * state) or not (a quick-fill's own guess, always re-derivable). Threaded
+   * explicitly rather than read from state inside this async function, since
+   * `quickFill` below also resets the state flag in the same tick — reading
+   * it here would race against that update.
+   */
+  async function simulate(nextForm: FormState, touched: boolean) {
     if (!finalConfig) {
       return;
     }
+    // Roadmap 015: empty-form guard — an all-blank descriptor is guaranteed
+    // to match nothing, and running it just renders hundreds of "no match"
+    // rows with no explanation (the study's "did I break something?" moment).
+    if (!hasMeaningfulInput(nextForm)) {
+      setEmptyGuardTriggered(true);
+      return;
+    }
+    setEmptyGuardTriggered(false);
     setRunning(true);
     setError(null);
     try {
       const engine = await import("@renovate-config-visualizer/engine");
+      const derived = engine.deriveUpdateType(
+        nextForm.currentValue,
+        nextForm.newValue,
+        nextForm.versioning,
+      );
+      const effectiveType = touched || derived === undefined ? nextForm.updateType : derived;
       const simResult = await engine.simulatePackageRules({
         config: finalConfig,
-        dep: toDescriptor(nextForm),
+        dep: toDescriptor(nextForm, effectiveType),
       });
       setSim(simResult);
       setRanKey(JSON.stringify(nextForm));
@@ -575,7 +665,38 @@ export function RuleSimulator({
   function quickFill(fill: Partial<FormState>) {
     const next = { ...EMPTY_FORM, ...fill };
     setForm(next);
-    void simulate(next);
+    // A quick-fill's updateType is only a starting guess, not the user's own
+    // choice — derivation should keep tracking it if they go on to edit the
+    // pre-filled versions.
+    setUpdateTypeTouched(false);
+    void simulate(next, false);
+  }
+
+  /**
+   * Roadmap 015: step the updateType select ourselves on ArrowUp/ArrowDown.
+   * Investigation: this select is a plain, unstyled native `<select>` with no
+   * other keydown listener anywhere in the app — but its native one-option-
+   * at-a-time arrow stepping turned out to be unreliable specifically under
+   * the persona study's browser-automation driver (confirmed by reproducing
+   * it against a bare, app-free `<select>` under the same driver: even a
+   * from-scratch page with zero JS doesn't step). Handling the keys directly
+   * makes stepping deterministic for every input path — a real keyboard
+   * included, where this exactly mirrors what native stepping already did.
+   */
+  function updateTypeKeyDown(e: React.KeyboardEvent<HTMLSelectElement>) {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") {
+      return;
+    }
+    e.preventDefault();
+    const values = ["", ...UPDATE_TYPES];
+    const currentIndex = values.indexOf(effectiveUpdateType);
+    const baseIndex = currentIndex === -1 ? 0 : currentIndex;
+    const nextIndex =
+      e.key === "ArrowDown"
+        ? Math.min(values.length - 1, baseIndex + 1)
+        : Math.max(0, baseIndex - 1);
+    setUpdateTypeTouched(true);
+    setForm({ ...form, updateType: values[nextIndex] ?? "" });
   }
 
   if (packageRules.length === 0) {
@@ -596,6 +717,9 @@ export function RuleSimulator({
   }
 
   const stale = sim !== null && ranKey !== JSON.stringify(form);
+  // Roadmap 015: reactive, not sticky — the moment the form gains ANY
+  // meaningful field, the guard clears itself even without clicking Simulate.
+  const showEmptyGuard = emptyGuardTriggered && !hasMeaningfulInput(form);
   const matchedCount = sim?.rules.filter((r) => r.verdict === "matched").length ?? 0;
   // Default the results list to the rules that actually did something (matched
   // or unresolved), hiding the sea of "no match" rows behind a toggle.
@@ -683,11 +807,23 @@ export function RuleSimulator({
           onChange={(v) => setForm({ ...form, newValue: v })}
           placeholder="4.17.21"
         />
+        {/* Roadmap 015: promoted out of "More fields" — sourceUrl was the
+            decisive matcher in two of the persona study's three problems. */}
+        <Field
+          label={<Term id="simSourceUrl">sourceUrl</Term>}
+          value={form.sourceUrl}
+          onChange={(v) => setForm({ ...form, sourceUrl: v })}
+          placeholder="https://github.com/facebook/react — the DEPENDENCY's repo"
+        />
         <label className="sim-field">
           updateType
           <select
-            value={form.updateType}
-            onChange={(e) => setForm({ ...form, updateType: e.target.value })}
+            value={effectiveUpdateType}
+            onChange={(e) => {
+              setUpdateTypeTouched(true);
+              setForm({ ...form, updateType: e.target.value });
+            }}
+            onKeyDown={updateTypeKeyDown}
           >
             <option value="">(unset)</option>
             {UPDATE_TYPES.map((t) => (
@@ -696,6 +832,20 @@ export function RuleSimulator({
               </option>
             ))}
           </select>
+          {/* Roadmap 015: a quick-fill's updateType must not silently survive
+              editing the versions — while untouched, this tracks
+              currentValue -> newValue live via the selected versioning
+              scheme, and says so, so "major (derived)" can't be mistaken for
+              a manual choice. */}
+          {!updateTypeTouched && derivedUpdateType !== undefined ? (
+            <span className="sim-derived-hint">
+              (derived from currentValue → newValue —{" "}
+              <button type="button" className="sim-link" onClick={() => setUpdateTypeTouched(true)}>
+                override
+              </button>
+              )
+            </span>
+          ) : null}
         </label>
       </div>
       <details className="sim-more">
@@ -727,12 +877,6 @@ export function RuleSimulator({
             placeholder="semver"
           />
           <Field
-            label="sourceUrl"
-            value={form.sourceUrl}
-            onChange={(v) => setForm({ ...form, sourceUrl: v })}
-            placeholder="https://github.com/lodash/lodash"
-          />
-          <Field
             label="registryUrls (comma-separated)"
             value={form.registryUrls}
             onChange={(v) => setForm({ ...form, registryUrls: v })}
@@ -745,10 +889,10 @@ export function RuleSimulator({
             placeholder="js"
           />
           <Field
-            label="repository"
+            label={<Term id="simRepository">repository</Term>}
             value={form.repository}
             onChange={(v) => setForm({ ...form, repository: v })}
-            placeholder="my-org/my-repo"
+            placeholder="your-org/your-repo — the repo Renovate runs in"
           />
           <Field
             label="baseBranch"
@@ -768,7 +912,7 @@ export function RuleSimulator({
         <button
           type="button"
           className="primary"
-          onClick={() => void simulate(form)}
+          onClick={() => void simulate(form, updateTypeTouched)}
           disabled={running}
         >
           {running ? "Simulating…" : "Simulate"}
@@ -777,144 +921,166 @@ export function RuleSimulator({
           <span className="sim-stale">inputs changed — simulate again to refresh</span>
         ) : null}
       </div>
+      {/* Roadmap 015: empty-form guard — replaces a would-be "0 of N rules
+          matched" wall of no-matches with a plain nudge. */}
+      {showEmptyGuard ? (
+        <p className="sim-empty-guard">
+          Pick an example above, or fill in a package name (or another identifying field) below — an
+          empty form can't match anything.
+        </p>
+      ) : null}
 
       {error ? <p className="sim-error">Simulation failed: {error}</p> : null}
 
+      {/* Roadmap 015: while stale, the whole results block is visibly greyed
+          out (not just the small text hint below, which the persona study
+          found easy to skim past) with a banner explaining why. */}
       {sim ? (
         <div className="sim-results">
-          {/* Roadmap 012: the answer first — a pinned verdict directly under
+          {stale ? (
+            <p className="sim-stale-banner">
+              Inputs changed since this run — these results may no longer reflect the form above.
+              Simulate again to refresh.
+            </p>
+          ) : null}
+          {/* The banner above stays full-strength; everything below it (the
+              actual results) is what gets visibly veiled while stale. */}
+          <div className={`sim-results-body${stale ? " stale" : ""}`}>
+            {/* Roadmap 012: the answer first — a pinned verdict directly under
               the Simulate button, before the rule list. */}
-          <div className={`sim-verdict-block${matchedCount === 0 ? " none" : ""}`}>
-            <p className="sim-verdict-sentence">{verdictSentence}</p>
-            {changedWithValues.length > 0 ? (
-              <ul className="sim-verdict-keys">
-                {changedWithValues.map(({ key, value, present }) => (
-                  <li key={key}>
-                    <code>
-                      <OptionKey name={key} flagUnknown />
-                    </code>
-                    {present ? (
-                      <>
-                        {" = "}
-                        <span className="sim-verdict-value">{previewValue(value, 80)}</span>
-                        {sim.flattened.merged.some((m) => m.key === key) ? (
-                          <span className="sim-verdict-from">
-                            {" "}
-                            from the <Term id="updateType">{sim.flattened.updateType}</Term> block
-                          </span>
-                        ) : null}
-                      </>
-                    ) : (
-                      <span className="sim-verdict-value removed"> removed</span>
-                    )}
+            <div className={`sim-verdict-block${matchedCount === 0 ? " none" : ""}`}>
+              <p className="sim-verdict-sentence">{verdictSentence}</p>
+              {changedWithValues.length > 0 ? (
+                <ul className="sim-verdict-keys">
+                  {changedWithValues.map(({ key, value, present }) => (
+                    <li key={key}>
+                      <code>
+                        <OptionKey name={key} flagUnknown />
+                      </code>
+                      {present ? (
+                        <>
+                          {" = "}
+                          <span className="sim-verdict-value">{previewValue(value, 80)}</span>
+                          {sim.flattened.merged.some((m) => m.key === key) ? (
+                            <span className="sim-verdict-from">
+                              {" "}
+                              from the <Term id="updateType">{sim.flattened.updateType}</Term> block
+                            </span>
+                          ) : null}
+                        </>
+                      ) : (
+                        <span className="sim-verdict-value removed"> removed</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="sim-verdict-none">
+                  No rule changed anything for this dependency — the defaults apply.
+                </p>
+              )}
+              <button type="button" className="sim-jump" onClick={jumpToRules}>
+                {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched
+                →
+              </button>
+            </div>
+
+            {[...sim.errors, ...sim.warnings].length > 0 ? (
+              <ul className="messages sim-messages">
+                {sim.errors.map((m, i) => (
+                  <li key={`e${i}`} className="error">
+                    <strong>{m.topic}</strong>:{" "}
+                    <RuleMessage
+                      message={m}
+                      indexKind="merged"
+                      ruleAttribution={ruleAttribution}
+                      onJumpToEditor={onJumpToEditor}
+                      onJumpToSimRule={focusRule}
+                    />
+                    <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
+                  </li>
+                ))}
+                {sim.warnings.map((m, i) => (
+                  <li key={`w${i}`} className="warn">
+                    <strong>{m.topic}</strong>:{" "}
+                    <RuleMessage
+                      message={m}
+                      indexKind="merged"
+                      ruleAttribution={ruleAttribution}
+                      onJumpToEditor={onJumpToEditor}
+                      onJumpToSimRule={focusRule}
+                    />
+                    <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
                   </li>
                 ))}
               </ul>
-            ) : (
-              <p className="sim-verdict-none">
-                No rule changed anything for this dependency — the defaults apply.
-              </p>
-            )}
-            <button type="button" className="sim-jump" onClick={jumpToRules}>
-              {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched →
-            </button>
-          </div>
-
-          {[...sim.errors, ...sim.warnings].length > 0 ? (
-            <ul className="messages sim-messages">
-              {sim.errors.map((m, i) => (
-                <li key={`e${i}`} className="error">
-                  <strong>{m.topic}</strong>:{" "}
-                  <RuleMessage
-                    message={m}
-                    indexKind="merged"
-                    ruleAttribution={ruleAttribution}
-                    onJumpToEditor={onJumpToEditor}
-                    onJumpToSimRule={focusRule}
-                  />
-                  <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
-                </li>
-              ))}
-              {sim.warnings.map((m, i) => (
-                <li key={`w${i}`} className="warn">
-                  <strong>{m.topic}</strong>:{" "}
-                  <RuleMessage
-                    message={m}
-                    indexKind="merged"
-                    ruleAttribution={ruleAttribution}
-                    onJumpToEditor={onJumpToEditor}
-                    onJumpToSimRule={focusRule}
-                  />
-                  <ErrorTranslationView message={m} errorLib={errorLib ?? null} config={null} />
-                </li>
-              ))}
-            </ul>
-          ) : null}
-          {sim.notes.map((note) => (
-            <p key={note} className="sim-note">
-              {note}
-            </p>
-          ))}
-          <div className="sim-rules-head" ref={rulesRef}>
-            <span className="sim-summary">
-              {showAll
-                ? `all ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"}`
-                : `${notableRules.length} of ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"} shown`}
-            </span>
-            {hiddenCount > 0 ? (
-              <button type="button" className="sim-toggle" onClick={() => setShowAll(!showAll)}>
-                {showAll ? "show matched only" : `show all ${sim.rules.length}`}
-              </button>
             ) : null}
-          </div>
-          {shownRules.length > 0 ? (
-            <div className="sim-rules">
-              {shownRules.map((rule) => (
-                <RuleRow
-                  key={rule.index}
-                  rule={rule}
-                  layer={layerByIndex.get(rule.index)}
-                  onSelectPreset={onSelectPreset}
-                />
-              ))}
-            </div>
-          ) : (
-            <p className="empty-note">
-              No rule matched this dependency.{" "}
+            {sim.notes.map((note) => (
+              <p key={note} className="sim-note">
+                {note}
+              </p>
+            ))}
+            <div className="sim-rules-head" ref={rulesRef}>
+              <span className="sim-summary">
+                {showAll
+                  ? `all ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"}`
+                  : `${notableRules.length} of ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"} shown`}
+              </span>
               {hiddenCount > 0 ? (
-                <button
-                  type="button"
-                  className="sim-toggle inline"
-                  onClick={() => setShowAll(true)}
-                >
-                  Show all {sim.rules.length} anyway.
+                <button type="button" className="sim-toggle" onClick={() => setShowAll(!showAll)}>
+                  {showAll ? "show matched only" : `show all ${sim.rules.length}`}
                 </button>
               ) : null}
-            </p>
-          )}
-          <div className="sim-final">
-            <div className="sim-merged-title">Final per-dependency config</div>
-            {changedKeys.length > 0 ? (
-              <p className="sim-changed">
-                Rules changed:{" "}
-                {changedKeys.map((key, i) => (
-                  <span key={key}>
-                    {i > 0 ? ", " : null}
-                    <code>
-                      <OptionKey name={key} flagUnknown />
-                    </code>
-                  </span>
+            </div>
+            {shownRules.length > 0 ? (
+              <div className="sim-rules">
+                {shownRules.map((rule) => (
+                  <RuleRow
+                    key={rule.index}
+                    rule={rule}
+                    layer={layerByIndex.get(rule.index)}
+                    onSelectPreset={onSelectPreset}
+                  />
                 ))}
-              </p>
+              </div>
             ) : (
-              <p className="sim-changed">No rule changed anything for this dependency.</p>
+              <p className="empty-note">
+                No rule matched this dependency.{" "}
+                {hiddenCount > 0 ? (
+                  <button
+                    type="button"
+                    className="sim-toggle inline"
+                    onClick={() => setShowAll(true)}
+                  >
+                    Show all {sim.rules.length} anyway.
+                  </button>
+                ) : null}
+              </p>
             )}
-            <details>
-              <summary>Show the full resolved dependency config</summary>
-              <pre className="config-view">
-                <ConfigJson value={sim.finalDependencyConfig} />
-              </pre>
-            </details>
+            <div className="sim-final">
+              <div className="sim-merged-title">Final per-dependency config</div>
+              {changedKeys.length > 0 ? (
+                <p className="sim-changed">
+                  Rules changed:{" "}
+                  {changedKeys.map((key, i) => (
+                    <span key={key}>
+                      {i > 0 ? ", " : null}
+                      <code>
+                        <OptionKey name={key} flagUnknown />
+                      </code>
+                    </span>
+                  ))}
+                </p>
+              ) : (
+                <p className="sim-changed">No rule changed anything for this dependency.</p>
+              )}
+              <details>
+                <summary>Show the full resolved dependency config</summary>
+                <pre className="config-view">
+                  <ConfigJson value={sim.finalDependencyConfig} />
+                </pre>
+              </details>
+            </div>
           </div>
         </div>
       ) : null}

--- a/packages/app/src/glossary.tsx
+++ b/packages/app/src/glossary.tsx
@@ -99,6 +99,23 @@ export const GLOSSARY = {
     plain:
       "The final result after defaults, presets and your own settings are merged in order — the configuration Renovate actually acts on for your repository.",
   },
+  simSourceUrl: {
+    name: "sourceUrl",
+    plain:
+      'The DEPENDENCY\'s own source repository — e.g. "https://github.com/facebook/react" ' +
+      "for the react package. This is what matchSourceUrls compares against, and is often the " +
+      "only way to identify a dependency across renames or monorepo moves. It is NOT the repo " +
+      "Renovate is running in — that's the repository field.",
+    url: "https://docs.renovatebot.com/configuration-options/#matchsourceurls",
+  },
+  simRepository: {
+    name: "repository",
+    plain:
+      'The repo Renovate is running IN — e.g. "your-org/your-repo". This is what ' +
+      "matchRepositories compares against. It is NOT the dependency's own source — that's " +
+      "the sourceUrl field.",
+    url: "https://docs.renovatebot.com/configuration-options/#matchrepositories",
+  },
   dependencyDashboard: {
     name: "Dependency Dashboard",
     plain:

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1977,3 +1977,48 @@ pre.config-view.prov-before {
   font-size: 0.78rem;
   margin-top: 0.35rem;
 }
+
+/* Roadmap 015: simulator input ergonomics — derived-updateType hint, the
+   empty-form guard, and an unmissable stale-results veil (the small
+   .sim-stale text hint alone was skimmed past in the persona study). */
+
+.sim-derived-hint {
+  color: var(--muted);
+  font-size: 0.72rem;
+  margin-top: 0.15rem;
+}
+
+.sim-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.sim-empty-guard {
+  color: var(--warn);
+  font-size: 0.85rem;
+  margin: -0.25rem 0.75rem 0.75rem;
+}
+
+.sim-stale-banner {
+  background: color-mix(in srgb, var(--warn) 12%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 45%, var(--border));
+  border-radius: 6px;
+  color: var(--warn);
+  font-size: 0.85rem;
+  margin: 0 0 0.6rem;
+  padding: 0.5rem 0.65rem;
+}
+
+.sim-results-body.stale {
+  filter: grayscale(65%);
+  opacity: 0.5;
+  transition:
+    opacity 0.15s ease,
+    filter 0.15s ease;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -12,7 +12,7 @@ export {
   type SimulationResult,
 } from "./simulate-package-rules";
 export { setPresetAuth, type PresetAuth } from "./auth";
-export { renovateVersion } from "./version";
+export { deriveUpdateType, renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
 export {

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -28,3 +28,12 @@ export {
   type PackageRuleMatcher,
 } from "renovate/dist/util/package-rules/matchers.js";
 export * as memCache from "renovate/dist/util/cache/memory/index.js";
+// The simulator's updateType derivation (roadmap 015) needs a versioning
+// scheme's compare functions plus upstream's own major/minor/patch bucketing
+// — the same two calls the real dependency lookup makes before an update's
+// updateType is ever set.
+export {
+  get as getVersioningApi,
+  type VersioningApi,
+} from "renovate/dist/modules/versioning/index.js";
+export { getUpdateType } from "renovate/dist/workers/repository/process/lookup/update-type.js";

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -159,6 +159,39 @@ declare module "renovate/dist/util/package-rules/index.js" {
   ): Promise<RenovateConfig>;
 }
 
+declare module "renovate/dist/modules/versioning/index.js" {
+  /**
+   * The subset of Renovate's VersioningApi the simulator's updateType
+   * derivation (roadmap 015) reads. `getMajor`/`getMinor` return null when
+   * the input isn't a version the scheme can parse.
+   */
+  export interface VersioningApi {
+    isVersion(input: string | undefined | null): boolean;
+    equals(version: string, other: string): boolean;
+    getMajor(version: string): number | null;
+    getMinor(version: string): number | null;
+    isSame?(type: "major" | "minor" | "patch", a: string, b: string): boolean;
+  }
+  /** Looks up a versioning scheme by name; defaults to semver-coerced when
+   *  omitted/null. Throws for an unregistered name, same as upstream. */
+  export function get(versioning?: string | null): VersioningApi;
+}
+
+declare module "renovate/dist/workers/repository/process/lookup/update-type.js" {
+  import type { VersioningApi } from "renovate/dist/modules/versioning/index.js";
+  /**
+   * Upstream's own major/minor/patch bucketing (`config` is accepted but
+   * unused by the current implementation). Only ever returns one of these
+   * three — rollback/pin/digest/bump/replacement are decided elsewhere.
+   */
+  export function getUpdateType(
+    config: RenovateConfig,
+    versioningApi: VersioningApi,
+    currentVersion: string,
+    newVersion: string,
+  ): "major" | "minor" | "patch";
+}
+
 declare module "renovate/dist/util/cache/memory/index.js" {
   export function init(): void;
   export function reset(): void;

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,4 +1,45 @@
 import pkg from "renovate/package.json";
+import { getUpdateType, getVersioningApi } from "./renovate-adapter";
 
 /** Version of the bundled Renovate whose code processes every config. */
 export const renovateVersion: string = pkg.version;
+
+/**
+ * Roadmap 015: derive an update's `updateType` (major/minor/patch) from
+ * `currentValue`/`newValue`, via the versioning scheme the simulator form's
+ * own `versioning` field names — the same two upstream calls a real
+ * dependency lookup makes (`lib/workers/repository/process/lookup/update-type.ts`:
+ * `getMajor`/`getMinor` comparisons, falling back to `isSame` when the
+ * scheme defines it) before `updateType` is ever set on a real update. Only
+ * ever returns `major`/`minor`/`patch` — `pin`/`digest`/`rollback`/`bump`/
+ * `replacement` are never derivable from a version pair alone and stay
+ * whatever the user (or a quick-fill) set explicitly.
+ *
+ * Returns undefined — "can't derive, leave whatever's there alone" — when
+ * either value is blank, the versioning name isn't one Renovate recognizes,
+ * or either value isn't a version the scheme can parse (e.g. a range like
+ * `^4.17.20`, or literal gibberish).
+ */
+export function deriveUpdateType(
+  currentValue: string | undefined,
+  newValue: string | undefined,
+  versioning: string | undefined,
+): "major" | "minor" | "patch" | undefined {
+  const current = currentValue?.trim();
+  const next = newValue?.trim();
+  if (!current || !next) {
+    return undefined;
+  }
+  let versioningApi;
+  try {
+    versioningApi = getVersioningApi(versioning?.trim() || undefined);
+  } catch {
+    // Unregistered versioning name — same as a real run, which would fail
+    // config validation long before reaching this point.
+    return undefined;
+  }
+  if (!versioningApi.isVersion(current) || !versioningApi.isVersion(next)) {
+    return undefined;
+  }
+  return getUpdateType({}, versioningApi, current, next);
+}

--- a/packages/engine/test/version.node.test.ts
+++ b/packages/engine/test/version.node.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Golden twin of version.shimmed.test.ts: roadmap 015's `deriveUpdateType`
+ * against real, unshimmed renovate/dist versioning modules — including
+ * oracle parity against upstream's own `getUpdateType` + `get`.
+ */
+import { get as getVersioningApi } from "renovate/dist/modules/versioning/index.js";
+import { getUpdateType } from "renovate/dist/workers/repository/process/lookup/update-type.js";
+import { describe, expect, it } from "vitest";
+import { deriveUpdateType } from "../src/version";
+
+describe("deriveUpdateType (golden)", () => {
+  it("derives major/minor/patch from a semver pair, default (semver-coerced) versioning", () => {
+    expect(deriveUpdateType("18.2.0", "19.2.0", undefined)).toBe("major");
+    expect(deriveUpdateType("4.17.20", "4.18.0", undefined)).toBe("minor");
+    expect(deriveUpdateType("4.17.20", "4.17.21", undefined)).toBe("patch");
+  });
+
+  it("respects the versioning scheme named in the form", () => {
+    expect(deriveUpdateType("18.2.0", "19.2.0", "semver")).toBe("major");
+    expect(deriveUpdateType("1.2.3", "1.3.0", "npm")).toBe("minor");
+  });
+
+  it("coerces manager-flavored values (docker tags) via the default scheme", () => {
+    expect(deriveUpdateType("20-alpine", "22-alpine", undefined)).toBe("major");
+    // matches the "GitHub Action" quick-fill's v4 -> v5
+    expect(deriveUpdateType("v4", "v5", undefined)).toBe("major");
+  });
+
+  it("returns undefined when it can't confidently derive", () => {
+    expect(deriveUpdateType(undefined, "1.2.3", undefined)).toBeUndefined();
+    expect(deriveUpdateType("1.2.3", undefined, undefined)).toBeUndefined();
+    expect(deriveUpdateType("", "1.2.3", undefined)).toBeUndefined();
+    // an unparseable "regex:" versioning config throws from `get()` itself
+    expect(deriveUpdateType("1.2.3", "1.2.4", "regex:(")).toBeUndefined();
+    // ranges aren't versions the scheme can parse
+    expect(deriveUpdateType("^4.17.20", "^4.18.0", "npm")).toBeUndefined();
+  });
+
+  it("falls back to the default scheme for an unrecognized versioning name, like upstream", () => {
+    // upstream's own Versioning schema logs and falls back rather than
+    // throwing for a plain unknown name (only malformed configs like
+    // "regex:(" throw) — mirrored here rather than silently refusing to derive.
+    expect(deriveUpdateType("1.2.3", "1.2.4", "not-a-real-scheme")).toBe("patch");
+  });
+
+  it("agrees with upstream getUpdateType + get (oracle parity)", () => {
+    const cases: Array<[string, string, string | undefined]> = [
+      ["18.2.0", "19.2.0", undefined],
+      ["4.17.20", "4.17.21", "semver"],
+      ["2.31.0", "2.32.0", "pep440"],
+      ["1.0.0", "1.0.0", undefined],
+    ];
+    for (const [current, next, versioning] of cases) {
+      const oracleApi = getVersioningApi(versioning);
+      const oracle = getUpdateType({}, oracleApi, current, next);
+      expect(deriveUpdateType(current, next, versioning)).toBe(oracle);
+    }
+  });
+});

--- a/packages/engine/test/version.shimmed.test.ts
+++ b/packages/engine/test/version.shimmed.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Shimmed-project twin of version.node.test.ts: the same assertions for
+ * roadmap 015's `deriveUpdateType`, but through the exact module graph the
+ * browser bundle uses (shim plugin + renovate inlined via the Vite pipeline)
+ * — proves the conda WASM-parser shim swap doesn't change behavior for the
+ * versioning schemes this simulator field actually exercises.
+ */
+import { get as getVersioningApi } from "renovate/dist/modules/versioning/index.js";
+import { getUpdateType } from "renovate/dist/workers/repository/process/lookup/update-type.js";
+import { describe, expect, it } from "vitest";
+import { deriveUpdateType } from "../src/version";
+
+describe("deriveUpdateType (shimmed)", () => {
+  it("derives major/minor/patch from a semver pair, default (semver-coerced) versioning", () => {
+    expect(deriveUpdateType("18.2.0", "19.2.0", undefined)).toBe("major");
+    expect(deriveUpdateType("4.17.20", "4.18.0", undefined)).toBe("minor");
+    expect(deriveUpdateType("4.17.20", "4.17.21", undefined)).toBe("patch");
+  });
+
+  it("respects the versioning scheme named in the form", () => {
+    expect(deriveUpdateType("18.2.0", "19.2.0", "semver")).toBe("major");
+    expect(deriveUpdateType("1.2.3", "1.3.0", "npm")).toBe("minor");
+  });
+
+  it("coerces manager-flavored values (docker tags) via the default scheme", () => {
+    expect(deriveUpdateType("20-alpine", "22-alpine", undefined)).toBe("major");
+    // matches the "GitHub Action" quick-fill's v4 -> v5
+    expect(deriveUpdateType("v4", "v5", undefined)).toBe("major");
+  });
+
+  it("returns undefined when it can't confidently derive", () => {
+    expect(deriveUpdateType(undefined, "1.2.3", undefined)).toBeUndefined();
+    expect(deriveUpdateType("1.2.3", undefined, undefined)).toBeUndefined();
+    expect(deriveUpdateType("", "1.2.3", undefined)).toBeUndefined();
+    // an unparseable "regex:" versioning config throws from `get()` itself
+    expect(deriveUpdateType("1.2.3", "1.2.4", "regex:(")).toBeUndefined();
+    // ranges aren't versions the scheme can parse
+    expect(deriveUpdateType("^4.17.20", "^4.18.0", "npm")).toBeUndefined();
+  });
+
+  it("falls back to the default scheme for an unrecognized versioning name, like upstream", () => {
+    // upstream's own Versioning schema logs and falls back rather than
+    // throwing for a plain unknown name (only malformed configs like
+    // "regex:(" throw) — mirrored here rather than silently refusing to derive.
+    expect(deriveUpdateType("1.2.3", "1.2.4", "not-a-real-scheme")).toBe("patch");
+  });
+
+  it("agrees with upstream getUpdateType + get (oracle parity)", () => {
+    const cases: Array<[string, string, string | undefined]> = [
+      ["18.2.0", "19.2.0", undefined],
+      ["4.17.20", "4.17.21", "semver"],
+      ["2.31.0", "2.32.0", "pep440"],
+      ["1.0.0", "1.0.0", undefined],
+    ];
+    for (const [current, next, versioning] of cases) {
+      const oracleApi = getVersioningApi(versioning);
+      const oracle = getUpdateType({}, oracleApi, current, next);
+      expect(deriveUpdateType(current, next, versioning)).toBe(oracle);
+    }
+  });
+});

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
             "test/provenance.shimmed.test.ts",
             "test/repo-config.test.ts",
             "test/simulate-package-rules.shimmed.test.ts",
+            "test/version.shimmed.test.ts",
           ],
           environment: "node",
           server: {

--- a/roadmap/015-simulator-input-ergonomics.md
+++ b/roadmap/015-simulator-input-ergonomics.md
@@ -1,6 +1,27 @@
 # 015 — Simulator input ergonomics
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified. `sourceUrl` is now a primary field (next to
+> currentValue/newValue) with a placeholder and a glossary hover card that
+> names it as the DEPENDENCY's repo and cross-references `repository` (also
+> given a hover card) as the repo Renovate runs in. `updateType` derivation
+> wraps Renovate's own `getUpdateType` plus its versioning `get()` lookup
+> (`packages/engine/src/version.ts`'s `deriveUpdateType`, both re-exported
+> through `renovate-adapter.ts`'s import boundary) — live in the form via a
+> "(derived)" hint next to the select, and independently recomputed inside
+> `simulate()` at run time so a manual override always wins but a stale
+> quick-fill value never silently survives an edited version pair. The
+> empty-form guard and the stale-results veil are both reactive: the guard
+> clears itself the moment any field gets content, and staleness now dims the
+> entire results block (not just the small text hint) under a banner that
+> stays full-strength. Added a `nuget` quick-fill chip. The updateType
+> select's arrow-key handling is now done manually in JS rather than left to
+> the browser — investigation traced the reported "arrow keys ignored" not to
+> any app bug (a bare, JS-free `<select>` under the same automated-browser
+> driver used by the persona study reproduces the identical non-response),
+> but per-option manual stepping is deterministic everywhere regardless, so
+> it's implemented anyway as a robustness fix.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -19,7 +19,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
 | [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
 | [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
-| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | planned |
+| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | planned |
 | [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | planned |
 | [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | planned |


### PR DESCRIPTION
Implements roadmap item 015 (M5, from the 2026-07 persona UX study).

- `sourceUrl` (the decisive matcher in 2 of 3 studied problems) promoted to the primary field grid; `repository` and `sourceUrl` each get a glossary hover card that explicitly says it is NOT the other field, with concrete examples.
- `updateType` is derived live from currentValue → newValue via renovate's own `getUpdateType` + versioning lookup (engine `deriveUpdateType`, oracle-parity tested in both suites). Shown as "major (derived)"; touching the select overrides; quick-fill guesses keep tracking edited versions (the study's 18.2.0 → 19.2.0 silently-stays-patch trap is closed).
- Empty-form Simulate shows a "pick an example or fill in a package first" prompt instead of ~714 no-match rows.
- Stale results get a dim + grayscale veil under a clear banner (the small orange hint was skimmed past twice in the study).
- `nuget` quick-fill chip; ArrowUp/ArrowDown stepping on the updateType select.

Validated: lint, format, typecheck, golden (55) + shimmed (76) tests, production build; behaviors manually verified in a live browser session (derived flip to major, empty-form guard, stale veil, nuget chip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ