### PR TITLE
fix(017): share links opened in a running app (hashchange)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -42,6 +42,7 @@ import {
 import {
   buildShareUrl,
   decodeShare,
+  decideHashChangeAction,
   encodeShare,
   readShareToken,
   type ShareFileName,
@@ -313,6 +314,31 @@ export function App() {
   // result (identities → node ids need the resolved tree). A ref, not state, so
   // consuming it does not trigger a render.
   const pendingViewRef = useRef<ShareView | null>(null);
+  // Roadmap 017: the last `#config=` token (or null) the app itself wrote
+  // into the address bar via `history.replaceState` — Copy link, clearing an
+  // unreadable share link, or restoring a pre-sign-in fragment after OAuth.
+  // The hashchange listener compares against this to ignore its own writes
+  // (replaceState doesn't fire `hashchange`, but this stays correct even if
+  // a browser ever did, or a future navigation replays the same URL).
+  const lastWrittenTokenRef = useRef<string | null>(null);
+  // Roadmap 017: mirrors of `content`/`loadedContent` for the hashchange
+  // listener, which is registered once (empty deps) and would otherwise
+  // close over the state from that first render.
+  const contentRef = useRef(content);
+  contentRef.current = content;
+  const loadedContentRef = useRef(loadedContent);
+  loadedContentRef.current = loadedContent;
+  // Roadmap 017: guards a decode against a later hashchange (or unmount)
+  // superseding it before its async work (decodeShare, getRenovateVersion)
+  // resolves.
+  const decodeGenerationRef = useRef(0);
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
   // Load-from-repo form.
   const [repoInput, setRepoInput] = useState("");
   const [repoRef, setRepoRef] = useState("");
@@ -346,6 +372,19 @@ export function App() {
     setContent(text);
     setLoadedContent(text);
     setEditorKey((k) => k + 1);
+  }
+
+  /** Roadmap 017: the one path every self-initiated hash write goes through —
+   *  updates the address bar and records the token (or lack of one) so the
+   *  hashchange listener can recognize its own writes. */
+  function writeHash(url: string, shareToken: string | null) {
+    lastWrittenTokenRef.current = shareToken;
+    history.replaceState(null, "", url);
+  }
+
+  /** Drops the `#config=` fragment, keeping any query string. */
+  function clearShareHash() {
+    writeHash(window.location.pathname + window.location.search, null);
   }
 
   useEffect(() => {
@@ -487,12 +526,69 @@ export function App() {
     await onRun(undefined, buildInputs(nextContent));
   }
 
+  /**
+   * Roadmap 007/017: decodes a share token, populates every piece of state
+   * a link can carry, and runs — the single decode→populate→run path shared
+   * by the mount effect (a link opened fresh) and the hashchange listener
+   * below (a link opened while the app is already running). `isCancelled`
+   * lets either caller abandon the result of a decode a later event has
+   * superseded (component unmount, or a second hashchange arriving before
+   * the first finishes its awaits).
+   */
+  async function loadShareToken(shareToken: string, isCancelled: () => boolean): Promise<void> {
+    const payload = await decodeShare(shareToken);
+    if (isCancelled()) {
+      return;
+    }
+    if (!payload) {
+      setNotice("This shared link could not be read; showing the default config instead.");
+      clearShareHash();
+      return;
+    }
+    const nextPlatform = payload.platform ?? "github";
+    const nextEndpoint = payload.endpoint ?? "https://api.github.com";
+    loadConfigText(payload.config);
+    setFileName(payload.fileName);
+    setPlatform(nextPlatform);
+    persistLocal(PLATFORM_KEY, nextPlatform);
+    setEndpoint(nextEndpoint);
+    persistLocal(ENDPOINT_KEY, nextEndpoint);
+    // 008 layers ride along in v2 links; absent = layers off.
+    setGlobalText(payload.globalConfig ? JSON.stringify(payload.globalConfig, null, 2) : "");
+    setInheritedText(
+      payload.inheritedConfig ? JSON.stringify(payload.inheritedConfig, null, 2) : "",
+    );
+    setPlatformOverride(payload.platformOverride === true);
+    if (payload.globalConfig || payload.inheritedConfig) {
+      setAdvancedOpen(true);
+    }
+    pendingViewRef.current = payload.view ?? null;
+    const current = await getRenovateVersion();
+    if (!isCancelled() && payload.renovate && payload.renovate !== current) {
+      setNotice(
+        `This link was created with Renovate v${payload.renovate}; you're on v${current} — results may differ.`,
+      );
+    }
+    if (!isCancelled()) {
+      void onRun(undefined, {
+        fileName: payload.fileName,
+        content: payload.config,
+        platform: nextPlatform,
+        endpoint: nextEndpoint,
+        globalConfig: payload.globalConfig,
+        inheritedConfig: payload.inheritedConfig,
+        platformOverride: payload.platformOverride === true,
+      });
+    }
+  }
+
   // On mount: first complete an OAuth callback if the URL carries one (QUERY
   // params ?code&state), then — reading the possibly-restored fragment — decode
   // a shared config, populate state and auto-run. OAuth runs before the share
   // decode so a share link survives a sign-in round-trip. Runs once.
   useEffect(() => {
-    let cancelled = false;
+    const generation = ++decodeGenerationRef.current;
+    const isCancelled = () => !mountedRef.current || decodeGenerationRef.current !== generation;
     void (async () => {
       // 1. OAuth callback (009): validate state, exchange via the Worker, store
       // the token, then strip the query and restore the pre-sign-in fragment.
@@ -500,20 +596,20 @@ export function App() {
       if (callback) {
         try {
           const { user, returnHash } = await completeCallback(callback.code, callback.state);
-          if (cancelled) {
+          if (isCancelled()) {
             return;
           }
           setSignedIn(true);
           setAuthUser(user);
-          history.replaceState(null, "", window.location.pathname + returnHash);
+          writeHash(window.location.pathname + returnHash, readShareToken(returnHash));
         } catch (err) {
-          if (cancelled) {
+          if (isCancelled()) {
             return;
           }
           setNotice(
             `GitHub sign-in failed: ${err instanceof Error ? err.message : String(err)}. You can still use the app signed out.`,
           );
-          history.replaceState(null, "", window.location.pathname);
+          writeHash(window.location.pathname, null);
           return;
         }
       }
@@ -523,55 +619,46 @@ export function App() {
       if (!shareToken) {
         return;
       }
-      const payload = await decodeShare(shareToken);
-      if (cancelled) {
-        return;
-      }
-      if (!payload) {
-        setNotice("This shared link could not be read; showing the default config instead.");
-        history.replaceState(null, "", window.location.pathname + window.location.search);
-        return;
-      }
-      const nextPlatform = payload.platform ?? "github";
-      const nextEndpoint = payload.endpoint ?? "https://api.github.com";
-      loadConfigText(payload.config);
-      setFileName(payload.fileName);
-      setPlatform(nextPlatform);
-      persistLocal(PLATFORM_KEY, nextPlatform);
-      setEndpoint(nextEndpoint);
-      persistLocal(ENDPOINT_KEY, nextEndpoint);
-      // 008 layers ride along in v2 links; absent = layers off.
-      setGlobalText(payload.globalConfig ? JSON.stringify(payload.globalConfig, null, 2) : "");
-      setInheritedText(
-        payload.inheritedConfig ? JSON.stringify(payload.inheritedConfig, null, 2) : "",
-      );
-      setPlatformOverride(payload.platformOverride === true);
-      if (payload.globalConfig || payload.inheritedConfig) {
-        setAdvancedOpen(true);
-      }
-      pendingViewRef.current = payload.view ?? null;
-      const current = await getRenovateVersion();
-      if (!cancelled && payload.renovate && payload.renovate !== current) {
-        setNotice(
-          `This link was created with Renovate v${payload.renovate}; you're on v${current} — results may differ.`,
-        );
-      }
-      if (!cancelled) {
-        void onRun(undefined, {
-          fileName: payload.fileName,
-          content: payload.config,
-          platform: nextPlatform,
-          endpoint: nextEndpoint,
-          globalConfig: payload.globalConfig,
-          inheritedConfig: payload.inheritedConfig,
-          platformOverride: payload.platformOverride === true,
-        });
-      }
+      await loadShareToken(shareToken, isCancelled);
     })();
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Roadmap 017: a share link opened while the app is already running is a
+  // hash-only navigation — nothing reloads, so without this listener nothing
+  // happens (no load, no run, no error). `decideHashChangeAction` (pure, in
+  // share.ts) decides whether the new hash carries a token worth loading and
+  // whether loading it would clobber unsaved edits; `event.oldURL` is what
+  // lets a declined confirm restore exactly the hash that was showing before
+  // the navigation, so the address bar never lies about what's on screen.
+  // Registered once (empty deps) — `contentRef`/`loadedContentRef` keep it
+  // reading current state despite that.
+  useEffect(() => {
+    function onHashChange(event: HashChangeEvent) {
+      const decision = decideHashChangeAction(
+        window.location.hash,
+        lastWrittenTokenRef.current,
+        contentRef.current !== loadedContentRef.current,
+      );
+      if (decision.action === "ignore") {
+        return;
+      }
+      if (
+        decision.needsConfirm &&
+        !window.confirm("Load shared config? Your current edits will be replaced.")
+      ) {
+        const oldHash = new URL(event.oldURL).hash;
+        writeHash(
+          window.location.pathname + window.location.search + oldHash,
+          readShareToken(oldHash),
+        );
+        return;
+      }
+      const generation = ++decodeGenerationRef.current;
+      const isCancelled = () => !mountedRef.current || decodeGenerationRef.current !== generation;
+      void loadShareToken(decision.token, isCancelled);
+    }
+    window.addEventListener("hashchange", onHashChange);
+    return () => window.removeEventListener("hashchange", onHashChange);
   }, []);
 
   function makeTokenHandler(key: string, setter: (v: string) => void) {
@@ -671,7 +758,7 @@ export function App() {
     } catch {
       // Clipboard can be unavailable (insecure context); the URL bar still updates.
     }
-    history.replaceState(null, "", url);
+    writeHash(url, shareToken);
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }

--- a/packages/app/src/share.ts
+++ b/packages/app/src/share.ts
@@ -191,3 +191,28 @@ export function buildShareUrl(token: string): string {
   const { origin, pathname } = window.location;
   return `${origin}${pathname}#${FRAGMENT_KEY}=${token}`;
 }
+
+/**
+ * Roadmap 017: what a `hashchange` event should do, decided as a pure
+ * function of the new hash, the last token the app itself wrote into the
+ * address bar (Copy link, or clearing an unreadable link — never a real
+ * navigation), and whether the editor has drifted from the last
+ * loaded/run baseline. Kept pure and DOM-free so it can be unit-tested
+ * without mounting the app; App.tsx supplies the three inputs from
+ * `window.location.hash`, a ref, and `content !== loadedContent`.
+ */
+export type HashChangeDecision =
+  | { action: "ignore" }
+  | { action: "load"; token: string; needsConfirm: boolean };
+
+export function decideHashChangeAction(
+  newHash: string,
+  lastSelfWrittenToken: string | null,
+  contentDiffersFromLoaded: boolean,
+): HashChangeDecision {
+  const token = readShareToken(newHash);
+  if (!token || token === lastSelfWrittenToken) {
+    return { action: "ignore" };
+  }
+  return { action: "load", token, needsConfirm: contentDiffersFromLoaded };
+}

--- a/roadmap/017-share-links-in-a-running-app.md
+++ b/roadmap/017-share-links-in-a-running-app.md
@@ -1,6 +1,43 @@
 # 017 — Share links opened in a running app (hashchange)
 
-Milestone: M5 · Status: planned
+Milestone: M5 · Status: done 2026-07-24
+
+> Implemented as specified. The mount effect's decode→populate→run body
+> (config text, filename, platform/endpoint, 008 layers, pending view, the
+> version-drift notice, the run itself) is now one `loadShareToken` function
+> called from both the mount effect (a link opened fresh) and a new
+> `hashchange` listener (a link opened while the app is already running,
+> which is a hash-only navigation — nothing reloads, so without a listener
+> nothing happens at all). Whether a `hashchange` event should do anything is
+> a pure predicate, `decideHashChangeAction(newHash, lastSelfWrittenToken,
+contentDiffersFromLoaded)` in `share.ts`: it reads the new hash's token,
+> ignores it if absent or equal to the last token the app itself wrote, and
+> otherwise reports whether loading it would clobber unsaved edits. Clobber
+> guard: when the editor's current text differs from `loadedContent` (016's
+> baseline), `window.confirm("Load shared config? Your current edits will be
+replaced.")` gates the load; declining restores the address bar to exactly
+> what was showing before the navigation, read from the `hashchange` event's
+> own `event.oldURL` (not reconstructed) so a stale token from three
+> navigations ago can never leak back in. Self-mutations: every place the app
+> writes the hash itself — Copy link, clearing an unreadable link, restoring
+> the pre-sign-in fragment after an OAuth round-trip — now goes through one
+> `writeHash(url, token)` helper that records the token in a ref before
+> calling `history.replaceState`, so the listener recognizes and ignores its
+> own writes (defense in depth: `replaceState` doesn't fire `hashchange` in
+> any current browser, but the bookkeeping is cheap and future-proof).
+> Verified by hand against a production build (`vite preview`, not `vite
+dev`) with hand-generated tokens: a same-tab hash change with no pending
+> edits loads and runs silently; with edits present it prompts, declining
+> leaves the editor and address bar untouched, accepting loads and re-runs;
+> dispatching a synthetic `hashchange` for the app's own just-written token
+> triggers no prompt and no reload. `decideHashChangeAction` is exported as a
+> pure, DOM-free function specifically so it's ready to unit-test, but the
+> app package has no vitest setup and none was added here — pulling it into
+> the engine package to test it there would be contrived (it depends on
+> app-only share-link plumbing, not engine concerns) and adding a vitest
+> config to the app package is disproportionate to a small bugfix. The
+> regression test for this — including the exact "share link opened in a
+> running app" scenario — lands with the e2e suite in 020.
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -21,7 +21,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
-| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | planned |
+| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done    |
 | [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | planned |
 | [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | planned |
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | planned |


### PR DESCRIPTION
Implements roadmap item 017 (M5) — the bug found while preparing the persona study: clicking a share link while the app is already open is a hash-only navigation, and the mount-only decode effect silently ignored it.

- `hashchange` listener reuses the exact mount decode→populate→run path (factored into `loadShareToken`).
- Clobber guard: unsaved edits (vs 016's `loadedContent` baseline) prompt "Load shared config? Your current edits will be replaced."; declining restores the previous hash from `event.oldURL`.
- Self-mutations ignored: every app-initiated hash write goes through one `writeHash` helper that records the token — Copy link and the OAuth fragment restore can't re-trigger a run.
- Pure decision predicate `decideHashChangeAction` extracted in share.ts; the e2e regression test for this exact scenario lands with item 020.

Verified in a live browser against the production build: silent load with no edits, confirm + decline restores hash, self-written token ignored. Validated: lint, format, typecheck, golden (55) + shimmed (76), build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ