### PR TITLE
feat(024): stage chips signal what each stage did

### DIFF
--- a/packages/app/e2e/07-stage-chip-outcomes.spec.ts
+++ b/packages/app/e2e/07-stage-chip-outcomes.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { PACKAGE_RULES_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
+import { runAndAwaitResult, setEditorContent } from "./helpers";
+
+/**
+ * Roadmap 024 — stage chips signal what each stage did. A config that
+ * triggers a migration renders the Migrate chip in its amber "changed" state
+ * with a step count; a config with nothing to migrate renders it green/clean.
+ * Both dots are distinguished by shape too, not just color (see index.css).
+ */
+test("the Migrate chip shows amber with a count when it rewrote the config", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+
+  await setEditorContent(page, SEMANTIC_COMMITS_CONFIG);
+  await runAndAwaitResult(page);
+
+  const migrateChip = page.locator('.stage-chip[data-stage="migrate"]');
+  await expect(migrateChip).toBeVisible();
+  await expect(migrateChip.locator(".dot.changed")).toBeVisible();
+  await expect(migrateChip.locator(".dot.clean")).toHaveCount(0);
+  await expect(migrateChip.locator(".stage-chip-count")).toHaveText("·1");
+  await expect(migrateChip).toHaveAttribute("aria-label", /migration applied/i);
+
+  // The rule is documented in the stage's own hover card, not just implied
+  // by the color.
+  await migrateChip.hover();
+  const card = page.locator(".glossary-card");
+  await expect(card).toBeVisible({ timeout: 5_000 });
+  await expect(card).toContainText(/amber/i);
+});
+
+test("the Migrate chip stays green/clean with no count when nothing was migrated", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+
+  await setEditorContent(page, PACKAGE_RULES_CONFIG);
+  await runAndAwaitResult(page);
+
+  const migrateChip = page.locator('.stage-chip[data-stage="migrate"]');
+  await expect(migrateChip).toBeVisible();
+  await expect(migrateChip.locator(".dot.clean")).toBeVisible();
+  await expect(migrateChip.locator(".dot.changed")).toHaveCount(0);
+  await expect(migrateChip.locator(".stage-chip-count")).toHaveCount(0);
+  await expect(migrateChip).toHaveAttribute("aria-label", /nothing to migrate/i);
+});

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -109,6 +109,16 @@ export const FIXED_AUTOMERGE_CONFIG = `{
 }
 `;
 
+/** A config whose only issue is a deprecated option: `semanticCommits` used
+ *  to be a boolean and is now the enum `"enabled"`/`"disabled"` — migrateConfig
+ *  rewrites it. No `extends`, so it runs offline. Used by journey 024 (the
+ *  Migrate stage chip's "changed" outcome). */
+export const SEMANTIC_COMMITS_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "semanticCommits": true
+}
+`;
+
 /** A packageRules config with a minor/patch-scoped automerge rule matching a
  *  named npm dependency (lodash). The "npm dependency" quick-fill chip
  *  describes exactly such an update, so it matches this rule. No `extends`, so

--- a/packages/app/src/components/StageTimeline.tsx
+++ b/packages/app/src/components/StageTimeline.tsx
@@ -1,5 +1,6 @@
 import type { StageId, TraceResult } from "@renovate-config-visualizer/engine";
 import { Explained, type GlossaryEntry } from "../glossary";
+import { describeStageActivity, getStageActivity } from "../stage-activity";
 
 const STAGE_ORDER: StageId[] = [
   "global",
@@ -23,51 +24,59 @@ export const STAGE_LABELS: Record<StageId, string> = {
   merge: "Merge",
 };
 
-/** Plain-language card per stage — what Renovate does there, with docs. */
+/**
+ * Plain-language card per stage — what Renovate does there, with docs, plus
+ * (024) the rule for what its dot means: amber only where a stage can
+ * meaningfully do nothing (migrate/massage/validate); the always-transform
+ * stages (parse, global, inherit, presets, merge) stay green whenever they
+ * succeed, since flagging their normal job as "amber" would just be
+ * permanently lit and uninformative.
+ */
 export const STAGE_EXPLAINERS: Record<StageId, GlossaryEntry> = {
   global: {
     name: "global config stage",
     plain:
-      "Applies the bot-level settings a self-hosted administrator configured, including any globalExtends presets. Skipped unless you provide a global config under Advanced options.",
+      "Applies the bot-level settings a self-hosted administrator configured, including any globalExtends presets. Skipped unless you provide a global config under Advanced options. Assembling this layer is what the stage always does, so its dot stays green whenever it succeeds and only turns red on an outright failure.",
     url: "https://docs.renovatebot.com/self-hosted-configuration/",
   },
   inherit: {
     name: "inherited config stage",
     plain:
-      "Applies org-level defaults shared across repositories (inheritConfig): validated, its presets resolved, and bot-only options stripped. Skipped unless you provide one under Advanced options.",
+      "Applies org-level defaults shared across repositories (inheritConfig): validated, its presets resolved, and bot-only options stripped. Skipped unless you provide one under Advanced options. Like the global layer, assembling it is this stage's normal job — its dot stays green whenever it succeeds.",
     url: "https://docs.renovatebot.com/self-hosted-configuration/#inheritconfig",
   },
   parse: {
     name: "parse stage",
-    plain: "Reads your config file text and turns it into a configuration object.",
+    plain:
+      "Reads your config file text and turns it into a configuration object. Its dot is green when parsing succeeds and red when the file can't be read — there's no partial outcome to flag amber here.",
   },
   migrate: {
     name: "migrate stage",
     plain:
-      "Rewrites deprecated options to their current names and shapes — the same rewriting Renovate applies (or proposes as a config-migration PR) on every real run.",
+      "Rewrites deprecated options to their current names and shapes — the same rewriting Renovate applies (or proposes as a config-migration PR) on every real run. Its dot turns amber when this run actually rewrote at least one option, with a count of how many; it stays green when nothing needed rewriting.",
     url: "https://docs.renovatebot.com/config-migration/",
   },
   massage: {
     name: "massage stage",
     plain:
-      "Normalizes allowed shorthand into the full form Renovate works with internally — for example a single string where a list is expected.",
+      "Normalizes allowed shorthand into the full form Renovate works with internally — for example a single string where a list is expected. Its dot turns amber when massaging actually changed the config this run, green when it left it untouched.",
   },
   validate: {
     name: "validate stage",
     plain:
-      "Checks every option against Renovate's schema and reports unknown names, wrong types and misplaced options.",
+      "Checks every option against Renovate's schema and reports unknown names, wrong types and misplaced options. Its dot turns amber when this run has warnings (shown as a count), and red when it has errors — a config can have both, in which case red wins.",
     url: "https://docs.renovatebot.com/config-validation/",
   },
   preset: {
     name: "presets stage",
     plain:
-      "Downloads everything listed in extends, expands presets referenced inside presets, and merges the result in order underneath your own settings.",
+      "Downloads everything listed in extends, expands presets referenced inside presets, and merges the result in order underneath your own settings. Resolving extends is what this stage always does, so its dot stays green whenever resolution succeeds — it turns red only if a preset fails to resolve, never amber for a normal preset chain.",
     url: "https://docs.renovatebot.com/config-presets/",
   },
   merge: {
     name: "merge stage",
     plain:
-      "Combines Renovate's built-in defaults, the resolved presets and your config — in that order — into the effective config Renovate would act on.",
+      "Combines Renovate's built-in defaults, the resolved presets and your config — in that order — into the effective config Renovate would act on. Merging layers is this stage's entire job, so its dot stays green whenever it completes — there's no routine-vs-noteworthy merge outcome to flag amber.",
   },
 };
 
@@ -80,21 +89,29 @@ interface Props {
 export function StageTimeline({ result, selected, onSelect }: Props) {
   return (
     <div className="stage-timeline">
-      {STAGE_ORDER.map((stage) => (
-        <Explained key={stage} entry={STAGE_EXPLAINERS[stage]}>
-          {(handlers) => (
-            <button
-              type="button"
-              className={`stage-chip${stage === selected ? " selected" : ""}`}
-              onClick={() => onSelect(stage)}
-              {...handlers}
-            >
-              <span className={`dot ${result.stageStatus[stage]}`} />
-              {STAGE_LABELS[stage]}
-            </button>
-          )}
-        </Explained>
-      ))}
+      {STAGE_ORDER.map((stage) => {
+        const activity = getStageActivity(result, stage);
+        return (
+          <Explained key={stage} entry={STAGE_EXPLAINERS[stage]}>
+            {(handlers) => (
+              <button
+                type="button"
+                data-stage={stage}
+                className={`stage-chip${stage === selected ? " selected" : ""}`}
+                aria-label={describeStageActivity(stage, STAGE_LABELS[stage], activity)}
+                onClick={() => onSelect(stage)}
+                {...handlers}
+              >
+                <span className={`dot ${activity.level}`} />
+                {STAGE_LABELS[stage]}
+                {activity.count !== undefined ? (
+                  <span className="stage-chip-count">·{activity.count}</span>
+                ) : null}
+              </button>
+            )}
+          </Explained>
+        );
+      })}
     </div>
   );
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -122,22 +122,47 @@ h1 {
   outline: 1px solid var(--accent);
 }
 
+/* Roadmap 024: the dot is never color-only — clean/changed/error/skipped
+   each get a distinct shape too (circle / diamond / square / hollow ring),
+   so the signal survives grayscale and color-blind viewing. */
 .stage-chip .dot {
   border-radius: 50%;
-  height: 0.5rem;
-  width: 0.5rem;
+  flex: none;
+  height: 0.55rem;
+  width: 0.55rem;
 }
 
-.stage-chip .dot.ok {
+.stage-chip .dot.clean {
   background: var(--ok);
+}
+
+.stage-chip .dot.changed {
+  background: var(--warn);
+  border-radius: 2px;
+  transform: rotate(45deg);
 }
 
 .stage-chip .dot.error {
   background: var(--error);
+  border-radius: 2px;
 }
 
 .stage-chip .dot.skipped {
-  background: var(--muted);
+  background: transparent;
+  border: 1.5px solid var(--muted);
+}
+
+.stage-chip-count {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.stage-chip .dot.changed ~ .stage-chip-count {
+  color: var(--warn);
+}
+
+.stage-chip .dot.error ~ .stage-chip-count {
+  color: var(--error);
 }
 
 .messages li.error {

--- a/packages/app/src/stage-activity.ts
+++ b/packages/app/src/stage-activity.ts
@@ -1,0 +1,112 @@
+import type { StageId, TraceEvent, TraceResult } from "@renovate-config-visualizer/engine";
+
+/**
+ * Roadmap 024: what a stage chip's dot should say happened this run, on top
+ * of the raw ok/error/skipped `stageStatus`. Green universally read as
+ * "nothing to see here" — the one stage that actually rewrote your config
+ * (e.g. Migrate turning `semanticCommits: true` into `"enabled"`) looked
+ * identical to a stage that passed it through untouched.
+ *
+ * The per-stage rule (documented again in each stage's STAGE_EXPLAINERS
+ * card in StageTimeline.tsx):
+ *  - migrate/massage/validate can meaningfully do nothing, so "clean" (green)
+ *    vs "changed" (amber) is worth showing: migrate steps > 0, massage
+ *    actually changed the config, validate has warnings.
+ *  - parse/global/inherit/preset/merge always "transform" by nature —
+ *    parsing text, assembling a config layer, resolving extends, merging
+ *    defaults — so amber there would be permanently lit and meaningless.
+ *    They stay "clean" whenever they succeed and only turn red on error.
+ */
+export type StageActivityLevel = "clean" | "changed" | "error" | "skipped";
+
+export interface StageActivity {
+  level: StageActivityLevel;
+  /** Shown beside the chip label, e.g. "Migrate ·2" — omitted when not meaningful. */
+  count?: number;
+}
+
+function stageEvents(result: TraceResult, stage: StageId): TraceEvent[] {
+  return result.events.filter((e) => e.stage === stage);
+}
+
+export function getStageActivity(result: TraceResult, stage: StageId): StageActivity {
+  const status = result.stageStatus[stage];
+  if (status === "skipped") {
+    return { level: "skipped" };
+  }
+
+  // Validate is the one stage where errors and a count coexist: an errored
+  // run still reports how many errors, not just red.
+  if (stage === "validate") {
+    const events = stageEvents(result, "validate");
+    if (status === "error") {
+      const errorCount = events.filter(
+        (e) => e.kind === "validation-message" && e.level === "error",
+      ).length;
+      return errorCount > 0 ? { level: "error", count: errorCount } : { level: "error" };
+    }
+    const warnCount = events.filter(
+      (e) => e.kind === "validation-message" && e.level === "warn",
+    ).length;
+    return warnCount > 0 ? { level: "changed", count: warnCount } : { level: "clean" };
+  }
+
+  if (status === "error") {
+    return { level: "error" };
+  }
+
+  if (stage === "migrate") {
+    const count = stageEvents(result, "migrate").filter(
+      (e) => e.kind === "migration-applied",
+    ).length;
+    return count > 0 ? { level: "changed", count } : { level: "clean" };
+  }
+
+  if (stage === "massage") {
+    const completed = stageEvents(result, "massage").findLast((e) => e.kind === "stage-complete");
+    const count = completed?.delta?.length ?? 0;
+    return count > 0 ? { level: "changed", count } : { level: "clean" };
+  }
+
+  // parse/global/inherit/preset/merge: always-transform stages (see the
+  // module doc above) — clean whenever they succeed, never amber.
+  return { level: "clean" };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** Short, human sentence for the chip's accessible name — screen readers get
+ *  the outcome even though it's shown visually as a dot shape + color + count. */
+export function describeStageActivity(
+  stage: StageId,
+  label: string,
+  activity: StageActivity,
+): string {
+  if (activity.level === "skipped") {
+    return `${label}: skipped`;
+  }
+  if (activity.level === "error") {
+    return activity.count ? `${label}: ${plural(activity.count, "error")}` : `${label}: failed`;
+  }
+  if (activity.level === "changed" && activity.count !== undefined) {
+    if (stage === "migrate") {
+      return `${label}: ${plural(activity.count, "migration")} applied`;
+    }
+    if (stage === "validate") {
+      return `${label}: ${plural(activity.count, "warning")}`;
+    }
+    return `${label}: ${plural(activity.count, "change")}`;
+  }
+  if (stage === "migrate") {
+    return `${label}: nothing to migrate`;
+  }
+  if (stage === "massage") {
+    return `${label}: unchanged`;
+  }
+  if (stage === "validate") {
+    return `${label}: no warnings`;
+  }
+  return `${label}: ok`;
+}

--- a/roadmap/024-stage-chips-signal-outcomes.md
+++ b/roadmap/024-stage-chips-signal-outcomes.md
@@ -1,6 +1,6 @@
 # 024 — Stage chips signal what each stage did
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 
@@ -40,3 +40,32 @@ a glance.
 ## Dependencies
 
 - 001 (stage timeline), first-load UX pass (stage explainer cards).
+
+## Delivered
+
+- Per-stage activity signal derived entirely from data already on
+  `TraceResult` (no engine changes): `stage-activity.ts` computes a
+  `clean | changed | error | skipped` level plus an optional count from the
+  stage's own trace events — migrate steps counted from `migration-applied`
+  events, massage from the stage-complete event's JSON-patch delta length,
+  validate warnings/errors from `validation-message` events.
+- Explicit per-stage rule: migrate/massage/validate turn amber when they
+  produced a non-empty transformation (with a count); parse/global/inherit/
+  presets/merge always "transform" by nature (parsing text, assembling a
+  layer, resolving extends, merging defaults) so they stay green whenever
+  they succeed and only turn red on error — never amber for their routine
+  job. Validate shows a count in both its amber (warnings) and red (errors)
+  states.
+- Each rule is spelled out in that stage's existing hover card
+  (`STAGE_EXPLAINERS` in `StageTimeline.tsx`), so "why is this one green and
+  that one amber" is one hover away.
+- Accessibility: the dot's shape changes with its level (circle / diamond /
+  square / hollow ring for clean / changed / error / skipped) so the signal
+  survives grayscale and color-blind viewing, not just its color; a
+  `·N` count renders beside the chip label, and each chip gets an
+  `aria-label` stating the outcome in words (e.g. "Migrate: 1 migration
+  applied").
+
+## Deferred
+
+- None.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -28,7 +28,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done    |
 | [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done    |
 | [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done    |
-| [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | planned |
+| [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | done    |
 | [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | planned |
 | [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | planned |
 | [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | planned |


### PR DESCRIPTION
Implements roadmap item 024 (M7, user-reported).

- Stage chips now carry an activity signal derived from trace events: green only for clean pass-through, amber when the stage transformed the config (Migrate steps > 0, Massage delta, Validate warnings) with a `·N` count, red for errors.
- Presets/Merge/Global/Inherit/Parse stay green/red-only — transforming is their routine job, so amber is reserved for stages where a change is noteworthy. The rule per stage is documented in each stage's explainer hover card.
- Color-blind safe: dot shape varies by level (circle/diamond/square/ring) and the count + aria-labels carry the signal without color.
- New e2e spec: `semanticCommits: true` renders Migrate amber with a count; a clean config renders it green (suite now 12 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ