### PR TITLE
feat(018): evidence export + expert-grade precision

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -46,6 +46,7 @@ import {
   encodeShare,
   readShareToken,
   type ShareFileName,
+  type ShareSimulator,
   type ShareView,
 } from "./share";
 import { useBackToTopVisible, useHomeEndPageScroll } from "./scroll-ergonomics";
@@ -165,6 +166,13 @@ function parseRepoRef(raw: string): { host: string | null; repo: string } | null
 }
 
 type InjectionMap = Record<string, Record<string, unknown>>;
+
+/** Roadmap 018: a share link's simulator inputs, applied once by nonce. */
+interface SimRequest {
+  form: Record<string, string>;
+  autoSimulate: boolean;
+  nonce: number;
+}
 
 interface RunInputs {
   fileName: ShareFileName;
@@ -314,6 +322,13 @@ export function App() {
   // result (identities → node ids need the resolved tree). A ref, not state, so
   // consuming it does not trigger a render.
   const pendingViewRef = useRef<ShareView | null>(null);
+  // Roadmap 018: a decoded link's simulator inputs, handed to the RuleSimulator
+  // to pre-fill (and, when `autoSimulate`, run) once the pipeline run this link
+  // triggered has produced its result. A fresh nonce per link lets the child
+  // apply each request exactly once; set AFTER the run so the child applies it
+  // against the freshly-run config, on both mount and hashchange.
+  const [simRequest, setSimRequest] = useState<SimRequest | null>(null);
+  const simNonceRef = useRef(0);
   // Roadmap 017: the last `#config=` token (or null) the app itself wrote
   // into the address bar via `history.replaceState` — Copy link, clearing an
   // unreadable share link, or restoring a pre-sign-in fragment after OAuth.
@@ -570,7 +585,10 @@ export function App() {
       );
     }
     if (!isCancelled()) {
-      void onRun(undefined, {
+      // Awaited (not fire-and-forget) so a carried simulator descriptor is
+      // armed AFTER the result commits — the RuleSimulator then applies it
+      // against the freshly-run config, identically on mount and hashchange.
+      await onRun(undefined, {
         fileName: payload.fileName,
         content: payload.config,
         platform: nextPlatform,
@@ -578,6 +596,13 @@ export function App() {
         globalConfig: payload.globalConfig,
         inheritedConfig: payload.inheritedConfig,
         platformOverride: payload.platformOverride === true,
+      });
+    }
+    if (!isCancelled() && payload.sim) {
+      setSimRequest({
+        form: payload.sim.form,
+        autoSimulate: payload.sim.autoSimulate === true,
+        nonce: ++simNonceRef.current,
       });
     }
   }
@@ -726,10 +751,12 @@ export function App() {
 
   const migrateStepperMounted = deferredStage === "migrate" && migrateSteps.length > 0;
 
-  // Encodes the CURRENT state (config + view) into a link and copies it. Never
-  // continuously syncs the hash (huge configs would thrash the URL) — on demand
-  // only. Also mirrors the copied link into the address bar.
-  async function onCopyLink() {
+  // Encodes the CURRENT state (config + view, optionally simulator inputs) into
+  // a link, copies it, and mirrors it into the address bar. Never continuously
+  // syncs the hash (huge configs would thrash the URL) — on demand only. Tokens
+  // are never encoded (see share.ts); `sim` carries only dependency-descriptor
+  // form fields (roadmap 018).
+  async function buildShareLinkAndCopy(sim?: ShareSimulator) {
     const renovate = result?.renovateVersion ?? (await getRenovateVersion());
     const view: ShareView = { stage: selectedStage };
     if (selectedNodeId && result?.presetTree) {
@@ -751,6 +778,7 @@ export function App() {
       inheritedConfig: inheritedParse.config,
       platformOverride: platformOverride && hasGlobalContext,
       view,
+      sim,
     });
     const url = buildShareUrl(shareToken);
     try {
@@ -759,6 +787,10 @@ export function App() {
       // Clipboard can be unavailable (insecure context); the URL bar still updates.
     }
     writeHash(url, shareToken);
+  }
+
+  async function onCopyLink() {
+    await buildShareLinkAndCopy();
     setCopied(true);
     setTimeout(() => setCopied(false), 1500);
   }
@@ -1333,6 +1365,8 @@ export function App() {
               focusRuleIndex={pendingRuleFocus}
               onRuleFocused={() => setPendingRuleFocus(null)}
               errorLib={errorLib}
+              simRequest={simRequest}
+              onCopySimLink={buildShareLinkAndCopy}
             />
           </>
         ) : null}

--- a/packages/app/src/components/CopyMarkdownButton.tsx
+++ b/packages/app/src/components/CopyMarkdownButton.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+/**
+ * Roadmap 018 — a small "Copy as markdown" affordance for evidence export.
+ * Copies a fenced code block with a one-line header (preset name / rule
+ * identity + verdict) to the clipboard, ready to paste into a GitHub
+ * discussion answer. The markdown is built lazily on click so re-renders of a
+ * long results list don't serialize every block up front.
+ */
+export function CopyMarkdownButton({
+  header,
+  code,
+  lang = "",
+  label = "Copy as markdown",
+  className,
+}: {
+  /** The one-line header rendered above the fence. */
+  header: string;
+  /** The already-formatted body placed inside the fence. */
+  code: string;
+  /** Fence info string (e.g. `json`); empty for a plain fence. */
+  lang?: string;
+  label?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    const markdown = `${header}\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`;
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard can be unavailable (insecure context) — fail quietly.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={`copy-md${className ? ` ${className}` : ""}`}
+      onClick={(e) => {
+        // These buttons live inside <summary> elements; without this a click
+        // would toggle the surrounding <details> open/closed.
+        e.preventDefault();
+        e.stopPropagation();
+        void copy();
+      }}
+      title="Copy this as a markdown code block for a discussion answer"
+    >
+      {copied ? "Copied!" : label}
+    </button>
+  );
+}

--- a/packages/app/src/components/PresetTree.tsx
+++ b/packages/app/src/components/PresetTree.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@renovate-config-visualizer/engine";
 import { Explained, GLOSSARY, Term, type GlossaryEntry } from "../glossary";
 import { ConfigJson } from "./ConfigJson";
+import { CopyMarkdownButton } from "./CopyMarkdownButton";
 import { type AuthState, GithubAuthHint } from "./GithubAuthHint";
 import { JsonDiff } from "./JsonDiff";
 import { MigrationSteps } from "./MigrationSteps";
@@ -1363,7 +1364,15 @@ function PresetDetail({
 
       {node.fetched !== undefined ? (
         <details open={!migrationChanged}>
-          <summary>Fetched content</summary>
+          <summary>
+            Fetched content
+            <CopyMarkdownButton
+              className="inline"
+              header={`\`${node.name}\` — fetched preset body`}
+              code={JSON.stringify(node.afterParams ?? node.fetched, null, 2)}
+              lang="json"
+            />
+          </summary>
           <pre className="config-view">
             <ConfigJson value={node.afterParams ?? node.fetched} />
           </pre>
@@ -1392,7 +1401,15 @@ function PresetDetail({
       {node.resolved !== undefined &&
       JSON.stringify(node.resolved) !== JSON.stringify(node.input) ? (
         <details>
-          <summary>Fully resolved (sub-presets merged)</summary>
+          <summary>
+            Fully resolved (sub-presets merged)
+            <CopyMarkdownButton
+              className="inline"
+              header={`\`${node.name}\` — fully resolved preset body`}
+              code={JSON.stringify(node.resolved, null, 2)}
+              lang="json"
+            />
+          </summary>
           <pre className="config-view">
             <ConfigJson value={node.resolved} />
           </pre>

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -1,9 +1,13 @@
 import { type ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   ClauseEvaluation,
+  ConfigKeyDelta,
   DependencyDescriptor,
+  MergedKey,
   ProvenanceLayer,
   RuleEvaluation,
+  RuleRef,
+  SimulationComparison,
   SimulationResult,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
@@ -12,10 +16,19 @@ import { OptionKey } from "../option-docs";
 import { useRuleProvenance } from "../rule-provenance";
 import { RuleFramingText } from "../rule-framing";
 import type { ErrorTranslationLib } from "../run";
+import type { ShareSimulator } from "../share";
 import { ConfigJson } from "./ConfigJson";
+import { CopyMarkdownButton } from "./CopyMarkdownButton";
 import { ErrorTranslationView } from "./ErrorTranslationView";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { RuleMessage } from "./RuleMessage";
+
+/** Roadmap 018: a share link's simulator inputs, applied to the form once. */
+interface SimRequest {
+  form: Record<string, string>;
+  autoSimulate: boolean;
+  nonce: number;
+}
 
 /**
  * Roadmap 006: the packageRules simulator. Describe a hypothetical dependency
@@ -213,12 +226,26 @@ function previewValue(value: unknown, max = 60): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
+/** Untruncated JSON rendering for copy-as-markdown export. */
+function fullValue(value: unknown): string {
+  return JSON.stringify(value) ?? "undefined";
+}
+
+/** Roadmap 018: a matched rule's applied keys as `key: before → after` lines. */
+function ruleAppliedMarkdown(merged: MergedKey[]): string {
+  return merged
+    .map((m) =>
+      "before" in m
+        ? `${m.key}: ${fullValue(m.before)} → ${fullValue(m.after)}`
+        : `${m.key}: ${fullValue(m.after)}`,
+    )
+    .join("\n");
+}
+
 function inputsPreview(clause: ClauseEvaluation): string {
-  const entries = Object.entries(clause.inputValues);
-  if (entries.length === 0) {
-    return "no input value set";
-  }
-  return entries.map(([key, value]) => `${key} = ${previewValue(value, 40)}`).join(", ");
+  return Object.entries(clause.inputValues)
+    .map(([key, value]) => `${key} = ${previewValue(value, 40)}`)
+    .join(", ");
 }
 
 function clauseIcon(state: ClauseEvaluation["state"]): string {
@@ -228,15 +255,29 @@ function clauseIcon(state: ClauseEvaluation["state"]): string {
   if (state === "no-match" || state === "error") {
     return "✗";
   }
+  // no-input / not-applicable / not-simulated — the clause was skipped, not a
+  // genuine mismatch.
   return "⚠";
 }
 
+/**
+ * Roadmap 018: the clause row's right-hand explanation, precise about WHY a
+ * clause did not match — a genuine mismatch names the input it compared
+ * ("no match against sourceUrl = …"); a fail-closed clause names the field the
+ * dependency lacks ("skipped — no sourceUrl set …", from the engine's note);
+ * a null-returning matcher reads "not applicable (skipped)".
+ */
 function clauseExplanation(clause: ClauseEvaluation): string {
+  const hasInputs = Object.keys(clause.inputValues).length > 0;
   switch (clause.state) {
     case "matched":
-      return `matched (${inputsPreview(clause)})`;
+      return hasInputs ? `matched (${inputsPreview(clause)})` : "matched";
     case "no-match":
-      return `no match against ${inputsPreview(clause)}`;
+      return hasInputs ? `no match against ${inputsPreview(clause)}` : "no match";
+    case "no-input":
+      return clause.note ?? "skipped — required input not set on the simulated dependency";
+    case "not-applicable":
+      return clause.note ?? "not applicable (skipped)";
     default:
       return clause.note ?? clause.state;
   }
@@ -349,7 +390,11 @@ function ruleLabel(rule: RuleEvaluation): string {
     return "no match* selectors";
   }
   const joined = rule.clauses.map((c) => c.key).join(" + ");
-  const failing = rule.clauses.find((c) => c.state === "no-match" || c.state === "error");
+  // no-input (fail-closed: the dependency lacks the field) fails the rule just
+  // like a genuine no-match, so it counts as the deciding clause here too.
+  const failing = rule.clauses.find(
+    (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
+  );
   return failing ? `${joined} — failed on ${failing.key}` : joined;
 }
 
@@ -410,7 +455,14 @@ function RuleRow({
           ))}
           {rule.merged && rule.merged.length > 0 ? (
             <div className="sim-merged">
-              <div className="sim-merged-title">Applied to the dependency config</div>
+              <div className="sim-merged-title">
+                Applied to the dependency config
+                <CopyMarkdownButton
+                  className="inline"
+                  header={`\`packageRules[${rule.index}]\` ${ruleLabel(rule)} — ${VERDICT_LABEL[rule.verdict]}`}
+                  code={ruleAppliedMarkdown(rule.merged)}
+                />
+              </div>
               <ul>
                 {rule.merged.map((m) => (
                   <li key={m.key}>
@@ -433,6 +485,113 @@ function RuleRow({
           ) : null}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+/** Roadmap 018: one of the three matched-rule columns in the A/B comparison. */
+function RuleDeltaList({
+  title,
+  refs,
+  kind,
+}: {
+  title: string;
+  refs: RuleRef[];
+  kind: "only-a" | "only-b" | "both";
+}) {
+  return (
+    <div className={`sim-compare-col ${kind}`}>
+      <div className="sim-compare-col-title">
+        {title} <span className="count">{refs.length}</span>
+      </div>
+      {refs.length === 0 ? (
+        <p className="empty-note">none</p>
+      ) : (
+        <ul>
+          {refs.map((r) => (
+            <li key={`${r.index}-${r.signature}`}>
+              <span className="sim-rule-index">packageRules[{r.index}]</span> <code>{r.label}</code>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+/** Roadmap 018: one changed key of the final per-dependency config (A → B). */
+function ConfigDeltaRow({ delta }: { delta: ConfigKeyDelta }) {
+  return (
+    <li>
+      <span className="sim-merged-key">
+        <OptionKey name={delta.key} flagUnknown />
+      </span>{" "}
+      <span className="sim-merged-before">
+        {delta.inA ? previewValue(delta.before) : "(unset)"}
+      </span>
+      {" → "}
+      <span className="sim-merged-after">
+        {delta.inB ? previewValue(delta.after) : "(removed)"}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * Roadmap 018: the A/B comparison panel. `comparison` is null while a result is
+ * pinned but no NEW simulation has replaced it yet (a "waiting" hint shows);
+ * once a fresh run produces B, it renders the matched-rule set delta, the
+ * final-config key delta, and an explicit "no behavioral change" verdict when
+ * both are identical.
+ */
+function ComparisonPanel({ comparison }: { comparison: SimulationComparison | null }) {
+  if (!comparison) {
+    return (
+      <div className="sim-compare">
+        <div className="sim-compare-title">A/B comparison</div>
+        <p className="empty-note">
+          Pinned this result as <strong>A</strong>. Edit the config and run the pipeline again, then
+          simulate to compare it against <strong>B</strong>.
+        </p>
+      </div>
+    );
+  }
+  const { matchedOnlyInA, matchedOnlyInB, matchedInBoth, configDelta, noChange } = comparison;
+  return (
+    <div className="sim-compare">
+      <div className="sim-compare-title">A/B comparison — pinned (A) vs current (B)</div>
+      {noChange ? (
+        <p className="sim-compare-nochange">
+          No behavioral change — the matched rules and the final per-dependency config are identical
+          in A and B.
+        </p>
+      ) : (
+        <>
+          <div className="sim-compare-rules">
+            <RuleDeltaList
+              title="Only in A (stopped matching)"
+              refs={matchedOnlyInA}
+              kind="only-a"
+            />
+            <RuleDeltaList title="Only in B (now matching)" refs={matchedOnlyInB} kind="only-b" />
+            <RuleDeltaList title="Matched in both" refs={matchedInBoth} kind="both" />
+          </div>
+          <div className="sim-compare-config">
+            <div className="sim-merged-title">Final per-dependency config changes</div>
+            {configDelta.length > 0 ? (
+              <ul>
+                {configDelta.map((d) => (
+                  <ConfigDeltaRow key={d.key} delta={d} />
+                ))}
+              </ul>
+            ) : (
+              <p className="empty-note">
+                Final per-dependency config is identical — only the matched-rule set differs.
+              </p>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }
@@ -469,6 +628,8 @@ export function RuleSimulator({
   focusRuleIndex,
   onRuleFocused,
   errorLib,
+  simRequest,
+  onCopySimLink,
 }: {
   result: TraceResult;
   /** Roadmap 013: a rule row's provenance chip → the contributing preset node in the tree. */
@@ -487,9 +648,22 @@ export function RuleSimulator({
    *  When the same issue exists in the user's own rule, it also surfaces
    *  (with a fix) in the top-level Errors & warnings panel. */
   errorLib?: ErrorTranslationLib | null;
+  /** Roadmap 018: simulator inputs a decoded share link carries; applied to the
+   *  form (and auto-run when its flag is set) once per nonce. */
+  simRequest?: SimRequest | null;
+  /** Roadmap 018: encode the current config + view + these simulator inputs into
+   *  a share link and copy it (App owns the full share state). */
+  onCopySimLink?: (sim: ShareSimulator) => Promise<void>;
 }) {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [sim, setSim] = useState<SimulationResult | null>(null);
+  // Roadmap 018: a pinned A-run kept for A/B comparison — deliberately NOT
+  // cleared when a new pipeline result arrives (the whole point is to pin, edit
+  // the config, re-run, and compare); only "Unpin" clears it.
+  const [pinned, setPinned] = useState<SimulationResult | null>(null);
+  const [simLinkCopied, setSimLinkCopied] = useState(false);
+  // Roadmap 018: applied-once bookkeeping for an incoming share `simRequest`.
+  const appliedSimNonce = useRef<number | null>(null);
   const [ranKey, setRanKey] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -544,6 +718,33 @@ export function RuleSimulator({
     setShowAll(false);
     setEmptyGuardTriggered(false);
   }, [result]);
+
+  // Roadmap 018: apply a decoded share link's simulator inputs exactly once (by
+  // nonce). Depends on `result` too, so — whether the link opened on mount or
+  // via hashchange — the form is applied (and optionally auto-run) against the
+  // freshly-run config rather than a stale one. Declared AFTER the reset effect
+  // so it wins for a decoded link (the reset clears, then this re-populates).
+  useEffect(() => {
+    if (!simRequest || appliedSimNonce.current === simRequest.nonce || !result.finalConfig) {
+      return;
+    }
+    appliedSimNonce.current = simRequest.nonce;
+    const next: FormState = { ...EMPTY_FORM };
+    for (const key of Object.keys(EMPTY_FORM) as (keyof FormState)[]) {
+      const value = simRequest.form[key];
+      if (typeof value === "string") {
+        next[key] = value;
+      }
+    }
+    setForm(next);
+    // The link always encodes the EFFECTIVE updateType, so a non-empty one is a
+    // deliberate pin — mark it touched so derivation can't override it.
+    const touched = next.updateType.trim() !== "";
+    setUpdateTypeTouched(touched);
+    if (simRequest.autoSimulate) {
+      void simulate(next, touched);
+    }
+  }, [simRequest, result]);
 
   useEffect(() => {
     if (focusRuleIndex != null) {
@@ -608,6 +809,17 @@ export function RuleSimulator({
   );
   const effectiveUpdateType =
     updateTypeTouched || derivedUpdateType === undefined ? form.updateType : derivedUpdateType;
+
+  // Roadmap 018: the A/B comparison — the pinned run (A) vs the current run (B).
+  // Null until a NEW simulation replaces the one that was pinned (comparing a
+  // result against itself is not useful — the panel shows a "waiting" hint
+  // instead). The comparison logic itself is pure and lives in the engine.
+  const comparison = useMemo<SimulationComparison | null>(() => {
+    if (!engineModule || !pinned || !sim || pinned === sim) {
+      return null;
+    }
+    return engineModule.compareSimulations(pinned, sim);
+  }, [engineModule, pinned, sim]);
 
   // Keys the rules changed vs. the pre-rules effective config, for the final
   // section's summary chips.
@@ -686,6 +898,31 @@ export function RuleSimulator({
     } finally {
       setRunning(false);
     }
+  }
+
+  /**
+   * Roadmap 018: build a share link that reproduces THIS simulation. The
+   * effective updateType (derived or manual) is what actually drove the run, so
+   * it is what gets encoded — the opener reproduces the exact verdict, not a
+   * re-derivation. `autoSimulate` is always set: the affordance's whole promise
+   * is "open this and it runs". Never includes tokens (the form has none).
+   */
+  async function copySimLink() {
+    if (!onCopySimLink) {
+      return;
+    }
+    const shareForm: Record<string, string> = {};
+    for (const [key, value] of Object.entries(form)) {
+      if (typeof value === "string" && value.trim() !== "") {
+        shareForm[key] = value;
+      }
+    }
+    if (effectiveUpdateType && effectiveUpdateType.trim() !== "") {
+      shareForm.updateType = effectiveUpdateType;
+    }
+    await onCopySimLink({ form: shareForm, autoSimulate: true });
+    setSimLinkCopied(true);
+    setTimeout(() => setSimLinkCopied(false), 1500);
   }
 
   function quickFill(fill: Partial<FormState>) {
@@ -1012,7 +1249,40 @@ export function RuleSimulator({
                 {matchedCount} of {sim.rules.length} rule{sim.rules.length === 1 ? "" : "s"} matched
                 →
               </button>
+              {/* Roadmap 018: evidence-export affordances on the verdict block —
+                  a reproducible link (form + auto-run encoded) and A/B pinning. */}
+              <div className="sim-verdict-actions">
+                {onCopySimLink ? (
+                  <button
+                    type="button"
+                    className="sim-verdict-action"
+                    onClick={() => void copySimLink()}
+                  >
+                    {simLinkCopied ? "Copied!" : "Copy link with this simulation"}
+                  </button>
+                ) : null}
+                {pinned ? (
+                  <button
+                    type="button"
+                    className="sim-verdict-action"
+                    onClick={() => setPinned(null)}
+                  >
+                    Unpin comparison
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    className="sim-verdict-action"
+                    onClick={() => setPinned(sim)}
+                    title="Pin this result as A, edit the config, then simulate again to compare"
+                  >
+                    Pin result for comparison
+                  </button>
+                )}
+              </div>
             </div>
+
+            {pinned ? <ComparisonPanel comparison={comparison} /> : null}
 
             {[...sim.errors, ...sim.warnings].length > 0 ? (
               <ul className="messages sim-messages">

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1503,7 +1503,8 @@ pre.config-view.prov-before {
   color: var(--error);
 }
 
-.sim-clause.state-invalid .sim-clause-icon,
+.sim-clause.state-no-input .sim-clause-icon,
+.sim-clause.state-not-applicable .sim-clause-icon,
 .sim-clause.state-not-simulated .sim-clause-icon {
   color: var(--warn);
 }
@@ -1642,6 +1643,136 @@ pre.config-view.prov-before {
 
 .sim-jump:hover {
   text-decoration: underline;
+}
+
+/* ---------- 018 evidence export: copy-as-markdown, sim link, A/B ---------- */
+
+.sim-verdict-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+  margin-top: 0.55rem;
+}
+
+.sim-verdict-action {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.2rem 0.55rem;
+}
+
+.sim-verdict-action:hover {
+  border-color: var(--accent);
+}
+
+.copy-md {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.45rem;
+}
+
+.copy-md:hover {
+  border-color: var(--accent);
+}
+
+.copy-md.inline {
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.sim-compare {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 0.75rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.sim-compare-title {
+  color: var(--muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.sim-compare-nochange {
+  background: color-mix(in srgb, var(--ok) 10%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--ok) 35%, var(--border));
+  border-radius: 6px;
+  color: var(--ok);
+  font-size: 0.88rem;
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.7rem;
+}
+
+.sim-compare-rules {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 0.55rem;
+}
+
+.sim-compare-col {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.4rem 0.55rem;
+}
+
+.sim-compare-col.only-a {
+  border-color: color-mix(in srgb, var(--error) 40%, var(--border));
+}
+
+.sim-compare-col.only-b {
+  border-color: color-mix(in srgb, var(--ok) 40%, var(--border));
+}
+
+.sim-compare-col-title {
+  font-size: 0.76rem;
+  font-weight: 600;
+  margin-bottom: 0.3rem;
+}
+
+.sim-compare-col-title .count {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.sim-compare-col ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sim-compare-col li {
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+  padding: 0.12rem 0;
+}
+
+.sim-compare-config {
+  margin-top: 0.6rem;
+}
+
+.sim-compare-config ul {
+  list-style: none;
+  margin: 0.3rem 0 0;
+  padding: 0;
+}
+
+.sim-compare-config li {
+  font-size: 0.82rem;
+  overflow-wrap: anywhere;
+  padding: 0.1rem 0;
 }
 
 .sim-rules-head {

--- a/packages/app/src/share.ts
+++ b/packages/app/src/share.ts
@@ -26,6 +26,20 @@ export interface ShareView {
   step?: number;
 }
 
+/**
+ * Roadmap 018 — an optional simulator-form descriptor a link can carry so
+ * "open this link and it reproduces my exact demonstration" works. `form` is
+ * the simulator's text fields (a dependency descriptor — package name, source
+ * URL, versions, …); it NEVER contains tokens or credentials (the form has no
+ * such fields, and the share payload has never encoded them). `autoSimulate`
+ * asks the opener to run the simulation automatically once the pipeline run
+ * finishes, rather than just pre-filling the form.
+ */
+export interface ShareSimulator {
+  form: Record<string, string>;
+  autoSimulate?: boolean;
+}
+
 /** The app-facing shape passed to encodeShare. */
 export interface ShareState {
   config: string;
@@ -39,11 +53,16 @@ export interface ShareState {
   /** The platform/endpoint explicitly override the global config's values. */
   platformOverride?: boolean;
   view?: ShareView;
+  /** Roadmap 018: optional simulator inputs (never tokens). */
+  sim?: ShareSimulator;
 }
 
 /**
  * The decoded payload as stored in the fragment. v2 (008) added the optional
- * global/inherited config layers; v1 payloads simply lack them.
+ * global/inherited config layers; v1 payloads simply lack them. Roadmap 018
+ * adds the optional `sim` field WITHOUT a version bump: it is purely additive,
+ * so a v2 consumer that predates it simply ignores the unknown key, and this
+ * decoder tolerates its absence — the version stays 2.
  */
 export interface SharePayload {
   v: 1 | 2;
@@ -56,6 +75,7 @@ export interface SharePayload {
   inheritedConfig?: Record<string, unknown>;
   platformOverride?: boolean;
   view?: ShareView;
+  sim?: ShareSimulator;
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -122,6 +142,10 @@ export async function encodeShare(state: ShareState): Promise<string> {
   if (view) {
     payload.view = view;
   }
+  const sim = normalizeSim(state.sim);
+  if (sim) {
+    payload.sim = sim;
+  }
   const json = JSON.stringify(payload);
   const compressed = await deflateRaw(new TextEncoder().encode(json));
   return bytesToBase64url(compressed);
@@ -143,6 +167,28 @@ function normalizeView(view: ShareView | undefined): ShareView | undefined {
     out.step = view.step;
   }
   return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/**
+ * Keeps only string→(non-empty)string form fields and the autoSimulate flag;
+ * returns undefined when there is nothing worth encoding. Guards against
+ * anything non-string sneaking into the payload (tokens have no field here, but
+ * this also keeps the encoded form small and well-typed).
+ */
+function normalizeSim(sim: ShareSimulator | undefined): ShareSimulator | undefined {
+  if (!sim) {
+    return undefined;
+  }
+  const form: Record<string, string> = {};
+  for (const [key, value] of Object.entries(sim.form ?? {})) {
+    if (typeof value === "string" && value !== "") {
+      form[key] = value;
+    }
+  }
+  if (Object.keys(form).length === 0) {
+    return undefined;
+  }
+  return sim.autoSimulate ? { form, autoSimulate: true } : { form };
 }
 
 /** Decodes a fragment token back to a payload, or null on any failure. */
@@ -172,6 +218,19 @@ export async function decodeShare(token: string): Promise<SharePayload | null> {
     }
     if (typeof p.platformOverride !== "boolean") {
       delete p.platformOverride;
+    }
+    // Roadmap 018: sanitize the optional simulator descriptor — must be a plain
+    // object with a plain-object `form` of string values; drop anything else so
+    // a hand-tampered link can't inject non-string values into the form.
+    const rawSim: unknown = p.sim;
+    const cleanSim =
+      isPlainObject(rawSim) && isPlainObject(rawSim.form)
+        ? normalizeSim(rawSim as unknown as ShareSimulator)
+        : undefined;
+    if (cleanSim) {
+      p.sim = cleanSim;
+    } else {
+      delete p.sim;
     }
     return p;
   } catch {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -11,6 +11,12 @@ export {
   type SimulationInput,
   type SimulationResult,
 } from "./simulate-package-rules";
+export {
+  compareSimulations,
+  type ConfigKeyDelta,
+  type RuleRef,
+  type SimulationComparison,
+} from "./simulate-compare";
 export { setPresetAuth, type PresetAuth } from "./auth";
 export { deriveUpdateType, renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";

--- a/packages/engine/src/simulate-compare.ts
+++ b/packages/engine/src/simulate-compare.ts
@@ -1,0 +1,121 @@
+/**
+ * Roadmap 018 — A/B run comparison. A pure, dependency-free diff of two
+ * `SimulationResult`s (A = a pinned earlier run, B = the current run after the
+ * config was edited and re-simulated): which rules matched only in A, only in
+ * B, or in both, plus the key-level delta of the final per-dependency config,
+ * plus an explicit "no behavioral change" verdict when both sets are equal.
+ *
+ * No Renovate imports — the `SimulationResult` reference is a `import type`,
+ * erased at compile time — so this module runs (and unit-tests) with zero
+ * engine/browser machinery.
+ */
+import type { RuleEvaluation, SimulationResult } from "./simulate-package-rules";
+
+/** A matched rule identified by its selector signature (stable across edits). */
+export interface RuleRef {
+  /** Position in the run this rule came from (A's index for `both`). */
+  index: number;
+  /**
+   * The rule's `match*` selectors as a stable string — key+value of every
+   * clause, in registry order. Two rules with the same selectors compare equal
+   * even if their position in `packageRules` shifted between edits.
+   */
+  signature: string;
+  /** Human label: the joined clause keys, e.g. `matchSourceUrls + matchUpdateTypes`. */
+  label: string;
+}
+
+/** One key whose final per-dependency value differs between A and B. */
+export interface ConfigKeyDelta {
+  key: string;
+  /** A's value (only meaningful when `inA`). */
+  before?: unknown;
+  /** B's value (only meaningful when `inB`). */
+  after?: unknown;
+  inA: boolean;
+  inB: boolean;
+}
+
+export interface SimulationComparison {
+  /** Rules that matched in A but not in B (removed / no longer firing). */
+  matchedOnlyInA: RuleRef[];
+  /** Rules that matched in B but not in A (added / newly firing). */
+  matchedOnlyInB: RuleRef[];
+  /** Rules that matched in both runs. */
+  matchedInBoth: RuleRef[];
+  /** Final per-dependency config keys that changed, sorted by key. */
+  configDelta: ConfigKeyDelta[];
+  /** True when the matched-rule sets AND the final configs are identical. */
+  noChange: boolean;
+}
+
+function signatureOf(rule: RuleEvaluation): string {
+  return JSON.stringify(rule.clauses.map((c) => [c.key, c.value]));
+}
+
+function labelOf(rule: RuleEvaluation): string {
+  return rule.clauses.length === 0
+    ? "no match* selectors"
+    : rule.clauses.map((c) => c.key).join(" + ");
+}
+
+function refOf(rule: RuleEvaluation): RuleRef {
+  return { index: rule.index, signature: signatureOf(rule), label: labelOf(rule) };
+}
+
+function matchedRules(result: SimulationResult): RuleEvaluation[] {
+  return result.rules.filter((r) => r.verdict === "matched");
+}
+
+function jsonEqual(a: unknown, b: unknown): boolean {
+  return a === b || JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Compares a pinned run (`a`) with the current run (`b`). Matched rules are
+ * paired greedily by selector signature (a multiset match, so a config with two
+ * rules sharing selectors is handled), leftover A rules become `matchedOnlyInA`
+ * and leftover B rules `matchedOnlyInB`.
+ */
+export function compareSimulations(a: SimulationResult, b: SimulationResult): SimulationComparison {
+  const aMatched = matchedRules(a);
+  const bRemaining = matchedRules(b);
+  const matchedInBoth: RuleRef[] = [];
+  const matchedOnlyInA: RuleRef[] = [];
+
+  for (const ra of aMatched) {
+    const sig = signatureOf(ra);
+    const i = bRemaining.findIndex((rb) => signatureOf(rb) === sig);
+    if (i >= 0) {
+      matchedInBoth.push(refOf(ra));
+      bRemaining.splice(i, 1);
+    } else {
+      matchedOnlyInA.push(refOf(ra));
+    }
+  }
+  const matchedOnlyInB = bRemaining.map(refOf);
+
+  const configA = a.finalDependencyConfig;
+  const configB = b.finalDependencyConfig;
+  const keys = [...new Set([...Object.keys(configA), ...Object.keys(configB)])].toSorted();
+  const configDelta: ConfigKeyDelta[] = [];
+  for (const key of keys) {
+    const inA = key in configA;
+    const inB = key in configB;
+    if (jsonEqual(configA[key], configB[key])) {
+      continue;
+    }
+    configDelta.push({
+      key,
+      ...(inA ? { before: configA[key] } : {}),
+      ...(inB ? { after: configB[key] } : {}),
+      inA,
+      inB,
+    });
+  }
+
+  const noChange =
+    matchedOnlyInA.length === 0 && matchedOnlyInB.length === 0 && configDelta.length === 0;
+
+  return { matchedOnlyInA, matchedOnlyInB, matchedInBoth, configDelta, noChange };
+}

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -65,7 +65,29 @@ export interface SimulationInput {
   dep: DependencyDescriptor;
 }
 
-export type ClauseState = "matched" | "no-match" | "not-simulated" | "invalid" | "error";
+/**
+ * Roadmap 018: the matcher return `boolean | null` is reported at three
+ * levels of precision instead of the old two:
+ * - `matched` — the matcher returned `true`.
+ * - `no-match` — the matcher returned `false` AND at least one input field it
+ *   reads was set on the dependency: a genuine mismatch (e.g. the money-shot
+ *   `matchSourceUrls: [...] — no match against sourceUrl = "…"`).
+ * - `no-input` — the matcher returned `false` because NONE of the fields it
+ *   reads were set on the simulated dependency (upstream's fail-closed
+ *   `if (!sourceUrl) return false`). Still fails the rule (verdict → no-match,
+ *   oracle-identical), but is reported as "skipped — no sourceUrl set …" so it
+ *   isn't mistaken for a real mismatch.
+ * - `not-applicable` — the matcher returned `null` (it could not evaluate the
+ *   clause, e.g. an unparseable age range); upstream skips it, so it does not
+ *   affect whether the rule matches.
+ */
+export type ClauseState =
+  | "matched"
+  | "no-match"
+  | "no-input"
+  | "not-applicable"
+  | "not-simulated"
+  | "error";
 
 export interface ClauseEvaluation {
   /** The `match*` selector key, e.g. `matchPackageNames`. */
@@ -75,7 +97,9 @@ export interface ClauseEvaluation {
   state: ClauseState;
   /** The input fields the matcher consulted, for human explanations. */
   inputValues: Record<string, unknown>;
-  /** Present for not-simulated / invalid / error states. */
+  /** The dependency fields this matcher reads (for a "no X set" explanation). */
+  readFields: readonly string[];
+  /** Present for no-input / not-applicable / not-simulated / error states. */
   note?: string;
 }
 
@@ -262,6 +286,15 @@ function applyTemplate(value: string, field: string, notes: string[]): string {
   return value;
 }
 
+/** "sourceUrl" / "packageFile or lockFiles" — the fields a matcher reads,
+ *  for the fail-closed "no X set on the simulated dependency" explanation. */
+function humanFieldList(fields: readonly string[]): string {
+  if (fields.length <= 1) {
+    return fields[0] ?? "matching input";
+  }
+  return `${fields.slice(0, -1).join(", ")} or ${fields.at(-1)}`;
+}
+
 async function evaluateRule(
   index: number,
   inputConfig: Record<string, unknown>,
@@ -285,12 +318,14 @@ async function evaluateRule(
         inputValues[field] = inputConfig[field];
       }
     }
+    const readFields = entry.inputFields;
     if (entry.key === "matchConfidence") {
       clauses.push({
         key: entry.key,
         value,
         state: "not-simulated",
         inputValues,
+        readFields,
         note: NOT_SIMULATED_NOTE,
       });
       // The registry evaluates matchConfidence FIRST, so a real run throws
@@ -307,9 +342,27 @@ async function evaluateRule(
     try {
       const raw = await matcher.matches(inputConfig, rule);
       if (raw === true) {
-        clauses.push({ key: entry.key, value, state: "matched", inputValues });
+        clauses.push({ key: entry.key, value, state: "matched", inputValues, readFields });
       } else if (raw === false) {
-        clauses.push({ key: entry.key, value, state: "no-match", inputValues });
+        // Roadmap 018: a `false` from a matcher that reads dependency fields
+        // NONE of which are set is upstream's fail-closed branch
+        // (`if (!sourceUrl) return false`), not a real mismatch — report it as
+        // "skipped — no <field> set" and name the missing field(s). Matchers
+        // that read nothing off the dependency (matchJsonata) never take this
+        // path. Either way the rule still fails to match, exactly as upstream.
+        const failClosed = readFields.length > 0 && Object.keys(inputValues).length === 0;
+        clauses.push({
+          key: entry.key,
+          value,
+          state: failClosed ? "no-input" : "no-match",
+          inputValues,
+          readFields,
+          ...(failClosed
+            ? {
+                note: `skipped — no ${humanFieldList(readFields)} set on the simulated dependency`,
+              }
+            : {}),
+        });
         if (verdict === "matched") {
           verdict = "no-match";
         }
@@ -317,11 +370,12 @@ async function evaluateRule(
         clauses.push({
           key: entry.key,
           value,
-          state: "invalid",
+          state: "not-applicable",
           inputValues,
+          readFields,
           note:
-            "the matcher returned null for this clause (invalid or incomplete input) — " +
-            "Renovate skips it, so it does not affect whether the rule matches",
+            "not applicable — the matcher returned null (it could not evaluate this clause), " +
+            "so Renovate skips it and it does not affect whether the rule matches",
         });
       }
     } catch (err) {
@@ -330,6 +384,7 @@ async function evaluateRule(
         value,
         state: "error",
         inputValues,
+        readFields,
         note: `matcher threw: ${err instanceof Error ? err.message : String(err)} — treated as not matching`,
       });
       if (verdict === "matched") {

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Roadmap 018 — unit tests for the pure A/B `compareSimulations` diff. Builds
+ * `SimulationResult`-shaped fixtures by hand (the module only reads `rules` and
+ * `finalDependencyConfig`), so this needs no Renovate machinery and runs as a
+ * plain node test.
+ */
+import { describe, expect, it } from "vitest";
+import { compareSimulations, type RuleEvaluation, type SimulationResult } from "../src/index";
+
+/** A matched rule with the given selector clauses (only key+value are read). */
+function matched(index: number, clauses: [string, unknown][]): RuleEvaluation {
+  return {
+    index,
+    verdict: "matched",
+    clauses: clauses.map(([key, value]) => ({
+      key,
+      value,
+      state: "matched" as const,
+      inputValues: {},
+      readFields: [],
+    })),
+    notes: [],
+  };
+}
+
+function noMatch(index: number, clauses: [string, unknown][]): RuleEvaluation {
+  return { ...matched(index, clauses), verdict: "no-match" };
+}
+
+function sim(
+  rules: RuleEvaluation[],
+  finalDependencyConfig: Record<string, unknown>,
+): SimulationResult {
+  return {
+    rules,
+    rawFinalConfig: {},
+    finalDependencyConfig,
+    flattened: { merged: [], blocks: {} },
+    errors: [],
+    warnings: [],
+    notes: [],
+  };
+}
+
+describe("compareSimulations", () => {
+  it("reports no behavioral change when matched rules and final config are equal", () => {
+    const a = sim([matched(0, [["matchPackageNames", ["react"]]])], { automerge: true });
+    // B: same selectors at a DIFFERENT index, same final config — still equal.
+    const b = sim(
+      [noMatch(0, [["matchDepTypes", ["dev"]]]), matched(1, [["matchPackageNames", ["react"]]])],
+      { automerge: true },
+    );
+    const cmp = compareSimulations(a, b);
+    expect(cmp.noChange).toBe(true);
+    expect(cmp.matchedOnlyInA).toEqual([]);
+    expect(cmp.matchedOnlyInB).toEqual([]);
+    expect(cmp.configDelta).toEqual([]);
+    expect(cmp.matchedInBoth.map((r) => r.signature)).toEqual([
+      JSON.stringify([["matchPackageNames", ["react"]]]),
+    ]);
+  });
+
+  it("splits matched rules into only-A, only-B, and both by selector signature", () => {
+    const shared: [string, unknown][] = [["matchDatasources", ["npm"]]];
+    const a = sim([matched(0, shared), matched(1, [["matchPackageNames", ["lodash"]]])], {
+      labels: ["a"],
+    });
+    const b = sim([matched(0, shared), matched(1, [["matchSourceUrls", ["https://x"]]])], {
+      labels: ["a"],
+    });
+    const cmp = compareSimulations(a, b);
+    expect(cmp.matchedInBoth.map((r) => r.label)).toEqual(["matchDatasources"]);
+    expect(cmp.matchedOnlyInA.map((r) => r.label)).toEqual(["matchPackageNames"]);
+    expect(cmp.matchedOnlyInB.map((r) => r.label)).toEqual(["matchSourceUrls"]);
+    expect(cmp.noChange).toBe(false);
+  });
+
+  it("emits key-level config deltas with before/after and presence flags", () => {
+    const a = sim([matched(0, [["matchPackageNames", ["x"]]])], {
+      automerge: false,
+      labels: ["old"],
+    });
+    const b = sim([matched(0, [["matchPackageNames", ["x"]]])], {
+      automerge: true,
+      groupName: "grp",
+    });
+    const cmp = compareSimulations(a, b);
+    expect(cmp.noChange).toBe(false);
+    // sorted by key: automerge (changed), groupName (added in B), labels (removed from A)
+    expect(cmp.configDelta).toEqual([
+      { key: "automerge", before: false, after: true, inA: true, inB: true },
+      { key: "groupName", after: "grp", inA: false, inB: true },
+      { key: "labels", before: ["old"], inA: true, inB: false },
+    ]);
+  });
+
+  it("ignores non-matched rules on both sides", () => {
+    const a = sim(
+      [matched(0, [["matchManagers", ["npm"]]]), noMatch(1, [["matchPackageNames", ["gone"]]])],
+      {},
+    );
+    const b = sim(
+      [noMatch(0, [["matchManagers", ["npm"]]]), matched(1, [["matchManagers", ["npm"]]])],
+      {},
+    );
+    const cmp = compareSimulations(a, b);
+    // matchManagers matched in both (A idx0, B idx1); the no-match rules drop out.
+    expect(cmp.matchedInBoth.map((r) => r.label)).toEqual(["matchManagers"]);
+    expect(cmp.matchedOnlyInA).toEqual([]);
+    expect(cmp.matchedOnlyInB).toEqual([]);
+    expect(cmp.noChange).toBe(true);
+  });
+
+  it("pairs duplicate-signature matched rules as a multiset", () => {
+    const clause: [string, unknown][] = [["matchDatasources", ["npm"]]];
+    const a = sim([matched(0, clause), matched(1, clause)], {});
+    const b = sim([matched(0, clause)], {});
+    const cmp = compareSimulations(a, b);
+    expect(cmp.matchedInBoth).toHaveLength(1);
+    expect(cmp.matchedOnlyInA).toHaveLength(1);
+    expect(cmp.matchedOnlyInB).toHaveLength(0);
+  });
+});

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -208,7 +208,7 @@ describe("simulatePackageRules", () => {
     expect(result.notes.some((n) => n.includes("MISSING_API_CREDENTIALS"))).toBe(true);
   });
 
-  it("treats a present clause that returns null as skipped, like upstream", async () => {
+  it("reports a null-returning clause as not-applicable (skipped), like upstream", async () => {
     const config = {
       packageRules: [
         {
@@ -223,10 +223,45 @@ describe("simulatePackageRules", () => {
       dep: { ...npmDep, currentVersionTimestamp: "2020-01-01T00:00:00.000Z" },
     });
     const clause = result.rules[0]?.clauses.find((c) => c.key === "matchCurrentAge");
-    expect(clause?.state).toBe("invalid");
+    expect(clause?.state).toBe("not-applicable");
     // upstream skips null even for present clauses — the rule still matches
     expect(result.rules[0]?.verdict).toBe("matched");
     expect(result.rawFinalConfig.labels).toEqual(["aged"]);
+  });
+
+  it("distinguishes a real mismatch (no-match) from a fail-closed missing input (no-input)", async () => {
+    const config = {
+      packageRules: [{ matchSourceUrls: ["https://github.com/facebook/react"], labels: ["fb"] }],
+    };
+
+    // sourceUrl set but different → a genuine no-match against a named input.
+    const mismatch = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, sourceUrl: "https://github.com/react/react" },
+    });
+    const mismatchClause = mismatch.rules[0]?.clauses[0];
+    expect(mismatchClause?.state).toBe("no-match");
+    expect(mismatchClause?.inputValues).toEqual({ sourceUrl: "https://github.com/react/react" });
+    expect(mismatch.rules[0]?.verdict).toBe("no-match");
+
+    // sourceUrl absent → upstream's `if (!sourceUrl) return false` fail-closed
+    // branch: reported as no-input, naming the missing field, still no-match.
+    const missing = await simulatePackageRules({ config, dep: npmDep });
+    const missingClause = missing.rules[0]?.clauses[0];
+    expect(missingClause?.state).toBe("no-input");
+    expect(missingClause?.inputValues).toEqual({});
+    expect(missingClause?.readFields).toContain("sourceUrl");
+    expect(missingClause?.note).toMatch(/no sourceUrl set on the simulated dependency/);
+    expect(missing.rules[0]?.verdict).toBe("no-match");
+
+    // oracle parity is unaffected by the finer reporting.
+    for (const [dep, sim] of [
+      [{ ...npmDep, sourceUrl: "https://github.com/react/react" }, mismatch],
+      [npmDep, missing],
+    ] as const) {
+      const oracle = await applyPackageRules(oracleInput(config, dep));
+      expect(sim.rawFinalConfig).toEqual(oracle);
+    }
   });
 
   it("evaluates matchJsonata against the whole input config", async () => {

--- a/roadmap/018-evidence-export-and-expert-precision.md
+++ b/roadmap/018-evidence-export-and-expert-precision.md
@@ -1,6 +1,45 @@
 # 018 — Evidence export + expert-grade precision
 
-Milestone: M6 · Status: planned
+Milestone: M6 · Status: done 2026-07-24
+
+> Implemented as specified across the engine and app. **Share links + auto-run:**
+> the versioned share payload gains one optional additive field, `sim`
+> (`{ form, autoSimulate? }`, form = the simulator's dependency-descriptor
+> fields, never tokens), with NO version bump — a pre-018 v2 consumer ignores
+> the unknown key and the decoder tolerates its absence; `decodeShare`
+> sanitizes it to string→string form entries only. A "Copy link with this
+> simulation" button by the verdict block encodes the current form (with the
+> EFFECTIVE updateType, so the opener reproduces the exact verdict) and sets
+> `autoSimulate`. `App.loadShareToken` now `await`s the pipeline run and only
+> then arms a nonced `simRequest`, so the `RuleSimulator` applies the form and
+> auto-runs against the freshly-run config — identically on mount and on
+> hashchange (017's path), verified in a production `vite preview`. **Copy as
+> markdown:** a reusable `CopyMarkdownButton` (fenced block + one-line header,
+> `navigator.clipboard.writeText`) on the preset inspector's Fetched/Fully-
+> resolved bodies and on each matched rule's applied-diff panel (header =
+> `packageRules[N] <selectors> — <verdict>`, body = `key: before → after`
+> lines). **A/B runs:** "Pin result for comparison" on the verdict block keeps
+> an A result across pipeline re-runs; editing + re-simulating renders a
+> structured diff — matched-rule set delta (only-A / only-B / both, paired by a
+> selector signature stable across index shifts) and final per-dependency
+> config key delta — with an explicit "No behavioral change" verdict when both
+> are equal. The comparison is a pure engine module,
+> `simulate-compare.ts` (`compareSimulations`, type-only import of
+> `SimulationResult`, zero Renovate deps), unit-tested in
+> `test/simulate-compare.node.test.ts` (noChange, only-A/only-B/both split,
+> key-level deltas with presence flags, multiset pairing). **Matcher
+> precision:** clause evaluation now distinguishes a matcher's `false` with the
+> read field present (`no-match` — a real mismatch) from `false` with none of
+> the read fields set (`no-input` — upstream's fail-closed `if (!sourceUrl)
+return false`, reported "skipped — no sourceUrl set on the simulated
+> dependency", naming the field), and renames the `null` case `not-applicable`
+> ("skipped, doesn't affect the rule"). `no-input` still fails the rule
+> (verdict + "failed on <clause>" unchanged) so the oracle is untouched — only
+> the reporting sharpened; engine tests updated.
+
+Original plan below.
+
+---
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -22,7 +22,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
 | [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done    |
-| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | planned |
+| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done    |
 | [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | planned |
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | planned |
 


### PR DESCRIPTION
Implements roadmap item 018 (M6, from the 2026-07 persona UX study — the expert personas' 'citable with caveats' gaps).

- **Reproducible simulator links**: the share payload optionally carries the simulator form + an `autoSimulate` flag (additive to v2; decoder tolerant; credentials cannot appear — the form has no token fields and encode filters to plain strings). Opening one pre-fills and auto-runs after the pipeline run, on both mount and hashchange.
- **Copy-as-markdown** on preset inspector bodies and per-rule applied diffs — fenced block + identity header, paste-ready for discussion answers.
- **A/B runs**: pin a result, edit config, re-simulate → structured diff of the matched-rule set (only-A / only-B / both, paired by selector signature so index shifts don't produce noise) and key-level final-config delta, with an explicit **"No behavioral change"** verdict. Pure engine module + 5 unit tests.
- **Matcher precision**: clause rows distinguish `no match` (input present, matcher returned false), `skipped — no sourceUrl set on the simulated dependency` (fail-closed false), and `not applicable` (returned null). Oracle behavior untouched; shimmed test asserts the distinction with parity.

Validated: lint, format, typecheck, golden (60) + shimmed (77) tests, production build; flows verified in a live browser against the production build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ