### PR TITLE
fix(025): hover cards wrap, clamp to viewport, ignore scroll-under-cursor

### DIFF
--- a/packages/app/e2e/08-hover-card-containment.spec.ts
+++ b/packages/app/e2e/08-hover-card-containment.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { runAndAwaitResult } from "./helpers";
+
+/**
+ * Roadmap 025 — a badge-glossary hover card used to inherit `white-space:
+ * nowrap` from its `.preset-row` ancestor (position: fixed takes a card out
+ * of layout, not out of the CSS inheritance chain), so multi-sentence copy
+ * rendered as one unwrapped line that spilled past the card's background.
+ * Guard both symptoms directly: the card's content must actually wrap (no
+ * horizontal overflow) and the card itself must never render off-screen.
+ */
+test("the preset-tree 'own options' hover card wraps its text and stays on-screen at a narrow viewport", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 700, height: 900 });
+  await page.goto("/");
+  // Default editor content (config:recommended) needs no fixture — it's
+  // bundled with Renovate, so resolving it needs no network.
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+  await runAndAwaitResult(page);
+
+  await page.getByRole("button", { name: "Expand" }).first().click();
+  const badge = page.locator(".badge.contrib.opts.explained").first();
+  await expect(badge).toBeVisible();
+  await badge.scrollIntoViewIfNeeded();
+  await badge.hover();
+
+  const card = page.locator(".glossary-card").first();
+  await expect(card).toBeVisible({ timeout: 5_000 });
+  await expect(card).toContainText("own options");
+
+  const metrics = await card.evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+  }));
+  // Text wraps inside the box rather than overflowing it.
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+
+  const box = await card.boundingBox();
+  expect(box).not.toBeNull();
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width + 1);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height + 1);
+});

--- a/packages/app/src/glossary.tsx
+++ b/packages/app/src/glossary.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { useMoveGatedHover } from "./hover-gate";
 
 /**
  * Plain-language explanations for Renovate concepts used in the app's own
@@ -288,7 +289,9 @@ function GlossaryCard({
   onLeave: () => void;
 }) {
   const { entry, pos } = card;
-  const width = 320;
+  // Clamp to the viewport, not just a fixed constant — a 320px card doesn't
+  // fit an under-320px viewport (roadmap 025).
+  const width = Math.min(320, window.innerWidth - 32);
   const left = Math.max(8, Math.min(pos.left, window.innerWidth - width - 16));
   const openUpward = pos.bottom > window.innerHeight - 200;
   const style: React.CSSProperties = openUpward
@@ -330,13 +333,18 @@ interface TermProps {
 export function Term({ id, children }: TermProps) {
   const entry = GLOSSARY[id];
   const { card, show, hide, hideNow, cancelHide } = useHoverCard(entry);
+  const moveGate = useMoveGatedHover<HTMLSpanElement>(show);
   return (
     <>
       <span
         className="term"
         tabIndex={0}
-        onMouseEnter={(e) => show(e.currentTarget)}
-        onMouseLeave={hide}
+        onMouseEnter={moveGate.onMouseEnter}
+        onMouseMove={moveGate.onMouseMove}
+        onMouseLeave={() => {
+          moveGate.onMouseLeave();
+          hide();
+        }}
         onFocus={(e) => show(e.currentTarget)}
         onBlur={hide}
         onKeyDown={(e) => {
@@ -356,7 +364,8 @@ interface ExplainedProps {
   entry: GlossaryEntry;
   /** Renders the anchor element; receives the hover/focus handlers to spread. */
   children: (handlers: {
-    onMouseEnter: (e: React.MouseEvent) => void;
+    onMouseEnter: () => void;
+    onMouseMove: (e: React.MouseEvent) => void;
     onMouseLeave: () => void;
     onFocus: (e: React.FocusEvent) => void;
     onBlur: () => void;
@@ -369,11 +378,16 @@ interface ExplainedProps {
  */
 export function Explained({ entry, children }: ExplainedProps) {
   const { card, show, hide, cancelHide } = useHoverCard(entry);
+  const moveGate = useMoveGatedHover(show);
   return (
     <>
       {children({
-        onMouseEnter: (e) => show(e.currentTarget),
-        onMouseLeave: hide,
+        onMouseEnter: moveGate.onMouseEnter,
+        onMouseMove: moveGate.onMouseMove,
+        onMouseLeave: () => {
+          moveGate.onMouseLeave();
+          hide();
+        },
         onFocus: (e) => show(e.currentTarget),
         onBlur: hide,
       })}

--- a/packages/app/src/hover-gate.ts
+++ b/packages/app/src/hover-gate.ts
@@ -1,0 +1,41 @@
+import { useRef } from "react";
+
+/**
+ * Roadmap 025: hover cards opened on plain `mouseenter` also open when
+ * scrolled content merely slides an anchor under an already-stationary
+ * cursor — the browser fires `mouseenter` for the element that ends up
+ * under the pointer regardless of whether the pointer itself moved. That
+ * synthesized hover then sits there occluding whatever the user actually
+ * scrolled to see, since nothing moves it away again.
+ *
+ * `mousemove` only fires on genuine input-device motion, so gating the
+ * "show" call behind the first `mousemove` after `mouseenter` — rather than
+ * `mouseenter` itself — treats a pure-scroll hover as (correctly) not a
+ * hover. A real hover still opens instantly for any user: the pointer
+ * essentially always wobbles by a pixel the moment it lands.
+ */
+export function useMoveGatedHover<T extends Element = Element>(
+  onShow: (el: T) => void,
+): {
+  onMouseEnter: () => void;
+  onMouseMove: (e: React.MouseEvent<T>) => void;
+  onMouseLeave: () => void;
+} {
+  const moved = useRef(false);
+
+  return {
+    onMouseEnter: () => {
+      moved.current = false;
+    },
+    onMouseMove: (e) => {
+      if (moved.current) {
+        return;
+      }
+      moved.current = true;
+      onShow(e.currentTarget);
+    },
+    onMouseLeave: () => {
+      moved.current = false;
+    },
+  };
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -796,8 +796,20 @@ textarea.layer-editor:focus {
   border-radius: 8px;
   box-shadow: 0 8px 24px light-dark(rgba(140, 149, 159, 0.3), rgba(0, 0, 0, 0.5));
   font-size: 0.8rem;
+  /* Fallback for producers that don't compute an inline max-width themselves
+     (the CodeMirror preset-string hover, roadmap 023). Anchors that DO set an
+     inline max-width (the glossary/option cards below) override this. */
+  max-width: min(340px, calc(100vw - 2rem));
+  overflow-wrap: anywhere;
   padding: 0.6rem 0.75rem;
   position: fixed;
+  /* Roadmap 025: these cards render position:fixed, which takes them out of
+     layout flow but NOT out of the inheritance chain — an ancestor row with
+     `white-space: nowrap` (e.g. .preset-row) still inherits onto them,
+     turning multi-sentence copy into one unwrapped line that overflows the
+     box. Pin it back to normal explicitly rather than relying on no ancestor
+     ever setting nowrap. */
+  white-space: normal;
   z-index: 10;
 }
 

--- a/packages/app/src/option-docs.tsx
+++ b/packages/app/src/option-docs.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import type { OptionDoc, OptionIndex } from "@renovate-config-visualizer/engine";
+import { useMoveGatedHover } from "./hover-gate";
 
 /**
  * Inline documentation for renovate options (roadmap 003): a context carrying
@@ -106,7 +107,9 @@ function OptionCard({
   onLeave: () => void;
 }) {
   const { doc, name, anchor } = card;
-  const width = 340;
+  // Clamp to the viewport, not just a fixed constant — a 340px card doesn't
+  // fit an under-340px viewport (roadmap 025).
+  const width = Math.min(340, window.innerWidth - 32);
   const left = Math.max(8, Math.min(anchor.left, window.innerWidth - width - 16));
   const openUpward = anchor.bottom > window.innerHeight - 280;
   const style: React.CSSProperties = openUpward
@@ -201,13 +204,22 @@ export function OptionKey({ name, flagUnknown }: OptionKeyProps) {
     className += " unknown";
   }
   const interactive = Boolean(doc) || unknown;
+  const moveGate = useMoveGatedHover<HTMLSpanElement>((el) =>
+    show(name, el.getBoundingClientRect()),
+  );
   return (
     <span
       className={className}
-      onMouseEnter={
-        interactive ? (e) => show(name, e.currentTarget.getBoundingClientRect()) : undefined
+      onMouseEnter={interactive ? moveGate.onMouseEnter : undefined}
+      onMouseMove={interactive ? moveGate.onMouseMove : undefined}
+      onMouseLeave={
+        interactive
+          ? () => {
+              moveGate.onMouseLeave();
+              hide();
+            }
+          : undefined
       }
-      onMouseLeave={interactive ? () => hide() : undefined}
     >
       {name}
     </span>

--- a/roadmap/025-hover-card-overflow.md
+++ b/roadmap/025-hover-card-overflow.md
@@ -1,6 +1,6 @@
 # 025 — Hover card text overflows its box
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 
@@ -38,3 +38,40 @@ not bleeding across the page.
 ## Dependencies
 
 - First-load UX pass (glossary cards), 016 (badge cards).
+
+## Delivered
+
+- Root cause: `.option-card`/`.glossary-card` are `position: fixed`, which
+  takes them out of layout but not out of the CSS inheritance chain — a
+  `.preset-row` ancestor's `white-space: nowrap` still inherited onto the
+  card, so multi-sentence copy rendered as one unwrapped line spilling past
+  the card's background. Fixed on the shared `.option-card` base: explicit
+  `white-space: normal`, `overflow-wrap: anywhere`, and a `max-width`
+  fallback for the one producer (the CodeMirror preset-string hover, 023)
+  that had never set an inline width at all.
+- Audited every producer: glossary terms and stage explainers (`Term`/
+  `Explained` in `glossary.tsx`), badge cards (016's preset-tree
+  contribution/rollup/source/duplicate/nested badges, `EffectiveConfig`'s
+  multi-layer badges), option-doc cards (003's `OptionCard`/`OptionKey`),
+  and the preset-string hover (023's CodeMirror tooltip) — all share the
+  `.option-card` base class, so the one CSS fix covers all of them. Checked
+  each renders contained at 700px, 400px and 300px viewports.
+- Horizontal clamping already existed (`Math.max(8, Math.min(left, …))`) but
+  used a hardcoded 320/340px width constant that didn't fit sub-320px
+  viewports; both `GlossaryCard` and `OptionCard` now clamp the width itself
+  to the viewport first.
+- Scroll-under-cursor occlusion: `Term`, `Explained` and `OptionKey` opened
+  their card on plain `mouseenter`, which also fires when scrolled content
+  slides an anchor under an already-stationary cursor. New shared
+  `useMoveGatedHover` (`hover-gate.ts`) defers the "show" call to the first
+  `mousemove` after `mouseenter` — a pure scroll produces no `mousemove`, so
+  it no longer opens a card, while a genuine hover (which always has at
+  least a pixel of motion) still opens instantly.
+- New permanent e2e assertion (`e2e/08-hover-card-containment.spec.ts`):
+  hovering the preset-tree "own options" badge at a 700px viewport asserts
+  `scrollWidth <= clientWidth + 1` and that the card's bounding box stays
+  within the viewport.
+
+## Deferred
+
+- None.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -29,7 +29,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done    |
 | [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done    |
 | [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | done    |
-| [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | planned |
+| [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | done    |
 | [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | planned |
 | [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | planned |
 


### PR DESCRIPTION
Implements roadmap item 025 (M7, user-reported with screenshot).

- Root cause of the overflow: hover cards are `position: fixed` but still inherit `white-space: nowrap` from `.preset-row`, so multi-sentence copy rendered as one unwrapped line past the card edge. `.option-card` now forces `white-space: normal`, `overflow-wrap: anywhere`, and a viewport-aware max-width — one fix covers all producers (glossary, stage explainers, badge cards, option docs, effective-config badges, the CodeMirror preset hover).
- Card width clamps to `viewport - 32px`, verified contained at 700/400/300px viewports.
- Cards no longer open when content merely scrolls under a stationary cursor: opening now requires an actual `mousemove` on the anchor (new `useMoveGatedHover` hook, wired into glossary terms and option keys).
- Permanent e2e containment test added (suite now 13 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ