### PR TITLE
feat(022): verdict & translation copy precision

### DIFF
--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -5,6 +5,7 @@ import type {
   DependencyDescriptor,
   MergedKey,
   ProvenanceLayer,
+  RuleAttribution,
   RuleEvaluation,
   RuleRef,
   SimulationComparison,
@@ -255,17 +256,21 @@ function clauseIcon(state: ClauseEvaluation["state"]): string {
   if (state === "no-match" || state === "error") {
     return "✗";
   }
-  // no-input / not-applicable / not-simulated — the clause was skipped, not a
-  // genuine mismatch.
+  // no-input — evaluated to a real fail-closed `false` (see clauseExplanation),
+  // but flagged rather than a plain ✗ since the cause is a missing input, not
+  // a genuine mismatch against a value. not-applicable / not-simulated — the
+  // matcher never produced a true-or-false verdict at all.
   return "⚠";
 }
 
 /**
- * Roadmap 018: the clause row's right-hand explanation, precise about WHY a
- * clause did not match — a genuine mismatch names the input it compared
- * ("no match against sourceUrl = …"); a fail-closed clause names the field the
- * dependency lacks ("skipped — no sourceUrl set …", from the engine's note);
- * a null-returning matcher reads "not applicable (skipped)".
+ * Roadmap 018/022: the clause row's right-hand explanation, precise about WHY
+ * a clause did not match — a genuine mismatch names the input it compared
+ * ("no match against sourceUrl = …"); a fail-closed clause states the actual
+ * verdict and its cause ("evaluated false — the simulated dependency has no
+ * sourceUrl (Renovate treats a missing value as a non-match)", from the
+ * engine's note) rather than reading like the clause was never evaluated; a
+ * null-returning matcher reads "not applicable (skipped)".
  */
 function clauseExplanation(clause: ClauseEvaluation): string {
   const hasInputs = Object.keys(clause.inputValues).length > 0;
@@ -275,7 +280,10 @@ function clauseExplanation(clause: ClauseEvaluation): string {
     case "no-match":
       return hasInputs ? `no match against ${inputsPreview(clause)}` : "no match";
     case "no-input":
-      return clause.note ?? "skipped — required input not set on the simulated dependency";
+      return (
+        clause.note ??
+        "evaluated false — required input not set on the simulated dependency (Renovate treats a missing value as a non-match)"
+      );
     case "not-applicable":
       return clause.note ?? "not applicable (skipped)";
     default:
@@ -311,17 +319,62 @@ function joinClauses(items: string[]): string {
   return `${items.slice(0, -1).join(", ")}, and ${items.at(-1)}`;
 }
 
+/** Renovate's default `schedule` value — "unrestricted", not a real limit
+ *  (upstream `config/options/index.ts`: `default: ['at any time']`). It
+ *  survives onto `finalDependencyConfig` whenever no rule set a real
+ *  schedule, so treating it as one of the update's clauses would quote a
+ *  no-op as if it were a restriction. */
+function isNoopSchedule(schedule: unknown[]): boolean {
+  return schedule.length === 1 && schedule[0] === "at any time";
+}
+
+/**
+ * Roadmap 013/022: which matched rule turned `automerge: true` on inside a
+ * given update-type block (e.g. `minor`), and — only when it's unambiguous —
+ * the preset that rule came from, for the verdict sentence's "from
+ * `:automergeMinor`" attribution. Best-effort from data the simulator and
+ * `computeRuleProvenance` already compute; no new provenance tracking.
+ */
+function automergeScopeSource(
+  sim: SimulationResult,
+  updateType: string,
+  ruleAttribution: RuleAttribution[] | null | undefined,
+): string | undefined {
+  const rule = sim.rules.find(
+    (r) =>
+      r.verdict === "matched" &&
+      r.merged?.some(
+        (m) =>
+          m.key === updateType &&
+          typeof m.after === "object" &&
+          m.after !== null &&
+          !Array.isArray(m.after) &&
+          (m.after as Record<string, unknown>).automerge === true,
+      ),
+  );
+  if (!rule) {
+    return undefined;
+  }
+  const attribution = ruleAttribution?.find((a) => a.index === rule.index);
+  return attribution?.layer.kind === "preset" ? attribution.layer.name : undefined;
+}
+
 /**
  * The plain-language outcome sentence (roadmap 012). Covers the high-signal
- * options — enabled/skipReason, automerge (with update-type scoping),
- * labels, grouping, schedule — splitting them into what the update WOULD and
- * would NOT get, e.g. "This major update WOULD get labels [deploy_pr] and
- * auto-approval, but would NOT automerge (automerge is scoped to minor/patch)".
+ * options — enabled/skipReason, automerge (with update-type scoping and,
+ * when known, its source preset), labels, grouping, schedule — splitting
+ * them into what the update WOULD and would NOT get, e.g. "This major update
+ * WOULD get labels [deploy_pr] and auto-approval, but would NOT automerge
+ * (automerge is scoped to minor/patch — from `:automergeMinor`)". Roadmap
+ * 022: no-op clauses (an empty label list, the default unrestricted
+ * schedule) are left out entirely rather than quoted as if they meant
+ * something, so the sentence stays quotable verbatim.
  */
 function buildVerdictSentence(
   sim: SimulationResult,
   updateType: string | undefined,
   changedKeys: string[],
+  ruleAttribution: RuleAttribution[] | null | undefined,
 ): string {
   const c = sim.finalDependencyConfig;
   const subject = `This ${updateType ? `${updateType} ` : ""}update`;
@@ -344,24 +397,32 @@ function buildVerdictSentence(
   if (c.automerge === true) {
     positives.push("automerge");
   } else if (scopedAutomerge.length > 0) {
-    negatives.push(`automerge (automerge is scoped to ${scopedAutomerge.join("/")})`);
+    const sources = scopedAutomerge.map((type) => automergeScopeSource(sim, type, ruleAttribution));
+    // Only cite a source when every scoped type traces to the SAME preset —
+    // a mixed or unknown provenance is left uncredited rather than guessed.
+    const source = sources.every((s) => s !== undefined && s === sources[0])
+      ? sources[0]
+      : undefined;
+    negatives.push(
+      `automerge (automerge is scoped to ${scopedAutomerge.join("/")}${source ? ` — from \`${source}\`` : ""})`,
+    );
   } else if (c.automerge === false && changed.has("automerge")) {
     negatives.push("automerge");
   }
 
-  if (Array.isArray(c.labels)) {
+  if (Array.isArray(c.labels) && c.labels.length > 0) {
     positives.push(`get labels ${plainValue(c.labels)}`);
   }
-  if (Array.isArray(c.addLabels)) {
+  if (Array.isArray(c.addLabels) && c.addLabels.length > 0) {
     positives.push(`add labels ${plainValue(c.addLabels)}`);
   }
   if (c.autoApprove === true) {
     positives.push("auto-approval");
   }
-  if (typeof c.groupName === "string") {
+  if (typeof c.groupName === "string" && c.groupName.length > 0) {
     positives.push(`be grouped as "${c.groupName}"`);
   }
-  if (Array.isArray(c.schedule) && c.schedule.length > 0) {
+  if (Array.isArray(c.schedule) && c.schedule.length > 0 && !isNoopSchedule(c.schedule)) {
     positives.push(`only run on schedule ${plainValue(c.schedule)}`);
   }
 
@@ -1114,7 +1175,7 @@ export function RuleSimulator({
   const hiddenCount = sim ? sim.rules.length - notableRules.length : 0;
   const shownRules = showAll ? (sim?.rules ?? []) : notableRules;
   const verdictSentence = sim
-    ? buildVerdictSentence(sim, sim.flattened.updateType, changedKeys)
+    ? buildVerdictSentence(sim, sim.flattened.updateType, changedKeys, ruleAttribution)
     : "";
   const changedWithValues = changedKeys.map((key) => ({
     key,

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -51,6 +51,12 @@ export interface ErrorTranslation {
   explain(message: ValidationMessage): string;
   /** Renovate option name(s) the message concerns, for a 003 docs-link. */
   optionNames(message: ValidationMessage): string[];
+  /**
+   * Overrides the 003 option-index docs link with a more specific docs page
+   * (e.g. matcher semantics rather than a single option's reference entry),
+   * when the explanation cites something the option index doesn't cover.
+   */
+  docsUrl?: string;
   /** `config` is the exact snapshot the message was validated against. */
   suggestFix?(message: ValidationMessage, config: Record<string, unknown>): ErrorFixResult | null;
 }
@@ -157,6 +163,9 @@ function backtickedTokens(text: string): string[] {
 const REDUNDANT_GLOB_RE =
   /^(.+?): Your input contains \* or \*\* along with other patterns\. Please remove them, as \* or \*\* matches all patterns\.$/;
 
+const REDUNDANT_GLOB_STAR_DOCS_URL =
+  "https://docs.renovatebot.com/string-pattern-matching/#negative-matching";
+
 const redundantGlobStar: ErrorTranslation = {
   id: "redundant-glob-star",
   matches: (m) => REDUNDANT_GLOB_RE.test(m.message),
@@ -166,11 +175,17 @@ const redundantGlobStar: ErrorTranslation = {
     const path = match?.[1] ?? "this list";
     return (
       `\`*\`/\`**\` already matches everything, so listing it alongside other patterns in ` +
-      `\`${path}\` is redundant — newer Renovate rejects the combination outright. Removing the ` +
-      `\`*\`/\`**\` entry and keeping the rest is the same behavior (the other patterns already ` +
-      `covered every case \`*\` did).`
+      `\`${path}\` is redundant — newer Renovate rejects the combination outright. The suggested ` +
+      `fix below drops \`*\`/\`**\` and keeps the rest, which is safe when every remaining entry is ` +
+      `a negation (\`!name\`): Renovate's array-matching rule already treats a negation-only array ` +
+      `as matching everything except what it excludes — the exact "match everything but…" behavior ` +
+      `\`*\` plus those negations was producing (see "Negative matching" at ${REDUNDANT_GLOB_STAR_DOCS_URL}). ` +
+      `If a remaining entry is a plain, non-negated pattern instead, dropping \`*\`/\`**\` narrows the ` +
+      `match to just what's listed — check that's what you want.`
     );
   },
+
+  docsUrl: REDUNDANT_GLOB_STAR_DOCS_URL,
 
   optionNames: (m) => {
     const match = REDUNDANT_GLOB_RE.exec(m.message);
@@ -371,7 +386,7 @@ export function translateMessage(
     id: translation.id,
     explanation: translation.explain(message),
     fix,
-    docsUrl: doc?.url,
+    docsUrl: translation.docsUrl ?? doc?.url,
   };
 }
 

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -75,8 +75,10 @@ export interface SimulationInput {
  * - `no-input` — the matcher returned `false` because NONE of the fields it
  *   reads were set on the simulated dependency (upstream's fail-closed
  *   `if (!sourceUrl) return false`). Still fails the rule (verdict → no-match,
- *   oracle-identical), but is reported as "skipped — no sourceUrl set …" so it
- *   isn't mistaken for a real mismatch.
+ *   oracle-identical), but is reported as "evaluated false — the simulated
+ *   dependency has no sourceUrl (Renovate treats a missing value as a
+ *   non-match)" rather than "skipped", so it reads as the real (if
+ *   fail-closed) verdict it is, not as "not evaluated".
  * - `not-applicable` — the matcher returned `null` (it could not evaluate the
  *   clause, e.g. an unparseable age range); upstream skips it, so it does not
  *   affect whether the rule matches.
@@ -344,12 +346,14 @@ async function evaluateRule(
       if (raw === true) {
         clauses.push({ key: entry.key, value, state: "matched", inputValues, readFields });
       } else if (raw === false) {
-        // Roadmap 018: a `false` from a matcher that reads dependency fields
-        // NONE of which are set is upstream's fail-closed branch
-        // (`if (!sourceUrl) return false`), not a real mismatch — report it as
-        // "skipped — no <field> set" and name the missing field(s). Matchers
-        // that read nothing off the dependency (matchJsonata) never take this
-        // path. Either way the rule still fails to match, exactly as upstream.
+        // Roadmap 018/022: a `false` from a matcher that reads dependency
+        // fields NONE of which are set is upstream's fail-closed branch
+        // (`if (!sourceUrl) return false`), not a real mismatch — but it IS a
+        // real (fail-closed) `false`, not a skip, so report it as "evaluated
+        // false" and name the missing field(s) plus WHY Renovate treats that
+        // as a non-match. Matchers that read nothing off the dependency
+        // (matchJsonata) never take this path. Either way the rule still
+        // fails to match, exactly as upstream.
         const failClosed = readFields.length > 0 && Object.keys(inputValues).length === 0;
         clauses.push({
           key: entry.key,
@@ -359,7 +363,7 @@ async function evaluateRule(
           readFields,
           ...(failClosed
             ? {
-                note: `skipped — no ${humanFieldList(readFields)} set on the simulated dependency`,
+                note: `evaluated false — the simulated dependency has no ${humanFieldList(readFields)} (Renovate treats a missing value as a non-match)`,
               }
             : {}),
         });

--- a/packages/engine/test/error-translations.node.test.ts
+++ b/packages/engine/test/error-translations.node.test.ts
@@ -97,11 +97,18 @@ describe("redundant-glob-star translation (P2 study case)", () => {
     expect(translated!.fix).toBeNull();
   });
 
-  it("attaches a docs link for the named matcher option", () => {
+  it("links the matcher-semantics docs page (negative-matching) rather than the bare option reference", () => {
     const translated = translateMessage(message("matchPackageNames"), null);
     expect(translated!.docsUrl).toBe(
-      "https://docs.renovatebot.com/configuration-options/#matchpackagenames",
+      "https://docs.renovatebot.com/string-pattern-matching/#negative-matching",
     );
+  });
+
+  it("states the negation-only match-all-except rule instead of the false 'other patterns already covered every case' claim", () => {
+    const translated = translateMessage(message("matchPackageNames"), null);
+    expect(translated!.explanation).not.toMatch(/already covered every case/);
+    expect(translated!.explanation).toMatch(/negation-only/);
+    expect(translated!.explanation).toMatch(/string-pattern-matching/);
   });
 });
 

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -251,7 +251,9 @@ describe("simulatePackageRules", () => {
     expect(missingClause?.state).toBe("no-input");
     expect(missingClause?.inputValues).toEqual({});
     expect(missingClause?.readFields).toContain("sourceUrl");
-    expect(missingClause?.note).toMatch(/no sourceUrl set on the simulated dependency/);
+    expect(missingClause?.note).toMatch(
+      /evaluated false — the simulated dependency has no sourceUrl \(Renovate treats a missing value as a non-match\)/,
+    );
     expect(missing.rules[0]?.verdict).toBe("no-match");
 
     // oracle parity is unaffected by the finer reporting.

--- a/roadmap/022-verdict-copy-precision.md
+++ b/roadmap/022-verdict-copy-precision.md
@@ -1,6 +1,6 @@
 # 022 — Verdict & translation copy precision
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 
@@ -40,6 +40,37 @@ paragraph.
 ## Out of scope
 
 - New verdict semantics; this is wording and export only.
+
+## Implementation notes
+
+- Redundant-`*` translation (`packages/engine/src/error-translations.ts`):
+  reworded to state the actual rule — a negation-only remaining array already
+  matches everything it doesn't exclude, which is why dropping `*`/`**` is
+  equivalent in that case (and why it ISN'T when a remaining pattern is a
+  plain positive) — and links
+  `https://docs.renovatebot.com/string-pattern-matching/#negative-matching`
+  instead of the generic per-option docs page.
+- Fail-closed clause wording (`packages/engine/src/simulate-package-rules.ts`,
+  rendered in `packages/app/src/components/RuleSimulator.tsx`): `no-input`
+  clauses now read "evaluated false — the simulated dependency has no
+  \<field\> (Renovate treats a missing value as a non-match)" instead of
+  "skipped — no \<field\> set …". The tri-state (`no-match` / `no-input` /
+  `not-applicable`) is unchanged; only prose and the `no-input` icon's
+  tooltip framing moved.
+- Verdict sentence (`buildVerdictSentence` in `RuleSimulator.tsx`): empty
+  `labels`/`addLabels` and the default unrestricted `schedule: ["at any
+time"]` are now suppressed as no-ops instead of rendered as clauses.
+  Automerge update-type scoping cites its source preset ("— from
+  `:automergeMinor`") when every scoped update type traces to the same
+  preset via the existing `computeRuleProvenance` data; left uncredited when
+  the source is mixed or unknown.
+- Deferred: the combined "quote this verdict" export (stretch). The other
+  three pieces (preset body excerpt, rule delta, version pin) live behind
+  copy buttons in unrelated components (`PresetTree.tsx` for preset bodies)
+  with no shared plumbing back to the simulator's verdict block; wiring them
+  together cleanly would mean prop-drilling preset text through `App.tsx`
+  into `RuleSimulator`, which didn't fit in this pass. Left for a future
+  item if wanted.
 
 ## Dependencies
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -26,7 +26,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done    |
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done    |
 | [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done    |
-| [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | planned |
+| [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done    |
 | [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | planned |
 | [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | planned |
 | [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | planned |


### PR DESCRIPTION
Implements roadmap item 022 (M7).

- Corrected the factually wrong redundant-`*` translation rationale: now states the actual rule (a negation-only pattern array implicitly matches everything not excluded) and links the string-pattern-matching negative-matching docs; regression test added.
- Reworded the fail-closed clause state: "evaluated false — the simulated dependency has no sourceUrl (Renovate treats a missing value as a non-match)" instead of "skipped", keeping the 018 tri-state intact.
- Verdict sentence no longer emits no-op clauses (empty labels arrays, the default `["at any time"]` schedule sentinel, empty groupName).
- Update-type-scoped automerge is now attributed to its source preset in the quotable sentence ("— from `:automergeMinor`") when provenance resolves unambiguously.
- Combined "quote this verdict" markdown export deferred (documented in the roadmap item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ