### PR TITLE
feat(app): config-driven Google Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,14 @@ jobs:
         # a regime neither the Node tests nor the production build exercise.
         run: pnpm --filter @renovate-config-visualizer/app check:dev-graph
       - name: Browser bundle build
-        # Sign-in (009) is enabled only when these repo Actions variables are
-        # set; absent = empty string = feature cleanly off (PAT UX remains).
+        # Sign-in (009) and Google Analytics are enabled only when these repo
+        # Actions variables are set; absent = empty string = feature cleanly
+        # off (PAT UX remains, no analytics).
         env:
           VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
           VITE_OAUTH_WORKER_URL: ${{ vars.VITE_OAUTH_WORKER_URL }}
           VITE_GITHUB_APP_SLUG: ${{ vars.VITE_GITHUB_APP_SLUG }}
+          VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
         run: pnpm --filter @renovate-config-visualizer/app build
       - name: Critical-path entry-set sizes (roadmap 031)
         # Prints the gzip size of everything fetched before first paint (the

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -56,10 +56,10 @@
     "typescript/no-import-type-side-effects": "error",
     "typescript/no-explicit-any": "error",
     "unicorn/no-array-for-each": "error",
-    // Roadmap 043: `__RCV_OAUTH__` is the ONE injected global — the dangling
-    // underscores are the convention that says "written by a deployment, not
-    // by this codebase". Everything else keeps the rule.
-    "no-underscore-dangle": ["error", { "allow": ["__RCV_OAUTH__"] }],
+    // Roadmap 043: the `__RCV_*__` globals are the injected deployment config —
+    // the dangling underscores are the convention that says "written by a
+    // deployment, not by this codebase". Everything else keeps the rule.
+    "no-underscore-dangle": ["error", { "allow": ["__RCV_OAUTH__", "__RCV_ANALYTICS__"] }],
 
     // --- Type-aware tier (needs `--type-aware` + oxlint-tsgolint) -----------
     "typescript/no-misused-promises": "error",

--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@ OAuth-off and an OAuth-on deployment: with both required variables set the
 container writes `/rcv-config.js` at startup and the sign-in UI appears,
 otherwise the shipped stub stays and the feature is off.
 
-| Variable               | Required for sign-in | Notes                                                               |
-| ---------------------- | -------------------- | ------------------------------------------------------------------- |
-| `RCV_GITHUB_CLIENT_ID` | yes                  | Client id of **your own** GitHub App (public value).                |
-| `RCV_OAUTH_WORKER_URL` | yes                  | Base URL of the token-exchange proxy **as the browser reaches it**. |
-| `RCV_GITHUB_APP_SLUG`  | no                   | The App's slug; enables a direct "install on repositories" link.    |
+| Variable                | Required for sign-in | Notes                                                               |
+| ----------------------- | -------------------- | ------------------------------------------------------------------- |
+| `RCV_GITHUB_CLIENT_ID`  | yes                  | Client id of **your own** GitHub App (public value).                |
+| `RCV_OAUTH_WORKER_URL`  | yes                  | Base URL of the token-exchange proxy **as the browser reaches it**. |
+| `RCV_GITHUB_APP_SLUG`   | no                   | The App's slug; enables a direct "install on repositories" link.    |
+| `RCV_GA_MEASUREMENT_ID` | no                   | GA4 measurement id (`G-…`); enables Google Analytics. Off unset.    |
 
 <details>
 <summary>Sign in with GitHub, self-hosted</summary>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
     #   RCV_OAUTH_WORKER_URL: "http://localhost:8788"
     #   # Optional: the App's slug, for a direct "install on repositories" link.
     #   RCV_GITHUB_APP_SLUG: "my-renovate-config-visualizer"
+    #   # Optional and independent of sign-in: a GA4 measurement id turns on
+    #   # Google Analytics; without it the app loads no tracking at all.
+    #   RCV_GA_MEASUREMENT_ID: "G-XXXXXXXXXX"
 
   # OPTIONAL — only needed for "Sign in with GitHub". A static page cannot hold
   # the client_secret GitHub requires at the token exchange, so this tiny proxy

--- a/docker/40-rcv-config.sh
+++ b/docker/40-rcv-config.sh
@@ -1,20 +1,16 @@
 #!/bin/sh
 # Roadmap 043 — writes /rcv-config.js at container start so ONE published image
-# serves both an OAuth-off and an OAuth-on deployment.
+# serves OAuth-off and OAuth-on (and analytics-off/on) deployments.
 #
 # The official nginx image runs every executable /docker-entrypoint.d/*.sh
 # before nginx starts, so this needs no custom ENTRYPOINT. Sign-in needs BOTH
-# ids; with either missing the file keeps its shipped stub and the app runs with
-# the PAT fallback as its only GitHub auth.
+# ids; analytics needs its one id. With nothing set the file keeps its shipped
+# stub: the app runs with the PAT fallback as its only GitHub auth and sends
+# no analytics.
 set -e
 
 target=/usr/share/nginx/html/rcv-config.js
 label="40-rcv-config.sh"
-
-if [ -z "$RCV_GITHUB_CLIENT_ID" ] || [ -z "$RCV_OAUTH_WORKER_URL" ]; then
-    echo "$label: RCV_GITHUB_CLIENT_ID / RCV_OAUTH_WORKER_URL not both set, sign-in stays off"
-    exit 0
-fi
 
 # Values are operator-supplied rather than attacker-supplied, but a stray
 # backslash, quote or newline must not emit a broken file that white-screens
@@ -23,18 +19,43 @@ js_escape() {
     printf '%s' "$1" | tr -d '\n\r' | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
 }
 
-client_id=$(js_escape "$RCV_GITHUB_CLIENT_ID")
-worker_url=$(js_escape "$RCV_OAUTH_WORKER_URL")
+oauth=false
+if [ -n "$RCV_GITHUB_CLIENT_ID" ] && [ -n "$RCV_OAUTH_WORKER_URL" ]; then
+    oauth=true
+else
+    echo "$label: RCV_GITHUB_CLIENT_ID / RCV_OAUTH_WORKER_URL not both set, sign-in stays off"
+fi
+
+analytics=false
+if [ -n "$RCV_GA_MEASUREMENT_ID" ]; then
+    analytics=true
+fi
+
+if ! $oauth && ! $analytics; then
+    exit 0
+fi
 
 {
     echo "// Generated at container start from the RCV_* environment variables."
-    echo "globalThis.__RCV_OAUTH__ = {"
-    echo "  clientId: \"$client_id\","
-    echo "  workerUrl: \"$worker_url\","
-    if [ -n "$RCV_GITHUB_APP_SLUG" ]; then
-        echo "  appSlug: \"$(js_escape "$RCV_GITHUB_APP_SLUG")\","
+    if $oauth; then
+        echo "globalThis.__RCV_OAUTH__ = {"
+        echo "  clientId: \"$(js_escape "$RCV_GITHUB_CLIENT_ID")\","
+        echo "  workerUrl: \"$(js_escape "$RCV_OAUTH_WORKER_URL")\","
+        if [ -n "$RCV_GITHUB_APP_SLUG" ]; then
+            echo "  appSlug: \"$(js_escape "$RCV_GITHUB_APP_SLUG")\","
+        fi
+        echo "};"
     fi
-    echo "};"
+    if $analytics; then
+        echo "globalThis.__RCV_ANALYTICS__ = {"
+        echo "  measurementId: \"$(js_escape "$RCV_GA_MEASUREMENT_ID")\","
+        echo "};"
+    fi
 } >"$target"
 
-echo "$label: wrote $target (sign-in enabled)"
+if $oauth; then
+    echo "$label: wrote $target (sign-in enabled)"
+fi
+if $analytics; then
+    echo "$label: wrote $target (analytics enabled)"
+fi

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { initAnalytics } from "@/platform/analytics";
 import { applyTheme, readTheme, runStorageMigrations } from "@/platform/storage";
 import "./index.css";
 
@@ -14,6 +15,10 @@ runStorageMigrations();
 // `createRoot()`. From a React effect the first paint would use the OS scheme
 // and then flip — the theme flash the switcher exists to avoid.
 applyTheme(readTheme());
+
+// Google Analytics loads only when a deployment configured a measurement id
+// (rcv-config.js or the Pages build var) — dev and self-hosts stay silent.
+initAnalytics();
 
 const root = document.getElementById("root");
 if (!root) {

--- a/packages/app/src/platform/analytics-config.test.ts
+++ b/packages/app/src/platform/analytics-config.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { getMeasurementId } from "./analytics";
+
+/**
+ * `getMeasurementId` mirrors `getOAuthConfig` (roadmap 043): a deployment-time
+ * `globalThis.__RCV_ANALYTICS__` that wins over the build-time
+ * `VITE_GA_MEASUREMENT_ID` var, and a served-file source that must therefore
+ * be validated — a malformed global falls through to the var, and an id that
+ * is not `G-` + alphanumerics never loads gtag at all (it would end up in the
+ * script URL).
+ */
+
+function setEnv(id: string | undefined): void {
+  vi.stubEnv("VITE_GA_MEASUREMENT_ID", id);
+}
+
+function setGlobal(value: unknown): void {
+  globalThis.__RCV_ANALYTICS__ = value;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setGlobal(undefined);
+});
+
+describe("getMeasurementId", () => {
+  test("is null when neither source is configured", () => {
+    setEnv(undefined);
+    expect(getMeasurementId()).toBeNull();
+  });
+
+  test("reads the build-time var when there is no runtime global", () => {
+    setEnv("G-ENV123");
+    expect(getMeasurementId()).toBe("G-ENV123");
+  });
+
+  test("the runtime global wins over the build-time var", () => {
+    setEnv("G-ENV123");
+    setGlobal({ measurementId: "  G-RUNTIME1  " });
+    expect(getMeasurementId()).toBe("G-RUNTIME1");
+  });
+
+  test.for([
+    ["not an object", "G-RUNTIME1"],
+    ["missing the id", {}],
+    ["a non-string id", { measurementId: 42 }],
+    ["a blank id", { measurementId: "   " }],
+    ["not a GA4 id", { measurementId: "UA-12345-1" }],
+  ] as const)("a global that is %s falls through to the var", ([, value]) => {
+    setEnv("G-ENV123");
+    setGlobal(value);
+    expect(getMeasurementId()).toBe("G-ENV123");
+  });
+
+  test("an id that could break out of the script URL is rejected", () => {
+    setEnv(undefined);
+    setGlobal({ measurementId: "G-1&injected=x" });
+    expect(getMeasurementId()).toBeNull();
+  });
+});

--- a/packages/app/src/platform/analytics.ts
+++ b/packages/app/src/platform/analytics.ts
@@ -1,0 +1,67 @@
+/**
+ * Google Analytics (GA4), opt-in per deployment. Pure logic + one injector.
+ *
+ * The measurement id follows the same dual-source rule as the OAuth config
+ * (roadmap 043): the deployment-time `globalThis.__RCV_ANALYTICS__` (what the
+ * Docker entrypoint writes into `/rcv-config.js`) wins over the build-time
+ * `VITE_GA_MEASUREMENT_ID` var (what the Pages build inlines). With no usable
+ * id from either source gtag.js is never loaded — `vite dev`, previews and
+ * unconfigured self-hosts send nothing.
+ */
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+  }
+}
+
+/**
+ * GA4 measurement ids are `G-` plus alphanumerics. The id ends up in the
+ * gtag.js script URL, so anything else — including a UA-era id — reads as
+ * "not configured" instead of reaching the DOM.
+ */
+const MEASUREMENT_ID = /^G-[A-Z0-9]+$/;
+
+function toMeasurementId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const id = value.trim();
+  return MEASUREMENT_ID.test(id) ? id : null;
+}
+
+function runtimeMeasurementId(): string | null {
+  const raw = globalThis.__RCV_ANALYTICS__;
+  if (typeof raw !== "object" || raw === null) {
+    return null;
+  }
+  return toMeasurementId((raw as Record<string, unknown>).measurementId);
+}
+
+/** The measurement id to track with, or null when analytics is off. */
+export function getMeasurementId(): string | null {
+  return runtimeMeasurementId() ?? toMeasurementId(import.meta.env.VITE_GA_MEASUREMENT_ID);
+}
+
+/** Loads gtag.js and sends the initial page_view — a no-op without an id. */
+export function initAnalytics(): void {
+  const id = getMeasurementId();
+  if (!id) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${id}`;
+  document.head.append(script);
+
+  const dataLayer = (window.dataLayer ??= []);
+  // gtag.js dispatches on `arguments` objects, not arrays — pushing an array
+  // is silently ignored, hence no rest parameters here.
+  function gtag(..._args: unknown[]): void {
+    // eslint-disable-next-line prefer-rest-params
+    dataLayer.push(arguments);
+  }
+  gtag("js", new Date());
+  gtag("config", id);
+}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -7,6 +7,8 @@ interface ImportMetaEnv {
   readonly VITE_OAUTH_WORKER_URL?: string;
   /** GitHub App slug — optional; enables a direct install/manage link (009). */
   readonly VITE_GITHUB_APP_SLUG?: string;
+  /** GA4 measurement id — enables Google Analytics when set (Pages build). */
+  readonly VITE_GA_MEASUREMENT_ID?: string;
 }
 
 interface ImportMeta {
@@ -24,3 +26,9 @@ interface ImportMeta {
  * only the Docker entrypoint (and equivalent self-host setups) fills it in.
  */
 declare var __RCV_OAUTH__: unknown;
+
+/**
+ * Deployment-time analytics config, same mechanism and caveats as above.
+ * Expected shape: `{ measurementId: string }` (a GA4 `G-…` id).
+ */
+declare var __RCV_ANALYTICS__: unknown;


### PR DESCRIPTION
Adds GA4, loaded only when a deployment provides a measurement id — dev servers and unconfigured self-hosts send nothing.

- New `src/platform/analytics.ts` resolves the id with the same dual-source rule as the OAuth config (043): runtime `__RCV_ANALYTICS__` from `/rcv-config.js` wins over the build-time `VITE_GA_MEASUREMENT_ID` var. Ids are validated (`G-` + alphanumerics) since they are interpolated into the gtag.js script URL; unit tests cover precedence and malformed/injection cases.
- `docker/40-rcv-config.sh` now writes the analytics and OAuth sections independently (`RCV_GA_MEASUREMENT_ID`); previously it exited early without the OAuth vars.
- CI passes `VITE_GA_MEASUREMENT_ID` from repo Actions variables (already set to the shared `G-7KS92BZF7G`), so the Pages deploy picks it up on merge.
- README env table + docker-compose example document the new variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ