### PR TITLE
fix(app): resolve PageSpeed accessibility, SEO and best-practice findings

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -3,16 +3,22 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Step through what Renovate actually does with your config — parsing, migration, validation, preset resolution and packageRules matching — powered by Renovate's own code running in your browser."
+    />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Renovate Config Visualizer</title>
   </head>
   <body>
     <div id="root"></div>
     <!--
       Roadmap 043: deployment-time config, served verbatim from public/ so it
-      never 404s. A classic script would run before the module below anyway;
-      the order is explicit because the module reads what this file defines.
+      never 404s. `defer` keeps it off the parser's critical path while still
+      running before the module below (both queue as deferred, in tree order),
+      which matters because the module reads what this file defines.
     -->
-    <script src="/rcv-config.js"></script>
+    <script defer src="/rcv-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -14,6 +14,8 @@
   },
   "dependencies": {
     "@codemirror/lang-json": "6.0.2",
+    "@codemirror/language": "6.12.4",
+    "@lezer/highlight": "1.2.3",
     "@renovate-config-visualizer/engine": "workspace:*",
     "@uiw/react-codemirror": "4.25.11",
     "codemirror-json-schema": "0.8.1",

--- a/packages/app/public/favicon.svg
+++ b/packages/app/public/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- The app's accent blue (index.css --accent, light half) behind the one
+       glyph every screen of this app is about: a config object. -->
+  <rect width="64" height="64" rx="14" fill="#0969da"/>
+  <text x="32" y="44" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="32" font-weight="700" fill="#ffffff" text-anchor="middle">{}</text>
+</svg>

--- a/packages/app/public/robots.txt
+++ b/packages/app/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -385,7 +385,11 @@ function ProvFilters({
         value={query}
         onChange={(e) => onQueryChange(e.target.value)}
       />
-      <select value={layerFilter} onChange={(e) => onLayerFilterChange(e.target.value)}>
+      <select
+        aria-label="Filter keys by layer"
+        value={layerFilter}
+        onChange={(e) => onLayerFilterChange(e.target.value)}
+      >
         <option value="all">All layers</option>
         {layerOptions.map(([id, label]) => (
           <option key={id} value={id}>

--- a/packages/app/src/features/editor/ConfigEditor.tsx
+++ b/packages/app/src/features/editor/ConfigEditor.tsx
@@ -7,6 +7,7 @@ import { json } from "@codemirror/lang-json";
 import { forwardRef, type ReactNode, useEffect, useImperativeHandle, useMemo, useRef } from "react";
 import type { PresetHoverContext } from "@/lib/preset-hover";
 import { useEffectiveScheme } from "@/hooks/use-effective-scheme";
+import { oneDarkAccessible } from "./one-dark-accessible";
 
 interface Props {
   fileName: string;
@@ -49,7 +50,15 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
   // swapped in through this compartment, so first paint and typing never
   // wait on it; schema lint/hover appears a beat later.
   const compartment = useMemo(() => new Compartment(), []);
-  const extensions = useMemo(() => [compartment.of(json())], [compartment]);
+  const extensions = useMemo(
+    () => [
+      compartment.of(json()),
+      // PageSpeed a11y: CodeMirror's contenteditable is a role="textbox" with
+      // no accessible name of its own.
+      EditorView.contentAttributes.of({ "aria-label": "Renovate config" }),
+    ],
+    [compartment],
+  );
   const cmRef = useRef<ReactCodeMirrorRef>(null);
 
   useEffect(() => {
@@ -125,7 +134,7 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
         value={value}
         onChange={onChange}
         extensions={extensions}
-        theme={scheme}
+        theme={scheme === "dark" ? oneDarkAccessible : scheme}
         minHeight="14rem"
         maxHeight="28rem"
       />

--- a/packages/app/src/features/editor/ConfigToolbar.tsx
+++ b/packages/app/src/features/editor/ConfigToolbar.tsx
@@ -50,7 +50,12 @@ export function ConfigToolbar({
     <div className="toolbar">
       {/* Roadmap 039: `.ctl` gives form controls the same metrics as
           `.btn`, so this row is ONE height end to end. */}
-      <select className="ctl" value={fileName} onChange={(e) => onFileNameChange(e.target.value)}>
+      <select
+        className="ctl"
+        aria-label="Config file name"
+        value={fileName}
+        onChange={(e) => onFileNameChange(e.target.value)}
+      >
         <option value="renovate.json">renovate.json</option>
         <option value="renovate.json5">renovate.json5</option>
       </select>

--- a/packages/app/src/features/editor/one-dark-accessible.ts
+++ b/packages/app/src/features/editor/one-dark-accessible.ts
@@ -1,0 +1,62 @@
+import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { tags as t } from "@lezer/highlight";
+import { oneDarkTheme } from "@uiw/react-codemirror";
+
+/**
+ * PageSpeed a11y — `@codemirror/theme-one-dark`, which the `theme="dark"` prop
+ * resolves to, paints JSON property names in coral `#e06c75`: 4.38:1 on the
+ * `#282c34` editor background, under WCAG AA's 4.5:1. Every other one-dark
+ * color passes, so this is the stock theme with ONE ink swapped.
+ *
+ * A full copy of `oneDarkHighlightStyle` (v6.1.3) rather than a second
+ * highlighter layered on top: when two highlight styles match the same node,
+ * both emit a class and the winner falls to injected-stylesheet order, which
+ * nothing guarantees. Replacing the style keeps exactly one rule per tag.
+ */
+const chalky = "#e5c07b",
+  coral = "#e57c84", // was #e06c75 — lightened to 5.0:1, hue kept
+  cyan = "#56b6c2",
+  invalid = "#ffffff",
+  ivory = "#abb2bf",
+  stone = "#7d8799",
+  malibu = "#61afef",
+  sage = "#98c379",
+  whiskey = "#d19a66",
+  violet = "#c678dd";
+
+const highlightStyle = HighlightStyle.define([
+  { tag: t.keyword, color: violet },
+  { tag: [t.name, t.deleted, t.character, t.propertyName, t.macroName], color: coral },
+  { tag: [t.function(t.variableName), t.labelName], color: malibu },
+  { tag: [t.color, t.constant(t.name), t.standard(t.name)], color: whiskey },
+  { tag: [t.definition(t.name), t.separator], color: ivory },
+  {
+    tag: [
+      t.typeName,
+      t.className,
+      t.number,
+      t.changed,
+      t.annotation,
+      t.modifier,
+      t.self,
+      t.namespace,
+    ],
+    color: chalky,
+  },
+  {
+    tag: [t.operator, t.operatorKeyword, t.url, t.escape, t.regexp, t.link, t.special(t.string)],
+    color: cyan,
+  },
+  { tag: [t.meta, t.comment], color: stone },
+  { tag: t.strong, fontWeight: "bold" },
+  { tag: t.emphasis, fontStyle: "italic" },
+  { tag: t.strikethrough, textDecoration: "line-through" },
+  { tag: t.link, color: stone, textDecoration: "underline" },
+  { tag: t.heading, fontWeight: "bold", color: coral },
+  { tag: [t.atom, t.bool, t.special(t.variableName)], color: whiskey },
+  { tag: [t.processingInstruction, t.string, t.inserted], color: sage },
+  { tag: t.invalid, color: invalid },
+]);
+
+/** Drop-in for `theme="dark"`: the one-dark chrome, AA-contrast syntax inks. */
+export const oneDarkAccessible = [oneDarkTheme, syntaxHighlighting(highlightStyle)];

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -14,7 +14,13 @@
     sans-serif;
   --border: light-dark(#d0d7de, #3d444d);
   --surface: light-dark(#f6f8fa, #151b23);
-  --accent: #0969da;
+  /* PageSpeed a11y: #0969da is only 3.3–3.6:1 on the dark surfaces, so dark
+     gets GitHub's dark-mode accent (5.6:1 on --surface, 6.1:1 on --canvas). */
+  --accent: light-dark(#0969da, #4493f8);
+  /* Solid fills carrying --on-accent text need the INVERSE correction: the
+     link blue above is too light under white text (3.1:1), so fills keep a
+     deeper blue per theme (5.2:1 / 4.6:1 with #fff). */
+  --accent-fill: light-dark(#0969da, #1f6feb);
   --ok: #1a7f37;
   --error: #cf222e;
   --warn: #9a6700;
@@ -191,14 +197,14 @@ h1 {
 }
 
 .btn.primary {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-fill);
+  border-color: var(--accent-fill);
   color: var(--on-accent);
   font-weight: 600;
 }
 
 .btn.primary:hover {
-  background: color-mix(in srgb, var(--accent) 88%, #000);
+  background: color-mix(in srgb, var(--accent-fill) 88%, #000);
 }
 
 .btn.quiet {
@@ -975,8 +981,8 @@ textarea.layer-editor:focus {
 }
 
 .preset-inject-button {
-  background: var(--accent);
-  border: 1px solid var(--accent);
+  background: var(--accent-fill);
+  border: 1px solid var(--accent-fill);
   border-radius: 6px;
   color: var(--on-accent);
   cursor: pointer;
@@ -1847,8 +1853,8 @@ pre.config-view.prov-before {
 }
 
 .sim-actions button.primary {
-  background: var(--accent);
-  border: 1px solid var(--accent);
+  background: var(--accent-fill);
+  border: 1px solid var(--accent-fill);
   border-radius: 6px;
   color: var(--on-accent);
   cursor: pointer;
@@ -2503,7 +2509,7 @@ pre.config-view.prov-before {
 
 .welcome-steps li::before {
   align-items: center;
-  background: var(--accent);
+  background: var(--accent-fill);
   border-radius: 50%;
   color: var(--on-accent);
   content: counter(step);
@@ -2857,7 +2863,7 @@ pre.config-view.prov-before {
 /* Back-to-top affordance (roadmap 016): appears once the page has scrolled
    past the fold; simpler and more robust than a sticky mini-toolbar. */
 .back-to-top {
-  background: var(--accent);
+  background: var(--accent-fill);
   border: none;
   border-radius: 999px;
   bottom: 1.25rem;
@@ -2894,7 +2900,7 @@ pre.config-view.prov-before {
 /* Transient toast (e.g. Apply fix → "re-ran: 0 errors"): lands the user on a
    consequence without moving their scroll. */
 .rcv-toast {
-  background: var(--accent);
+  background: var(--accent-fill);
   border-radius: 8px;
   bottom: 1.25rem;
   box-shadow: var(--shadow-float);
@@ -2910,8 +2916,8 @@ pre.config-view.prov-before {
 
 /* The active state of the simulator "my rules only" filter toggle. */
 .sim-toggle.active {
-  background: var(--accent);
-  border-color: var(--accent);
+  background: var(--accent-fill);
+  border-color: var(--accent-fill);
   color: var(--on-accent);
 }
 

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -106,5 +106,12 @@ export default defineConfig({
      * already put the floor.
      */
     cssTarget: ["chrome123", "firefox120", "safari17.5"],
+    /**
+     * PageSpeed best-practices: production stack traces stay readable and
+     * Lighthouse stops flagging the large chunks as unmapped. `.map` files
+     * are fetched only when devtools asks for them, so shipping them costs
+     * page weight nothing.
+     */
+    sourcemap: true,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       '@codemirror/lang-json':
         specifier: 6.0.2
         version: 6.0.2
+      '@codemirror/language':
+        specifier: 6.12.4
+        version: 6.12.4
+      '@lezer/highlight':
+        specifier: 1.2.3
+        version: 1.2.3
       '@renovate-config-visualizer/engine':
         specifier: workspace:*
         version: link:../engine


### PR DESCRIPTION
Fixes the actionable findings from the [mobile PageSpeed report](https://pagespeed.web.dev/analysis/https-renovate-secustor-dev/hcqmzr3d23?form_factor=mobile). Local Lighthouse against the built dist after these changes: **accessibility 100, best practices 100, SEO 100** (from 88/96/90).

- **favicon 404 → console error**: adds `favicon.svg` (accent-blue `{}` mark) + link tag; adds `robots.txt` so it stops serving the SPA fallback; adds the missing `<meta name="description">`.
- **Unnamed form fields**: aria-labels on the file-name select (toolbar), the layer-filter select (Effective config), and CodeMirror's `role="textbox"` content via `EditorView.contentAttributes`.
- **Dark-theme contrast**: `--accent` gains a dark half (`#4493f8`, 5.6–6.1:1 on the dark surfaces; the shared `#0969da` was 3.3–3.6:1). Solid fills carrying white text move to a new `--accent-fill` token (`light-dark(#0969da, #1f6feb)`) because the lighter link blue fails *under* white. The editor's `theme="dark"` now resolves to `one-dark-accessible.ts` — the stock one-dark with its single failing ink (coral `#e06c75`, 4.38:1 for JSON property names) lightened to `#e57c84` (5.0:1); full style copy so exactly one rule paints each tag.
- **Best practices**: `build.sourcemap: true` (maps are only fetched by devtools); `rcv-config.js` gets `defer`, keeping it off the parser's critical path while still running before the module script.

Deliberately not addressed: the ~800 KiB cache-lifetime estimate (GitHub Pages pins `max-age=600`; would need a CDN in front) and the unused-JS estimate (that's the engine chunking story, roadmap 031).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ