### PR TITLE
fix: share links silently ignored under vite dev (StrictMode latch)

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -347,13 +347,17 @@ export function App() {
   // superseding it before its async work (decodeShare, getRenovateVersion)
   // resolves.
   const decodeGenerationRef = useRef(0);
+  // The flag must be (re)set in the effect BODY, not only in the ref
+  // initializer: React StrictMode (dev) mounts, runs the cleanup, then mounts
+  // again — a cleanup-only latch stays false forever after the second mount,
+  // which silently cancelled every share-link decode under `vite dev`.
   const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
       mountedRef.current = false;
-    },
-    [],
-  );
+    };
+  }, []);
   // Load-from-repo form.
   const [repoInput, setRepoInput] = useState("");
   const [repoRef, setRepoRef] = useState("");

--- a/roadmap/027-share-link-failure-diagnostics.md
+++ b/roadmap/027-share-link-failure-diagnostics.md
@@ -6,15 +6,23 @@ Milestone: M7 · Status: planned
 
 User-reported (2026-07-24): a share link opened against a running dev
 server "does not fill the configuration and doesn't run the pipeline."
-Investigated same day: the reported token is genuinely corrupted — it
-inflates cleanly up to the `view` field and then decodes to garbage
-(deflate-raw carries no checksum, so corruption/truncation can slip through
-inflation and only fail at `JSON.parse`). The current build's encoder and
-decoder round-trip the identical config correctly (verified in-browser,
-twice, plus the 020 e2e), so the app was right to reject the token — but
-its only signal is a small dismissable notice below the advanced-options
-row ("This shared link could not be read; showing the default config
-instead."), which in practice reads as _nothing happened_.
+
+> **Root cause found and fixed same day** (reproduced with the reporter's
+> exact steps): a React StrictMode double-mount latched `mountedRef` to
+> `false` — the cleanup-only effect never set it back on the second mount —
+> so under `vite dev` every share-link decode was treated as cancelled and
+> silently discarded: valid token in the address bar, default config on
+> screen, no notice. Production builds don't run StrictMode, which is why
+> `vite preview` and the 020 e2e suite always passed. Fixed by setting the
+> flag in the effect body.
+
+What remains for this item is the diagnostics gap the investigation also
+surfaced: a genuinely corrupted token (deflate-raw carries no checksum, so
+corruption/truncation can slip through inflation and only fail at
+`JSON.parse`) is rejected correctly, but the only signal is a small
+dismissable notice below the advanced-options row ("This shared link could
+not be read; showing the default config instead."), which in practice reads
+as _nothing happened_.
 
 ## User story
 


### PR DESCRIPTION
Fixes the reported repro exactly: `pnpm dev` → edit config → Copy link → open in new tab → default content.

**Root cause**: `mountedRef` was flipped to `false` by a cleanup-only effect and never set back in the effect body. StrictMode (dev only) runs mount → cleanup → mount, so from the second mount on, `isCancelled()` was permanently true and every share-link decode was silently discarded — valid token in the URL, default config on screen, no notice. Production has no StrictMode, which is why `vite preview` and the e2e suite always passed.

**Fix**: set the flag in the effect body (mount) as well as the cleanup. Verified in-browser under `vite dev`: the previously-failing link now fills the editor and auto-runs.

Also updates roadmap 027 with the root cause; its remaining scope (loud failure surface + truncation detection for genuinely corrupt tokens) is unchanged.

Validated: lint, typecheck, build, e2e 6/6. (Only `useRef(true)` latch of this shape in the codebase — grepped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ