### PR TITLE
feat(026): treat $schema as a first-class option

### DIFF
--- a/packages/app/e2e/09-schema-option.spec.ts
+++ b/packages/app/e2e/09-schema-option.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+import { runAndAwaitResult } from "./helpers";
+
+/**
+ * Roadmap 026 — `$schema` is standard practice in renovate.json (the app's
+ * own default config ships it) and Renovate's validator explicitly ignores
+ * it, but it used to fall into the unknown-option styling because it's
+ * absent from renovate's own option metadata. Guards the Effective config
+ * row directly: no red "unknown option" marker, and the hover card explains
+ * what the key is for instead of calling it a possible typo.
+ */
+test("$schema renders as a known option in Effective config, not an unknown-option marker", async ({
+  page,
+}) => {
+  await page.goto("/");
+  // Default editor content ships $schema and only extends config:recommended
+  // (bundled with Renovate), so this needs no network.
+  await expect(page.locator(".cm-content")).toContainText("$schema");
+  await runAndAwaitResult(page);
+
+  const effectiveConfig = page
+    .locator(".card")
+    .filter({ has: page.locator(".card-title", { hasText: "Effective config" }) });
+  await expect(effectiveConfig).toBeVisible();
+
+  // Narrow to just the $schema row.
+  await effectiveConfig.getByPlaceholder("Filter keys…").fill("schema");
+  const schemaKey = effectiveConfig.locator(".prov-row .opt-key", { hasText: "$schema" }).first();
+  await expect(schemaKey).toBeVisible();
+
+  const className = await schemaKey.getAttribute("class");
+  expect(className).not.toMatch(/\bunknown\b/);
+  expect(className).toMatch(/\bknown\b/);
+
+  await schemaKey.hover();
+  const card = page.locator(".option-card").first();
+  await expect(card).toBeVisible({ timeout: 5_000 });
+  await expect(card).toContainText("ignored by Renovate itself");
+  await expect(card).not.toContainText("possibly a typo");
+});

--- a/packages/app/src/components/JsonDiff.tsx
+++ b/packages/app/src/components/JsonDiff.tsx
@@ -1,6 +1,6 @@
 import { createTwoFilesPatch } from "diff";
-import { useMemo, useState, useTransition } from "react";
-import { Diff, Hunk, parseDiff } from "react-diff-view";
+import { type ReactNode, useMemo, useState, useTransition } from "react";
+import { Diff, getChangeKey, Hunk, parseDiff } from "react-diff-view";
 import { useDiffOptionHover } from "../option-docs";
 import "react-diff-view/style/index.css";
 
@@ -10,6 +10,32 @@ function pretty(value: unknown): string {
 
 type FileData = ReturnType<typeof parseDiff>[number];
 type HunkData = FileData["hunks"][number];
+
+/**
+ * `$schema` is a well-known editor-only key (roadmap 026): the presets stage
+ * correctly drops it from the resolved config (it's not a Renovate option),
+ * but an unannotated red "removed" row reads as a rejection. Attach an inline
+ * note to that specific line instead of leaving it looking like an error.
+ */
+const SCHEMA_KEY_LINE_RE = /^\s*"\$schema"\s*:/;
+
+function schemaRemovalWidgets(files: FileData[]): Record<string, ReactNode> {
+  const widgets: Record<string, ReactNode> = {};
+  for (const file of files) {
+    for (const hunk of file.hunks) {
+      for (const change of hunk.changes) {
+        if (change.type === "delete" && SCHEMA_KEY_LINE_RE.test(change.content)) {
+          widgets[getChangeKey(change)] = (
+            <span className="diff-benign-note">
+              editor-only key, dropped from the resolved config — not an error
+            </span>
+          );
+        }
+      }
+    }
+  }
+  return widgets;
+}
 
 /**
  * The preset and merge stages produce diffs of thousands of lines
@@ -93,12 +119,14 @@ export function JsonDiff({ before, after, names, title }: Props) {
     0,
   );
 
+  const showAll = showAllRequested || totalLines <= MAX_RENDERED_LINES;
+  const visibleFiles = showAll ? files : truncateHunks(files, MAX_RENDERED_LINES);
+  // Computed before the early return below — hooks can't follow one.
+  const widgets = useMemo(() => schemaRemovalWidgets(visibleFiles), [visibleFiles]);
+
   if (totalLines === 0) {
     return <div className="empty-note">No differences.</div>;
   }
-
-  const showAll = showAllRequested || totalLines <= MAX_RENDERED_LINES;
-  const visibleFiles = showAll ? files : truncateHunks(files, MAX_RENDERED_LINES);
 
   return (
     <div>
@@ -120,6 +148,7 @@ export function JsonDiff({ before, after, names, title }: Props) {
             viewType={viewType}
             diffType={file.type}
             hunks={file.hunks}
+            widgets={widgets}
           >
             {(hunks) => hunks.map((hunk) => <Hunk key={hunk.content} hunk={hunk} />)}
           </Diff>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -188,6 +188,16 @@ pre.config-view {
   overflow: auto;
 }
 
+/* Roadmap 026: annotates the `$schema` removal line in preset/merge diffs so
+   it reads as expected behavior, not a rejection. */
+.diff-benign-note {
+  color: var(--muted);
+  display: inline-block;
+  font-size: 0.75rem;
+  font-style: italic;
+  padding: 0.1rem 1ch;
+}
+
 .empty-note {
   color: var(--muted);
   font-size: 0.9rem;

--- a/packages/app/src/option-docs.tsx
+++ b/packages/app/src/option-docs.tsx
@@ -226,7 +226,9 @@ export function OptionKey({ name, flagUnknown }: OptionKeyProps) {
   );
 }
 
-const KEY_TOKEN_RE = /"([A-Za-z][\w-]*)"(?=\s*:)/g;
+// Leading `$` admitted for `$schema` (roadmap 026) — the only renovate.json
+// key that starts with one.
+const KEY_TOKEN_RE = /"(\$?[A-Za-z][\w-]*)"(?=\s*:)/g;
 
 function caretAt(x: number, y: number): { node: Node; offset: number } | null {
   const doc = document as Document & {

--- a/packages/engine/src/option-docs.ts
+++ b/packages/engine/src/option-docs.ts
@@ -33,6 +33,21 @@ export interface OptionIndex {
   containers: ReadonlySet<string>;
 }
 
+/**
+ * `$schema` is a JSON Schema keyword, not a Renovate config option — it's
+ * absent from `getOptions()` and Renovate's validator explicitly ignores it
+ * (see `ignoredNodes` in its validation module) rather than rejecting it.
+ * Modeled by hand so it renders like any other known key instead of tripping
+ * the unknown-option styling (roadmap 026).
+ */
+const SCHEMA_OPTION: OptionDoc = {
+  name: "$schema",
+  description:
+    "Points editors at Renovate's JSON schema for autocomplete and inline validation; ignored by Renovate itself.",
+  type: "string",
+  url: "https://docs.renovatebot.com/config-overview/",
+};
+
 let cached: OptionIndex | undefined;
 
 /** Builds (once) an index of renovate's own option metadata for hover docs. */
@@ -41,6 +56,7 @@ export function getOptionIndex(): OptionIndex {
     return cached;
   }
   const options = new Map<string, OptionDoc>();
+  options.set(SCHEMA_OPTION.name, SCHEMA_OPTION);
   const containers = new Set<string>();
   for (const option of getOptions()) {
     const page = option.globalOnly ? "self-hosted-configuration" : "configuration-options";

--- a/packages/engine/test/pipeline.shimmed.test.ts
+++ b/packages/engine/test/pipeline.shimmed.test.ts
@@ -6,7 +6,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { runPipeline } from "../src/index";
+import { getOptionIndex, runPipeline } from "../src/index";
 
 function fixture(name: string): string {
   return readFileSync(join(import.meta.dirname, "fixtures", name), "utf8");
@@ -121,6 +121,22 @@ describe("trace shape", () => {
     expect(resolvedEvents.some((e) => e.parentId)).toBe(true);
   });
 
+  it("never flags $schema in validation output (roadmap 026)", async () => {
+    // internal-presets.json ships $schema at the top, same as the app's
+    // default/example configs.
+    const result = await runPipeline({
+      fileName: "internal-presets.json",
+      content: fixture("internal-presets.json"),
+    });
+    expect(result.stageStatus.validate).toBe("ok");
+    const mentions = [...result.errors, ...result.warnings].filter(
+      (m) => m.topic.includes("$schema") || m.message.includes("$schema"),
+    );
+    // Guards against a future renovate bump silently starting to flag it —
+    // it's currently ignored via `ignoredNodes` in renovate's own validator.
+    expect(mentions).toEqual([]);
+  });
+
   it("emits validation-message events", async () => {
     const result = await runPipeline({
       fileName: "invalid.json",
@@ -150,5 +166,14 @@ describe("trace shape", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+describe("option index (roadmap 026)", () => {
+  it("models $schema as a known option, not renovate's own metadata", () => {
+    const doc = getOptionIndex().options.get("$schema");
+    expect(doc).toBeDefined();
+    expect(doc?.description).toContain("ignored by Renovate itself");
+    expect(doc?.url).toBeTruthy();
   });
 });

--- a/roadmap/026-schema-first-class-option.md
+++ b/roadmap/026-schema-first-class-option.md
@@ -1,6 +1,6 @@
 # 026 — Treat `$schema` as a first-class option
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -30,7 +30,7 @@ Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.
 | [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done    |
 | [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | done    |
 | [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | done    |
-| [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | planned |
+| [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | done    |
 | [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | planned |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):


### PR DESCRIPTION
Implements roadmap item 026 (M7, user-reported).

- `$schema` is now in the option index with a proper hover card ("points editors at Renovate's JSON schema for autocomplete and inline validation; ignored by Renovate itself") and a docs link — the red unknown-option squiggle is gone everywhere the index drives styling.
- The caret-hit-testing regex for raw-text diff hovers now accepts a leading `$`, so hovering `$schema` works there too.
- The Presets diff's removed `$schema` row carries an inline note: "editor-only key, dropped from the resolved config — not an error".
- New engine tests pin that no validation path flags `$schema` (so a future renovate bump that starts flagging it fails deliberately) and that the index entry exists; new e2e asserts the Effective config `$schema` row renders as known (suite now 14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ