### PR TITLE
feat(016): scale framing, badge glossary, page & editor ergonomics

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -47,6 +47,7 @@ import {
   type ShareFileName,
   type ShareView,
 } from "./share";
+import { useBackToTopVisible, useHomeEndPageScroll } from "./scroll-ergonomics";
 
 const DEFAULT_CONFIG = `{
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
@@ -109,6 +110,16 @@ const HOST_PLATFORM: Record<string, RepoPlatform> = {
   "gitea.com": "gitea",
   "codeberg.org": "forgejo",
 };
+
+/** Roadmap 016: the editor's undo-hint label — "Cmd" on macOS/iOS, "Ctrl"
+ *  elsewhere. Evaluated once; the platform doesn't change mid-session. */
+const MOD_KEY_LABEL = /Mac|iPhone|iPad|iPod/i.test(
+  (navigator as { userAgentData?: { platform?: string } }).userAgentData?.platform ??
+    navigator.platform ??
+    navigator.userAgent,
+)
+  ? "Cmd"
+  : "Ctrl";
 
 /** Strips a trailing `.git` and slashes from a repo path. */
 function stripRepoSuffix(path: string): string {
@@ -236,6 +247,19 @@ function onSignIn(): void {
 
 export function App() {
   const [content, setContent] = useState(DEFAULT_CONFIG);
+  // Roadmap 016: the text last loaded from an authoritative source (the
+  // default, an example, a share link, a repo fetch, or an applied error
+  // fix) — as opposed to whatever the user has typed since. The "revert to
+  // loaded config" button restores this; it never changes on a plain edit.
+  const [loadedContent, setLoadedContent] = useState(DEFAULT_CONFIG);
+  // Roadmap 016: bumped by `loadConfigText` to force the CodeMirror instance
+  // to remount. The editor's own prop→doc sync defers to a ~200ms "typing
+  // latch" that can be starved by browser timer throttling (backgrounded
+  // tabs) long enough that a load right after a fast edit never visibly
+  // applies, even though `content` state (and everything downstream of it,
+  // like Run) is correct — a fresh mount always initializes from `value`
+  // directly, sidestepping that debounce entirely.
+  const [editorKey, setEditorKey] = useState(0);
   const [fileName, setFileName] = useState<"renovate.json" | "renovate.json5">("renovate.json");
   const [token, setToken] = useState(() => readSession(TOKEN_KEY, ""));
   const [gitlabToken, setGitlabToken] = useState(() => readSession(GITLAB_TOKEN_KEY, ""));
@@ -281,6 +305,10 @@ export function App() {
   // the step; reset to 0 on a new result just like the uncontrolled stepper.
   const [migrationStepIndex, setMigrationStepIndex] = useState(0);
   const [copied, setCopied] = useState(false);
+  // Roadmap 016: End/Home always scroll the page, never a nested card's own
+  // scroll box; a back-to-top button appears once the page has scrolled down.
+  useHomeEndPageScroll();
+  const showBackToTop = useBackToTopVisible();
   // View state pending from a decoded link, applied once the run produces a
   // result (identities → node ids need the resolved tree). A ref, not state, so
   // consuming it does not trigger a render.
@@ -309,6 +337,15 @@ export function App() {
     if (offset !== undefined) {
       configEditorRef.current?.highlightOffset(offset);
     }
+  }
+
+  /** Roadmap 016: the one path every authoritative content load goes
+   *  through — sets the text, moves the "revert to loaded config" baseline
+   *  to match, and remounts the editor (see `editorKey`'s comment). */
+  function loadConfigText(text: string) {
+    setContent(text);
+    setLoadedContent(text);
+    setEditorKey((k) => k + 1);
   }
 
   useEffect(() => {
@@ -441,7 +478,7 @@ export function App() {
     const lib = errorLib ?? (await loadErrorTranslationLib());
     const applied = lib.applyFixToText(content, fix);
     const nextContent = applied?.text ?? JSON.stringify(fix.fixedConfig, null, 2);
-    setContent(nextContent);
+    loadConfigText(nextContent);
     if (applied && !applied.surgical) {
       setNotice(
         "Applied the fix by regenerating the whole config document — comments and custom formatting were not preserved.",
@@ -497,7 +534,7 @@ export function App() {
       }
       const nextPlatform = payload.platform ?? "github";
       const nextEndpoint = payload.endpoint ?? "https://api.github.com";
-      setContent(payload.config);
+      loadConfigText(payload.config);
       setFileName(payload.fileName);
       setPlatform(nextPlatform);
       persistLocal(PLATFORM_KEY, nextPlatform);
@@ -694,7 +731,7 @@ export function App() {
         setEndpoint(repoEndpoint);
         persistLocal(ENDPOINT_KEY, repoEndpoint);
       }
-      setContent(loaded.content);
+      loadConfigText(loaded.content);
       setFileName(nextFileName);
       setNotice(`Loaded ${loaded.fileName} from ${parsed.repo}`);
       await onRun(undefined, {
@@ -756,7 +793,7 @@ export function App() {
                 <button
                   type="button"
                   className="linklike"
-                  onClick={() => setContent(EXAMPLE_CONFIG)}
+                  onClick={() => loadConfigText(EXAMPLE_CONFIG)}
                 >
                   try an example
                 </button>
@@ -811,17 +848,31 @@ export function App() {
         </form>
 
         <ConfigEditor
+          key={editorKey}
           ref={configEditorRef}
           fileName={fileName}
           value={content}
           onChange={setContent}
         />
+        <p className="editor-hint">
+          <kbd>{MOD_KEY_LABEL}</kbd>+<kbd>Z</kbd> to undo, <kbd>Shift</kbd>+
+          <kbd>{MOD_KEY_LABEL}</kbd>+<kbd>Z</kbd> to redo.
+        </p>
 
         <div className="toolbar">
           <select value={fileName} onChange={(e) => setFileName(e.target.value as typeof fileName)}>
             <option value="renovate.json">renovate.json</option>
             <option value="renovate.json5">renovate.json5</option>
           </select>
+          <button
+            type="button"
+            className="secondary"
+            onClick={() => loadConfigText(loadedContent)}
+            disabled={content === loadedContent}
+            title="Restore the config text as it was last loaded — the default, an example, a share link, a repo fetch, or an applied fix — discarding edits made since"
+          >
+            Revert to loaded config
+          </button>
           {oauthConfig ? (
             signedIn ? (
               <span className="gh-auth-chip" title="Signed in with GitHub">
@@ -1199,6 +1250,17 @@ export function App() {
           </>
         ) : null}
       </main>
+      {showBackToTop ? (
+        <button
+          type="button"
+          className="back-to-top"
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          title="Back to top"
+          aria-label="Back to top"
+        >
+          ↑ Top
+        </button>
+      ) : null}
     </OptionDocsProvider>
   );
 }

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -5,11 +5,12 @@ import type {
   RuleAttribution,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
-import { Term } from "../glossary";
+import { Explained, GLOSSARY, Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { ConfigJson } from "./ConfigJson";
 import { layerId, layerLabel, type LayerId, ProvenanceChip } from "./ProvenanceChip";
 import { useRuleProvenance } from "../rule-provenance";
+import { RuleFramingText } from "../rule-framing";
 
 /**
  * Roadmap 005: the effective config as a provenance view. Every top-level key
@@ -71,6 +72,55 @@ function isOverridden(entry: KeyProvenance): boolean {
   return (
     contributors.length >= 2 ||
     entry.chain.some((s) => s.action === "overwrite" || s.action === "forced")
+  );
+}
+
+/**
+ * Roadmap 016: `isOverridden` above answers "did more than one layer touch
+ * this key" — it does NOT mean the value was replaced. A concatenating array
+ * key (`packageRules`, `labels`, …) touched by several layers is APPENDED to,
+ * never overwritten, so labelling it "overridden" is actively misleading (the
+ * expert persona called this out directly). This picks the accurate label
+ * from the actual merge actions of the contributing (non-default) steps.
+ */
+type MultiContribBadge = "overridden" | "appended" | "merged";
+
+function multiContribBadgeKind(entry: KeyProvenance): MultiContribBadge {
+  const contributors = entry.chain.filter((s) => !s.noop && s.layer.kind !== "defaults");
+  if (contributors.some((s) => s.action === "overwrite" || s.action === "forced")) {
+    return "overridden";
+  }
+  if (contributors.some((s) => s.action === "shallow-merge" || s.action === "deep-merge")) {
+    return "merged";
+  }
+  // Nothing left but "set" (the first contributor establishing the value) and
+  // "concat" (every later contributor appending to it) — this function is
+  // only called once `isOverridden` has already established there are ≥2
+  // contributors, so nothing here was ever replaced.
+  return "appended";
+}
+
+const MULTI_BADGE_GLOSSARY: Record<MultiContribBadge, keyof typeof GLOSSARY> = {
+  overridden: "keyOverridden",
+  appended: "keyAppended",
+  merged: "keyMerged",
+};
+
+/** The badge shown on a row touched by more than one layer — `overridden`
+ *  only when a value was actually replaced; `appended`/`merged` otherwise. */
+function MultiContribBadgeChip({ entry }: { entry: KeyProvenance }) {
+  if (!isOverridden(entry)) {
+    return null;
+  }
+  const kind = multiContribBadgeKind(entry);
+  return (
+    <Explained entry={GLOSSARY[MULTI_BADGE_GLOSSARY[kind]]}>
+      {(handlers) => (
+        <span className={`badge explained prov-${kind}`} tabIndex={0} {...handlers}>
+          {kind}
+        </span>
+      )}
+    </Explained>
   );
 }
 
@@ -203,12 +253,18 @@ function KeyRow({
         <span className="prov-key-name">
           <OptionKey name={entry.key} flagUnknown />
         </span>
-        <span className="prov-key-preview">{preview(entry.finalValue)}</span>
-        {isOverridden(entry) ? (
-          <span className="badge prov-overridden" title="Set more than once, or overwritten/forced">
-            overridden
-          </span>
-        ) : null}
+        <span className="prov-key-preview">
+          {rules ? (
+            <RuleFramingText
+              total={rules.length}
+              attribution={ruleAttribution ?? null}
+              variant="full"
+            />
+          ) : (
+            preview(entry.finalValue)
+          )}
+        </span>
+        <MultiContribBadgeChip entry={entry} />
         <ProvenanceChip layer={winner.layer} onSelectPreset={onSelectPreset} />
       </button>
       {expanded ? (

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -5,7 +5,7 @@ import type {
   TraceEvent,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
-import { Term } from "../glossary";
+import { Explained, GLOSSARY, Term, type GlossaryEntry } from "../glossary";
 import { ConfigJson } from "./ConfigJson";
 import { type AuthState, GithubAuthHint } from "./GithubAuthHint";
 import { JsonDiff } from "./JsonDiff";
@@ -88,6 +88,28 @@ const nf = new Intl.NumberFormat();
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Roadmap 016: hover-card text for a preset's `src-<kind>` badge — internal
+ *  presets reuse the summary header's wording; every fetched kind gets a
+ *  kind-specific explanation of where it came from. */
+function sourceKindEntry(kind: string): GlossaryEntry {
+  if (kind === "internal") {
+    return GLOSSARY.presetSourceInternal;
+  }
+  const HOST_TEXT: Record<string, string> = {
+    github: "Fetched from a repository on GitHub.",
+    gitlab: "Fetched from a repository on GitLab.",
+    gitea: "Fetched from a repository on Gitea.",
+    forgejo: "Fetched from a repository on Forgejo.",
+    npm: "Fetched from the npm registry package's config.",
+    http: "Fetched from a raw HTTP(S) URL.",
+    local: "Resolved as a `local>` preset against the configured platform and repository.",
+  };
+  return {
+    name: `${kind} preset`,
+    plain: HOST_TEXT[kind] ?? GLOSSARY.presetSourceFetched.plain,
+  };
 }
 
 /** packageRules keys whose string contents feed the search index. */
@@ -570,33 +592,95 @@ function useWindow(count: number) {
   };
 }
 
+/** Regular English plural — every summary/badge word here happens to take a
+ *  plain trailing "s", so one helper covers them all. */
+function plural(n: number, word: string): string {
+  return n === 1 ? word : `${word}s`;
+}
+
+/**
+ * Roadmap 016: the counter strip gets the same hover-card treatment the stage
+ * pills already have (persona study finding 6) instead of a plain `title`
+ * tooltip, plus grammatically-correct singular/plural labels (was always "N
+ * duplicates" etc. even at N=1).
+ */
 function SummaryHeader({ summary }: { summary: TreeSummary }) {
-  const bits: { label: string; value: number; title: string }[] = [
-    { label: "presets", value: summary.resolved, title: "Unique presets resolved" },
-    { label: "fetched", value: summary.fetched, title: "Unique presets fetched from a host" },
-    { label: "internal", value: summary.internal, title: "Unique built-in presets" },
+  const bits: { key: keyof typeof GLOSSARY; label: string; value: number }[] = [
+    { key: "statPresets", label: plural(summary.resolved, "preset"), value: summary.resolved },
+    { key: "statFetched", label: "fetched", value: summary.fetched },
+    { key: "statInternal", label: "internal", value: summary.internal },
     {
-      label: "options set",
+      key: "statOptionsSet",
+      label: `option${summary.options === 1 ? "" : "s"} set`,
       value: summary.options,
-      title: "Distinct top-level options the presets set",
     },
-    { label: "rules", value: summary.rules, title: "packageRules contributed by presets" },
-    { label: "depth", value: summary.maxDepth, title: "Deepest extends chain" },
+    { key: "statRules", label: plural(summary.rules, "rule"), value: summary.rules },
+    { key: "statDepth", label: "depth", value: summary.maxDepth },
     {
-      label: "duplicates",
+      key: "statDuplicates",
+      label: `repeat occurrence${summary.duplicates === 1 ? "" : "s"}`,
       value: summary.duplicates,
-      title: "Repeat occurrences served from cache",
     },
-    { label: "errors", value: summary.errors, title: "Presets that failed to resolve" },
+    { key: "statErrors", label: plural(summary.errors, "error"), value: summary.errors },
   ];
   return (
     <div className="preset-summary">
       {bits.map((b) => (
-        <span key={b.label} className="preset-summary-stat" title={b.title}>
-          <strong>{nf.format(b.value)}</strong> {b.label}
-        </span>
+        <Explained key={b.key} entry={GLOSSARY[b.key]}>
+          {(handlers) => (
+            <span className="preset-summary-stat explained" tabIndex={0} {...handlers}>
+              <strong>{nf.format(b.value)}</strong> {b.label}
+            </span>
+          )}
+        </Explained>
       ))}
     </div>
+  );
+}
+
+/**
+ * Roadmap 016: honest origin framing for the headline preset count (persona
+ * study finding 6 — "Resolved 1076 preset(s)" reads as "did I break
+ * something?" with no origin attached). Purely a derivation of the already-
+ * computed per-node stats, never a re-walk; never claims precision it doesn't
+ * have (a dominant contributor is only named when it is a clear majority).
+ */
+function OriginFraming({ root, stats }: { root: PresetNode; stats: TreeStats }) {
+  const roots = root.children;
+  const total = stats.summary.resolved;
+  if (roots.length === 0 || total <= 1) {
+    return null;
+  }
+  const contributions = roots
+    .map((child) => {
+      const st = stats.statsById.get(child.id);
+      const selfResolved = child.state === "resolved" ? 1 : 0;
+      return { name: child.name, count: (st?.descResolved ?? 0) + selfResolved };
+    })
+    .toSorted((a, b) => b.count - a.count);
+  const top = contributions[0];
+
+  if (roots.length === 1) {
+    return (
+      <p className="origin-framing">
+        Your <Term id="extends">extends</Term> entry <code>{roots[0]!.name}</code> expands to{" "}
+        {nf.format(total)} preset{total === 1 ? "" : "s"}.
+      </p>
+    );
+  }
+
+  const majority = top && top.count > 1 && top.count / total > 0.5;
+  return (
+    <p className="origin-framing">
+      Your {nf.format(roots.length)} <Term id="extends">extends</Term> entries expand to{" "}
+      {nf.format(total)} preset{total === 1 ? "" : "s"}
+      {majority ? (
+        <>
+          , mostly via <code>{top!.name}</code> ({nf.format(top!.count)})
+        </>
+      ) : null}
+      .
+    </p>
   );
 }
 
@@ -604,20 +688,32 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
   return (
     <>
       {stats.ownOptions > 0 ? (
-        <span className="badge contrib opts" title="Top-level options this preset sets">
-          {stats.ownOptions} opt{stats.ownOptions === 1 ? "" : "s"}
-        </span>
+        <Explained entry={GLOSSARY.presetContribOpts}>
+          {(handlers) => (
+            <span className="badge contrib opts explained" tabIndex={0} {...handlers}>
+              {stats.ownOptions} opt{stats.ownOptions === 1 ? "" : "s"}
+            </span>
+          )}
+        </Explained>
       ) : null}
       {stats.ownRules > 0 ? (
-        <span className="badge contrib rules" title="packageRules this preset contributes">
-          {stats.ownRules} rule{stats.ownRules === 1 ? "" : "s"}
-        </span>
+        <Explained entry={GLOSSARY.presetContribRules}>
+          {(handlers) => (
+            <span className="badge contrib rules explained" tabIndex={0} {...handlers}>
+              {stats.ownRules} rule{stats.ownRules === 1 ? "" : "s"}
+            </span>
+          )}
+        </Explained>
       ) : null}
       {collapsed && (stats.descResolved > 0 || stats.descRules > 0) ? (
-        <span className="badge rollup" title="Totals hidden inside this collapsed subtree">
-          {stats.descResolved > 0 ? `· ${nf.format(stats.descResolved)} presets ` : ""}
-          {stats.descRules > 0 ? `· ${nf.format(stats.descRules)} rules` : ""}
-        </span>
+        <Explained entry={GLOSSARY.presetRollup}>
+          {(handlers) => (
+            <span className="badge rollup explained" tabIndex={0} {...handlers}>
+              {stats.descResolved > 0 ? `· ${nf.format(stats.descResolved)} presets ` : ""}
+              {stats.descRules > 0 ? `· ${nf.format(stats.descRules)} rules` : ""}
+            </span>
+          )}
+        </Explained>
       ) : null}
     </>
   );
@@ -695,9 +791,17 @@ function TreeRow({
         {node.name}
       </button>
       {node.source?.presetSource ? (
-        <span className={`badge src src-${node.source.presetSource}`}>
-          {node.source.presetSource}
-        </span>
+        <Explained entry={sourceKindEntry(node.source.presetSource)}>
+          {(handlers) => (
+            <span
+              className={`badge src src-${node.source!.presetSource} explained`}
+              tabIndex={0}
+              {...handlers}
+            >
+              {node.source!.presetSource}
+            </span>
+          )}
+        </Explained>
       ) : null}
       {node.source?.platform ? (
         <span
@@ -714,22 +818,32 @@ function TreeRow({
       ) : null}
       <ContributionBadges stats={stats} collapsed={row.hasChildren && !row.expanded} />
       {node.duplicate ? (
-        <button
-          type="button"
-          className="badge dup"
-          title={`Appears ${dupCount}× in this tree — click to cycle to the next occurrence`}
-          onClick={() => onCycleDup(node)}
+        <Explained
+          entry={{
+            ...GLOSSARY.presetDuplicate,
+            plain: `${GLOSSARY.presetDuplicate.plain} Click to cycle through all ${dupCount} occurrences.`,
+          }}
         >
-          duplicate ×{dupCount}
-        </button>
+          {(handlers) => (
+            <button
+              type="button"
+              className="badge dup explained"
+              onClick={() => onCycleDup(node)}
+              {...handlers}
+            >
+              duplicate ×{dupCount}
+            </button>
+          )}
+        </Explained>
       ) : null}
       {node.nested ? (
-        <span
-          className="badge nested"
-          title="Found while resolving a nested value (e.g. packageRules[n].extends), not this parent's own extends"
-        >
-          nested
-        </span>
+        <Explained entry={GLOSSARY.presetNested}>
+          {(handlers) => (
+            <span className="badge nested explained" tabIndex={0} {...handlers}>
+              nested
+            </span>
+          )}
+        </Explained>
       ) : null}
       {stateLabel ? <span className={`badge state state-${node.state}`}>{stateLabel}</span> : null}
       {node.state === "error" && node.error ? (
@@ -945,6 +1059,7 @@ export const PresetTree = memo(function PresetTree({
         <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
         resolved)
       </div>
+      <OriginFraming root={root} stats={stats} />
       <SummaryHeader summary={stats.summary} />
       <div className="preset-controls">
         <input

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   ClauseEvaluation,
   DependencyDescriptor,
@@ -10,6 +10,7 @@ import type {
 import { Term } from "../glossary";
 import { OptionKey } from "../option-docs";
 import { useRuleProvenance } from "../rule-provenance";
+import { RuleFramingText } from "../rule-framing";
 import type { ErrorTranslationLib } from "../run";
 import { ConfigJson } from "./ConfigJson";
 import { ErrorTranslationView } from "./ErrorTranslationView";
@@ -510,6 +511,14 @@ export function RuleSimulator({
   const [emptyGuardTriggered, setEmptyGuardTriggered] = useState(false);
   const rulesRef = useRef<HTMLDivElement>(null);
   const ruleAttribution = useRuleProvenance(result);
+  // Roadmap 016: re-simulating (e.g. after editing the form and clicking
+  // Simulate again) resets `showAll` to the matched-only default, which can
+  // unmount rows the user was scrolled past — the browser's scroll-anchoring
+  // then repicks a higher anchor and the page visibly jumps. Capture the
+  // scroll position right before the state update that causes the unmount,
+  // then restore it once the new DOM has painted (clamped automatically by
+  // the browser if the new content is shorter than before).
+  const scrollYBeforeSimulate = useRef<number | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -614,6 +623,18 @@ export function RuleSimulator({
       .toSorted();
   }, [sim, finalConfig]);
 
+  // Roadmap 016: restore the scroll position captured in `simulate` right
+  // before the DOM the browser is about to repaint — after `sim`/`showAll`
+  // change together, so this runs once against the settled layout rather than
+  // an intermediate one.
+  useLayoutEffect(() => {
+    const y = scrollYBeforeSimulate.current;
+    if (y !== null) {
+      scrollYBeforeSimulate.current = null;
+      window.scrollTo({ top: y, behavior: "auto" });
+    }
+  }, [sim, showAll]);
+
   if (!finalConfig) {
     return null;
   }
@@ -652,6 +673,11 @@ export function RuleSimulator({
         config: finalConfig,
         dep: toDescriptor(nextForm, effectiveType),
       });
+      // Captured right before the state updates that can shrink the results
+      // list (see the layout effect above) — not at the top of `simulate`,
+      // so an in-flight fetch doesn't capture a scroll position the user has
+      // since abandoned.
+      scrollYBeforeSimulate.current = window.scrollY;
       setSim(simResult);
       setRanKey(JSON.stringify(nextForm));
       setShowAll(false);
@@ -745,9 +771,12 @@ export function RuleSimulator({
         Update simulator
         <span className="sim-title-hint">
           {" "}
-          — describe a hypothetical dependency update and see which of the {
-            packageRules.length
-          }{" "}
+          — describe a hypothetical dependency update and see which of the{" "}
+          <RuleFramingText
+            total={packageRules.length}
+            attribution={ruleAttribution ?? null}
+            variant="compact"
+          />{" "}
           <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
         </span>
       </div>

--- a/packages/app/src/glossary.tsx
+++ b/packages/app/src/glossary.tsx
@@ -122,6 +122,95 @@ export const GLOSSARY = {
       "An issue Renovate keeps open in your repo listing every pending, open and rate-limited update, with checkboxes to trigger them.",
     url: "https://docs.renovatebot.com/key-concepts/dashboard/",
   },
+
+  // ---- roadmap 016: badge hover cards (preset tree + effective config) ----
+  presetContribOpts: {
+    name: "own options",
+    plain:
+      "Top-level config options this preset sets directly on itself — not counting packageRules, and not counting anything contributed by presets it extends.",
+  },
+  presetContribRules: {
+    name: "own packageRules",
+    plain:
+      "packageRules entries this preset contributes directly. Presets it extends may contribute their own rules too, counted on their own row.",
+    url: "https://docs.renovatebot.com/configuration-options/#packagerules",
+  },
+  presetDuplicate: {
+    name: "duplicate preset",
+    plain:
+      'This preset also appears elsewhere in the tree. Renovate resolves each preset once and reuses ("dedupes") the result everywhere it recurs — the ×N count is every occurrence, including this one.',
+  },
+  presetNested: {
+    name: "nested preset",
+    plain:
+      "Found while resolving a nested value — typically a packageRules[n].extends — rather than this parent's own top-level extends list.",
+  },
+  presetSourceInternal: {
+    name: "internal preset",
+    plain: "Bundled inside Renovate itself — no network fetch is needed to resolve it.",
+  },
+  presetSourceFetched: {
+    name: "fetched preset",
+    plain: "Downloaded from an external host at run time, rather than bundled with Renovate.",
+  },
+  presetRollup: {
+    name: "collapsed subtree totals",
+    plain:
+      "Unique presets and packageRules contributed by this subtree's descendants, hidden while it is collapsed. Expand the row to see them individually.",
+  },
+  keyOverridden: {
+    name: "overridden",
+    plain:
+      "Set more than once, and a later layer explicitly replaced the earlier value — by overwriting a scalar or object, or via a force override.",
+  },
+  keyAppended: {
+    name: "appended",
+    plain:
+      "This option merges by concatenation: every contributing layer's list entries are appended in order. Nothing here was overridden or replaced.",
+    url: "https://docs.renovatebot.com/config-presets/",
+  },
+  keyMerged: {
+    name: "merged",
+    plain:
+      "Contributed by more than one layer, combined by merging objects together (a shallow or deep merge) rather than by replacing or appending.",
+  },
+  statPresets: {
+    name: "presets",
+    plain:
+      "Every preset Renovate resolved while expanding your extends list, counted once even when referenced from multiple places.",
+  },
+  statFetched: {
+    name: "fetched",
+    plain: "Presets fetched over the network — from GitHub, GitLab, npm, or another host.",
+  },
+  statInternal: {
+    name: "internal",
+    plain: "Presets bundled inside Renovate itself — no network fetch needed for these.",
+  },
+  statOptionsSet: {
+    name: "options set",
+    plain:
+      "Distinct top-level config keys these presets set between them (not counting packageRules).",
+  },
+  statRules: {
+    name: "rules",
+    plain:
+      "packageRules entries these presets contribute directly. Your own repo config's rules aren't counted here — see the effective config's packageRules row for the full merged total.",
+    url: "https://docs.renovatebot.com/configuration-options/#packagerules",
+  },
+  statDepth: {
+    name: "depth",
+    plain: "The longest chain of extends → extends → … from your config down to a leaf preset.",
+  },
+  statDuplicates: {
+    name: "repeat occurrences",
+    plain:
+      "Presets referenced more than once in the tree: resolved a single time and reused everywhere else. A row's own \"duplicate ×N\" badge counts ALL of that preset's occurrences, including the first — this total counts only the repeats beyond the first.",
+  },
+  statErrors: {
+    name: "errors",
+    plain: "Presets that failed to resolve — a fetch failure, invalid content, or an aborted run.",
+  },
 } satisfies Record<string, GlossaryEntry>;
 
 export type TermId = keyof typeof GLOSSARY;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2022,3 +2022,85 @@ pre.config-view.prov-before {
     opacity 0.15s ease,
     filter 0.15s ease;
 }
+
+/* ---------- scale framing, badge glossary, page & editor ergonomics (016) ---------- */
+
+/* Honest origin sentence under a card title, e.g. "your extends entry
+   `config:recommended` expands to 1,076 presets." */
+.origin-framing {
+  border-bottom: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.82rem;
+  margin: 0;
+  padding: 0.4rem 0.75rem;
+}
+
+.origin-framing code {
+  font-size: 0.85em;
+}
+
+/* Any badge/stat given a glossary hover card (see glossary.tsx's `Explained`)
+   gets a quiet affordance; more-specific rules elsewhere (e.g. the clickable
+   dup/elided badges' own `cursor: pointer`) still win by specificity. */
+.badge.explained,
+.preset-summary-stat.explained {
+  cursor: help;
+}
+
+.badge.explained:hover,
+.badge.explained:focus-visible,
+.preset-summary-stat.explained:hover,
+.preset-summary-stat.explained:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* Roadmap 016: `appended`/`merged` replace the misleading `overridden` badge
+   on effective-config keys that were combined, not replaced. */
+.badge.prov-appended {
+  border-color: var(--ok);
+  color: var(--ok);
+}
+
+.badge.prov-merged {
+  border-color: light-dark(#1b7c83, #56d4dd);
+  color: light-dark(#1b7c83, #56d4dd);
+}
+
+/* Editor undo hint + revert-to-loaded button. */
+.editor-hint {
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin: 0.3rem 0 0;
+}
+
+.editor-hint kbd {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 0.75rem;
+  padding: 0.05rem 0.35rem;
+}
+
+/* Back-to-top affordance (roadmap 016): appears once the page has scrolled
+   past the fold; simpler and more robust than a sticky mini-toolbar. */
+.back-to-top {
+  background: var(--accent);
+  border: none;
+  border-radius: 999px;
+  bottom: 1.25rem;
+  box-shadow: 0 2px 10px rgb(0 0 0 / 0.25);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  padding: 0.5rem 0.9rem;
+  position: fixed;
+  right: 1.25rem;
+  z-index: 20;
+}
+
+.back-to-top:hover {
+  filter: brightness(1.1);
+}

--- a/packages/app/src/rule-framing.tsx
+++ b/packages/app/src/rule-framing.tsx
@@ -1,0 +1,129 @@
+import type { RuleAttribution } from "@renovate-config-visualizer/engine";
+import type { ReactNode } from "react";
+import { layerLabel } from "./components/ProvenanceChip";
+
+/**
+ * Roadmap 016: honest "N rules — M from your config, K pulled in by
+ * `preset`" framing for a merged packageRules count, shared by the effective
+ * config's packageRules row and the simulator's heading — the two places the
+ * number first appears (finding 6 of the persona study: big counts with no
+ * origin read as "did I break something?"). Built entirely from 013's
+ * per-rule provenance (`computeRuleProvenance`); returns `null` — never a
+ * guessed fallback — when attribution is unavailable or doesn't cover every
+ * rule, so callers can fall back to the bare count.
+ */
+
+const nf = new Intl.NumberFormat();
+
+interface TopContributor {
+  label: string;
+  count: number;
+  isPreset: boolean;
+}
+
+export interface RuleFramingData {
+  own: number;
+  top: TopContributor | null;
+  /** Rules from other, smaller contributors beyond the top one (not "your config", not the top). */
+  otherCount: number;
+}
+
+export function computeRuleFraming(
+  total: number,
+  attribution: RuleAttribution[] | null | undefined,
+): RuleFramingData | null {
+  if (!attribution || attribution.length !== total || total === 0) {
+    return null;
+  }
+  let own = 0;
+  const byOther = new Map<string, { label: string; n: number; isPreset: boolean }>();
+  for (const a of attribution) {
+    if (a.layer.kind === "repo") {
+      own++;
+      continue;
+    }
+    const key = a.layer.kind === "preset" ? `preset:${a.layer.name}` : a.layer.kind;
+    const existing = byOther.get(key);
+    if (existing) {
+      existing.n++;
+    } else {
+      byOther.set(key, { label: layerLabel(a.layer), n: 1, isPreset: a.layer.kind === "preset" });
+    }
+  }
+  const sorted = [...byOther.values()].toSorted((a, b) => b.n - a.n);
+  const top = sorted[0];
+  const otherCount = sorted.slice(1).reduce((n, e) => n + e.n, 0);
+  return {
+    own,
+    top: top ? { label: top.label, count: top.n, isPreset: top.isPreset } : null,
+    otherCount,
+  };
+}
+
+/** Renders the "M from your config, K pulled in by `preset`, and R more from
+ *  other presets" clause — the part after the em dash. */
+function FramingBreakdown({ framing }: { framing: RuleFramingData }) {
+  const segs: { key: string; node: ReactNode }[] = [];
+  if (framing.own > 0) {
+    segs.push({ key: "own", node: `${nf.format(framing.own)} from your config` });
+  }
+  if (framing.top) {
+    segs.push({
+      key: "top",
+      node: (
+        <>
+          {nf.format(framing.top.count)} pulled in by{" "}
+          {framing.top.isPreset ? <code>{framing.top.label}</code> : framing.top.label}
+        </>
+      ),
+    });
+  }
+  if (framing.otherCount > 0) {
+    segs.push({ key: "rest", node: `${nf.format(framing.otherCount)} more from other presets` });
+  }
+  return (
+    <>
+      {segs.map((seg, i) => (
+        <span key={seg.key}>
+          {i > 0 ? (i === segs.length - 1 ? (segs.length > 2 ? ", and " : " and ") : ", ") : null}
+          {seg.node}
+        </span>
+      ))}
+    </>
+  );
+}
+
+/**
+ * `variant: "compact"` — just the number, with a parenthetical breakdown when
+ * available: `713 (2 from your config, 711 pulled in by config:recommended)`.
+ * `variant: "full"` — a standalone clause with the word "rule(s)":
+ * `713 rules — 2 from your config, 711 pulled in by config:recommended`.
+ */
+export function RuleFramingText({
+  total,
+  attribution,
+  variant,
+}: {
+  total: number;
+  attribution: RuleAttribution[] | null | undefined;
+  variant: "compact" | "full";
+}) {
+  const framing = computeRuleFraming(total, attribution);
+  const bare =
+    variant === "full" ? `${nf.format(total)} rule${total === 1 ? "" : "s"}` : nf.format(total);
+  if (!framing || (framing.own === 0 && !framing.top)) {
+    return <>{bare}</>;
+  }
+  if (variant === "compact") {
+    return (
+      <>
+        {nf.format(total)} (<FramingBreakdown framing={framing} />)
+      </>
+    );
+  }
+  return (
+    <>
+      {bare} — <FramingBreakdown framing={framing} />
+    </>
+  );
+}

--- a/packages/app/src/scroll-ergonomics.ts
+++ b/packages/app/src/scroll-ergonomics.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Roadmap 016: `End` "lands on a blank over-scrolled viewport" (persona study
+ * finding 7). Root cause: several cards nest their own scrollable box (the
+ * preset tree, the preset detail panel, the effective config's key list —
+ * each a fixed-`max-height`, `overflow: auto` region full of focusable
+ * buttons). Browsers scroll the NEAREST SCROLLABLE ANCESTOR of the currently
+ * focused element on Home/End, not the page — so after clicking a button
+ * inside one of those boxes, Home/End silently scrolls that small box to its
+ * own top/bottom instead of the page, which looks exactly like "nothing
+ * happened" or "landed somewhere wrong" depending on where the box sits.
+ * Fix: make the document the effective scroll container for Home/End
+ * regardless of focus, the way a page with no nested scroll regions would
+ * already behave — skipped for genuine text-editing contexts (inputs,
+ * textareas, CodeMirror's contenteditable) where Home/End must keep moving
+ * the text cursor, and for any modified key combo (e.g. shift-select).
+ */
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") {
+    return true;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  return target.closest(".cm-editor") !== null;
+}
+
+export function useHomeEndPageScroll(): void {
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Home" && e.key !== "End") {
+        return;
+      }
+      if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+        return;
+      }
+      if (isTextEditingTarget(e.target)) {
+        return;
+      }
+      e.preventDefault();
+      window.scrollTo({
+        top: e.key === "End" ? document.documentElement.scrollHeight : 0,
+        behavior: "auto",
+      });
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}
+
+/**
+ * Roadmap 016: a back-to-top affordance for long results pages (persona
+ * study finding 7) — the simpler, more robust alternative to a sticky
+ * mini-toolbar. Visible once the page has scrolled past `threshold`.
+ */
+export function useBackToTopVisible(threshold = 480): boolean {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    function onScroll() {
+      setVisible(window.scrollY > threshold);
+    }
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+  return visible;
+}

--- a/roadmap/016-scale-framing-and-page-ergonomics.md
+++ b/roadmap/016-scale-framing-and-page-ergonomics.md
@@ -1,6 +1,55 @@
 # 016 — Scale framing, badge glossary, page & editor ergonomics
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified. Framing sentences are honest derivations of data
+> already computed elsewhere, never re-walks: the preset tree header names
+> which top-level `extends` entry a resolved count came from (`stats.descResolved`
+> per root child, naming the dominant contributor only when it's a clear
+> majority); the effective config's `packageRules` row and the simulator
+> heading share one `rule-framing.tsx` helper built on 013's
+> `computeRuleProvenance`, falling back to the bare count — never a guess —
+> when attribution is unavailable. Every named badge — options/rules
+> contributed, duplicate count, nested, source kind, collapsed-subtree
+> rollups — and the counter strip now use the glossary's `Explained` render-prop instead of a
+> plain `title`, with grammatically-correct singular/plural counts (was
+> unconditionally "N duplicates"); the header stat is relabeled "repeat
+> occurrences" with a hover card that explicitly reconciles it against the
+> per-row `duplicate ×N` badge's different (inclusive) count. The `overridden`
+> badge on effective-config keys is now computed from the actual merge
+> actions of its contributing layers (`overwrite`/`forced` → `overridden`;
+> `shallow-merge`/`deep-merge` → `merged`; otherwise — critically, `set` then
+> `concat`, since the FIRST contributor to any key is always `set`, never
+> `concat`, so requiring every contributor to be `concat` never matched —
+> `appended`), fixing exactly the misleading case the expert persona called
+> out. `End`/`Home` investigation found the actual cause: several cards
+> (preset tree, preset detail panel, effective-config key list) nest their
+> own fixed-height `overflow: auto` scroll box full of focusable buttons, and
+> browsers scroll the nearest scrollable ANCESTOR of the focused element on
+> Home/End — not the page — so after clicking anything inside one of those
+> boxes, Home/End silently scrolled that small box instead. Fixed by making
+> the document the effective scroll target for Home/End regardless of focus
+> (skipped for real text-editing contexts and modified key combos), verified
+> by dispatching the keys with focus forced inside the preset tree. Chose a
+> back-to-top button (simpler, more robust) over a sticky mini-bar. Scroll
+> preservation across re-simulation: re-running Simulate resets `showAll` to
+> the matched-only default, which can unmount rows above the viewport and
+> trigger the browser's scroll-anchoring to jump the page — fixed by
+> capturing `window.scrollY` right before the state update and restoring it
+> in a `useLayoutEffect` once the new results have painted (the browser
+> naturally clamps the restore to the new, possibly shorter, max scroll).
+> Editor safety: an undo/redo hint (CodeMirror's bundled history already
+> handles the keys; this only surfaces it) plus a "revert to loaded config"
+> button, disabled when unchanged. Investigation surfaced a real, if narrow,
+> library bug along the way: `@uiw/react-codemirror`'s prop→doc sync defers
+> to an internal ~200ms "typing latch" that can be starved by browser
+> background-tab timer throttling long enough that a programmatic content
+> load right after a fast edit updates React state (and everything
+> downstream, e.g. Run) correctly while the visible editor silently keeps
+> showing the stale text. Fixed — for revert and every other authoritative
+> load (example/share-link/repo-fetch/applied-fix) alike — by remounting the
+> `ConfigEditor` (a bumped `key`) on every such load, which always
+> initializes fresh from `value` and sidesteps the debounce entirely.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -20,7 +20,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
 | [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
-| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | planned |
+| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
 | [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | planned |
 | [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | planned |
 | [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | planned |


### PR DESCRIPTION
Implements roadmap item 016 (M5, from the 2026-07 persona UX study).

- Every large count now carries its origin: "713 rules — 2 from your config, 711 pulled in by `config:recommended`" on the preset-tree header, effective-config `packageRules` row and simulator heading (built on 013's `computeRuleProvenance`; falls back to the bare count, never a guess).
- Hover cards for all tree/row badges (`N opts`, `duplicate ×N`, `nested`, `internal`, …) and the summary stat strip, reusing the glossary card mechanism.
- `overridden` on concatenated arrays was wrong — badges are now classified from the actual provenance actions: `appended` / `merged` / `overridden` (found & fixed a classifier bug live: the first contributing layer is always `set`, so an every-concat check never matched).
- End/Home reliably scroll the page (nested `overflow: auto` cards were capturing them once focused), with text-editing targets exempt; back-to-top button; scroll position preserved across re-simulations.
- Editor: visible undo hint + "Revert to loaded config" (disabled when unchanged); remount-on-load bypasses a react-codemirror prop-sync latch that could leave stale text visible.

Validated: lint, format, typecheck, golden (55) + shimmed (76) tests, production build; each behavior verified in a live browser session against the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ