### PR TITLE
docs(roadmap): replay #1 report + M7 items (021–027)

### DIFF
--- a/roadmap/021-simulator-input-hardening.md
+++ b/roadmap/021-simulator-input-hardening.md
@@ -1,0 +1,39 @@
+# 021 — Simulator input hardening + A/B comparison integrity
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+Three of nine sessions in [replay #1](2026-07-persona-replay-01.md) mangled a
+simulator input the same way: a quick-fill chip or a pipeline re-run leaves
+unselected text in a field, the next keystrokes append, and the persona
+simulates "reactgradle" without noticing. Separately, the 018 pin/compare
+panel compares pinned-A against current-B even when the inputs differ (a
+gradle run was silently compared against a lodash pin) — an easy path to a
+wrong conclusion presented with full confidence.
+
+## User story
+
+As a user iterating on simulations, I want fields I re-target to replace
+rather than extend their old content, and I want the A/B panel to tell me
+when I'm comparing runs of two different hypothetical updates — so a wrong
+conclusion can't come from stale characters or mismatched baselines.
+
+## Scope
+
+- Select-on-focus (or an explicit one-click clear) for simulator text
+  fields; quick-fill chips leave fields in a state where typing replaces.
+- The A/B pin snapshots the full input descriptor with the result; the
+  comparison panel shows both input sets and warns prominently (or refuses)
+  when they differ.
+- Optional: named pins / a second pin slot (both advanced and expert built
+  multi-baseline comparisons by hand).
+
+## Out of scope
+
+- Registry lookups for real dependency metadata (see 015's out-of-scope; the
+  "prefill sourceUrl from the datasource" wish stays a possible follow-up).
+
+## Dependencies
+
+- 006 (simulator), 015 (input form), 018 (pin/compare).

--- a/roadmap/022-verdict-copy-precision.md
+++ b/roadmap/022-verdict-copy-precision.md
@@ -1,0 +1,47 @@
+# 022 — Verdict & translation copy precision
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+[Replay #1](2026-07-persona-replay-01.md)'s experts want to paste the tool's
+sentences into discussion-board answers, and found three places the prose
+fails that bar: the 43936 translation's rationale is factually wrong ("the
+other patterns already covered every case `*` did" — false for a
+negation-only array; the equivalence holds because negative-only arrays
+imply match-all-except); the 018 "skipped — no sourceUrl set" clause state
+reads as "not evaluated" when upstream semantics are a fail-closed `false`;
+and the verdict sentence emits no-op clauses ("add labels []", "only run on
+schedule [at any time]") that must be hand-edited out before quoting.
+
+## User story
+
+As an expert answering someone's config question, I want every sentence the
+tool renders to be quotable verbatim — factually right, no filler clauses,
+naming its evidence — so citing the tool doesn't cost me a correcting
+paragraph.
+
+## Scope
+
+- Fix the redundant-`*` translation rationale: state the actual rule (a
+  negative-only pattern array implicitly matches everything not excluded),
+  link the matcher docs section.
+- Reword the fail-closed clause state: "evaluated false — the simulated
+  dependency has no sourceUrl (Renovate treats a missing value as a
+  non-match)" instead of "skipped", keeping the tri-state distinction from
+  018 (matched / evaluated false / not applicable).
+- Suppress empty/no-op clauses from the verdict sentence; attribute
+  update-type scoping to its source preset in the quotable sentence
+  ("automerge is scoped to minor/patch — from `:automergeMinor`").
+- Stretch: a combined "quote this verdict" export — verdict sentence +
+  preset body excerpt + rule delta + version pin as one markdown block (the
+  pieces exist behind separate copy buttons).
+
+## Out of scope
+
+- New verdict semantics; this is wording and export only.
+
+## Dependencies
+
+- 012 (verdict block), 014 (translations), 018 (clause states,
+  copy-as-markdown).

--- a/roadmap/023-post-action-focus-and-guidance.md
+++ b/roadmap/023-post-action-focus-and-guidance.md
@@ -1,0 +1,48 @@
+# 023 — Post-action focus, honest error states, rule-filter shortcuts
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+Navigation and state-honesty gaps from [replay #1](2026-07-persona-replay-01.md).
+Apply fix re-runs the pipeline and lands the user on the Presets diff — the
+question they actually have ("is the error gone?") is answered on Validate,
+which they must find themselves. Pipeline re-runs reset scroll position.
+The simulator happily evaluates a config whose validation failed, with
+nothing saying a real Renovate run would refuse it. And the most common
+wish across all nine sessions: a "why didn't my rule match?" shortcut —
+finding your own rule among 713 still takes "show all" plus hunting.
+
+## User story
+
+As a user acting on the tool's advice, I want each action to land me on its
+consequence (fix → validation result), the tool to tell me when what I'm
+looking at is hypothetical (invalid config still simulated), and my own
+rules to be one click away in any rule list.
+
+## Scope
+
+- Apply fix returns to (or toasts) the Validate outcome: "re-ran — 0
+  errors"; preserve scroll position across pipeline re-runs (016 covered
+  re-simulations; runs still reset).
+- A banner on post-Validate stages and the simulator when validation
+  errors exist: "a real Renovate run would refuse this config; results
+  below show what it _would_ do."
+- "My rules only" filter in the simulator results (repo-config provenance
+  already known from 013), pre-expanded clause evidence for those rows.
+- Editor affordance for preset strings: hovering `:automergeMinor` in the
+  config editor currently shows a bare "string" type tooltip; surface the
+  preset inspector content (or at least a glossary card + jump link) where
+  the cursor already is.
+- Make the "(= merged rule packageRules[N])" annotation in validation
+  messages visibly interactive or visibly informational — entry users click
+  it and conclude it's broken.
+
+## Out of scope
+
+- Layout restructuring of the long page (the collapsed-by-default Presets
+  diff idea belongs to a broader information-architecture pass).
+
+## Dependencies
+
+- 013 (provenance), 014 (apply fix), 016 (scroll ergonomics).

--- a/roadmap/024-stage-chips-signal-outcomes.md
+++ b/roadmap/024-stage-chips-signal-outcomes.md
@@ -1,0 +1,42 @@
+# 024 — Stage chips signal what each stage did
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+User-reported (2026-07-24): every stage chip shows a green dot as long as it
+didn't error — Migrate shows green even when it rewrote the config
+(`semanticCommits: true` → `"enabled"`). Green universally reads as
+"nothing to see here", so the one stage that _did something to your config_
+looks identical to the stages that passed it through untouched.
+
+## User story
+
+As a user scanning the stage row, I want the dots to tell me where my
+config was changed or flagged before I click anything: green = passed
+through unchanged, amber = this stage transformed the config (with how many
+steps/changes), red = errors — so "Migrate rewrote something" is visible at
+a glance.
+
+## Scope
+
+- Per-stage activity signal: amber/orange dot when the stage produced a
+  non-empty transformation (migrate steps > 0, massage changed the config,
+  validation warnings), red retained for errors, green only for
+  pass-through/clean.
+- A small count on or beside the chip where meaningful ("Migrate ·1").
+- Define the semantics per stage explicitly: Presets/Merge always
+  "transform" by nature — for those, amber should mean something
+  non-routine (e.g. resolution errors already red; consider leaving them
+  neutral) rather than being permanently amber. Document the chosen rule in
+  the stage explainer hover cards (which already exist per stage).
+- Keep the colors legible in both themes and for color-blind users (shape
+  or count, not color alone).
+
+## Out of scope
+
+- Reordering stages or changing stage content.
+
+## Dependencies
+
+- 001 (stage timeline), first-load UX pass (stage explainer cards).

--- a/roadmap/025-hover-card-overflow.md
+++ b/roadmap/025-hover-card-overflow.md
@@ -1,0 +1,40 @@
+# 025 — Hover card text overflows its box
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+User-reported (2026-07-24, with screenshot): the badge-glossary hover card
+(e.g. the "own options" card on preset-tree badges, from the 016 pass)
+renders its explanation text flowing past the card's right edge — the card
+background ends mid-sentence and the text continues over the page. Long
+unwrapped lines and/or a missing max-width/wrapping rule on the shared
+glossary-card styling; 44006's expert session also saw option-doc tooltips
+occluding unrelated content when scrolled under the cursor, so the hover
+layer deserves one consolidated pass.
+
+## User story
+
+As a user hovering a badge to learn what it means, I want the explanation
+contained in its card — wrapped, sized, and positioned to stay readable —
+not bleeding across the page.
+
+## Scope
+
+- Fix wrapping/sizing on the shared hover-card styles (`.glossary-card` and
+  whatever the badge cards use): max-width, `overflow-wrap`, and no
+  `white-space` rules that defeat wrapping.
+- Audit every hover-card producer (glossary terms, stage explainers, badge
+  cards, option-doc cards) with the longest current copy at narrow and wide
+  viewports; fix positioning so cards never render off-screen.
+- Don't open cards for elements that merely scroll under a stationary
+  cursor (the occlusion complaint) — require actual pointer movement onto
+  the anchor, matching typical tooltip behavior.
+
+## Out of scope
+
+- Rewriting card copy (022 handles wording).
+
+## Dependencies
+
+- First-load UX pass (glossary cards), 016 (badge cards).

--- a/roadmap/026-schema-first-class-option.md
+++ b/roadmap/026-schema-first-class-option.md
@@ -1,0 +1,42 @@
+# 026 — Treat `$schema` as a first-class option
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+User-reported (2026-07-24). `$schema` is standard practice in
+`renovate.json` (the default and example configs both ship it), and
+Renovate's validator accepts it — the app's Validate stage reports 0
+errors. But the app still presents it as suspect in two places: the
+Effective config row renders `$schema` with the red "unknown option"
+squiggle (it's absent from the 003 option-docs index, so it falls into the
+unknown-name styling), and the Presets-stage diff shows it on the removed
+side with no explanation (upstream drops it from the resolved output, which
+is correct but reads as "rejected").
+
+## User story
+
+As a user whose config starts with `$schema`, I want the tool to treat it
+like the well-known key it is — no red underline, a hover card explaining
+what it's for — so I don't burn time investigating a non-problem.
+
+## Scope
+
+- Add `$schema` to the option index / known-keys set with a proper hover
+  card ("points editors at Renovate's JSON schema for autocomplete and
+  inline validation; ignored by Renovate itself") and a docs link.
+- Remove the unknown-option squiggle for it everywhere the index is used
+  (editor hovers, effective config rows).
+- Annotate its removal in the Presets/Merge diff (or filter it from the
+  "removed" presentation): "editor-only key, dropped from the resolved
+  config" — the current red row without context reads as an error.
+- Verify no validation path flags it (none found today; add a test so a
+  future renovate bump that starts flagging it is caught deliberately).
+
+## Out of scope
+
+- Fetching or validating against the schema file itself.
+
+## Dependencies
+
+- 003 (option index).

--- a/roadmap/027-share-link-failure-diagnostics.md
+++ b/roadmap/027-share-link-failure-diagnostics.md
@@ -1,0 +1,49 @@
+# 027 — Share-link failure diagnostics
+
+Milestone: M7 · Status: planned
+
+## Summary
+
+User-reported (2026-07-24): a share link opened against a running dev
+server "does not fill the configuration and doesn't run the pipeline."
+Investigated same day: the reported token is genuinely corrupted — it
+inflates cleanly up to the `view` field and then decodes to garbage
+(deflate-raw carries no checksum, so corruption/truncation can slip through
+inflation and only fail at `JSON.parse`). The current build's encoder and
+decoder round-trip the identical config correctly (verified in-browser,
+twice, plus the 020 e2e), so the app was right to reject the token — but
+its only signal is a small dismissable notice below the advanced-options
+row ("This shared link could not be read; showing the default config
+instead."), which in practice reads as _nothing happened_.
+
+## User story
+
+As someone opening a colleague's share link that got mangled in transit, I
+want the app to tell me loudly that the link is broken — and ideally
+whether it looks truncated — so I ask for a fresh link instead of
+concluding the tool is broken.
+
+## Scope
+
+- Make the unreadable-link state prominent: banner at the top of the page
+  (not a dismissable footnote), stating what happened and what to do
+  ("ask the sender to copy the link again; make sure the whole URL was
+  copied").
+- Distinguish failure modes where possible: token present but inflate
+  fails vs inflates but JSON-invalid (the truncation/corruption signature)
+  vs decodes but wrong shape — with tailored wording ("this link appears
+  cut off").
+- Add an integrity field to the payload (additive to v2, e.g. a config
+  length or short checksum) so truncation is detectable _reliably_ rather
+  than heuristically; old links without the field keep today's behavior.
+- e2e case (020 suite): corrupted and truncated tokens surface the banner
+  and never leave the app silently on the default config.
+
+## Out of scope
+
+- Recovering partial configs from corrupt tokens (the readable prefix is
+  not trustworthy input).
+
+## Dependencies
+
+- 007 (share codec), 017 (load paths), 020 (e2e suite).

--- a/roadmap/2026-07-persona-replay-01.md
+++ b/roadmap/2026-07-persona-replay-01.md
@@ -1,0 +1,91 @@
+# 2026-07 persona study replay #1
+
+First full replay of the [2026-07 persona UX study](2026-07-persona-ux-study.md)
+via the [persona-test skill](../.claude/skills/persona-test/SKILL.md) (roadmap
+019), run 2026-07-24 against main at the completed M5/M6 state (all of 012–020
+merged). Method identical to the baseline: 3 scenarios × 3 personas
+(entry/advanced/expert) = 9 serial browser sessions against the production
+build (`vite preview`), fresh share link per session, ~30-action budgets,
+ground truth withheld.
+
+## Headline
+
+**All 9 personas reached a correct or mechanism-correct diagnosis**, and the
+single most direct regression check passed: the expert goal the baseline
+could not complete — render "minor ⇒ automerge true" as a first-class verdict
+(Finding 1 / roadmap 012) — now completes with the tool alone at 95%
+confidence. The expert called the 44006 evidence chain "airtight" and
+citable.
+
+## Outcomes
+
+### 44772 — `monorepo:react` not blocking react
+
+| Persona  | vs ground truth                                                                                                                    | Confidence |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| Entry    | Partial — proved the rule matches only on source URL; couldn't name why the real-world URL differs                                 | 75%        |
+| Advanced | Partial-correct — mechanism proven both directions; shipped + verified a name-based fix                                            | 90–95%     |
+| Expert   | Correct on mechanism and remedy (upstream preset staleness, AND-semantics shown on screen); antecedent inferred from own knowledge | 95%        |
+
+No persona could name the actual current `sourceUrl` — the simulator is
+purely hypothetical (registry lookup is 015's explicit out-of-scope). All
+three flagged that the `sourceUrl` placeholder (`https://github.com/facebook/react`)
+nudges users toward simulating the world in which the bug doesn't exist.
+
+### 43936 — `["*","!gradle"]` validator rejection
+
+All three **correct**. The 014 translation + Apply fix + 018 pin/compare
+turned the baseline advanced persona's ~10-minute manual equivalence proof
+into a built-in "No behavioral change" verdict. Entry 95%, advanced 92–98%,
+expert 90–100% (all goals completed with the tool alone).
+
+### 44006 — `:automergeMinor` half-applying
+
+All three **correct at ~95%**. Entry explained rule-level vs type-scoped
+settings unaided; advanced and expert both produced the direct A/B contrast
+(same 4 rules matched, final-config delta exactly `automerge false → true`,
+annotated "update-type flattening merged the `minor` block").
+
+## Baseline findings status
+
+- **Resolved**: F1 update-type flattening, F2 verdict buried under no-match
+  rows, F4 raw validator messages, F8 evidence export (copy-as-markdown,
+  pin/compare and the version badge were all used in anger).
+- **Improved**: F3 rule identity (the `repo [0] = merged [712]` annotation
+  was cited approvingly by advanced/expert; entry found it cryptic and its
+  click a no-op), F5 input ergonomics (promoted sourceUrl + derived
+  updateType praised), F6 scale framing (personas quoted the framing
+  phrasing back verbatim; the 10k-line Presets diff still buries mid-page
+  content for entry users).
+- **Not exercised**: F7 hashchange (fresh tabs by design; covered by the 020
+  e2e suite instead).
+
+## New findings (not in the baseline), ranked
+
+1. **Simulator inputs append instead of replace** — three independent
+   sessions produced "reactreact" / "reactgradle" / "lodashgradle" after a
+   quick-fill or pipeline re-run left unselected text in the field.
+2. **Post-action landing position** — Apply fix jumps to the Presets diff
+   instead of showing "0 errors" on Validate; pipeline re-runs reset scroll.
+3. **A wrong sentence in the 43936 translation** — "the other patterns
+   already covered every case `*` did" is false for a negation-only array;
+   the equivalence holds because negative-only arrays imply
+   match-all-except. Expert would not cite it as written.
+4. **A/B compare doesn't snapshot inputs** — it silently compared a gradle
+   run against a lodash pin; no differing-inputs warning.
+5. **"failed on matchSourceUrls" vs "skipped — no sourceUrl set" wording
+   tension** — the fail-closed `false` reads as "not evaluated"; expert
+   wants "evaluated false: dependency has no sourceUrl".
+6. **Simulation runs on a config with a fatal validation error** with no
+   "real Renovate would refuse this config" banner.
+7. Polish: no-op clauses in the verdict prose ("add labels []", "only run on
+   schedule [at any time]"); editor hover on `:preset` strings shows a
+   useless "string" tooltip; option-doc tooltips occlude content when
+   scrolled under the cursor; copy buttons too close to expand targets.
+
+Top cross-session wishes: a "why didn't my rule match?" shortcut (filter
+results to repo-config rules, pre-expanded) and a combined "quote this
+verdict" citation export.
+
+These findings feed roadmap items 021–023; user-reported findings from the
+same review round feed 024–027.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,29 +3,41 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.agents/spec/renovate-config-visualizer.md).
 
-| #                                                     | Feature                                                   | Milestone            | Status |
-| ----------------------------------------------------- | --------------------------------------------------------- | -------------------- | ------ |
-| [001](001-engine-and-config-input.md)                 | Trace engine + config input                               | M0/M1                | done   |
-| [002](002-preset-resolution-tree.md)                  | Preset resolution tree                                    | M1 (MVP centerpiece) | done   |
-| [003](003-inline-option-docs.md)                      | Inline option documentation                               | M1                   | done   |
-| [004](004-migration-step-through.md)                  | Migration step-through                                    | M2                   | done   |
-| [005](005-merge-provenance-view.md)                   | Merge provenance view                                     | M2                   | done   |
-| [006](006-package-rules-simulator.md)                 | packageRules simulator                                    | M3                   | done   |
-| [007](007-shareable-links-and-repo-fetch.md)          | Shareable links + fetch config from repo                  | M4                   | done   |
-| [008](008-global-and-inherited-config.md)             | Global + inherited config layers                          | M3                   | done   |
-| [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done   |
-| [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done   |
-| [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done   |
-| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done   |
-| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done   |
-| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done   |
-| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done   |
-| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done   |
-| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done   |
-| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done   |
-| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done   |
-| [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done   |
+| #                                                     | Feature                                                   | Milestone            | Status  |
+| ----------------------------------------------------- | --------------------------------------------------------- | -------------------- | ------- |
+| [001](001-engine-and-config-input.md)                 | Trace engine + config input                               | M0/M1                | done    |
+| [002](002-preset-resolution-tree.md)                  | Preset resolution tree                                    | M1 (MVP centerpiece) | done    |
+| [003](003-inline-option-docs.md)                      | Inline option documentation                               | M1                   | done    |
+| [004](004-migration-step-through.md)                  | Migration step-through                                    | M2                   | done    |
+| [005](005-merge-provenance-view.md)                   | Merge provenance view                                     | M2                   | done    |
+| [006](006-package-rules-simulator.md)                 | packageRules simulator                                    | M3                   | done    |
+| [007](007-shareable-links-and-repo-fetch.md)          | Shareable links + fetch config from repo                  | M4                   | done    |
+| [008](008-global-and-inherited-config.md)             | Global + inherited config layers                          | M3                   | done    |
+| [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done    |
+| [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done    |
+| [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
+| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
+| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
+| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
+| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
+| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
+| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done    |
+| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done    |
+| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done    |
+| [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done    |
+| [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | planned |
+| [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | planned |
+| [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | planned |
+| [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | planned |
+| [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | planned |
+| [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | planned |
+| [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | planned |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
 app by entry-, advanced- and expert-level user personas.
+
+M7 items derive from [replay #1 of that study](2026-07-persona-replay-01.md)
+(the first run of the 019 skill, against the finished M5/M6 state) plus
+user-reported findings from the same review round (021–023 replay,
+024–027 user-reported).


### PR DESCRIPTION
Adds the first persona-study replay report and the M7 backlog derived from it plus same-day user-reported findings.

## Replay #1 (`roadmap/2026-07-persona-replay-01.md`)
9/9 sessions, all correct or mechanism-correct; the 012 regression check passed (minor ⇒ automerge renders as a verdict; baseline expert had failed this). New findings ranked: input append bug, post-action landing, a factually wrong translation sentence, A/B input mismatch, wording precision, invalid-config simulation banner.

## New items
- **021** simulator input hardening + A/B comparison integrity
- **022** verdict & translation copy precision
- **023** post-action focus, honest error states, rule filters
- **024** stage chips signal what each stage did (Migrate stays green even when it rewrote the config)
- **025** hover card text overflows its box
- **026** treat `$schema` as a first-class option (Validate accepts it; the unknown-option squiggle + unexplained diff removal are the offenders)
- **027** share-link failure diagnostics (reported token verified corrupt mid-deflate-stream; current build round-trips cleanly; failure notice is too quiet and truncation is undetectable without an integrity field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ