### PR TITLE
feat(027): share-link failure diagnostics

### DIFF
--- a/.claude/skills/persona-test/generate-links.mjs
+++ b/.claude/skills/persona-test/generate-links.mjs
@@ -3,9 +3,9 @@
  * Roadmap 019 — share-link generator for persona-test scenarios.
  *
  * Produces a URL in the exact wire format `packages/app/src/share.ts` reads:
- *   payload {v:2, renovate, config, fileName} → JSON → UTF-8 →
+ *   payload {v:2, renovate, config, fileName, c} → JSON → UTF-8 →
  *   deflate-raw (CompressionStream) → base64url (no padding), placed after
- *   `#config=`.
+ *   `#config=`. `c` is the 027 integrity tag (config checksum).
  *
  * The URL also carries a unique `?s=<id>` query param BEFORE the hash. This
  * is not read by the app — it exists so pasting the link into an
@@ -201,6 +201,17 @@ function bytesToBase64url(bytes) {
     .replace(/=+$/, "");
 }
 
+/** Roadmap 027 integrity tag — must stay byte-for-byte identical to
+ *  `configChecksum` in packages/app/src/share.ts (32-bit FNV-1a, base36). */
+function configChecksum(config) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < config.length; i++) {
+    h ^= config.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
 function base64urlToBytes(token) {
   const b64 = token.replace(/-/g, "+").replace(/_/g, "/");
   return Buffer.from(b64, "base64");
@@ -254,14 +265,21 @@ async function main() {
 
   const config = await loadConfig(path.resolve(process.cwd(), args.config));
   const renovate = await resolveRenovateVersion(args.renovate);
-  const payload = { v: 2, renovate, config, fileName: args.filename };
+  // Roadmap 027: additive integrity tag (`c`) so the app can flag a link that
+  // arrived truncated/corrupted. Stays v2 — old decoders ignore the extra key.
+  const payload = { v: 2, renovate, config, fileName: args.filename, c: configChecksum(config) };
 
   const token = await encodeToken(payload);
 
   // Self-verify: inflate the token back and confirm it round-trips before
   // printing anything a caller might paste into a browser.
   const decoded = await decodeToken(token);
-  if (decoded.config !== config || decoded.v !== 2 || decoded.renovate !== renovate) {
+  if (
+    decoded.config !== config ||
+    decoded.v !== 2 ||
+    decoded.renovate !== renovate ||
+    decoded.c !== configChecksum(config)
+  ) {
     process.stderr.write(
       "error: token failed round-trip verification — refusing to print a broken link\n",
     );

--- a/packages/app/e2e/10-share-diagnostics.spec.ts
+++ b/packages/app/e2e/10-share-diagnostics.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import {
+  encodeShareFragment,
+  encodeShareToken,
+  garbleShareToken,
+  PACKAGE_RULES_CONFIG,
+  truncateShareToken,
+} from "./fixtures";
+
+/**
+ * Roadmap 027 — share-link failure diagnostics. A `#config=` token that can't
+ * be decoded must surface a prominent, unmissable banner (not the small
+ * dismissable notice), tailored to the failure mode, and must never leave the
+ * app silently sitting on the default config as if nothing was opened.
+ */
+
+const banner = ".share-error-banner";
+const DEFAULT_CONFIG_MARKER = "config:recommended";
+
+test("a truncated token surfaces the cut-off banner", async ({ page }) => {
+  const token = await encodeShareToken({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(`#config=${truncateShareToken(token)}`);
+
+  await expect(page.locator(banner)).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator(banner)).toContainText(/cut off/i);
+  await expect(page.locator(banner)).toContainText(/whole URL was copied/i);
+});
+
+test("a garbled token surfaces the damaged-link banner", async ({ page }) => {
+  const token = await encodeShareToken({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(`#config=${garbleShareToken(token)}`);
+
+  await expect(page.locator(banner)).toBeVisible({ timeout: 15_000 });
+  await expect(page.locator(banner)).toContainText(/damaged/i);
+});
+
+test("a valid pre-027 token without the integrity field still loads and runs", async ({ page }) => {
+  const fragment = await encodeShareFragment(
+    { config: PACKAGE_RULES_CONFIG },
+    { integrity: false },
+  );
+  await page.goto(fragment);
+
+  // Decodes, auto-runs, and shows no error banner — backward compat holds.
+  await expect(page.locator(".cm-content")).toContainText("matchPackageNames", {
+    timeout: 15_000,
+  });
+  await expect(page.locator(".stage-timeline")).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator(banner)).toHaveCount(0);
+});
+
+test("a broken token never leaves the app silently on the default config", async ({ page }) => {
+  const token = await encodeShareToken({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(`#config=${truncateShareToken(token)}`);
+
+  // The banner is shown (the failure is announced, not silent) ...
+  await expect(page.locator(banner)).toBeVisible({ timeout: 15_000 });
+  // ... while the app falls back to the default config without auto-running a
+  // pipeline off a config the sender never actually shared.
+  await expect(page.locator(".cm-content")).toContainText(DEFAULT_CONFIG_MARKER);
+  await expect(page.locator(".stage-timeline")).toHaveCount(0);
+});

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -57,9 +57,29 @@ function bytesToBase64url(bytes: Uint8Array): string {
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+/** Roadmap 027 integrity tag — must stay byte-for-byte identical to
+ *  `configChecksum` in src/share.ts (32-bit FNV-1a of the config, base36). */
+export function configChecksum(config: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < config.length; i++) {
+    h ^= config.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/** Options for shaping the encoded token (e.g. producing a pre-027 link). */
+export interface EncodeOptions {
+  /** Omit the 027 integrity field, reproducing an old link. Default: include it. */
+  integrity?: boolean;
+}
+
 /** Builds the `#config=` fragment token for a payload — same wire shape as
  *  `encodeShare()` in src/share.ts and 019's generator produce. */
-export async function encodeShareToken(input: SharePayloadInput): Promise<string> {
+export async function encodeShareToken(
+  input: SharePayloadInput,
+  opts: EncodeOptions = {},
+): Promise<string> {
   // Validate the config is real JSON before shipping it into a fixture — a
   // broken fixture should fail here, loudly, not silently in the browser.
   JSON.parse(input.config);
@@ -69,6 +89,9 @@ export async function encodeShareToken(input: SharePayloadInput): Promise<string
     config: input.config,
     fileName: input.fileName ?? "renovate.json",
   };
+  if (opts.integrity !== false) {
+    payload.c = configChecksum(input.config);
+  }
   if (input.platform && input.platform !== "github") {
     payload.platform = input.platform;
   }
@@ -84,8 +107,28 @@ export async function encodeShareToken(input: SharePayloadInput): Promise<string
 }
 
 /** Convenience: the `#config=<token>` fragment (relative navigation target). */
-export async function encodeShareFragment(input: SharePayloadInput): Promise<string> {
-  return `#config=${await encodeShareToken(input)}`;
+export async function encodeShareFragment(
+  input: SharePayloadInput,
+  opts: EncodeOptions = {},
+): Promise<string> {
+  return `#config=${await encodeShareToken(input, opts)}`;
+}
+
+/** Simulates a link cut short in transit: drops the token's trailing chars.
+ *  deflate-raw carries no length, so the shortened bytes fail to inflate —
+ *  the app's "cut off" signature. */
+export function truncateShareToken(token: string, chars = 12): string {
+  return token.slice(0, Math.max(0, token.length - chars));
+}
+
+/** Simulates transit garbling: overwrites a run of chars with characters
+ *  outside the base64url alphabet, so base64 decode itself fails — the app's
+ *  "damaged" signature. */
+export function garbleShareToken(token: string): string {
+  const mid = Math.floor(token.length / 2);
+  // Fragment-safe punctuation (no #/% to confuse the URL parser) that is still
+  // outside the base64url alphabet, so atob rejects it.
+  return `${token.slice(0, mid)}!!!!****~~~~${token.slice(mid + 12)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -43,10 +43,11 @@ import {
 } from "./run";
 import {
   buildShareUrl,
-  decodeShare,
+  decodeShareResult,
   decideHashChangeAction,
   encodeShare,
   readShareToken,
+  type ShareDecodeError,
   type ShareFileName,
   type ShareSimulator,
   type ShareView,
@@ -256,6 +257,21 @@ function onSignIn(): void {
   void beginSignIn(window.location.hash);
 }
 
+/**
+ * Roadmap 027: the prominent banner shown when a `#config=` token was present
+ * but unreadable, tailored to the failure mode. Every message says what to do
+ * (get a fresh link, check the whole URL was copied), since the fix is always
+ * on the sender's side.
+ */
+const SHARE_ERROR_MESSAGES: Record<ShareDecodeError, string> = {
+  damaged:
+    "This shared link is damaged and couldn’t be read. Ask the sender to copy the link again, and make sure the whole URL was copied. Showing the default config instead.",
+  cutOff:
+    "This shared link appears to be cut off. Ask the sender to copy the link again, and make sure the whole URL was copied. Showing the default config instead.",
+  incompatible:
+    "This shared link was made by an incompatible version of the app and couldn’t be read. Ask the sender for a fresh link. Showing the default config instead.",
+};
+
 export function App() {
   const [content, setContent] = useState(DEFAULT_CONFIG);
   // Roadmap 016: the text last loaded from an authoritative source (the
@@ -303,8 +319,12 @@ export function App() {
   // interruptible instead of blocking the main thread.
   const deferredStage = useDeferredValue(selectedStage);
   const [fatal, setFatal] = useState<string | null>(null);
-  // Non-fatal notices (version drift, load-from-repo results, bad share link).
+  // Non-fatal notices (version drift, load-from-repo results).
   const [notice, setNotice] = useState<string | null>(null);
+  // Roadmap 027: a token was present but unreadable — a prominent, top-of-page
+  // banner (not the dismissable notice), so a broken link never reads as
+  // "nothing happened". Cleared whenever a share load succeeds.
+  const [shareError, setShareError] = useState<string | null>(null);
   // Roadmap 023: a transient toast — used to land an "Apply fix" re-run on its
   // consequence ("re-ran: 0 errors") without yanking the user's scroll around.
   const [toast, setToast] = useState<string | null>(null);
@@ -350,7 +370,7 @@ export function App() {
   const loadedContentRef = useRef(loadedContent);
   loadedContentRef.current = loadedContent;
   // Roadmap 017: guards a decode against a later hashchange (or unmount)
-  // superseding it before its async work (decodeShare, getRenovateVersion)
+  // superseding it before its async work (decodeShareResult, getRenovateVersion)
   // resolves.
   const decodeGenerationRef = useRef(0);
   // The flag must be (re)set in the effect BODY, not only in the ref
@@ -615,15 +635,17 @@ export function App() {
    * the first finishes its awaits).
    */
   async function loadShareToken(shareToken: string, isCancelled: () => boolean): Promise<void> {
-    const payload = await decodeShare(shareToken);
+    const decoded = await decodeShareResult(shareToken);
     if (isCancelled()) {
       return;
     }
-    if (!payload) {
-      setNotice("This shared link could not be read; showing the default config instead.");
+    if (!decoded.ok) {
+      setShareError(SHARE_ERROR_MESSAGES[decoded.reason]);
       clearShareHash();
       return;
     }
+    setShareError(null);
+    const payload = decoded.payload;
     const nextPlatform = payload.platform ?? "github";
     const nextEndpoint = payload.endpoint ?? "https://api.github.com";
     loadConfigText(payload.config);
@@ -956,6 +978,12 @@ export function App() {
   return (
     <OptionDocsProvider index={optionIndex}>
       <main>
+        {shareError ? (
+          <div className="share-error-banner" role="alert">
+            <strong className="share-error-banner-title">Shared link couldn’t be opened</strong>
+            <span>{shareError}</span>
+          </div>
+        ) : null}
         <header className="app-header">
           <h1>Renovate Config Visualizer</h1>
           {result ? (

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1235,6 +1235,27 @@ pre.config-view.prov-before {
   opacity: 0.6;
 }
 
+/* Roadmap 027: a broken share link must be unmissable — a full-width banner at
+   the top of the page, not the small dismissable notice below the fold. */
+.share-error-banner {
+  background: light-dark(#fff1f0, #2b1614);
+  border: 1px solid var(--error);
+  border-left: 4px solid var(--error);
+  border-radius: 6px;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  line-height: 1.4;
+  margin: 0 0 1rem;
+  padding: 0.75rem 1rem;
+}
+
+.share-error-banner-title {
+  color: var(--error);
+  font-size: 1rem;
+}
+
 .app-notice {
   align-items: baseline;
   background: var(--surface);

--- a/packages/app/src/share.ts
+++ b/packages/app/src/share.ts
@@ -76,10 +76,34 @@ export interface SharePayload {
   platformOverride?: boolean;
   view?: ShareView;
   sim?: ShareSimulator;
+  /**
+   * Roadmap 027: additive integrity tag — the config's `configChecksum`. Stays
+   * v2 (a decoder that predates it just ignores the extra key); when present it
+   * lets the decoder catch a config that survived inflation but arrived
+   * corrupted/truncated. Old links lack it and keep their prior behavior.
+   */
+  c?: string;
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Roadmap 027: 32-bit FNV-1a of the config string, base36 — a tiny additive
+ * integrity tag (payload field `c`) so a token whose config survived inflation
+ * but arrived corrupted/truncated is caught reliably instead of only when
+ * JSON.parse happens to trip. NOT security (a hand-tampered link can recompute
+ * it); it only flags accidental transit damage. Ported byte-for-byte into the
+ * e2e fixtures and the 019 generator so every producer tags identically.
+ */
+export function configChecksum(config: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < config.length; i++) {
+    h ^= config.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
 }
 
 async function pipeThrough(bytes: Uint8Array, stream: GenericTransformStream): Promise<Uint8Array> {
@@ -121,6 +145,7 @@ export async function encodeShare(state: ShareState): Promise<string> {
     renovate: state.renovate,
     config: state.config,
     fileName: state.fileName,
+    c: configChecksum(state.config),
   };
   // Omit platform/endpoint when they equal the defaults.
   if (state.platform && state.platform !== DEFAULT_PLATFORM) {
@@ -191,51 +216,96 @@ function normalizeSim(sim: ShareSimulator | undefined): ShareSimulator | undefin
   return sim.autoSimulate ? { form, autoSimulate: true } : { form };
 }
 
-/** Decodes a fragment token back to a payload, or null on any failure. */
-export async function decodeShare(token: string): Promise<SharePayload | null> {
+/**
+ * Roadmap 027: why a token failed to decode, so the app can say what happened
+ * rather than a single "couldn't read it". The reason is the earliest failing
+ * stage:
+ *  - `damaged`      — the token text isn't valid base64 (genuinely garbled).
+ *  - `cutOff`       — base64 decoded but the deflate stream / JSON is
+ *                     incomplete or corrupt, or the integrity tag mismatches.
+ *                     deflate-raw carries no length, so a truncated link fails
+ *                     here (Z_BUF_ERROR) rather than at a checksum — this is
+ *                     the "make sure the whole URL was copied" signature.
+ *  - `incompatible` — decoded to JSON but not a shape/version this app reads.
+ */
+export type ShareDecodeError = "damaged" | "cutOff" | "incompatible";
+
+export type DecodeResult =
+  | { ok: true; payload: SharePayload }
+  | { ok: false; reason: ShareDecodeError };
+
+/** Decodes a fragment token, distinguishing the failure mode (see DecodeResult). */
+export async function decodeShareResult(token: string): Promise<DecodeResult> {
+  let bytes: Uint8Array;
   try {
-    const bytes = base64urlToBytes(token);
-    const json = new TextDecoder().decode(await inflateRaw(bytes));
-    const parsed: unknown = JSON.parse(json);
-    const version = (parsed as { v?: unknown } | null)?.v;
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      (version !== 1 && version !== 2) ||
-      typeof (parsed as { config?: unknown }).config !== "string"
-    ) {
-      return null;
-    }
-    const p = parsed as SharePayload;
-    // Normalize fileName to the two supported values.
-    p.fileName = p.fileName === "renovate.json5" ? "renovate.json5" : "renovate.json";
-    // Layer configs (v2) must be plain objects; drop anything else.
-    if (!isPlainObject(p.globalConfig)) {
-      delete p.globalConfig;
-    }
-    if (!isPlainObject(p.inheritedConfig)) {
-      delete p.inheritedConfig;
-    }
-    if (typeof p.platformOverride !== "boolean") {
-      delete p.platformOverride;
-    }
-    // Roadmap 018: sanitize the optional simulator descriptor — must be a plain
-    // object with a plain-object `form` of string values; drop anything else so
-    // a hand-tampered link can't inject non-string values into the form.
-    const rawSim: unknown = p.sim;
-    const cleanSim =
-      isPlainObject(rawSim) && isPlainObject(rawSim.form)
-        ? normalizeSim(rawSim as unknown as ShareSimulator)
-        : undefined;
-    if (cleanSim) {
-      p.sim = cleanSim;
-    } else {
-      delete p.sim;
-    }
-    return p;
+    bytes = base64urlToBytes(token);
   } catch {
-    return null;
+    return { ok: false, reason: "damaged" };
   }
+  let json: string;
+  try {
+    json = new TextDecoder().decode(await inflateRaw(bytes));
+  } catch {
+    return { ok: false, reason: "cutOff" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: "cutOff" };
+  }
+  const version = (parsed as { v?: unknown } | null)?.v;
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    (version !== 1 && version !== 2) ||
+    typeof (parsed as { config?: unknown }).config !== "string"
+  ) {
+    return { ok: false, reason: "incompatible" };
+  }
+  const p = parsed as SharePayload;
+  // Integrity tag (additive to v2): when present it must match the config it
+  // rode with. A mismatch is transit corruption the earlier stages passed.
+  // Absent (old links) = no check — today's behavior is preserved.
+  if (typeof p.c === "string" && p.c !== configChecksum(p.config)) {
+    return { ok: false, reason: "cutOff" };
+  }
+  // Normalize fileName to the two supported values.
+  p.fileName = p.fileName === "renovate.json5" ? "renovate.json5" : "renovate.json";
+  // Layer configs (v2) must be plain objects; drop anything else.
+  if (!isPlainObject(p.globalConfig)) {
+    delete p.globalConfig;
+  }
+  if (!isPlainObject(p.inheritedConfig)) {
+    delete p.inheritedConfig;
+  }
+  if (typeof p.platformOverride !== "boolean") {
+    delete p.platformOverride;
+  }
+  // Roadmap 018: sanitize the optional simulator descriptor — must be a plain
+  // object with a plain-object `form` of string values; drop anything else so
+  // a hand-tampered link can't inject non-string values into the form.
+  const rawSim: unknown = p.sim;
+  const cleanSim =
+    isPlainObject(rawSim) && isPlainObject(rawSim.form)
+      ? normalizeSim(rawSim as unknown as ShareSimulator)
+      : undefined;
+  if (cleanSim) {
+    p.sim = cleanSim;
+  } else {
+    delete p.sim;
+  }
+  return { ok: true, payload: p };
+}
+
+/**
+ * Back-compat wrapper: the decoded payload, or null on any failure. Kept for
+ * call sites that only need "did it decode"; the load path uses
+ * decodeShareResult to surface the failure reason.
+ */
+export async function decodeShare(token: string): Promise<SharePayload | null> {
+  const result = await decodeShareResult(token);
+  return result.ok ? result.payload : null;
 }
 
 /** Extracts the token from a `#config=…` location hash, or null. */

--- a/roadmap/027-share-link-failure-diagnostics.md
+++ b/roadmap/027-share-link-failure-diagnostics.md
@@ -1,6 +1,6 @@
 # 027 — Share-link failure diagnostics
 
-Milestone: M7 · Status: planned
+Milestone: M7 · Status: done
 
 ## Summary
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,35 +3,35 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [.agents/spec/renovate-config-visualizer.md](../.agents/spec/renovate-config-visualizer.md).
 
-| #                                                     | Feature                                                   | Milestone            | Status  |
-| ----------------------------------------------------- | --------------------------------------------------------- | -------------------- | ------- |
-| [001](001-engine-and-config-input.md)                 | Trace engine + config input                               | M0/M1                | done    |
-| [002](002-preset-resolution-tree.md)                  | Preset resolution tree                                    | M1 (MVP centerpiece) | done    |
-| [003](003-inline-option-docs.md)                      | Inline option documentation                               | M1                   | done    |
-| [004](004-migration-step-through.md)                  | Migration step-through                                    | M2                   | done    |
-| [005](005-merge-provenance-view.md)                   | Merge provenance view                                     | M2                   | done    |
-| [006](006-package-rules-simulator.md)                 | packageRules simulator                                    | M3                   | done    |
-| [007](007-shareable-links-and-repo-fetch.md)          | Shareable links + fetch config from repo                  | M4                   | done    |
-| [008](008-global-and-inherited-config.md)             | Global + inherited config layers                          | M3                   | done    |
-| [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done    |
-| [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done    |
-| [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done    |
-| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done    |
-| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done    |
-| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done    |
-| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done    |
-| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done    |
-| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done    |
-| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done    |
-| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done    |
-| [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done    |
-| [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done    |
-| [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done    |
-| [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done    |
-| [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | done    |
-| [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | done    |
-| [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | done    |
-| [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | planned |
+| #                                                     | Feature                                                   | Milestone            | Status |
+| ----------------------------------------------------- | --------------------------------------------------------- | -------------------- | ------ |
+| [001](001-engine-and-config-input.md)                 | Trace engine + config input                               | M0/M1                | done   |
+| [002](002-preset-resolution-tree.md)                  | Preset resolution tree                                    | M1 (MVP centerpiece) | done   |
+| [003](003-inline-option-docs.md)                      | Inline option documentation                               | M1                   | done   |
+| [004](004-migration-step-through.md)                  | Migration step-through                                    | M2                   | done   |
+| [005](005-merge-provenance-view.md)                   | Merge provenance view                                     | M2                   | done   |
+| [006](006-package-rules-simulator.md)                 | packageRules simulator                                    | M3                   | done   |
+| [007](007-shareable-links-and-repo-fetch.md)          | Shareable links + fetch config from repo                  | M4                   | done   |
+| [008](008-global-and-inherited-config.md)             | Global + inherited config layers                          | M3                   | done   |
+| [009](009-github-oauth-sign-in.md)                    | "Sign in with GitHub" (replace PAT field)                 | M4                   | done   |
+| [010](010-preset-hosting-coverage.md)                 | Preset hosting coverage + `local>`                        | M2                   | done   |
+| [011](011-preset-tree-legibility-at-scale.md)         | Preset tree legibility at scale                           | M2                   | done   |
+| [012](012-simulator-verdict-first-results.md)         | Simulator: verdict-first results + update-type flattening | M5                   | done   |
+| [013](013-rule-identity-and-provenance.md)            | Rule identity: numbering, provenance, cross-links         | M5                   | done   |
+| [014](014-validation-translations-and-quick-fixes.md) | Validation error translations + suggested fixes           | M5                   | done   |
+| [015](015-simulator-input-ergonomics.md)              | Simulator input ergonomics                                | M5                   | done   |
+| [016](016-scale-framing-and-page-ergonomics.md)       | Scale framing, badge glossary, page & editor ergonomics   | M5                   | done   |
+| [017](017-share-links-in-a-running-app.md)            | Share links opened in a running app (hashchange)          | M5                   | done   |
+| [018](018-evidence-export-and-expert-precision.md)    | Evidence export + expert-grade precision                  | M6                   | done   |
+| [019](019-persona-replay-skill.md)                    | Persona usability-test replay skill                       | M6                   | done   |
+| [020](020-browser-e2e-tests.md)                       | Browser end-to-end test suite                             | M6                   | done   |
+| [021](021-simulator-input-hardening.md)               | Simulator input hardening + A/B comparison integrity      | M7                   | done   |
+| [022](022-verdict-copy-precision.md)                  | Verdict & translation copy precision                      | M7                   | done   |
+| [023](023-post-action-focus-and-guidance.md)          | Post-action focus, honest error states, rule filters      | M7                   | done   |
+| [024](024-stage-chips-signal-outcomes.md)             | Stage chips signal what each stage did                    | M7                   | done   |
+| [025](025-hover-card-overflow.md)                     | Hover card text overflows its box                         | M7                   | done   |
+| [026](026-schema-first-class-option.md)               | Treat `$schema` as a first-class option                   | M7                   | done   |
+| [027](027-share-link-failure-diagnostics.md)          | Share-link failure diagnostics                            | M7                   | done   |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
Implements roadmap item 027 (M7, user-reported; the StrictMode root cause was already fixed in #35 — this is the remaining diagnostics gap).

- `decodeShare` refactored to a discriminated result with a failure reason: `damaged` (token isn't valid base64), `cutOff` (valid base64 but inflate/JSON fails or integrity mismatches — the truncation signature; empirically a chopped deflate-raw stream fails at inflate, not JSON.parse), `incompatible` (parses but wrong shape/version).
- A broken token now renders an unmissable `role="alert"` banner at the top of the page with tailored wording per failure mode and recovery guidance ("ask the sender to copy the link again; make sure the whole URL was copied") — no more silent default config with a dismissable footnote.
- Additive integrity field: payload gains `c`, a 32-bit FNV-1a checksum of the config (still `v:2`, no dependencies) so truncation is detected reliably; old links without the field keep today's behavior (backward compat verified by test).
- Four new e2e tests: truncated token → cut-off banner, garbled token → damaged banner, legacy payload without `c` still loads, and a broken token never silently lands on the default config (suite now 18).
- persona-test link generator emits and self-verifies the integrity field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ