### PR TITLE
feat(019): persona usability-test replay skill

### DIFF
--- a/.claude/skills/persona-test/SKILL.md
+++ b/.claude/skills/persona-test/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: persona-test
+description: Replays the 2026-07 persona usability study (all scenarios, or a scenario/persona subset) against the live app — spawns entry/advanced/expert subagents that drive a real Chrome browser through the Renovate Config Visualizer, ground-truth withheld, and synthesizes their structured reports. Use when asked to run a persona test, replay the persona study, or evaluate a UX change against the benchmark scenarios.
+---
+
+# Persona-test replay
+
+Encodes the procedure from the
+[2026-07 persona UX study](../../../roadmap/2026-07-persona-ux-study.md) as a
+repeatable skill (roadmap 019). You (the agent running this skill) are the
+**orchestrator**: you build and serve the app, generate share links, spawn
+persona subagents one at a time against a single shared browser, collect
+their structured reports, and synthesize a comparison against the baseline
+study.
+
+You do not drive the browser yourself except for the server health check —
+all scenario exploration happens inside persona subagents.
+
+## 1. Parse arguments
+
+Args come as free text after the skill invocation, e.g. `/persona-test
+simulator advanced` or `/persona-test 44772 all` or with no args at all.
+
+- **Scenario filter** — optional. One of:
+  - `all` (default) — every file in `scenarios/`.
+  - a discussion id or filename fragment (e.g. `44772`, `star-exclusion`) —
+    matches against scenario filenames.
+  - a thematic word (e.g. `simulator`) — match against scenario content
+    (all three current scenarios exercise the simulator; a filter like this
+    only narrows once more scenarios exist — fall back to `all` with a note
+    if nothing matches).
+- **Persona filter** — optional. One or more of `entry`, `advanced`,
+  `expert`. Default: all three.
+
+If both are given, order doesn't matter — just identify which tokens are
+scenario matches vs. persona-level matches. If a token matches neither,
+say so and proceed with defaults rather than failing outright.
+
+State your resolved plan back before proceeding: which scenario files and
+which persona levels, and therefore how many subagent sessions (scenarios ×
+personas) you're about to run.
+
+## 2. Setup: build and serve
+
+```sh
+pnpm --filter @renovate-config-visualizer/app build
+```
+
+Then, from `packages/app`:
+
+```sh
+pnpm exec vite preview --port <port>
+```
+
+**Use `vite preview` (the production build), never `vite dev`.** This is a
+documented study finding (roadmap 019 / study report §10): a cold `vite dev`
+server can wedge the first engine import after a `--force`
+re-optimization — the production build has no such failure mode. Run
+`vite preview` as a background process (you'll keep it alive for the whole
+skill run, then stop it at the end).
+
+Pick a port not already in use (check with `lsof -i :<port>` or just try
+`4173`, `4174`, … on conflict — `vite preview`'s default is `4173`).
+
+**Verify the server responds before spawning any persona**: curl the root
+URL and confirm a 200 / HTML body comes back. Do not proceed to persona
+spawning on a server that isn't answering yet — retry briefly, but don't
+paper over a real startup failure.
+
+## 3. Generate share links
+
+For each `(scenario, persona)` pair you're running, generate the share URL
+with the bundled generator (no dependencies, already verified to round-trip
+its own tokens):
+
+```sh
+node .claude/skills/persona-test/generate-links.mjs \
+  --config .claude/skills/persona-test/scenarios/<scenario file> \
+  --port <port>
+```
+
+This prints a URL of the form `http://localhost:<port>/?s=<unique>#config=<token>`,
+built as:
+
+```
+payload = { v: 2, renovate: "<engine renovate version>", config: "<config text>", fileName: "renovate.json" }
+token   = base64url( deflate-raw( utf8( JSON.stringify(payload) ) ) )   // no padding
+url     = `http://localhost:<port>/?s=<unique>#config=${token}`
+```
+
+— the exact wire format `packages/app/src/share.ts` decodes. The generator
+reads the pinned Renovate version straight from
+`packages/engine/package.json`, so it always matches the build you just
+served; only pass `--renovate` explicitly if you need to deviate.
+
+The `?s=<unique>` query parameter is not read by the app. Its purpose: a
+same-origin URL that differs only in its hash is (correctly) treated by the
+in-app `hashchange` handler as a live navigation (roadmap 017 fixed that
+case) — but pasting a link into a **freshly-opened tab** with no prior app
+state is the common case here, and the unique query param guarantees a full
+document load regardless of which app build or browser tab state you land
+on. Keep it; it costs nothing and removes a whole class of flakiness.
+
+Each `(scenario, persona)` pair gets its **own freshly-generated link** — do
+not reuse a URL across personas even when the scenario config is identical,
+so each persona session starts from a clean load.
+
+## 4. Spawn persona subagents — serially, one shared browser
+
+Run persona sessions **one at a time**, never in parallel — the study used
+one shared browser tab/session throughout, and so does the replay (roadmap
+019 explicitly scopes out parallel personas). For each `(scenario, persona)`
+pair, in order:
+
+1. Load `personas.md` and extract the matching persona block (Entry /
+   Advanced / Expert) plus the shared mechanics footer.
+2. Load the scenario file and extract the matching `### <Level>` framing
+   from `## Symptom framing`, plus the `## Facts each level is allowed to
+know` bullet for that level. **Never** include the `## Ground truth`
+   section, or anything derived from it, in the subagent prompt.
+3. Compose the subagent prompt: persona block + shared mechanics footer +
+   scenario framing + allowed facts + the pre-generated share link for this
+   pair + instruction to navigate to that link first thing.
+4. Spawn as a **browser-only** subagent (it should have Chrome MCP tools
+   and nothing else it could use to route around the browser — no file
+   read/search, no web search, no shell). Enforce the ~30 action budget in
+   the prompt; the subagent self-reports when it stops, it isn't
+   externally metered.
+5. Collect its structured report (first impression / step log / outcome +
+   confidence / friction points / wishes) verbatim before moving to the
+   next pair.
+
+If a scenario config needs re-loading between personas (e.g. the previous
+persona edited the in-app config), the next persona's fresh share link
+navigation resets that — no manual cleanup needed between sessions, since
+each pair gets its own link and its own document load.
+
+## 5. Synthesize
+
+Once all sessions are collected, produce:
+
+1. **Per-scenario outcome table** — rows = persona levels, columns =
+   diagnosis correctness (graded by you, the orchestrator, against the
+   scenario's `## Ground truth` section — correct / partial / incorrect)
+   and confidence %. One table per scenario run.
+2. **Friction points, ranked by frequency** — pool every persona's friction
+   points across the run, group near-duplicates, sort by how many sessions
+   hit each one.
+3. **Comparison against the baseline** — the
+   [2026-07 study report](../../../roadmap/2026-07-persona-ux-study.md) is
+   the baseline. For each friction point or finding number (1–10) the
+   baseline documented that's in scope for this run's scenarios/personas,
+   state: still present / improved / resolved / not applicable this run.
+   Call out anything genuinely new (not in the baseline's 10 findings).
+   Pay particular attention to scenario `44006-automerge-nesting.md`'s
+   built-in regression check for roadmap 012 (update-type flattening) — an
+   expert run against it should now succeed where the baseline's expert
+   persona couldn't.
+
+Present this as your final report; do not silently drop a session's report
+even if it was short (budget ran out, or the persona bailed early) — note
+it as such in the table.
+
+## 6. Teardown
+
+Stop the `vite preview` process you started.
+
+---
+
+## Known infra pitfalls (from the study — avoid re-discovering these)
+
+- **Pasting into the CodeMirror config editor**: a synthesized paste needs
+  a real `ClipboardEvent` dispatched at the editor; `document.execCommand`
+  paste emulation does not work against CodeMirror's editable surface.
+  Before pasting replacement content, **select all and Delete first** —
+  pasting over a selection can behave differently than pasting into an
+  empty document, and stale selections have silently replaced the wrong
+  line in past sessions.
+- **Screenshot coordinates are in downscaled screenshot space**, not raw
+  page pixels — if you (or a persona) compute a click position from a
+  screenshot, remember the image you're looking at is scaled down from the
+  actual viewport; don't feed screenshot pixel coordinates directly to a
+  click without accounting for the scale factor.
+- **MCP-injected JavaScript runs in an isolated world** — it cannot see or
+  touch the page's own JS state/closures directly; interact through the DOM
+  and real events, not by reaching into React internals or module state.
+- **Never trigger native browser dialogs** (`confirm()`, `alert()`,
+  `beforeunload` prompts, file pickers) — a persona session has no way to
+  drive them and a stuck dialog silently ends the session. If a UI action
+  might trigger one (e.g. the "overwrite current work?" guard from roadmap
+  017's hashchange handling), avoid the sequence that provokes it rather
+  than trying to handle the dialog.
+- **`vite dev`, not `vite preview`, is the one with the cold-start wedge**
+  (see step 2) — don't "simplify" the setup back to `pnpm dev` for a faster
+  iteration loop; it's exactly the setup the study found unreliable.
+- **Hash-only navigation into an already-loaded tab was a real bug**
+  (roadmap 017, now fixed) — the `?s=<unique>` workaround in step 3 is
+  cheap insurance against the same bug class resurfacing or against
+  replaying this skill on an older build that predates the fix; keep it.

--- a/.claude/skills/persona-test/generate-links.mjs
+++ b/.claude/skills/persona-test/generate-links.mjs
@@ -1,0 +1,285 @@
+#!/usr/bin/env node
+/**
+ * Roadmap 019 — share-link generator for persona-test scenarios.
+ *
+ * Produces a URL in the exact wire format `packages/app/src/share.ts` reads:
+ *   payload {v:2, renovate, config, fileName} → JSON → UTF-8 →
+ *   deflate-raw (CompressionStream) → base64url (no padding), placed after
+ *   `#config=`.
+ *
+ * The URL also carries a unique `?s=<id>` query param BEFORE the hash. This
+ * is not read by the app — it exists so pasting the link into an
+ * already-open tab is a full document navigation, not a hash-only jump. A
+ * hash-only jump into a tab that already ran a previous scenario is exactly
+ * the bug class fixed by roadmap 017 (`hashchange` handling); keeping this
+ * workaround makes the generator robust regardless of which app build a
+ * replay targets.
+ *
+ * No dependencies — Node's global CompressionStream/DecompressionStream
+ * (stable since Node 21) do the deflate-raw work, same as the browser.
+ *
+ * Usage:
+ *   node generate-links.mjs --config <path> --port <port> [options]
+ *
+ * <path> is either:
+ *   - a plain JSON file (a renovate.json config), or
+ *   - a scenario markdown file (scenarios/*.md) — the FIRST ```json fenced
+ *     code block in the file is taken as the config.
+ *
+ * Options:
+ *   --config, -c <path>   Required. Config JSON file or scenario .md file.
+ *   --port, -p <port>     Required. Port `vite preview` is listening on.
+ *   --renovate <version>  Renovate version to embed. Default: read from
+ *                         packages/engine/package.json's pinned dependency.
+ *   --filename <name>     "renovate.json" (default) or "renovate.json5".
+ *   --base <path>         URL base path. Default "/".
+ *   --unique <id>         Fixed value for the `?s=` param (default: random,
+ *                         one per invocation — pass a fixed value for
+ *                         reproducible test output).
+ *   --list                List scenario files found under ./scenarios and
+ *                         exit.
+ *   --help, -h            Show this help and exit.
+ *
+ * Examples:
+ *   node generate-links.mjs --list
+ *   node generate-links.mjs -c scenarios/44772-monorepo-preset.md -p 4173
+ *   node generate-links.mjs -c /tmp/my-config.json -p 4173 --renovate 43.275.0
+ */
+
+import { readFile, readdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SCENARIOS_DIR = path.join(SCRIPT_DIR, "scenarios");
+// packages/engine/package.json relative to .claude/skills/persona-test/
+const ENGINE_PKG_JSON = path.resolve(
+  SCRIPT_DIR,
+  "..",
+  "..",
+  "..",
+  "packages",
+  "engine",
+  "package.json",
+);
+const FALLBACK_RENOVATE_VERSION = "43.275.0";
+
+const HELP = `Usage: node generate-links.mjs --config <path> --port <port> [options]
+
+<path> is a plain JSON renovate config file, or a scenario markdown file
+(scenarios/*.md) — the first \`\`\`json fenced block is used as the config.
+
+Options:
+  --config, -c <path>   Required. Config JSON file or scenario .md file.
+  --port, -p <port>     Required. Port \`vite preview\` is listening on.
+  --renovate <version>  Renovate version to embed (default: read from
+                         packages/engine/package.json).
+  --filename <name>     "renovate.json" (default) or "renovate.json5".
+  --base <path>         URL base path (default "/").
+  --unique <id>         Fixed value for the ?s= cache-busting param
+                         (default: random per invocation).
+  --list                List scenario files under ./scenarios and exit.
+  --help, -h            Show this help and exit.
+
+Examples:
+  node generate-links.mjs --list
+  node generate-links.mjs -c scenarios/44772-monorepo-preset.md -p 4173
+  node generate-links.mjs -c /tmp/my-config.json -p 4173 --renovate 43.275.0
+`;
+
+function parseArgs(argv) {
+  const args = { filename: "renovate.json", base: "/" };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--help":
+      case "-h":
+        args.help = true;
+        break;
+      case "--list":
+        args.list = true;
+        break;
+      case "--config":
+      case "-c":
+        args.config = argv[++i];
+        break;
+      case "--port":
+      case "-p":
+        args.port = argv[++i];
+        break;
+      case "--renovate":
+        args.renovate = argv[++i];
+        break;
+      case "--filename":
+        args.filename = argv[++i];
+        break;
+      case "--base":
+        args.base = argv[++i];
+        break;
+      case "--unique":
+        args.unique = argv[++i];
+        break;
+      default:
+        throw new Error(`Unknown argument: ${a} (--help for usage)`);
+    }
+  }
+  return args;
+}
+
+async function listScenarios() {
+  const entries = await readdir(SCENARIOS_DIR, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".md") && e.name !== "README.md")
+    .map((e) => path.join(SCENARIOS_DIR, e.name))
+    .toSorted();
+}
+
+/** Extracts the config: raw JSON file, or the first ```json fenced block in a .md file. */
+async function loadConfig(configPath) {
+  const raw = await readFile(configPath, "utf8");
+  if (configPath.endsWith(".md")) {
+    const match = raw.match(/```json\n([\s\S]*?)\n```/);
+    if (!match) {
+      throw new Error(`No \`\`\`json fenced block found in ${configPath}`);
+    }
+    const config = match[1];
+    JSON.parse(config); // validate — throws with a useful message on malformed JSON
+    return config;
+  }
+  JSON.parse(raw);
+  return raw;
+}
+
+async function resolveRenovateVersion(explicit) {
+  if (explicit) {
+    return explicit;
+  }
+  try {
+    const pkg = JSON.parse(await readFile(ENGINE_PKG_JSON, "utf8"));
+    const version = pkg.dependencies?.renovate;
+    if (typeof version === "string" && version.length > 0) {
+      return version.replace(/^[\^~]/, "");
+    }
+  } catch {
+    // fall through to hardcoded fallback
+  }
+  process.stderr.write(
+    `warning: could not read renovate version from ${ENGINE_PKG_JSON}; using fallback ${FALLBACK_RENOVATE_VERSION}\n`,
+  );
+  return FALLBACK_RENOVATE_VERSION;
+}
+
+async function deflateRaw(bytes) {
+  const stream = new CompressionStream("deflate-raw");
+  const writer = stream.writable.getWriter();
+  void writer.write(bytes);
+  void writer.close();
+  const chunks = [];
+  for await (const chunk of stream.readable) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function inflateRaw(bytes) {
+  const stream = new DecompressionStream("deflate-raw");
+  const writer = stream.writable.getWriter();
+  void writer.write(bytes);
+  void writer.close();
+  const chunks = [];
+  for await (const chunk of stream.readable) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+function bytesToBase64url(bytes) {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64urlToBytes(token) {
+  const b64 = token.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(b64, "base64");
+}
+
+function randomId() {
+  return Math.random().toString(36).slice(2, 8);
+}
+
+/** Builds the share token for a payload — same shape encodeShare() in share.ts produces. */
+async function encodeToken(payload) {
+  const json = JSON.stringify(payload);
+  const compressed = await deflateRaw(new TextEncoder().encode(json));
+  return bytesToBase64url(compressed);
+}
+
+/** Round-trips a token back to a payload, for self-verification. */
+async function decodeToken(token) {
+  const bytes = base64urlToBytes(token);
+  const json = new TextDecoder().decode(await inflateRaw(bytes));
+  return JSON.parse(json);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  if (args.list) {
+    const files = await listScenarios();
+    for (const f of files) {
+      process.stdout.write(`${path.relative(process.cwd(), f)}\n`);
+    }
+    return;
+  }
+
+  if (!args.config || !args.port) {
+    process.stderr.write("error: --config and --port are required (--help for usage)\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (args.filename !== "renovate.json" && args.filename !== "renovate.json5") {
+    process.stderr.write('error: --filename must be "renovate.json" or "renovate.json5"\n');
+    process.exitCode = 1;
+    return;
+  }
+
+  const config = await loadConfig(path.resolve(process.cwd(), args.config));
+  const renovate = await resolveRenovateVersion(args.renovate);
+  const payload = { v: 2, renovate, config, fileName: args.filename };
+
+  const token = await encodeToken(payload);
+
+  // Self-verify: inflate the token back and confirm it round-trips before
+  // printing anything a caller might paste into a browser.
+  const decoded = await decodeToken(token);
+  if (decoded.config !== config || decoded.v !== 2 || decoded.renovate !== renovate) {
+    process.stderr.write(
+      "error: token failed round-trip verification — refusing to print a broken link\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const unique = args.unique ?? randomId();
+  const base = args.base.endsWith("/") ? args.base : `${args.base}/`;
+  const url = `http://localhost:${args.port}${base}?s=${unique}#config=${token}`;
+
+  process.stderr.write(
+    `verified: token round-trips (${config.length}-char config, renovate ${renovate})\n`,
+  );
+  process.stdout.write(`${url}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`error: ${err.message}\n`);
+  process.exitCode = 1;
+});

--- a/.claude/skills/persona-test/personas.md
+++ b/.claude/skills/persona-test/personas.md
@@ -1,0 +1,146 @@
+# Persona prompt blocks
+
+Reusable, verbatim-includable prompt blocks for the three skill levels used by
+the persona-test skill. Derived from the
+[2026-07 persona UX study](../../../roadmap/2026-07-persona-ux-study.md)'s
+method section. Copy the matching block into a subagent's prompt, then append
+the scenario's per-level framing (`scenarios/<id>.md`) and the shared
+mechanics footer below.
+
+Every persona receives the problem as a pre-loaded share link and only the
+facts their skill level would plausibly know. **Ground truth is never given
+to a persona, under any circumstance** — not the scenario's answer key, not a
+hint that narrows it, not confirmation/denial of a guess mid-session.
+
+---
+
+## Entry
+
+**Role.** A developer who just inherited a repo with Renovate already
+configured. They did not write the config and have never operated Renovate
+before.
+
+**What they know.**
+
+- How to read JSON.
+- General software literacy (dependencies, pull requests, CI).
+- Whatever the app's UI teaches them as they go (labels, tooltips, the
+  glossary, hover cards).
+
+**What they must not know — and must not be told.**
+
+- Any Renovate-specific vocabulary before the UI shows it to them: don't say
+  "packageRules", "preset", "matcher", "extends", "updateType" etc. in the
+  scenario framing. Describe the symptom in plain language only ("this
+  dependency keeps showing up even though I told it to ignore it").
+- No hint at which part of the config is implicated.
+- No Renovate documentation, changelogs, or GitHub discussion content —
+  discovering that discussion (if the app surfaces something like it) is fine
+  in-session, but don't arrive already primed by it.
+
+**Instructions to the persona.**
+
+- Open the pre-loaded share link. You are looking at your own repo's config
+  in a tool you've never used before.
+- Work the problem using only what's on screen. If a term is unfamiliar,
+  look for the app's own explanation (glossary, tooltip, hover card) before
+  guessing at what it means.
+- Use the example chips / quick-fill affordances rather than hand-typing a
+  simulator form from scratch — an entry user would not know the right shape
+  offhand.
+- Budget: **~30 browser actions**. Stop and report once you've reached a
+  conclusion, a dead end, or the budget.
+
+## Advanced
+
+**Role.** A developer who has maintained this repo's Renovate config for
+about two years — writes and reviews `packageRules`, has hit validation
+errors before, knows the common presets by name.
+
+**What they know.**
+
+- Core Renovate vocabulary and mental model: `packageRules`, `extends`,
+  presets, matchers, `updateType`, automerge, validation errors.
+- How to read Renovate's own docs when needed (may reference doc content in
+  reasoning, as an advanced user genuinely would).
+- Enough to form a hypothesis quickly and go test it, rather than exploring
+  blind.
+
+**What they must not know — and must not be told.**
+
+- The specific bug/behavior at the root of _this_ scenario, or the accepted
+  answer from the source discussion.
+- Internal engine implementation details the app itself doesn't surface
+  (e.g. exact merge-order internals) — they reason from the tool's evidence,
+  not from source-diving Renovate's codebase.
+
+**Instructions to the persona.**
+
+- Open the pre-loaded share link.
+- State your working hypothesis before you start clicking, then use the tool
+  to confirm or refute it — this is how a two-year maintainer actually
+  works.
+- If the scenario framing includes multiple goals (e.g. "is this a real
+  error?", "what's minimal to fix it?", "prove the fix doesn't change
+  behavior"), address each one explicitly.
+- Budget: **~30 browser actions**.
+
+## Expert
+
+**Role.** Renovate-maintainer-level intrinsic knowledge — the kind of person
+who answers questions on the discussion board rather than asks them.
+
+**What they know.**
+
+- Deep, intrinsic knowledge of Renovate's actual resolution/merge semantics
+  (preset flattening, `matchSourceUrls` vs `matchPackageNames`, how
+  `automerge`/`labels`/`autoApprove` scope under nested update-type keys,
+  validator behavior) — brought from outside the tool, not taught by it.
+- What "citable" evidence looks like for answering someone else's config
+  question in public.
+
+**What they must not know — and must not be told.**
+
+- The specific source discussion this scenario is drawn from, or its
+  accepted answer text verbatim — they should independently arrive at (or
+  refute) the same conclusion using the tool, not recall it.
+
+**Instructions to the persona.**
+
+- Open the pre-loaded share link.
+- Judge the tool the way you'd judge whether you could paste a screenshot of
+  it into a discussion-board answer: is the evidence precise enough to be
+  citable? Where does it hedge, mangle grammar, or conflate two distinct
+  states (e.g. "no match" covering both "matcher returned `false`" and
+  "matcher returned `null`, not applicable")?
+- Push on multiple goals if the scenario gives you more than one; note
+  explicitly which goals you could and couldn't complete with the tool alone.
+- Budget: **~30 browser actions**.
+
+---
+
+## Shared mechanics footer (append to every persona prompt)
+
+- **Browser-only, one shared session.** You are driving a real Chrome tab via
+  the claude-in-chrome MCP tools. Do not read source code, do not open other
+  tools, do not search the web for the scenario's origin. Everything you use
+  to reach a conclusion must come from what the app shows you in this
+  session.
+- **Action budget ~30.** An "action" is one browser interaction (click, type,
+  scroll, screenshot, key-press). Track your count loosely; wrap up your
+  report when you're near budget even if unresolved — "ran out of budget,
+  still uncertain, last hypothesis was X" is a valid outcome.
+- **Never ask for or receive ground truth.** If the orchestrator or anything
+  in the environment offers to confirm your answer mid-session, decline and
+  keep working from the tool's evidence alone.
+- **Report structure (required, in this order):**
+  1. **First impression** — one or two sentences, gut reaction to the
+     landing state of the share link.
+  2. **Step log** — numbered, terse (one line per action or small batch of
+     actions): what you clicked/typed and what you saw.
+  3. **Outcome + confidence** — your diagnosis (or "unresolved") and a
+     confidence percentage.
+  4. **Friction points** — anything that slowed you down, confused you, or
+     you had to work around.
+  5. **Wishes** — features or changes that would have gotten you to the
+     answer faster or with more confidence.

--- a/.claude/skills/persona-test/scenarios/43936-star-exclusion.md
+++ b/.claude/skills/persona-test/scenarios/43936-star-exclusion.md
@@ -1,0 +1,93 @@
+# 43936 — star-exclusion pattern newly flagged as invalid
+
+## Discussion
+
+[renovatebot/renovate#43936 "Invalid configuration reported, but configuration seems correct"](https://github.com/renovatebot/renovate/discussions/43936)
+
+## Config
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["*", "!gradle"],
+      "groupName": "all dependencies except gradle"
+    }
+  ]
+}
+```
+
+## Symptom framing
+
+### Entry
+
+Your dependency bot's settings file just started failing a check, with a
+message that doesn't obviously make sense: something like _"Your input
+contains \* or \*\* along with other patterns. Please remove them."_ Nobody
+touched this file recently — it used to be accepted. Open the tool
+(pre-loaded with this repo's config) and figure out: (a) is this an actual
+problem with the file, or just a confusing message about something harmless;
+(b) what exactly is it complaining about; (c) what's the smallest change
+that would make the message go away, without changing what the file
+actually does.
+
+### Advanced
+
+Validation on this config newly fails with:
+
+> Your input contains \* or \*\* along with other patterns in the array.
+> Please remove them or convert to the recommended, safe syntax array.
+
+for `matchPackageNames: ["*", "!gradle"]`. Nothing about this rule's intent
+changed on your end — the config used to validate cleanly. Goals:
+
+1. Determine whether this is a real problem with the config or a validator
+   regression that shouldn't affect behavior.
+2. Pin down exactly which array/entry is being flagged, and why.
+3. Produce the minimal fix, and prove it doesn't change which packages the
+   rule matches.
+
+### Expert
+
+Same setup as Advanced. Goals:
+
+1. Produce a precise, citable explanation of why the validator now rejects
+   `["*", "!gradle"]` — precise enough to paste as a discussion-board answer.
+2. Pin down exactly which array/entry is flagged.
+3. Produce the minimal fix and prove — using the tool, not just by
+   inspection — that it is behavior-preserving.
+
+## Facts each level is allowed to know
+
+- Entry: the exact validation error text shown above; that the file
+  previously passed validation with no changes on their part; the config
+  content itself (their repo's real file). Not told what `matchPackageNames`
+  means, not told what a glob/wildcard convention means in this context, not
+  told the fix in advance.
+- Advanced: everything Entry knows, plus standard Renovate vocabulary and
+  that `matchPackageNames` accepts glob-style patterns including `*`/`**`
+  and negation (`!pattern`). Not told the specific rationale for the
+  validator tightening, not told the fix in advance.
+- Expert: everything Advanced knows. Not told the accepted answer from the
+  source discussion verbatim in advance — expected to reconstruct the
+  reasoning (redundant `*` next to an already-total negated set) themselves.
+
+## Ground truth — NEVER shown to personas
+
+Renovate's validator was tightened to flag any `matchPackageNames` (or
+similar matcher) array that mixes a wildcard (`*`/`**`) with other, more
+specific patterns, because mixing them is usually a sign of a mistaken
+intent. In this config, `*` is redundant: `!gradle` alone already means
+"match everything except `gradle`" (negation-only patterns imply "match all
+except…"), so `["*", "!gradle"]` and `["!gradle"]` select exactly the same
+set of packages. The fix is `matchPackageNames: ["!gradle"]` — remove the
+`*` — with **no behavioral change**. This is a real (if confusingly worded)
+validation error, not a false positive, and not something the user broke.
+
+Feeds the outcome table as: correct diagnosis = identifies the `*` as
+redundant given `!gradle` and proposes removing it (not adding `**`, not
+reordering, not adding an unrelated pattern); "confidence" should reflect
+whether the persona actually verified same-behavior (e.g. via a simulation
+before/after) rather than asserting it.

--- a/.claude/skills/persona-test/scenarios/44006-automerge-nesting.md
+++ b/.claude/skills/persona-test/scenarios/44006-automerge-nesting.md
@@ -1,0 +1,107 @@
+# 44006 — :automergeMinor merge behavior
+
+## Discussion
+
+[renovatebot/renovate#44006 ":automergeMinor merge behavior"](https://github.com/renovatebot/renovate/discussions/44006)
+
+## Config
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "extends": [":automergeMinor", ":label(deploy_pr)"],
+      "autoApprove": true
+    }
+  ]
+}
+```
+
+## Symptom framing
+
+### Entry
+
+There's a rule meant to give minor version bumps an easy, no-review path: a
+specific tag gets applied, the pull request is auto-approved, and it merges
+on its own. A recent update landed that's a much bigger jump than a minor
+bump — a major version change — and it got the tag and the auto-approval
+too. It just didn't merge on its own. That's confusing: shouldn't the whole
+"easy path" either apply or not apply as one unit? Open the tool (pre-loaded
+with this repo's config) and explain why it half-applied.
+
+### Advanced
+
+You have a `packageRule` that extends `:automergeMinor` and
+`:label(deploy_pr)`, plus sets `autoApprove: true`, intended to fast-track
+minor updates. A recent **major** update got the `deploy_pr` label and
+auto-approval — but (correctly, in your view) did not automerge. Goals:
+
+1. Work out why the label and approval applied to a non-minor update.
+2. Confirm (or correct) your mental model of how `extends`-based presets and
+   rule-level settings actually scope by update type — i.e. is "the whole
+   rule only applies to minors" right or wrong, and why.
+3. If the tool supports it, produce a **minor**-update run against this same
+   config and check whether it actually automerges, to fully verify the
+   scoping in both directions (this is the harder half — earlier tool
+   versions could not show this; check the current one).
+
+### Expert
+
+Same setup as Advanced. Goals:
+
+1. Produce a precise, citable explanation of why `labels`/`autoApprove`
+   apply to every matched update regardless of type, while `automerge` from
+   `:automergeMinor` does not — precise enough to correct someone's mental
+   model in a discussion-board answer.
+2. Run a **major**-update simulation (matching the reported symptom) and a
+   **minor**-update simulation against the same config, and contrast the two
+   final per-dependency verdicts directly. Note explicitly whether the tool
+   can show you "minor ⇒ automerge true" as a rendered verdict, or only as
+   raw unmerged fields you have to reason about yourself.
+
+## Facts each level is allowed to know
+
+- Entry: what happened (major update got the tag + approval, not the
+  automerge); that the rule was meant to fast-track minor updates only; the
+  config content itself. Not told what `:automergeMinor`, `extends`, or
+  rule-level vs. type-scoped settings mean.
+- Advanced: everything Entry knows, plus standard Renovate vocabulary,
+  that `:automergeMinor` is a bundled preset, and that presets can nest
+  settings under update-type keys (`minor: {...}`). Not told which specific
+  settings are type-scoped and which are rule-level in this preset.
+- Expert: everything Advanced knows. Not told the accepted answer from the
+  source discussion verbatim in advance.
+
+## Ground truth — NEVER shown to personas
+
+The `:automergeMinor` preset only nests `automerge: true` under the `minor`
+update-type key (equivalent to `packageRules: [{ minor: { automerge: true
+} } ]`), which Renovate merges into a matched update's effective config only
+when that update's `updateType` actually is `minor` (`mergeChildConfig`
+against `config[updateType]`, a.k.a. "update-type flattening"). `labels`
+and `autoApprove: true` in this config are set directly at the rule level,
+not nested under `minor`, so once `matchPackageNames: ["*"]` matches an
+update at all — major, minor, or patch — the label and auto-approval apply
+unconditionally. Only `automerge` is update-type-scoped. The user's "it
+should be one unit" mental model is the misconception; the tool's job is to
+show, not just assert, that only `automerge` is conditional.
+
+**This scenario doubles as a regression check for roadmap 012** (simulator
+update-type flattening): the original 2026-07 study found the simulator
+could not render the "minor ⇒ automerge true" contrast at all — a minor run
+showed unmerged `minor: {"automerge": true}` sitting next to a top-level
+`automerge: false`, indistinguishable from the major run, and the expert
+persona could not complete Goal 3/2 above as a result (Finding 1 in the
+study report). 012 shipped the flattening + verdict block specifically to
+close this gap. When synthesizing a replay's results against the baseline
+report, check specifically whether the minor-vs-major contrast is now
+produced correctly — this is the single most direct "did the fix work"
+signal this skill can produce.
+
+Feeds the outcome table as: correct diagnosis = names `automerge` as the
+only type-scoped setting among the three, and (post-012) whether the
+persona could actually produce and read the minor-run verdict, not just
+reason about it from raw fields.

--- a/.claude/skills/persona-test/scenarios/44772-monorepo-preset.md
+++ b/.claude/skills/persona-test/scenarios/44772-monorepo-preset.md
@@ -1,0 +1,90 @@
+# 44772 — monorepo:react preset not working
+
+## Discussion
+
+[renovatebot/renovate#44772 "monorepo:react preset not working"](https://github.com/renovatebot/renovate/discussions/44772)
+
+## Config
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "extends": ["monorepo:react"],
+      "enabled": false
+    }
+  ]
+}
+```
+
+## Symptom framing
+
+### Entry
+
+Someone on your team set this repo's dependency-update bot up to leave
+`react` alone — React upgrades need careful manual testing here, so a rule
+was added specifically to stop the bot from ever touching it. This week it
+opened a pull request anyway, bumping `react` from `18.2.0` to `19.2.0` —
+exactly the kind of change that was supposed to be blocked. Open the tool
+(pre-loaded with this repo's config) and figure out why the block didn't
+work.
+
+### Advanced
+
+You added a `packageRule` that extends `monorepo:react` with
+`enabled: false`, expecting it to silence updates to `react` and its
+monorepo siblings. You keep getting `react` PRs anyway — the latest one
+bumping `18.2.0` → `19.2.0`. Goals:
+
+1. Work out why your disable rule isn't matching the `react` dependency.
+2. Determine what config change (if any) would actually stop these PRs.
+
+### Expert
+
+Same setup as Advanced: a `packageRule` extending `monorepo:react` with
+`enabled: false` is not suppressing `react` updates (`18.2.0` → `19.2.0`
+observed). Goals:
+
+1. Produce a precise, citable explanation of why `monorepo:react` fails to
+   match `react` today — precise enough to paste into a discussion-board
+   answer, naming the exact clause that fails and why.
+2. Determine whether this is fixable purely by editing this repo's config
+   right now, or whether it needs an upstream preset update — i.e. what
+   should the person asking this actually do next.
+
+## Facts each level is allowed to know
+
+- Entry: the affected package is `react`; the observed version bump is
+  `18.2.0` → `19.2.0`; the rule was added on purpose to block react updates;
+  the config shown in the tool is this repo's real config. Not told what a
+  "preset" or "matcher" is, not told the preset's match target, not told
+  about any upstream repository move.
+- Advanced: everything Entry knows, plus standard Renovate vocabulary
+  (`packageRules`, `extends`, presets, matchers, `enabled`) and that
+  `monorepo:react` is a bundled preset they didn't author. Not told what the
+  preset's literal body matches on, not told about the repository move.
+- Expert: everything Advanced knows. Not told the specific accepted answer
+  from the source discussion, and not told in advance that a repository
+  rename is involved — that is exactly what they're expected to find via the
+  preset inspector and the simulator's per-clause evidence.
+
+## Ground truth — NEVER shown to personas
+
+The bundled `monorepo:react` preset's `packageRules` entry matches on
+`matchSourceUrls: ["https://github.com/facebook/react"]`. The upstream
+`react` npm package's source repository moved from `facebook/react` to
+`react/react`; Renovate now resolves `sourceUrl` for `react` as
+`https://github.com/react/react`, which does not match the preset's
+hard-coded `facebook/react` URL. The clause never matches, so the rule
+(and its `enabled: false`) never applies — `react` updates flow through
+normally, unaffected by the disable rule. This is an upstream-preset
+staleness issue, not a mistake in the user's own config; the fix is either
+an upstream preset update or a repo-level override
+(`matchSourceUrls: ["https://github.com/react/react"]`, `enabled: false`)
+added alongside the existing rule.
+
+Feeds the outcome table as: correct diagnosis = names the source-URL
+mismatch (repo move) as the cause, not "the preset doesn't exist" or "the
+version range is wrong" or similar.

--- a/.claude/skills/persona-test/scenarios/README.md
+++ b/.claude/skills/persona-test/scenarios/README.md
@@ -1,0 +1,72 @@
+# Scenario library
+
+Each file in this directory is one scenario for the `/persona-test` skill:
+a real, answered Renovate configuration problem, framed at three skill
+levels, with a ground-truth answer that is graded by a human after the run
+and **never shown to a persona**.
+
+Adding a scenario = adding one file here, named `<id>-<slug>.md` (`<id>` is
+the source discussion number, or any short stable id for a hand-built
+scenario). No registration step elsewhere is needed — `SKILL.md`'s scenario
+filter matches against the filename and the `## Discussion` heading.
+
+## Template
+
+Copy this into a new file. The `## Config` block is machine-read by
+`generate-links.mjs` (it takes the **first** ` ```json ` fenced block in the
+file), so keep exactly one fenced JSON config block per scenario, and put it
+under a `## Config` heading.
+
+````markdown
+# <id> — <short title>
+
+## Discussion
+
+<link to the source discussion, or "hand-built — no source discussion">
+
+## Config
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"]
+}
+```
+
+## Symptom framing
+
+### Entry
+
+<Plain-language description of the observed symptom only. No Renovate
+vocabulary — no "packageRules", "preset", "matcher", "extends", "updateType",
+etc. Describe what the user sees happening, not what's configured to cause
+it. The persona will see the raw config on screen regardless (it's "their"
+repo) — this framing is what they're TOLD about the problem, not a redaction
+of the screen.>
+
+### Advanced
+
+<Same symptom, in Renovate vocabulary, plus explicit numbered goals the
+persona should try to accomplish (typically 2-3: diagnose, propose/verify a
+fix, and/or prove behavior is unchanged).>
+
+### Expert
+
+<Same symptom and goals as Advanced, plus an explicit ask for citation-grade
+precision — e.g. "produce an explanation precise enough to paste into a
+public discussion-board answer.">
+
+## Facts each level is allowed to know
+
+- Entry: <...>
+- Advanced: <...>
+- Expert: <...>
+
+Facts NOT listed here must not be given to any persona, regardless of level.
+
+## Ground truth — NEVER shown to personas
+
+<The accepted-answer diagnosis, for grading only. State clearly which of the
+skill's synthesis step this feeds ("outcome table: correct/partial/incorrect
+diagnosis, per persona").>
+````

--- a/roadmap/019-persona-replay-skill.md
+++ b/roadmap/019-persona-replay-skill.md
@@ -1,6 +1,44 @@
 # 019 — Persona usability-test replay skill
 
-Milestone: M6 · Status: planned
+Milestone: M6 · Status: done 2026-07-24
+
+> Implemented as a Claude Code agent skill at `.claude/skills/persona-test/`.
+> **`SKILL.md`** encodes the full procedure: parse an optional scenario
+> filter (`all` default, discussion id, or filename fragment) and persona
+> filter (`entry`/`advanced`/`expert`, default all three); build the app and
+> serve it with `vite preview` (never `vite dev` — the study's documented
+> cold-start wedge); verify the server responds before spawning anyone;
+> generate one fresh share link per (scenario, persona) pair with the
+> bundled generator; spawn persona subagents **serially** against one shared
+> browser, browser-only, ~30-action budget, ground truth never given; collect
+> each structured report (first impression / step log / outcome + confidence
+> / friction points / wishes); synthesize a per-scenario outcome table,
+> friction points ranked by frequency, and an explicit comparison against
+> the 2026-07 study's baseline findings — including a built-in regression
+> check: the `44006-automerge-nesting` scenario is written to also verify
+> whether roadmap 012's update-type flattening now lets an expert persona
+> complete the "minor ⇒ automerge true" contrast the original study found
+> impossible. **`personas.md`** holds the three reusable prompt blocks
+> (role / what they know / what they must never be told / report structure)
+> plus a shared mechanics footer (browser-only, action budget, never accept
+> ground truth). **`scenarios/`** holds the three studied discussions
+> (44772 monorepo:react, 43936 star-exclusion validator, 44006 automerge
+> nesting), each reconstructed from the study report into a full
+> `renovate.json`, three-level symptom framing (entry framing deliberately
+> avoids Renovate vocabulary), a per-level "facts allowed" list, and a
+> ground-truth section explicitly marked never-shown-to-personas; plus a
+> `README.md` template for adding new scenarios (one file = one scenario, no
+> registration step). **`generate-links.mjs`** is a dependency-free Node
+> script producing the exact `share.ts` wire format (`{v:2, renovate,
+config, fileName}` → JSON → UTF-8 → deflate-raw → base64url, no padding)
+> via Node's global `CompressionStream`/`DecompressionStream`; it reads the
+> pinned Renovate version straight from `packages/engine/package.json`,
+> self-verifies every token by inflating it back before printing a URL, and
+> supports `--list`/`--help`/plain-JSON or scenario-`.md` input. Verified by
+> an independent round-trip decode outside the script (matches the on-disk
+> scenario config byte-for-byte). Out of scope per spec: automated
+> pass/fail scoring (synthesis stays a human judgment call) and parallel
+> personas (one shared browser, serial only).
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -23,7 +23,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
 | [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done    |
 | [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done    |
-| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | planned |
+| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done    |
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | planned |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):


### PR DESCRIPTION
Implements roadmap item 019 (M6).

- `.claude/skills/persona-test/` — `/persona-test [scenario] [persona]` replays the 2026-07 persona study (all 3×3 by default): build + `vite preview` (never `vite dev`), fresh share links per session, **serial** browser-only persona subagents (~30-action budget, ground truth withheld), synthesis with a comparison against the baseline study report.
- `personas.md`: reusable entry / advanced / expert prompt blocks with a shared reporting structure (first impression, step log, outcome + confidence, friction, wishes).
- `scenarios/`: the three studied discussions (#44772 monorepo preset, #43936 `["*","!gradle"]`, #44006 `:automergeMinor` nesting) with full configs, per-level symptom framing (entry framing avoids Renovate vocabulary), allowed facts, and clearly-marked ground truth; plus a template README — adding a scenario is adding one file.
- `generate-links.mjs`: dependency-free share-link generator using the real codec; self-verifies every token round-trips before printing. Verified end-to-end against a served production build.
- The 44006 scenario now doubles as a regression check for 012's update-type flattening — the baseline study's expert failed that goal; a replay should now succeed.

Validated: lint, format, typecheck, golden (60) + shimmed (77), build; generator round-trip verified independently of its own check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ