### PR TITLE
feat(023): post-action focus, honest error states, rule filters

### DIFF
--- a/packages/app/e2e/06-error-states-and-filters.spec.ts
+++ b/packages/app/e2e/06-error-states-and-filters.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test";
+import { encodeShareFragment, INVALID_AUTOMERGE_CONFIG, PACKAGE_RULES_CONFIG } from "./fixtures";
+import { runAndAwaitResult, setEditorContent } from "./helpers";
+
+/**
+ * Roadmap 023 — honest error states. A config with a validate-stage error is
+ * still processed and its post-Validate results shown, but a real Renovate run
+ * would refuse it — a banner must say so on those results.
+ */
+test("a validation error adds a hypothetical-run banner to post-Validate results", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+
+  await setEditorContent(page, INVALID_AUTOMERGE_CONFIG);
+  await runAndAwaitResult(page);
+
+  // The validate stage errored (a red dot, an Errors & warnings entry)…
+  await expect(page.locator(".stage-timeline .dot.error").first()).toBeVisible();
+  await expect(page.locator(".messages li.error").first()).toBeVisible();
+
+  // …and the honesty banner is present on the post-Validate results.
+  const banner = page.locator(".hypothetical-banner");
+  await expect(banner.first()).toBeVisible();
+  await expect(banner.first()).toContainText(/would refuse this config/i);
+});
+
+/**
+ * Roadmap 023 — the "my rules only" filter. The most common wish across the
+ * persona sessions: find your own rule fast. One click filters the simulator
+ * results to the repo config's own packageRules, with clause evidence expanded.
+ */
+test("the simulator 'my rules only' filter shows repo rules with clause evidence expanded", async ({
+  page,
+}) => {
+  const fragment = await encodeShareFragment({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(fragment);
+
+  await expect(page.locator(".stage-timeline")).toBeVisible({ timeout: 30_000 });
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await expect(simulator).toBeVisible();
+
+  // A run has to exist before the filter appears (it needs a simulation).
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+
+  const myRules = simulator.getByRole("button", { name: "my rules only" });
+  await expect(myRules).toBeVisible();
+  await myRules.click();
+
+  // The repo rule row is shown, pre-expanded, with its clause evidence visible.
+  const expandedRow = simulator.locator(".sim-rule.expanded").first();
+  await expect(expandedRow).toBeVisible();
+  await expect(expandedRow.locator(".sim-clause").first()).toBeVisible();
+});

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   ErrorFixResult,
   OptionIndex,
@@ -9,6 +9,7 @@ import type {
 import { ConfigEditor, type ConfigEditorHandle } from "./components/ConfigEditor";
 import { EffectiveConfig } from "./components/EffectiveConfig";
 import { type AuthState, GithubAuthHint } from "./components/GithubAuthHint";
+import { HypotheticalBanner } from "./components/HypotheticalBanner";
 import { MessagesPanel } from "./components/MessagesPanel";
 import { MigrationSteps } from "./components/MigrationSteps";
 import { identityForNodeId, nodeIdForIdentity, PresetTree } from "./components/PresetTree";
@@ -17,6 +18,7 @@ import { StageDiff } from "./components/StageDiff";
 import { STAGE_EXPLAINERS, STAGE_LABELS, StageTimeline } from "./components/StageTimeline";
 import { Term } from "./glossary";
 import { OptionDocsProvider } from "./option-docs";
+import { buildPresetLookup, type PresetHoverContext } from "./preset-hover";
 import { findPackageRuleOffsets } from "./rule-locate";
 import { useRuleProvenance } from "./rule-provenance";
 import {
@@ -303,6 +305,10 @@ export function App() {
   const [fatal, setFatal] = useState<string | null>(null);
   // Non-fatal notices (version drift, load-from-repo results, bad share link).
   const [notice, setNotice] = useState<string | null>(null);
+  // Roadmap 023: a transient toast — used to land an "Apply fix" re-run on its
+  // consequence ("re-ran: 0 errors") without yanking the user's scroll around.
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimer = useRef<number | undefined>(undefined);
   const [optionIndex, setOptionIndex] = useState<OptionIndex | null>(null);
   // Roadmap 014: curated validator-message translations + suggested fixes,
   // loaded lazily alongside the option index (same engine chunk).
@@ -375,6 +381,38 @@ export function App() {
   // render of something unrelated — this is a plain bracket-depth scan, not a
   // full parse, so it stays cheap even for large configs.
   const packageRuleOffsets = useMemo(() => findPackageRuleOffsets(content), [content]);
+  // Roadmap 023: preset-string hovers in the editor. Built from the current
+  // run's resolution tree; the jump link selects the preset's node in the tree.
+  const presetHover = useMemo<PresetHoverContext | null>(() => {
+    if (!result?.presetTree) {
+      return null;
+    }
+    const lookup = buildPresetLookup(result.presetTree);
+    return { lookup: (name) => lookup.get(name) ?? null, onSelectPreset: setSelectedNodeId };
+  }, [result]);
+  // Roadmap 023: validation ERRORS (not warnings) make post-Validate results
+  // hypothetical — a real Renovate run would refuse the config outright.
+  const validateHasErrors = result?.stageStatus.validate === "error";
+
+  // Roadmap 023: window.scrollY captured just before a scroll-preserving
+  // re-run's result commits, restored once the new DOM has painted (016 did
+  // this for re-simulations; full pipeline re-runs still reset scroll). null =
+  // this run should NOT preserve scroll (a fresh config, share link, or first run).
+  const preserveScrollRef = useRef<number | null>(null);
+  useLayoutEffect(() => {
+    const y = preserveScrollRef.current;
+    if (y !== null) {
+      preserveScrollRef.current = null;
+      window.scrollTo({ top: y, behavior: "auto" });
+    }
+  }, [result]);
+
+  /** Roadmap 023: shows a transient toast that auto-dismisses. */
+  function showToast(message: string) {
+    setToast(message);
+    window.clearTimeout(toastTimer.current);
+    toastTimer.current = window.setTimeout(() => setToast(null), 4500);
+  }
 
   /** A validation message's REPO-config `packageRules[repoIndex]` → the editor line. */
   function focusEditorRepoIndex(repoIndex: number) {
@@ -496,16 +534,24 @@ export function App() {
     };
   }
 
-  async function onRun(overrideInjected?: InjectionMap, overrideInputs?: RunInputs) {
+  async function onRun(
+    overrideInjected?: InjectionMap,
+    overrideInputs?: RunInputs,
+    opts?: { preserveScroll?: boolean },
+  ): Promise<TraceResult | null> {
     const injectedPresets = overrideInjected ?? injected;
     if (!overrideInputs && blockedByLayerErrors()) {
-      return;
+      return null;
     }
     const inputs: RunInputs = overrideInputs ?? buildInputs();
     setRunning(true);
     setFatal(null);
     try {
       const traceResult = await run({ ...inputs, injectedPresets });
+      // Roadmap 023: hold the current scroll so re-running an edited config
+      // doesn't jump the user back to the top (captured right before the result
+      // state commits, so an abandoned in-flight run can't pin a stale offset).
+      preserveScrollRef.current = opts?.preserveScroll ? window.scrollY : null;
       setResult(traceResult);
       const firstError = (Object.entries(traceResult.stageStatus) as [StageId, string][]).find(
         ([, status]) => status === "error",
@@ -515,8 +561,10 @@ export function App() {
       // error-translation library
       void loadOptionIndex().then(setOptionIndex);
       void loadErrorTranslationLib().then(setErrorLib);
+      return traceResult;
     } catch (err) {
       setFatal(err instanceof Error ? `${err.name}: ${err.message}` : String(err));
+      return null;
     } finally {
       setRunning(false);
     }
@@ -542,7 +590,19 @@ export function App() {
         "Applied the fix by regenerating the whole config document — comments and custom formatting were not preserved.",
       );
     }
-    await onRun(undefined, buildInputs(nextContent));
+    // Roadmap 023: land on the consequence. The question the user actually has
+    // is "did the error go away?" — answered on Validate, not the Presets diff
+    // onRun lands on by default. Re-run preserving scroll (Apply fix lives in
+    // the Errors & warnings panel, right by the Validate outcome), then select
+    // Validate and toast the fresh error count.
+    const next = await onRun(undefined, buildInputs(nextContent), { preserveScroll: true });
+    if (next) {
+      setSelectedStage("validate");
+      const n = next.errors.length;
+      showToast(
+        `Fix applied — re-ran: ${n === 0 ? "0 errors" : `${n} error${n === 1 ? "" : "s"}`}`,
+      );
+    }
   }
 
   /**
@@ -735,7 +795,7 @@ export function App() {
   function onInject(key: string, contentObj: Record<string, unknown>) {
     const next = { ...injected, [key]: contentObj };
     setInjected(next);
-    void onRun(next);
+    void onRun(next, undefined, { preserveScroll: true });
   }
 
   const usesLocal = displayPlatform !== "github";
@@ -976,6 +1036,7 @@ export function App() {
           fileName={fileName}
           value={content}
           onChange={setContent}
+          presetHover={presetHover}
         />
         <p className="editor-hint">
           <kbd>{MOD_KEY_LABEL}</kbd>+<kbd>Z</kbd> to undo, <kbd>Shift</kbd>+
@@ -1037,7 +1098,7 @@ export function App() {
           <button
             type="button"
             className="primary"
-            onClick={() => onRun()}
+            onClick={() => onRun(undefined, undefined, { preserveScroll: Boolean(result) })}
             disabled={running}
             title="Process this config with Renovate's own code — it never leaves your browser"
           >
@@ -1333,6 +1394,11 @@ export function App() {
                   <span className="rendering-note"> rendering…</span>
                 ) : null}
               </div>
+              {/* Roadmap 023: the presets/merge stages run on a config a real
+                  Renovate run would have already rejected — say so. */}
+              {validateHasErrors && (deferredStage === "preset" || deferredStage === "merge") ? (
+                <HypotheticalBanner />
+              ) : null}
               {migrateStepperMounted ? (
                 <MigrationSteps
                   steps={migrateSteps}
@@ -1361,6 +1427,7 @@ export function App() {
               onSignIn={onSignIn}
               installUrl={installUrl()}
             />
+            {validateHasErrors ? <HypotheticalBanner /> : null}
             <EffectiveConfig result={result} onSelectPreset={setSelectedNodeId} />
             <RuleSimulator
               result={result}
@@ -1371,6 +1438,7 @@ export function App() {
               errorLib={errorLib}
               simRequest={simRequest}
               onCopySimLink={buildShareLinkAndCopy}
+              configInvalid={validateHasErrors}
             />
           </>
         ) : null}
@@ -1385,6 +1453,11 @@ export function App() {
         >
           ↑ Top
         </button>
+      ) : null}
+      {toast ? (
+        <div className="rcv-toast" role="status" aria-live="polite">
+          {toast}
+        </div>
       ) : null}
     </OptionDocsProvider>
   );

--- a/packages/app/src/components/ConfigEditor.tsx
+++ b/packages/app/src/components/ConfigEditor.tsx
@@ -1,13 +1,15 @@
 import CodeMirror, { EditorView, type ReactCodeMirrorRef } from "@uiw/react-codemirror";
-import { jsonSchema } from "codemirror-json-schema";
-import { json5Schema } from "codemirror-json-schema/json5";
 import { renovateSchema } from "@renovate-config-visualizer/engine/schema";
 import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { buildEditorExtensions, type PresetHoverContext } from "../preset-hover";
 
 interface Props {
   fileName: string;
   value: string;
   onChange: (value: string) => void;
+  /** Roadmap 023: current run's preset-string hover data + jump callback, read
+   *  from a ref at hover time so a fresh run's tree updates without a remount. */
+  presetHover?: PresetHoverContext | null;
 }
 
 /**
@@ -21,11 +23,15 @@ export interface ConfigEditorHandle {
 }
 
 export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function ConfigEditor(
-  { fileName, value, onChange },
+  { fileName, value, onChange, presetHover },
   ref,
 ) {
+  // Kept current every render so the once-built hover extension reads fresh
+  // tree data (a Run updates it without remounting the editor).
+  const presetHoverRef = useRef<PresetHoverContext | null>(presetHover ?? null);
+  presetHoverRef.current = presetHover ?? null;
   const extensions = useMemo(
-    () => [fileName.endsWith(".json5") ? json5Schema(renovateSchema) : jsonSchema(renovateSchema)],
+    () => buildEditorExtensions(fileName.endsWith(".json5"), renovateSchema, presetHoverRef),
     [fileName],
   );
   const cmRef = useRef<ReactCodeMirrorRef>(null);

--- a/packages/app/src/components/HypotheticalBanner.tsx
+++ b/packages/app/src/components/HypotheticalBanner.tsx
@@ -1,0 +1,14 @@
+/**
+ * Roadmap 023: shown on post-Validate results (the presets/merge stage diffs,
+ * the effective config, the simulator) whenever validation reported errors —
+ * a real Renovate run would refuse the config outright, so everything below is
+ * hypothetical. Rendered only when validation ERRORS (not warnings) exist.
+ */
+export function HypotheticalBanner() {
+  return (
+    <p className="hypothetical-banner" role="note">
+      ⚠ Validation failed — a real Renovate run would refuse this config. What you see here is what
+      it <em>would</em> do if it ran anyway.
+    </p>
+  );
+}

--- a/packages/app/src/components/RuleSimulator.tsx
+++ b/packages/app/src/components/RuleSimulator.tsx
@@ -21,6 +21,7 @@ import type { ShareSimulator } from "../share";
 import { ConfigJson } from "./ConfigJson";
 import { CopyMarkdownButton } from "./CopyMarkdownButton";
 import { ErrorTranslationView } from "./ErrorTranslationView";
+import { HypotheticalBanner } from "./HypotheticalBanner";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { RuleMessage } from "./RuleMessage";
 
@@ -463,12 +464,17 @@ function RuleRow({
   rule,
   layer,
   onSelectPreset,
+  defaultExpanded = false,
 }: {
   rule: RuleEvaluation;
   layer?: ProvenanceLayer;
   onSelectPreset?: (nodeId: string) => void;
+  /** Roadmap 023: the "my rules only" filter pre-expands its rows' clause evidence. */
+  defaultExpanded?: boolean;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  // Re-sync when the filter toggles (re-expand my-rules rows, collapse otherwise).
+  useEffect(() => setExpanded(defaultExpanded), [defaultExpanded]);
   return (
     <div id={`sim-rule-${rule.index}`} className={`sim-rule${expanded ? " expanded" : ""}`}>
       <button
@@ -791,6 +797,7 @@ export function RuleSimulator({
   errorLib,
   simRequest,
   onCopySimLink,
+  configInvalid,
 }: {
   result: TraceResult;
   /** Roadmap 013: a rule row's provenance chip → the contributing preset node in the tree. */
@@ -815,6 +822,9 @@ export function RuleSimulator({
   /** Roadmap 018: encode the current config + view + these simulator inputs into
    *  a share link and copy it (App owns the full share state). */
   onCopySimLink?: (sim: ShareSimulator) => Promise<void>;
+  /** Roadmap 023: validation reported errors — a real Renovate run would refuse
+   *  this config, so these simulation results are hypothetical. */
+  configInvalid?: boolean;
 }) {
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [sim, setSim] = useState<SimulationResult | null>(null);
@@ -837,6 +847,14 @@ export function RuleSimulator({
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
+  // Roadmap 023: a one-click filter to the user's OWN repo-config rules (their
+  // most common "where's my rule?" wish), with clause evidence pre-expanded.
+  const [myRulesOnly, setMyRulesOnly] = useState(false);
+  // Roadmap 023: the merged index a cross-link asked to see before any
+  // simulation exists to render its row — kept to show a "run a simulation"
+  // hint rather than the click doing nothing (the "looks broken" finding).
+  const [focusHint, setFocusHint] = useState<number | null>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
   // Roadmap 015: updateType derivation. `engineModule` is loaded once, up
   // front — by the time this component can render, a run has already pulled
   // the engine chunk in (see `simulate` below), so this is a cache hit, not
@@ -854,6 +872,13 @@ export function RuleSimulator({
   const [emptyGuardTriggered, setEmptyGuardTriggered] = useState(false);
   const rulesRef = useRef<HTMLDivElement>(null);
   const ruleAttribution = useRuleProvenance(result);
+  // Roadmap 023: the user's own repo-config rules (013 provenance) — the merged
+  // indices that came from the repo layer, for the "my rules only" filter.
+  const repoRuleIndices = useMemo(
+    () =>
+      new Set((ruleAttribution ?? []).filter((a) => a.layer.kind === "repo").map((a) => a.index)),
+    [ruleAttribution],
+  );
   // Roadmap 016: re-simulating (e.g. after editing the form and clicking
   // Simulate again) resets `showAll` to the matched-only default, which can
   // unmount rows the user was scrolled past — the browser's scroll-anchoring
@@ -887,6 +912,8 @@ export function RuleSimulator({
     setRanKey(null);
     setError(null);
     setShowAll(false);
+    setMyRulesOnly(false);
+    setFocusHint(null);
     setEmptyGuardTriggered(false);
   }, [result]);
 
@@ -929,7 +956,17 @@ export function RuleSimulator({
   // the packageRules-empty early return below, since hooks can't be
   // conditional — checked against `sim` directly instead of `notableRules`).
   useEffect(() => {
-    if (scrollTarget == null || !sim) {
+    if (scrollTarget == null) {
+      return;
+    }
+    if (!sim) {
+      // No simulation has run yet, so the target row isn't rendered anywhere.
+      // Land the user on the simulator and prompt them to run one, rather than
+      // leaving the cross-link click looking dead (the "looks broken" finding).
+      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      setFocusHint(scrollTarget);
+      setScrollTarget(null);
+      onRuleFocused?.();
       return;
     }
     const rule = sim.rules.find((r) => r.index === scrollTarget);
@@ -938,7 +975,12 @@ export function RuleSimulator({
       onRuleFocused?.();
       return;
     }
-    const visible = showAll || rule.verdict !== "no-match";
+    // Reveal the target row if a filter is hiding it, then let the effect re-run.
+    if (myRulesOnly && !repoRuleIndices.has(rule.index)) {
+      setMyRulesOnly(false);
+      return;
+    }
+    const visible = myRulesOnly || showAll || rule.verdict !== "no-match";
     if (!visible) {
       setShowAll(true);
       return;
@@ -951,7 +993,7 @@ export function RuleSimulator({
     }
     setScrollTarget(null);
     onRuleFocused?.();
-  }, [scrollTarget, sim, showAll, onRuleFocused]);
+  }, [scrollTarget, sim, showAll, myRulesOnly, repoRuleIndices, onRuleFocused]);
 
   /** A merged rule index a click on a `packageRules[N]` message link asked to see. */
   function focusRule(mergedIndex: number) {
@@ -1078,6 +1120,7 @@ export function RuleSimulator({
       setSimEffectiveUpdateType(effectiveType);
       setRanKey(JSON.stringify(nextForm));
       setShowAll(false);
+      setFocusHint(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -1173,7 +1216,13 @@ export function RuleSimulator({
   // or unresolved), hiding the sea of "no match" rows behind a toggle.
   const notableRules = sim ? sim.rules.filter((r) => r.verdict !== "no-match") : [];
   const hiddenCount = sim ? sim.rules.length - notableRules.length : 0;
-  const shownRules = showAll ? (sim?.rules ?? []) : notableRules;
+  const shownRules = sim
+    ? myRulesOnly
+      ? sim.rules.filter((r) => repoRuleIndices.has(r.index))
+      : showAll
+        ? sim.rules
+        : notableRules
+    : [];
   const verdictSentence = sim
     ? buildVerdictSentence(sim, sim.flattened.updateType, changedKeys, ruleAttribution)
     : "";
@@ -1188,7 +1237,7 @@ export function RuleSimulator({
   }
 
   return (
-    <div className="card">
+    <div className="card" ref={cardRef}>
       <div className="card-title">
         Update simulator
         <span className="sim-title-hint">
@@ -1202,6 +1251,13 @@ export function RuleSimulator({
           <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
         </span>
       </div>
+      {configInvalid ? <HypotheticalBanner /> : null}
+      {focusHint !== null && !sim ? (
+        <p className="sim-focus-hint">
+          <code>packageRules[{focusHint}]</code> is evaluated here once you run a simulation —
+          describe a dependency below and click Simulate to see how it matches.
+        </p>
+      ) : null}
       <div className="sim-presets">
         {QUICK_FILLS.map(({ label, fill }) => (
           <button key={label} type="button" onClick={() => quickFill(fill)}>
@@ -1523,11 +1579,23 @@ export function RuleSimulator({
             ))}
             <div className="sim-rules-head" ref={rulesRef}>
               <span className="sim-summary">
-                {showAll
-                  ? `all ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"}`
-                  : `${notableRules.length} of ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"} shown`}
+                {myRulesOnly
+                  ? `your ${repoRuleIndices.size} config rule${repoRuleIndices.size === 1 ? "" : "s"}`
+                  : showAll
+                    ? `all ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"}`
+                    : `${notableRules.length} of ${sim.rules.length} rule${sim.rules.length === 1 ? "" : "s"} shown`}
               </span>
-              {hiddenCount > 0 ? (
+              {repoRuleIndices.size > 0 ? (
+                <button
+                  type="button"
+                  className={`sim-toggle${myRulesOnly ? " active" : ""}`}
+                  onClick={() => setMyRulesOnly(!myRulesOnly)}
+                  title="Show only the packageRules from your own repo config, with their clause evidence expanded"
+                >
+                  {myRulesOnly ? "show all rules" : "my rules only"}
+                </button>
+              ) : null}
+              {hiddenCount > 0 && !myRulesOnly ? (
                 <button type="button" className="sim-toggle" onClick={() => setShowAll(!showAll)}>
                   {showAll ? "show matched only" : `show all ${sim.rules.length}`}
                 </button>
@@ -1541,9 +1609,14 @@ export function RuleSimulator({
                     rule={rule}
                     layer={layerByIndex.get(rule.index)}
                     onSelectPreset={onSelectPreset}
+                    defaultExpanded={myRulesOnly}
                   />
                 ))}
               </div>
+            ) : myRulesOnly ? (
+              <p className="empty-note">
+                None of your repo config&apos;s rules are in the merged set for this run.
+              </p>
             ) : (
               <p className="empty-note">
                 No rule matched this dependency.{" "}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2269,3 +2269,68 @@ pre.config-view.prov-before {
 .back-to-top:hover {
   filter: brightness(1.1);
 }
+
+/* ---------- post-action focus, honest error states, rule filters (023) ---------- */
+
+/* Shown on post-Validate results (stage diffs, effective config, simulator)
+   when validation reported errors — everything below is hypothetical. */
+.hypothetical-banner {
+  background: color-mix(in srgb, var(--error) 10%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--error) 45%, var(--border));
+  border-left: 3px solid var(--error);
+  border-radius: 6px;
+  color: inherit;
+  font-size: 0.85rem;
+  margin: 0 0 0.6rem;
+  padding: 0.5rem 0.7rem;
+}
+
+/* Transient toast (e.g. Apply fix → "re-ran: 0 errors"): lands the user on a
+   consequence without moving their scroll. */
+.rcv-toast {
+  background: var(--accent);
+  border-radius: 8px;
+  bottom: 1.25rem;
+  box-shadow: 0 2px 12px rgb(0 0 0 / 0.3);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 600;
+  left: 50%;
+  padding: 0.6rem 1rem;
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 30;
+}
+
+/* The active state of the simulator "my rules only" filter toggle. */
+.sim-toggle.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+/* Hint shown when a "packageRules[N]" cross-link is clicked before any
+   simulation exists to render that row. */
+.sim-focus-hint {
+  background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+  border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border));
+  border-radius: 6px;
+  font-size: 0.85rem;
+  margin: 0 0 0.6rem;
+  padding: 0.5rem 0.7rem;
+}
+
+/* Preset-string hover card in the editor (extends the shared .option-card). */
+.preset-hover-jump {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.preset-hover-jump:hover {
+  filter: brightness(1.1);
+}

--- a/packages/app/src/preset-hover.ts
+++ b/packages/app/src/preset-hover.ts
@@ -1,0 +1,207 @@
+import { type EditorView, hoverTooltip, type Tooltip } from "@uiw/react-codemirror";
+import { jsonSchema, jsonSchemaHover } from "codemirror-json-schema";
+import { json5Schema, json5SchemaHover } from "codemirror-json-schema/json5";
+import type { MutableRefObject } from "react";
+import type { PresetNode, PresetNodeState } from "@renovate-config-visualizer/engine";
+
+/**
+ * Roadmap 023: preset-string hovers in the config editor. Hovering a preset
+ * like `:automergeMinor` inside an `extends` array used to show only the
+ * json-schema type ("string"); this surfaces a card identifying it as a
+ * Renovate preset, a short description drawn from the resolved tree, and a
+ * jump link to that preset's node in the resolution tree.
+ *
+ * The card content lives outside React (a CodeMirror tooltip is plain DOM), so
+ * the current lookup + jump callback are read from a ref at hover time — the
+ * editor extension is built once but a fresh run swaps in new tree data.
+ */
+
+export interface PresetHoverInfo {
+  nodeId: string;
+  name: string;
+  state: PresetNodeState;
+  /** e.g. `internal`, `github`, `npm` — the presetSource, defaulting to internal. */
+  sourceKind: string;
+  /** Top-level options this preset resolves to (excluding packageRules). */
+  optionCount: number;
+  /** packageRules entries this preset resolves to. */
+  ruleCount: number;
+}
+
+export interface PresetHoverContext {
+  lookup: (name: string) => PresetHoverInfo | null;
+  onSelectPreset: (nodeId: string) => void;
+}
+
+/** Builds a `name → info` lookup from a run's resolution tree — the first
+ *  occurrence of each preset name wins (they resolve to the same content). */
+export function buildPresetLookup(root: PresetNode | undefined): Map<string, PresetHoverInfo> {
+  const map = new Map<string, PresetHoverInfo>();
+  if (!root) {
+    return map;
+  }
+  const visit = (node: PresetNode): void => {
+    for (const child of node.children) {
+      if (!map.has(child.name)) {
+        const resolved =
+          typeof child.resolved === "object" &&
+          child.resolved !== null &&
+          !Array.isArray(child.resolved)
+            ? (child.resolved as Record<string, unknown>)
+            : undefined;
+        const ruleCount = Array.isArray(resolved?.packageRules) ? resolved.packageRules.length : 0;
+        const optionCount = resolved
+          ? Object.keys(resolved).filter((k) => k !== "packageRules").length
+          : 0;
+        map.set(child.name, {
+          nodeId: child.id,
+          name: child.name,
+          state: child.state,
+          sourceKind: child.source?.presetSource ?? "internal",
+          optionCount,
+          ruleCount,
+        });
+      }
+      visit(child);
+    }
+  };
+  visit(root);
+  return map;
+}
+
+const STRING_RE = /"(?:[^"\\]|\\.)*"/g;
+
+/** The quoted string literal covering `pos` on its own line, if any. */
+function stringLiteralAt(
+  view: EditorView,
+  pos: number,
+): { value: string; from: number; to: number } | null {
+  const line = view.state.doc.lineAt(pos);
+  const col = pos - line.from;
+  for (const match of line.text.matchAll(STRING_RE)) {
+    const start = match.index;
+    const end = start + match[0].length;
+    if (col >= start && col <= end) {
+      try {
+        const value = JSON.parse(match[0]) as unknown;
+        return typeof value === "string"
+          ? { value, from: line.from + start, to: line.from + end }
+          : null;
+      } catch {
+        return null;
+      }
+    }
+  }
+  return null;
+}
+
+const STATE_LABEL: Record<PresetNodeState, string> = {
+  resolved: "resolved",
+  error: "failed to resolve",
+  aborted: "not resolved (run aborted)",
+  ignored: "ignored (in ignorePresets)",
+  "already-seen": "already resolved above",
+};
+
+function presetCard(info: PresetHoverInfo, onSelectPreset: (nodeId: string) => void): HTMLElement {
+  const card = document.createElement("div");
+  card.className = "option-card preset-hover-card";
+
+  const head = document.createElement("div");
+  head.className = "option-card-head";
+  const name = document.createElement("code");
+  name.className = "option-card-name";
+  name.textContent = info.name;
+  head.append(name);
+  const badge = document.createElement("span");
+  badge.className = "badge type";
+  badge.textContent = "Renovate preset";
+  head.append(badge);
+  card.append(head);
+
+  const desc = document.createElement("p");
+  desc.className = "option-card-desc";
+  const contribs: string[] = [];
+  if (info.optionCount > 0) {
+    contribs.push(`${info.optionCount} option${info.optionCount === 1 ? "" : "s"}`);
+  }
+  if (info.ruleCount > 0) {
+    contribs.push(`${info.ruleCount} packageRule${info.ruleCount === 1 ? "" : "s"}`);
+  }
+  const summary =
+    info.state === "resolved" && contribs.length > 0
+      ? ` It resolves to ${contribs.join(" and ")}, merged under your own settings.`
+      : "";
+  desc.textContent = `A ${info.sourceKind} preset pulled in via extends (${STATE_LABEL[info.state]}).${summary}`;
+  card.append(desc);
+
+  const row = document.createElement("p");
+  row.className = "option-card-row";
+  const jump = document.createElement("button");
+  jump.type = "button";
+  jump.className = "preset-hover-jump";
+  jump.textContent = "Show in resolution tree →";
+  jump.addEventListener("mousedown", (e) => {
+    // mousedown, not click: the tooltip is torn down as the pointer moves, and
+    // mousedown fires before that teardown can steal the interaction.
+    e.preventDefault();
+    onSelectPreset(info.nodeId);
+  });
+  row.append(jump);
+  card.append(row);
+
+  const docsRow = document.createElement("p");
+  docsRow.className = "option-card-row";
+  const docs = document.createElement("a");
+  docs.href = "https://docs.renovatebot.com/config-presets/";
+  docs.target = "_blank";
+  docs.rel = "noreferrer";
+  docs.textContent = "docs.renovatebot.com ↗";
+  docsRow.append(docs);
+  card.append(docsRow);
+
+  return card;
+}
+
+/**
+ * The renovate-schema editor extensions with the default json-schema hover
+ * replaced by one that shows the preset card for known preset strings and
+ * otherwise falls back to the schema hover verbatim. The bundled `jsonSchema`
+ * array is `[lang, linter, linter, autocomplete, hover, stateExtensions]` (see
+ * codemirror-json-schema's `bundled.js`, pinned); swapping the second-to-last
+ * element keeps schema linting, completion and the schema-state field intact
+ * while overriding only the hover — a single hover source rather than a second
+ * one stacked on top of the default.
+ */
+export function buildEditorExtensions(
+  isJson5: boolean,
+  schema: Parameters<typeof jsonSchema>[0],
+  ctxRef: MutableRefObject<PresetHoverContext | null>,
+) {
+  const base = isJson5 ? json5Schema(schema) : jsonSchema(schema);
+  const fallback = isJson5 ? json5SchemaHover() : jsonSchemaHover();
+  const hoverIndex = base.length - 2;
+
+  const source = (
+    view: EditorView,
+    pos: number,
+    side: -1 | 1,
+  ): Tooltip | Promise<Tooltip | null> | null => {
+    const ctx = ctxRef.current;
+    const literal = ctx ? stringLiteralAt(view, pos) : null;
+    const info = literal && ctx ? ctx.lookup(literal.value) : null;
+    if (info && literal && ctx) {
+      const onSelectPreset = ctx.onSelectPreset;
+      return {
+        pos: literal.from,
+        end: literal.to,
+        above: true,
+        create: () => ({ dom: presetCard(info, onSelectPreset) }),
+      };
+    }
+    return fallback(view, pos, side);
+  };
+
+  base[hoverIndex] = hoverTooltip(source);
+  return base;
+}

--- a/roadmap/023-post-action-focus-and-guidance.md
+++ b/roadmap/023-post-action-focus-and-guidance.md
@@ -1,6 +1,6 @@
 # 023 — Post-action focus, honest error states, rule-filter shortcuts
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 
@@ -46,3 +46,27 @@ rules to be one click away in any rule list.
 ## Dependencies
 
 - 013 (provenance), 014 (apply fix), 016 (scroll ergonomics).
+
+## Delivered
+
+- Apply fix re-runs preserving scroll, selects the Validate stage, and toasts
+  the fresh error count ("re-ran: 0 errors"); Run / preset-injection re-runs
+  also preserve scroll (best-effort, restored after paint — no flaky e2e
+  assertion on the exact offset).
+- `HypotheticalBanner` on the presets/merge stage diffs, the effective config
+  and the simulator, shown only when the Validate stage reports errors.
+- Simulator "my rules only" filter (repo-config provenance from 013), the
+  filtered rows pre-expanded to their clause evidence.
+- Editor preset-string hovers: a Renovate-preset card with a short description
+  from the resolved tree and a "Show in resolution tree" jump link, replacing
+  the bare "string" schema tooltip for known preset strings (available after a
+  run, when the resolution tree exists).
+- The `(= merged rule packageRules[N])` annotation stays interactive but no
+  longer dead-clicks before a simulation: it lands the user on the simulator
+  with a hint to run one.
+
+## Deferred
+
+- None. Preset-string hovers need a completed run (the resolution tree is what
+  identifies a string as a preset); before the first run the schema tooltip
+  still shows, unchanged.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -27,7 +27,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done    |
 | [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done    |
 | [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done    |
-| [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | planned |
+| [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done    |
 | [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | planned |
 | [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | planned |
 | [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | planned |


### PR DESCRIPTION
Implements roadmap item 023 (M7).

- Apply fix now lands on its consequence: re-runs preserving scroll, selects the Validate stage, and toasts "Fix applied — re-ran: N error(s)" with the real new count. Scroll position is preserved across full pipeline re-runs generally (016 only covered re-simulations).
- Honest hypothetical state: when validation errors exist, a banner on post-Validate stage views and the simulator says a real Renovate run would refuse this config and results show what it *would* do.
- "My rules only" filter in simulator results (via 013 provenance), with clause evidence pre-expanded for repo-config rules.
- Preset strings in the config editor (e.g. `:automergeMinor`) get a real hover card after a run: preset identity, options/rules summary, "Show in resolution tree" jump link, docs link — replacing the bare "string" schema tooltip.
- The "(= merged rule packageRules[N])" annotation no longer dead-clicks before a simulation exists; it scrolls to the simulator with a hint.
- Two new e2e tests (suite now 10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ