### PR TITLE
feat(021): simulator input hardening + A/B comparison integrity

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -42,3 +42,66 @@ test("simulating a matching dependency shows a verdict with a matched rule and i
   await expect(applied).toContainText("automerge");
   await expect(applied.locator(".sim-merged-after").first()).toContainText("true");
 });
+
+/**
+ * Roadmap 021 — select-on-focus. Three of nine persona sessions mangled a
+ * simulator field the same way: a pre-filled field (here, the "npm
+ * dependency" quick-fill's packageName = "lodash") gets focused and typed
+ * into, and — without select-on-focus — the new characters land wherever the
+ * click placed the caret instead of replacing the old value outright.
+ */
+test("focusing a pre-filled simulator field selects its content so typing replaces it", async ({
+  page,
+}) => {
+  const fragment = await encodeShareFragment({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(fragment);
+
+  await expect(page.locator(".stage-timeline")).toBeVisible({ timeout: 30_000 });
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await expect(simulator).toBeVisible();
+
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  const packageNameInput = simulator.getByLabel("packageName", { exact: true });
+  await expect(packageNameInput).toHaveValue("lodash");
+
+  // A real click (not `.fill()`, which selects-all itself) — the field must
+  // select its own content on focus, so the very first typed character
+  // replaces "lodash" rather than inserting into it.
+  await packageNameInput.click();
+  await packageNameInput.pressSequentially("gradle");
+  await expect(packageNameInput).toHaveValue("gradle");
+});
+
+/**
+ * Roadmap 021 — A/B comparison integrity. Pinning a lodash run as A, then
+ * quick-filling and re-simulating a totally different dependency (a GitHub
+ * Action) as B, must not present a normal-looking delta — the panel has to
+ * flag that A and B describe different simulated inputs.
+ */
+test("A/B pin warns when the compared runs describe different simulated inputs", async ({
+  page,
+}) => {
+  const fragment = await encodeShareFragment({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(fragment);
+
+  await expect(page.locator(".stage-timeline")).toBeVisible({ timeout: 30_000 });
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await expect(simulator).toBeVisible();
+
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+  await simulator.getByRole("button", { name: "Pin result for comparison" }).click();
+
+  // A completely different simulated dependency re-runs and becomes B.
+  await simulator.getByRole("button", { name: "GitHub Action" }).click();
+
+  const mismatch = page.locator(".sim-compare-mismatch");
+  await expect(mismatch).toBeVisible({ timeout: 15_000 });
+  await expect(mismatch).toContainText("Inputs differ");
+  await expect(mismatch).toContainText("packageName");
+
+  // Both input sets are shown, not just the warning.
+  const inputsPanel = page.locator(".sim-compare-inputs");
+  await expect(inputsPanel).toContainText("lodash");
+  await expect(inputsPanel).toContainText("actions/checkout");
+});

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -489,6 +489,56 @@ function RuleRow({
   );
 }
 
+/**
+ * Roadmap 021: the fields two descriptors disagree on, sorted for a stable
+ * warning message. Compared via JSON so array-valued fields (lockFiles,
+ * registryUrls, categories) and the `isBump` flag (only present when
+ * updateType is "bump") are handled the same as everywhere else in this file.
+ */
+function descriptorDiffKeys(a: DependencyDescriptor, b: DependencyDescriptor): string[] {
+  const keys = new Set<string>([...Object.keys(a), ...Object.keys(b)]);
+  const diffs: string[] = [];
+  for (const key of keys) {
+    const av = (a as Record<string, unknown>)[key];
+    const bv = (b as Record<string, unknown>)[key];
+    if (JSON.stringify(av) !== JSON.stringify(bv)) {
+      diffs.push(key);
+    }
+  }
+  return diffs.toSorted();
+}
+
+/** Roadmap 021: one column ("A (pinned)" / "B (current)") of the A/B input
+ *  descriptor comparison — every field the simulator actually sent the
+ *  engine, with the fields that differ from the other column called out. */
+function DescriptorList({
+  title,
+  descriptor,
+  diffKeys,
+}: {
+  title: string;
+  descriptor: DependencyDescriptor;
+  diffKeys: Set<string>;
+}) {
+  const entries = Object.entries(descriptor).filter(([, v]) => v !== undefined);
+  return (
+    <div className="sim-compare-col">
+      <div className="sim-compare-col-title">{title}</div>
+      {entries.length === 0 ? (
+        <p className="empty-note">no fields set</p>
+      ) : (
+        <ul>
+          {entries.map(([key, value]) => (
+            <li key={key} className={diffKeys.has(key) ? "sim-input-diff" : undefined}>
+              <code>{key}</code>: {previewValue(value, 60)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 /** Roadmap 018: one of the three matched-rule columns in the A/B comparison. */
 function RuleDeltaList({
   title,
@@ -537,30 +587,62 @@ function ConfigDeltaRow({ delta }: { delta: ConfigKeyDelta }) {
   );
 }
 
+/** Roadmap 021: the pinned A-run plus the full form snapshot it was run
+ *  against (all simulator fields, not just the ones the engine reads) — so
+ *  the comparison panel can show and diff exactly what was simulated. */
+interface PinnedRun {
+  sim: SimulationResult;
+  form: FormState;
+  effectiveUpdateType: string;
+}
+
 /**
  * Roadmap 018: the A/B comparison panel. `comparison` is null while a result is
  * pinned but no NEW simulation has replaced it yet (a "waiting" hint shows);
  * once a fresh run produces B, it renders the matched-rule set delta, the
  * final-config key delta, and an explicit "no behavioral change" verdict when
  * both are identical.
+ *
+ * Roadmap 021: A and B can come from simulating two entirely different
+ * hypothetical dependencies (pin a lodash run, then quick-fill a Docker
+ * image and re-simulate) — the delta above would render as if it were a
+ * config edit, with no hint that the INPUTS changed too. `currentDescriptor`
+ * is always what actually produced `sim` (or, before any run since the pin,
+ * the live form) so the two input sets can be shown and diffed regardless of
+ * whether `comparison` exists yet.
  */
-function ComparisonPanel({ comparison }: { comparison: SimulationComparison | null }) {
-  if (!comparison) {
-    return (
-      <div className="sim-compare">
-        <div className="sim-compare-title">A/B comparison</div>
+function ComparisonPanel({
+  pinned,
+  comparison,
+  currentDescriptor,
+}: {
+  pinned: PinnedRun;
+  comparison: SimulationComparison | null;
+  currentDescriptor: DependencyDescriptor;
+}) {
+  const pinnedDescriptor = toDescriptor(pinned.form, pinned.effectiveUpdateType);
+  const diffKeys = new Set(descriptorDiffKeys(pinnedDescriptor, currentDescriptor));
+  return (
+    <div className="sim-compare">
+      <div className="sim-compare-title">A/B comparison — pinned (A) vs current (B)</div>
+      {diffKeys.size > 0 ? (
+        <p className="sim-compare-mismatch">
+          ⚠ Inputs differ between A and B — this compares two different simulated dependencies, not
+          just a config edit. Differing fields:{" "}
+          {[...diffKeys].map((k, i) => (
+            <span key={k}>
+              {i > 0 ? ", " : null}
+              <code>{k}</code>
+            </span>
+          ))}
+        </p>
+      ) : null}
+      {!comparison ? (
         <p className="empty-note">
           Pinned this result as <strong>A</strong>. Edit the config and run the pipeline again, then
           simulate to compare it against <strong>B</strong>.
         </p>
-      </div>
-    );
-  }
-  const { matchedOnlyInA, matchedOnlyInB, matchedInBoth, configDelta, noChange } = comparison;
-  return (
-    <div className="sim-compare">
-      <div className="sim-compare-title">A/B comparison — pinned (A) vs current (B)</div>
-      {noChange ? (
+      ) : comparison.noChange ? (
         <p className="sim-compare-nochange">
           No behavioral change — the matched rules and the final per-dependency config are identical
           in A and B.
@@ -570,17 +652,21 @@ function ComparisonPanel({ comparison }: { comparison: SimulationComparison | nu
           <div className="sim-compare-rules">
             <RuleDeltaList
               title="Only in A (stopped matching)"
-              refs={matchedOnlyInA}
+              refs={comparison.matchedOnlyInA}
               kind="only-a"
             />
-            <RuleDeltaList title="Only in B (now matching)" refs={matchedOnlyInB} kind="only-b" />
-            <RuleDeltaList title="Matched in both" refs={matchedInBoth} kind="both" />
+            <RuleDeltaList
+              title="Only in B (now matching)"
+              refs={comparison.matchedOnlyInB}
+              kind="only-b"
+            />
+            <RuleDeltaList title="Matched in both" refs={comparison.matchedInBoth} kind="both" />
           </div>
           <div className="sim-compare-config">
             <div className="sim-merged-title">Final per-dependency config changes</div>
-            {configDelta.length > 0 ? (
+            {comparison.configDelta.length > 0 ? (
               <ul>
-                {configDelta.map((d) => (
+                {comparison.configDelta.map((d) => (
                   <ConfigDeltaRow key={d.key} delta={d} />
                 ))}
               </ul>
@@ -592,6 +678,13 @@ function ComparisonPanel({ comparison }: { comparison: SimulationComparison | nu
           </div>
         </>
       )}
+      <details className="sim-compare-inputs" open={diffKeys.size > 0}>
+        <summary>Inputs compared</summary>
+        <div className="sim-compare-rules">
+          <DescriptorList title="A (pinned)" descriptor={pinnedDescriptor} diffKeys={diffKeys} />
+          <DescriptorList title="B (current)" descriptor={currentDescriptor} diffKeys={diffKeys} />
+        </div>
+      </details>
     </div>
   );
 }
@@ -615,6 +708,13 @@ function Field({
         value={value}
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value)}
+        // Roadmap 021: select-on-focus. A quick-fill or a re-run leaves a
+        // field pre-filled; without this, the persona study's users typed
+        // straight into it and got "reactgradle" instead of "gradle" without
+        // noticing. Selecting the content on focus makes the first keystroke
+        // replace it — repositioning the caret with a second click still
+        // works, since that click doesn't refire `focus`.
+        onFocus={(e) => e.target.select()}
         spellCheck={false}
       />
     </label>
@@ -657,10 +757,18 @@ export function RuleSimulator({
 }) {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [sim, setSim] = useState<SimulationResult | null>(null);
+  // Roadmap 021: the form (all fields) + effective updateType that produced
+  // `sim`, kept alongside it so the comparison panel can show/diff exactly
+  // what was simulated — never the live `form`, which may have been edited
+  // further without a re-run (that drift is what the "stale" banner covers).
+  const [simForm, setSimForm] = useState<FormState | null>(null);
+  const [simEffectiveUpdateType, setSimEffectiveUpdateType] = useState("");
   // Roadmap 018: a pinned A-run kept for A/B comparison — deliberately NOT
   // cleared when a new pipeline result arrives (the whole point is to pin, edit
-  // the config, re-run, and compare); only "Unpin" clears it.
-  const [pinned, setPinned] = useState<SimulationResult | null>(null);
+  // the config, re-run, and compare); only "Unpin" clears it. Roadmap 021: now
+  // carries the full input snapshot (`form` + `effectiveUpdateType`), not just
+  // the result, so the comparison panel can tell A and B's inputs apart.
+  const [pinned, setPinned] = useState<PinnedRun | null>(null);
   const [simLinkCopied, setSimLinkCopied] = useState(false);
   // Roadmap 018: applied-once bookkeeping for an incoming share `simRequest`.
   const appliedSimNonce = useRef<number | null>(null);
@@ -713,6 +821,8 @@ export function RuleSimulator({
   // A new run invalidates any previous simulation (the rules may differ).
   useEffect(() => {
     setSim(null);
+    setSimForm(null);
+    setSimEffectiveUpdateType("");
     setRanKey(null);
     setError(null);
     setShowAll(false);
@@ -815,11 +925,23 @@ export function RuleSimulator({
   // result against itself is not useful — the panel shows a "waiting" hint
   // instead). The comparison logic itself is pure and lives in the engine.
   const comparison = useMemo<SimulationComparison | null>(() => {
-    if (!engineModule || !pinned || !sim || pinned === sim) {
+    if (!engineModule || !pinned || !sim || pinned.sim === sim) {
       return null;
     }
-    return engineModule.compareSimulations(pinned, sim);
+    return engineModule.compareSimulations(pinned.sim, sim);
   }, [engineModule, pinned, sim]);
+
+  // Roadmap 021: what the comparison panel treats as "B"'s inputs — the form
+  // that actually produced `sim`, or (before any run since pinning, or after
+  // a fresh pipeline run cleared `sim`) the live form, so the panel always has
+  // something to show/diff against the pinned snapshot.
+  const currentDescriptor = useMemo(
+    () =>
+      simForm
+        ? toDescriptor(simForm, simEffectiveUpdateType)
+        : toDescriptor(form, effectiveUpdateType),
+    [simForm, simEffectiveUpdateType, form, effectiveUpdateType],
+  );
 
   // Keys the rules changed vs. the pre-rules effective config, for the final
   // section's summary chips.
@@ -891,6 +1013,8 @@ export function RuleSimulator({
       // since abandoned.
       scrollYBeforeSimulate.current = window.scrollY;
       setSim(simResult);
+      setSimForm(nextForm);
+      setSimEffectiveUpdateType(effectiveType);
       setRanKey(JSON.stringify(nextForm));
       setShowAll(false);
     } catch (err) {
@@ -1273,7 +1397,18 @@ export function RuleSimulator({
                   <button
                     type="button"
                     className="sim-verdict-action"
-                    onClick={() => setPinned(sim)}
+                    onClick={() => {
+                      // Roadmap 021: simForm is set in the same simulate() call as
+                      // sim, so it is never null here — the guard is only to
+                      // satisfy the type checker, not a real runtime branch.
+                      if (simForm) {
+                        setPinned({
+                          sim,
+                          form: simForm,
+                          effectiveUpdateType: simEffectiveUpdateType,
+                        });
+                      }
+                    }}
                     title="Pin this result as A, edit the config, then simulate again to compare"
                   >
                     Pin result for comparison
@@ -1282,7 +1417,13 @@ export function RuleSimulator({
               </div>
             </div>
 
-            {pinned ? <ComparisonPanel comparison={comparison} /> : null}
+            {pinned ? (
+              <ComparisonPanel
+                pinned={pinned}
+                comparison={comparison}
+                currentDescriptor={currentDescriptor}
+              />
+            ) : null}
 
             {[...sim.errors, ...sim.warnings].length > 0 ? (
               <ul className="messages sim-messages">

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1705,6 +1705,40 @@ pre.config-view.prov-before {
   text-transform: uppercase;
 }
 
+/* Roadmap 021: prominent — A and B describe different simulated dependencies,
+   not just a config edit — deliberately louder than .sim-compare-nochange /
+   .sim-stale-banner (bold, stronger tint) since a silently-wrong comparison
+   is the failure mode this exists to prevent. */
+.sim-compare-mismatch {
+  background: color-mix(in srgb, var(--warn) 16%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--warn) 55%, var(--border));
+  border-radius: 6px;
+  color: var(--warn);
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 0.6rem;
+  padding: 0.55rem 0.75rem;
+}
+
+.sim-compare-mismatch code {
+  font-weight: 600;
+}
+
+.sim-compare-inputs {
+  margin-top: 0.6rem;
+}
+
+.sim-compare-inputs > summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.sim-input-diff {
+  color: var(--warn);
+  font-weight: 600;
+}
+
 .sim-compare-nochange {
   background: color-mix(in srgb, var(--ok) 10%, var(--surface));
   border: 1px solid color-mix(in srgb, var(--ok) 35%, var(--border));

--- a/roadmap/021-simulator-input-hardening.md
+++ b/roadmap/021-simulator-input-hardening.md
@@ -1,6 +1,6 @@
 # 021 — Simulator input hardening + A/B comparison integrity
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 
@@ -33,6 +33,13 @@ conclusion can't come from stale characters or mismatched baselines.
 
 - Registry lookups for real dependency metadata (see 015's out-of-scope; the
   "prefill sourceUrl from the datasource" wish stays a possible follow-up).
+- Named pins / a second pin slot: the single-pin design already needed a real
+  rework here (the pin now snapshots the whole form, not just the result) —
+  stacking a multi-slot UI on top in the same pass risked the comparison UI
+  itself for a want (multi-baseline comparisons, built by hand today) rather
+  than the wrong-conclusion bug this item exists to fix. Left for a
+  follow-up if the single-pin-plus-mismatch-warning combination turns out
+  not to be enough.
 
 ## Dependencies
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -25,7 +25,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done    |
 | [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done    |
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done    |
-| [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | planned |
+| [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done    |
 | [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | planned |
 | [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | planned |
 | [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | planned |


### PR DESCRIPTION
Implements roadmap item 021 (M7).

- Select-on-focus on every simulator text field: after quick-fill chips or re-runs, typing replaces instead of appending (fixes the "reactgradle" class of silent input mangling seen 3× in replay #1).
- A/B pin now snapshots the full simulator input descriptor with the result; the comparison panel shows both input sets side by side and renders a prominent mismatch warning naming every differing field when A and B describe different simulated updates.
- Two new e2e tests cover both behaviors (suite now 8 tests).
- Named pins / second pin slot deliberately deferred (documented in the roadmap item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ