### PR TITLE
feat(051): resolved config as a copyable document

### DIFF
--- a/packages/app/e2e/15-resolved-config.spec.ts
+++ b/packages/app/e2e/15-resolved-config.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+import { openTab, runAndAwaitResult, tabPanel } from "./helpers";
+
+/**
+ * Roadmap 051 — the effective config's As-JSON rendering: the resolved config
+ * as a copyable document, with hosted presets inlined and internal presets
+ * kept as `extends` references (or everything expanded, optionally hydrated
+ * with the defaults). The default editor config extends `config:recommended`
+ * — an internal preset — so the keep-internal document must keep it
+ * referenced while the full document must consume it.
+ */
+
+test("the As JSON view keeps internal presets referenced, expands fully on demand, and hydrates defaults", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await runAndAwaitResult(page);
+  await openTab(page, "effective");
+  const panel = tabPanel(page, "effective");
+
+  // The provenance rows are the default rendering.
+  await expect(panel.locator(".prov-row").first()).toBeVisible({ timeout: 30_000 });
+
+  await panel.getByRole("radio", { name: "As JSON" }).click();
+  // The row filters are a per-rendering affordance — replaced by the output
+  // options, not left dangling over a document they cannot filter.
+  await expect(panel.locator("#resolved-expand")).toBeVisible();
+  await expect(panel.locator(".prov-filter-input")).toHaveCount(0);
+
+  // keep-internal (the default): config:recommended stays a reference.
+  const doc = panel.locator("pre.config-view");
+  await expect(doc).toContainText('"extends"');
+  await expect(doc).toContainText("config:recommended");
+  await expect(panel.getByRole("button", { name: "Copy resolved config" })).toBeVisible();
+  // Defaults cannot be written into a document that still extends presets.
+  const defaults = panel.getByRole("checkbox", { name: /include defaults/ });
+  await expect(defaults).toBeDisabled();
+
+  // Fully expanded: no extends survive, the preset's contribution is inline.
+  await panel.locator("#resolved-expand").selectOption("full");
+  await expect(doc).not.toContainText('"extends"');
+  await expect(defaults).toBeEnabled();
+
+  // Defaults hydration writes out pure defaults the bare document omits.
+  await expect(doc).not.toContainText('"branchPrefix"');
+  await defaults.check();
+  await expect(doc).toContainText('"branchPrefix"');
+
+  // Switching back restores the provenance rows and their filters.
+  await panel.getByRole("radio", { name: "By key" }).click();
+  await expect(panel.locator(".prov-row").first()).toBeVisible();
+  await expect(panel.locator(".prov-filter-input")).toBeVisible();
+});

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -2,6 +2,8 @@ import { memo, type RefObject, useEffect, useMemo, useRef, useState } from "reac
 import type {
   KeyProvenance,
   ProvenanceStep,
+  ResolvedConfigMode,
+  ResolvedConfigOutput,
   RuleAttribution,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
@@ -9,6 +11,7 @@ import { Explained, Term } from "./glossary";
 import { GLOSSARY } from "@/data/glossary-data";
 import { OptionKey } from "./option-docs";
 import { ConfigJson } from "./ConfigJson";
+import { CopyButton } from "./CopyButton";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { layerId, layerLabel, type LayerId } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
@@ -50,6 +53,45 @@ function useProvenance(result: TraceResult): Provenance | null | undefined {
       live = false;
     };
   }, [result]);
+  return state;
+}
+
+/** Roadmap 051: the card's two renderings — provenance rows / a standalone
+ *  JSON document. A MODE, not a filter: the JSON view is a different document
+ *  (and a different computation), so it must not sit in the filter bar where
+ *  checkboxes promise row-level composition. */
+type EffectiveView = "keys" | "json";
+
+/**
+ * Roadmap 051: computes the copyable resolved-config document once the JSON
+ * view is active. Mirrors `useProvenance` above — `undefined` = inactive or
+ * computing, `null` = unavailable (same guards as provenance). Cheap enough to
+ * recompute per option change: a handful of `mergeChildConfig` calls, and the
+ * engine chunk is already resident by the time this view can be reached.
+ */
+function useResolvedConfig(
+  result: TraceResult,
+  active: boolean,
+  mode: ResolvedConfigMode,
+  includeDefaults: boolean,
+): ResolvedConfigOutput | null | undefined {
+  const [state, setState] = useState<ResolvedConfigOutput | null | undefined>(undefined);
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    let live = true;
+    setState(undefined);
+    void (async () => {
+      const engine = await import("@renovate-config-visualizer/engine");
+      if (live) {
+        setState(engine.computeResolvedConfig(result, mode, { includeDefaults }) ?? null);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [result, active, mode, includeDefaults]);
   return state;
 }
 
@@ -417,6 +459,158 @@ function ProvFilters({
   );
 }
 
+/** Roadmap 051: the card-title view switch. Segmented, like the diff's
+ *  unified/side-by-side control and for the same 036 reason — it labels the
+ *  STATE, not an action, so the active rendering is always legible. */
+function ViewSwitch({
+  view,
+  onViewChange,
+}: {
+  view: EffectiveView;
+  onViewChange: (view: EffectiveView) => void;
+}) {
+  return (
+    <span className="card-title-actions">
+      <span className="seg" role="radiogroup" aria-label="Effective config view">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={view === "keys"}
+          className={view === "keys" ? "active" : undefined}
+          onClick={() => onViewChange("keys")}
+        >
+          By key
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={view === "json"}
+          className={view === "json" ? "active" : undefined}
+          onClick={() => onViewChange("json")}
+        >
+          As JSON
+        </button>
+      </span>
+    </span>
+  );
+}
+
+/** The JSON view's options row — the same chrome-row grammar as ProvFilters,
+ *  its own component for the same depth-ratchet reason. */
+function ResolvedOptionsRow({
+  expand,
+  onExpandChange,
+  includeDefaults,
+  onIncludeDefaultsChange,
+  defaultsCount,
+  getText,
+}: {
+  expand: ResolvedConfigMode;
+  onExpandChange: (mode: ResolvedConfigMode) => void;
+  includeDefaults: boolean;
+  onIncludeDefaultsChange: (checked: boolean) => void;
+  defaultsCount: number;
+  /** Null while the document is still computing — the copy button waits. */
+  getText: (() => string) | null;
+}) {
+  return (
+    <div className="prov-filters">
+      <label className="resolved-label" htmlFor="resolved-expand">
+        Expand presets:
+      </label>
+      <select
+        id="resolved-expand"
+        value={expand}
+        onChange={(e) => onExpandChange(e.target.value as ResolvedConfigMode)}
+      >
+        <option value="keep-internal">keep internal presets</option>
+        <option value="full">fully</option>
+      </select>
+      <label
+        className="prov-check"
+        title={
+          expand === "keep-internal"
+            ? "Defaults apply to the fully expanded document only — written into a config that still extends presets, they would override those presets"
+            : "Also write out every option Renovate defaults — the fully hydrated document"
+        }
+      >
+        <input
+          type="checkbox"
+          checked={includeDefaults}
+          disabled={expand === "keep-internal"}
+          onChange={(e) => onIncludeDefaultsChange(e.target.checked)}
+        />{" "}
+        include defaults ({defaultsCount})
+      </label>
+      {getText ? (
+        <CopyButton
+          className="resolved-copy"
+          getText={getText}
+          label="Copy resolved config"
+          title="Copy this document as JSON — ready to paste into a renovate.json"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Roadmap 051: the resolved config as a standalone document — hosted presets
+ * inlined, internal presets kept as `extends` references (or everything
+ * expanded). The counterpart artifact to the Rewrites tab's "Copy migrated
+ * config", which owns the pre-resolution document.
+ */
+function ResolvedJsonView({
+  output,
+  expand,
+  onExpandChange,
+  includeDefaults,
+  onIncludeDefaultsChange,
+  defaultsCount,
+}: {
+  output: ResolvedConfigOutput | null | undefined;
+  expand: ResolvedConfigMode;
+  onExpandChange: (mode: ResolvedConfigMode) => void;
+  includeDefaults: boolean;
+  onIncludeDefaultsChange: (checked: boolean) => void;
+  defaultsCount: number;
+}) {
+  return (
+    <>
+      <ResolvedOptionsRow
+        expand={expand}
+        onExpandChange={onExpandChange}
+        includeDefaults={includeDefaults}
+        onIncludeDefaultsChange={onIncludeDefaultsChange}
+        defaultsCount={defaultsCount}
+        getText={output ? () => `${JSON.stringify(output.config, null, 2)}\n` : null}
+      />
+      {output === undefined ? <p className="empty-note">Computing…</p> : null}
+      {output === null ? (
+        <p className="empty-note">
+          This document needs a completed preset resolution — see the Problems tab.
+        </p>
+      ) : null}
+      {output ? (
+        <pre className="config-view">
+          <ConfigJson value={output.config} />
+        </pre>
+      ) : null}
+      {output && output.divergingKeys.length > 0 ? (
+        <p className="resolved-caveat">
+          Merge-order caveat: <code>{output.divergingKeys.join(", ")}</code> would resolve
+          differently from this document — a kept internal preset written after an inlined preset
+          now merges first. Switch “Expand presets” to “fully” for an exact document.
+        </p>
+      ) : null}
+      <p className="empty-note">
+        Need the config <em>before</em> preset resolution? The Rewrites tab’s “Copy migrated config”
+        has it — syntax modernised, extends untouched.
+      </p>
+    </>
+  );
+}
+
 // Roadmap 032: memoized — this view renders ~100 provenance rows and reads
 // nothing that changes while the user types in the editor, so a keystroke
 // must not re-render it. All props are identity-stable in App (the callbacks
@@ -445,6 +639,16 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   const [onlyOverridden, setOnlyOverridden] = useState(false);
   const [showDefaults, setShowDefaults] = useState(false);
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+  // Roadmap 051: the As-JSON rendering and its output options
+  const [view, setView] = useState<EffectiveView>("keys");
+  const [expand, setExpand] = useState<ResolvedConfigMode>("keep-internal");
+  const [includeDefaults, setIncludeDefaults] = useState(false);
+  const resolvedOutput = useResolvedConfig(
+    result,
+    provenance !== undefined && view === "json",
+    expand,
+    expand === "full" && includeDefaults,
+  );
 
   // node ids and keys are per-run, so drop any stale expansion/filter state
   useEffect(() => {
@@ -453,6 +657,9 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     setLayerFilter("all");
     setOnlyOverridden(false);
     setShowDefaults(false);
+    setView("keys");
+    setExpand("keep-internal");
+    setIncludeDefaults(false);
   }, [provenance]);
 
   const entries = useMemo(() => (provenance ? [...provenance.values()] : []), [provenance]);
@@ -552,13 +759,27 @@ export const EffectiveConfig = memo(function EffectiveConfig({
 
   return (
     <div className="card">
-      <div className="card-title">
+      <div className="card-title effective-card-title">
         <Term id="effectiveConfig">Effective config</Term>
-        <span className="card-title-hint"> — and which layer set each option</span>
+        <span className="card-title-hint">
+          {view === "json"
+            ? " — the resolved config as a document"
+            : " — and which layer set each option"}
+        </span>
+        {provenance !== undefined ? <ViewSwitch view={view} onViewChange={setView} /> : null}
       </div>
-      {provenance === undefined ? (
-        <p className="empty-note">Computing provenance…</p>
-      ) : (
+      {provenance === undefined ? <p className="empty-note">Computing provenance…</p> : null}
+      {provenance !== undefined && view === "json" ? (
+        <ResolvedJsonView
+          output={resolvedOutput}
+          expand={expand}
+          onExpandChange={setExpand}
+          includeDefaults={includeDefaults}
+          onIncludeDefaultsChange={setIncludeDefaults}
+          defaultsCount={hiddenDefaults}
+        />
+      ) : null}
+      {provenance !== undefined && view === "keys" ? (
         <>
           <ProvFilters
             filterInputRef={filterInputRef}
@@ -611,7 +832,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
             </p>
           ) : null}
         </>
-      )}
+      ) : null}
     </div>
   );
 });

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1397,6 +1397,27 @@ textarea.layer-editor:focus {
   white-space: nowrap;
 }
 
+/* Roadmap 051: the As-JSON view's options row shares the .prov-filters chrome;
+   only its own pieces live here. */
+.resolved-label {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.resolved-copy {
+  margin-left: auto;
+}
+
+/* The merge-order honesty note — the warn notice tint (050 families), attached
+   under the document it qualifies. */
+.resolved-caveat {
+  background: var(--warn-bg);
+  border-top: 1px solid var(--warn-border);
+  font-size: 0.85rem;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+}
+
 .prov-list {
   max-height: 40rem;
   overflow: auto;
@@ -1609,12 +1630,21 @@ pre.config-view.prov-before {
 }
 
 /* The card title becomes a row when it carries actions (039). Only the editor
-   card does; every other card title stays plain text so its inline hints and
-   copy buttons keep wrapping as prose. */
-.editor-card-title {
+   card and the effective config's card (051: the view switch) do; every other
+   card title stays plain text so its inline hints and copy buttons keep
+   wrapping as prose. The hint is allowed to vanish before the actions wrap. */
+.editor-card-title,
+.effective-card-title {
   align-items: center;
   display: flex;
   gap: 0.5rem;
+}
+
+.effective-card-title .card-title-hint {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .card-title-actions {

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -44,6 +44,11 @@ export {
   type RuleAttribution,
 } from "./trace/provenance";
 export {
+  computeResolvedConfig,
+  type ResolvedConfigMode,
+  type ResolvedConfigOutput,
+} from "./trace/resolved-config";
+export {
   parseInjectedPreset,
   type PresetIdentity,
   presetInjectionKey,

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -61,7 +61,8 @@ function isPlainObject(v: unknown): v is Obj {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-function deepEqual(a: unknown, b: unknown): boolean {
+/** Structural equality over JSON-shaped values (also used by resolved-config.ts). */
+export function deepEqual(a: unknown, b: unknown): boolean {
   if (a === b) {
     return true;
   }

--- a/packages/engine/src/trace/resolved-config.ts
+++ b/packages/engine/src/trace/resolved-config.ts
@@ -1,0 +1,151 @@
+import { getDefaultConfig, mergeChildConfig } from "../renovate-adapter";
+import type { PresetNode, TraceResult } from "./model";
+import { deepEqual } from "./provenance";
+
+/**
+ * Roadmap 051: the effective config as a copyable DOCUMENT — the counterpart
+ * to `computeProvenance`'s per-key view, built from the same trace data by the
+ * same `mergeChildConfig` replay.
+ *
+ * Two expansion levels:
+ *
+ * - `"full"` — the repo-level resolution exactly as the pipeline produced it
+ *   (`root.resolved`): every preset inlined, no `extends` left. Optionally
+ *   hydrated with the defaults underneath, matching how Renovate itself
+ *   applies them (defaults first, resolved config on top).
+ * - `"keep-internal"` — hosted/fetched presets inlined, internal presets
+ *   (and anything that cannot be inlined: errored, ignored, unclassifiable
+ *   nodes) kept as `extends` references. The consolidation people actually
+ *   paste back into a renovate.json: their own preset plumbing flattened,
+ *   `config:recommended` still readable and still tracking upstream.
+ *
+ * The keep-internal document necessarily reorders merges: a kept reference
+ * resolves BEFORE the emitted body, even when it was written after an inlined
+ * preset. `mergeChildConfig` is order-sensitive (overwrites, concat order), so
+ * instead of pretending the output is always exact, the same replay is run in
+ * both orders and every top-level key whose value changes is reported in
+ * `divergingKeys` — the UI's honesty note. In the common shape (internal
+ * presets listed before hosted ones, or touching disjoint keys) the list is
+ * empty.
+ *
+ * Deliberately repo-scoped: the 008 global/inherited layers are runtime
+ * context, not part of a committable repo config, so they never appear here —
+ * unlike `finalConfig`, which merges them.
+ */
+
+export type ResolvedConfigMode = "full" | "keep-internal";
+
+export interface ResolvedConfigOutput {
+  config: Record<string, unknown>;
+  /**
+   * `keep-internal` only (always empty for `full`): top-level keys whose
+   * value would differ when the emitted document is re-resolved, because a
+   * kept `extends` reference now merges before formerly-later inlined
+   * content. Empty = the document reproduces the traced resolution exactly.
+   */
+  divergingKeys: string[];
+}
+
+type Obj = Record<string, unknown>;
+
+/** A child the emitted document can safely inline: successfully resolved AND
+ *  positively known to be non-internal. Unclassifiable nodes stay referenced —
+ *  a kept reference is at worst verbose, a wrongly-inlined one is wrong. */
+function inlineable(child: PresetNode): boolean {
+  return (
+    child.state === "resolved" &&
+    child.resolved !== undefined &&
+    child.source?.presetSource !== undefined &&
+    child.source.presetSource !== "internal"
+  );
+}
+
+function resolvedOf(child: PresetNode): Obj | undefined {
+  return child.state === "resolved" && child.resolved !== undefined
+    ? (child.resolved as Obj)
+    : undefined;
+}
+
+/** `mergeChildConfig` folded over the layers, then the body — both cloned,
+ *  since Renovate's merge mutates its parent argument. */
+function replay(layers: (Obj | undefined)[], body: Obj): Obj {
+  let acc: Obj = {};
+  for (const layer of layers) {
+    if (layer) {
+      acc = mergeChildConfig(acc, structuredClone(layer)) as Obj;
+    }
+  }
+  return mergeChildConfig(acc, structuredClone(body)) as Obj;
+}
+
+/**
+ * Computes the resolved config as a standalone document, or `undefined` when
+ * the run lacks the data (mirrors `computeProvenance`'s availability: no final
+ * config, or preset resolution did not finish).
+ *
+ * `includeDefaults` applies to `"full"` only. For `"keep-internal"` it is
+ * ignored: explicit defaults in a config body would merge AFTER the kept
+ * presets and override them — the hydrated document would not mean what the
+ * traced run meant.
+ */
+export function computeResolvedConfig(
+  result: TraceResult,
+  mode: ResolvedConfigMode,
+  opts?: { includeDefaults?: boolean },
+): ResolvedConfigOutput | undefined {
+  const root = result.presetTree;
+  if (!result.finalConfig || !root || root.resolved === undefined || root.input === undefined) {
+    return undefined;
+  }
+
+  if (mode === "full") {
+    const resolved = structuredClone(root.resolved) as Obj;
+    const config = opts?.includeDefaults
+      ? (mergeChildConfig(structuredClone(getDefaultConfig()) as Obj, resolved) as Obj)
+      : resolved;
+    return { config, divergingKeys: [] };
+  }
+
+  // Same participant filter as provenance's buildLayers: nested nodes merge
+  // inside their parent value, never at the top level.
+  const children = root.children.filter((child) => !child.nested);
+  const kept = children.filter((child) => !inlineable(child));
+  const inlined = children.filter(inlineable);
+
+  // `extends` is consumed by resolution and `ignorePresets` is deliberately
+  // KEPT: a kept-but-ignored reference re-resolves to "skipped" only while
+  // the body still says to ignore it.
+  const body = structuredClone(root.input) as Obj;
+  delete body.extends;
+
+  const merged = replay(
+    inlined.map((child) => child.resolved as Obj),
+    body,
+  );
+  // Resolved preset payloads never carry `extends` (resolution consumes it),
+  // but if one ever does, the entries belong after the kept references.
+  const carried = Array.isArray(merged.extends) ? (merged.extends as unknown[]) : [];
+  delete merged.extends;
+  const extendsList = [...kept.map((child) => child.name), ...carried];
+  const config: Obj = extendsList.length > 0 ? { extends: extendsList, ...merged } : merged;
+
+  // Order honesty: the traced run merged the children in tree order; the
+  // emitted document resolves kept references first, then the inlined+body
+  // content. Replay both sequences (identically nested-unexpanded, so only
+  // the reordering can differ) and report every key that changes.
+  const original = replay(
+    children.map((child) => resolvedOf(child)),
+    body,
+  );
+  const reordered = replay(
+    [...kept, ...inlined].map((child) => resolvedOf(child)),
+    body,
+  );
+  const divergingKeys: string[] = [];
+  for (const key of new Set([...Object.keys(original), ...Object.keys(reordered)])) {
+    if (!deepEqual(original[key], reordered[key])) {
+      divergingKeys.push(key);
+    }
+  }
+  return { config, divergingKeys };
+}

--- a/packages/engine/test/resolved-config.shimmed.test.ts
+++ b/packages/engine/test/resolved-config.shimmed.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Shimmed-project tests for roadmap 051 resolved-config output. Injected
+ * github presets stand in for hosted ("fetched") presets; internal presets
+ * resolve offline from Renovate's own bundle, so the round-trip assertions —
+ * re-running the pipeline on the emitted document — need no network.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeResolvedConfig,
+  presetInjectionKey,
+  type ResolvedConfigOutput,
+  runPipeline,
+  type TraceResult,
+} from "../src/index";
+import { must } from "./helpers";
+
+const injectedPresets = {
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/preset-a" })]: {
+    rangeStrategy: "bump",
+    addLabels: ["a"],
+    packageRules: [{ matchPackageNames: ["left-pad"], enabled: false }],
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/sets-automerge" })]: {
+    automerge: true,
+  },
+};
+
+async function run(content: Record<string, unknown>): Promise<TraceResult> {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(content),
+    injectedPresets,
+  });
+  expect(result.stageStatus.preset).toBe("ok");
+  return result;
+}
+
+function keepInternal(result: TraceResult): ResolvedConfigOutput {
+  return must(
+    computeResolvedConfig(result, "keep-internal"),
+    "a keep-internal resolved config for a completed run",
+  );
+}
+
+describe("computeResolvedConfig — keep-internal", () => {
+  const repoConfig = {
+    extends: [":dependencyDashboard", "github>test-org/preset-a"],
+    automerge: false,
+    packageRules: [{ matchDepTypes: ["devDependencies"], addLabels: ["dev"] }],
+  };
+
+  it("keeps internal presets referenced and inlines the fetched preset", async () => {
+    const out = keepInternal(await run(repoConfig));
+    expect(out.config.extends).toEqual([":dependencyDashboard"]);
+    // preset-a's contribution is now part of the body…
+    expect(out.config.rangeStrategy).toBe("bump");
+    expect(out.config.addLabels).toEqual(["a"]);
+    // …its rules concatenated before the repo's own, as the traced merge did
+    expect(out.config.packageRules).toEqual([
+      { matchPackageNames: ["left-pad"], enabled: false },
+      { matchDepTypes: ["devDependencies"], addLabels: ["dev"] },
+    ]);
+    // repo body survives, dependencyDashboard is NOT inlined
+    expect(out.config.automerge).toBe(false);
+    expect(out.config).not.toHaveProperty("dependencyDashboard");
+  });
+
+  it("round-trips: re-running the pipeline on the emitted document reproduces the effective config", async () => {
+    const original = await run(repoConfig);
+    const out = keepInternal(original);
+    expect(out.divergingKeys).toEqual([]);
+    const rerun = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify(out.config),
+      injectedPresets,
+    });
+    expect(rerun.stageStatus.preset).toBe("ok");
+    expect(rerun.finalConfig).toEqual(original.finalConfig);
+  });
+
+  it("reports keys whose value flips when a kept reference merged after inlined content", async () => {
+    // Traced order: sets-automerge (true), then :automergeDisabled (false) →
+    // false wins. The emitted document must resolve the kept reference FIRST,
+    // so the inlined `automerge: true` would win instead — a real divergence.
+    const original = await run({
+      extends: ["github>test-org/sets-automerge", ":automergeDisabled"],
+    });
+    expect(original.finalConfig?.automerge).toBe(false);
+    const out = keepInternal(original);
+    expect(out.config.extends).toEqual([":automergeDisabled"]);
+    expect(out.config.automerge).toBe(true);
+    expect(out.divergingKeys).toEqual(["automerge"]);
+    // and the divergence is real: the re-run flips the key
+    const rerun = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify(out.config),
+      injectedPresets,
+    });
+    expect(rerun.finalConfig?.automerge).toBe(true);
+  });
+
+  it("emits no extends key when every preset was inlined", async () => {
+    const out = keepInternal(await run({ extends: ["github>test-org/preset-a"] }));
+    expect(out.config).not.toHaveProperty("extends");
+    expect(out.config.rangeStrategy).toBe("bump");
+    expect(out.divergingKeys).toEqual([]);
+  });
+
+  it("keeps an ignored preset referenced alongside its ignorePresets entry", async () => {
+    const out = keepInternal(
+      await run({
+        extends: [":dependencyDashboard"],
+        ignorePresets: [":dependencyDashboard"],
+        automerge: false,
+      }),
+    );
+    expect(out.config.extends).toEqual([":dependencyDashboard"]);
+    expect(out.config.ignorePresets).toEqual([":dependencyDashboard"]);
+    expect(out.config).not.toHaveProperty("dependencyDashboard");
+  });
+
+  it("preserves nested extends in the repo body as written", async () => {
+    const out = keepInternal(
+      await run({
+        packageRules: [{ matchDepTypes: ["devDependencies"], extends: [":automergeDisabled"] }],
+      }),
+    );
+    const rules = out.config.packageRules as Record<string, unknown>[];
+    expect(rules[0]?.extends).toEqual([":automergeDisabled"]);
+  });
+});
+
+describe("computeResolvedConfig — full", () => {
+  it("returns the repo-level resolution with every preset inlined and no extends", async () => {
+    const result = await run({
+      extends: [":dependencyDashboard", "github>test-org/preset-a"],
+      automerge: false,
+    });
+    const out = must(computeResolvedConfig(result, "full"), "a full resolved config");
+    expect(out.config).not.toHaveProperty("extends");
+    expect(out.config.dependencyDashboard).toBe(true);
+    expect(out.config.rangeStrategy).toBe("bump");
+    expect(out.config.automerge).toBe(false);
+    expect(out.divergingKeys).toEqual([]);
+    // without defaults: untouched default keys are absent
+    expect(out.config).not.toHaveProperty("branchPrefix");
+  });
+
+  it("includeDefaults hydrates the defaults underneath the resolved keys", async () => {
+    const result = await run({ extends: [":automergeDisabled"] });
+    const bare = must(computeResolvedConfig(result, "full"), "a full resolved config");
+    const hydrated = must(
+      computeResolvedConfig(result, "full", { includeDefaults: true }),
+      "a defaults-hydrated full resolved config",
+    );
+    // a pure default appears only in the hydrated document…
+    expect(bare.config).not.toHaveProperty("branchPrefix");
+    expect(hydrated.config.branchPrefix).toBe("renovate/");
+    // …and the resolved value still wins over the default underneath
+    expect(hydrated.config.automerge).toBe(false);
+  });
+});
+
+describe("computeResolvedConfig — availability", () => {
+  it("returns undefined when preset resolution did not complete", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify({ extends: ["github>test-org/does-not-resolve"] }),
+    });
+    expect(result.stageStatus.preset).toBe("error");
+    expect(computeResolvedConfig(result, "keep-internal")).toBeUndefined();
+    expect(computeResolvedConfig(result, "full")).toBeUndefined();
+  });
+});

--- a/roadmap/051-resolved-config-output.md
+++ b/roadmap/051-resolved-config-output.md
@@ -1,0 +1,99 @@
+# 051 — Effective config: the resolved config as a copyable document
+
+Milestone: M14 · Status: done (2026-07-28)
+
+Mockup (approved 2026-07-28, variant B — explicit view switch + output
+options; the proposed filter-bar checkbox was rejected in review, see
+"Why a mode" below):
+[mockups/051/effective-config-output.html](mockups/051/effective-config-output.html)
+
+## Summary
+
+The Effective config tab explained _where every option came from_ but
+could not produce _the document those options add up to_. The one
+copyable config artifact in the app was the Rewrites tab's "Copy
+migrated config" — the pre-resolution document, extends untouched. 051
+adds the post-resolution counterpart: an **As JSON** rendering of the
+Effective config card with two expansion levels —
+
+- **keep internal presets** (default): hosted/fetched presets inlined,
+  internal presets kept as `extends` references. The consolidation
+  people actually paste back into a renovate.json: their own preset
+  plumbing flattened, `config:recommended` still readable and still
+  tracking upstream.
+- **fully**: every preset consumed, no `extends` left — optionally
+  hydrated with the defaults underneath ("include defaults"), matching
+  how Renovate applies them (defaults first, resolved config on top).
+
+Each copyable document is one stage of the pipeline the app already
+teaches, owned by the tab that explains that stage; the tab boundary is
+preset resolution. The JSON view cross-links back to Rewrites for the
+pre-resolution document.
+
+## Why a mode, not a checkbox
+
+The original ask was a "resolved shallow config, without internal
+presets" checkbox in the filter bar. Rejected: the existing checkboxes
+(_only overridden_, _show default-only_) filter rows of the SAME
+document and promise composition; this option produces a DIFFERENT
+document (a second merge replay) in a different rendering. Composed
+with the row filters it yields incoherent states — override chains
+referencing layers that no longer exist — and half the card's controls
+would go dead while staying visible. The segmented **By key / As JSON**
+switch in the card title (the diff chrome's unified/side-by-side
+grammar, 036: label the state, not the action) makes the whole-panel
+change legible, and each rendering carries only the controls that apply
+to it.
+
+## Engine
+
+`computeResolvedConfig(result, mode, opts)` in
+`packages/engine/src/trace/resolved-config.ts` — the document
+counterpart to `computeProvenance`, built from the same trace data by
+the same `mergeChildConfig` replay, same availability guards.
+
+- `"full"` is `root.resolved` (the repo-level resolution), optionally
+  defaults-hydrated. Deliberately repo-scoped: the 008 global/inherited
+  layers are runtime context, not part of a committable repo config.
+- `"keep-internal"` inlines only children positively known to be
+  non-internal AND successfully resolved; everything else (internal,
+  errored, ignored, unclassifiable) stays referenced — a kept reference
+  is at worst verbose, a wrongly-inlined one is wrong. `ignorePresets`
+  is preserved so kept-but-ignored references stay ignored.
+- **Merge-order honesty.** The emitted document necessarily reorders
+  merges: kept references resolve before the body, even when written
+  after an inlined preset. Rather than pretend exactness, the replay
+  runs in both orders and reports every top-level key that changes as
+  `divergingKeys`; the UI attaches a warn-tinted caveat naming them and
+  pointing at "fully" for an exact document. The shimmed test proves a
+  reported divergence is real by re-running the pipeline on the emitted
+  document (internal presets resolve offline) and watching the key
+  flip — and conversely that an empty list round-trips to an identical
+  `finalConfig`.
+- "include defaults" is a `"full"`-only option, enforced in the engine
+  AND disabled in the UI: explicit defaults written into a body that
+  still extends presets would merge after — and override — the kept
+  presets.
+
+## App
+
+`EffectiveConfig.tsx`: an `EffectiveView` mode (`keys`/`json`) with the
+segmented switch in the card title (`.effective-card-title` joins the
+039 title-row grammar), reset per run with the rest of the view state.
+The JSON view is `ResolvedJsonView` — an options row in the
+`.prov-filters` chrome (expansion select, defaults checkbox with an
+explanatory title, "Copy resolved config" aligned with Rewrites' "Copy
+migrated config" naming) over a `config-view` render of the document,
+computed through `useResolvedConfig` (dynamic engine import, mirrors
+`useProvenance`). Row filters render only in the By-key view.
+
+## Verification
+
+- Engine: `resolved-config.shimmed.test.ts` — keep/inline split, rule
+  concat order, pipeline round-trip, real-divergence flip, ignored
+  presets, nested extends preserved as written, full/defaults
+  hydration, unavailability.
+- e2e 15: switch to As JSON on the default config → `config:recommended`
+  stays referenced, filters absent; fully → no extends, defaults
+  checkbox enables and hydrates `branchPrefix`; switch back restores
+  the rows.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -55,6 +55,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [048](048-app-decomposition-and-depth-ratchet.md)       | App decomposition + depth ratchet to 3                    | M13                  | done   |
 | [049](049-feature-layer-expansion.md)                   | Feature-layer expansion: editor, presets                  | M13                  | done   |
 | [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement      | M13                  | done   |
+| [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document  | M14                  | done   |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -136,3 +137,13 @@ simulator. 050 brought the same discipline to the stylesheet: repeated
 theme values promoted to design tokens, drifted status tints
 consolidated onto token families, and stylelint enforcing var()-only
 colors from then on.
+
+M14 opens with 051, the 2026-07-28 user request to read the resolved
+config "without internal presets" out of the Effective config tab —
+landed as an As-JSON rendering with two expansion levels (hosted
+presets inlined with internal ones kept as `extends` references, or
+everything expanded, optionally defaults-hydrated), settled through the
+approved
+[mockups/051/effective-config-output.html](mockups/051/effective-config-output.html)
+(variant B; the originally proposed filter-bar checkbox was rejected as
+a mode masquerading as a filter).

--- a/roadmap/mockups/051/effective-config-output.html
+++ b/roadmap/mockups/051/effective-config-output.html
@@ -1,0 +1,989 @@
+<title>Effective Config — resolved-output mock</title>
+<style>
+  :root {
+    --canvas: #ffffff;
+    --surface: #f6f8fa;
+    --surface-raised: #ffffff;
+    --border: #d0d7de;
+    --ink: #1f2328;
+    --muted: #59636e;
+    --accent: #0969da;
+    --accent-fill: #0969da;
+    --on-accent: #fff;
+    --accent-purple: #8250df;
+    --accent-teal: #1b7c83;
+    --warn: #9a6700;
+    --ok: #1a7f37;
+    --json-key: #0550ae;
+    --json-str: #0a3069;
+    --json-lit: #953800;
+    --shadow-popover: 0 8px 24px rgba(140, 149, 159, 0.3);
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --canvas: #0d1117;
+      --surface: #151b23;
+      --surface-raised: #151b23;
+      --border: #3d444d;
+      --ink: #f0f6fc;
+      --muted: #9198a1;
+      --accent: #4493f8;
+      --accent-fill: #1f6feb;
+      --accent-teal: #56d4dd;
+      --warn: #d4a72c;
+      --ok: #3fb950;
+      --json-key: #79c0ff;
+      --json-str: #a5d6ff;
+      --json-lit: #ffa657;
+      --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.5);
+    }
+  }
+  :root[data-theme="dark"] {
+    --canvas: #0d1117;
+    --surface: #151b23;
+    --surface-raised: #151b23;
+    --border: #3d444d;
+    --ink: #f0f6fc;
+    --muted: #9198a1;
+    --accent: #4493f8;
+    --accent-fill: #1f6feb;
+    --accent-teal: #56d4dd;
+    --warn: #d4a72c;
+    --ok: #3fb950;
+    --json-key: #79c0ff;
+    --json-str: #a5d6ff;
+    --json-lit: #ffa657;
+    --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.5);
+  }
+  :root[data-theme="light"] {
+    --canvas: #ffffff;
+    --surface: #f6f8fa;
+    --surface-raised: #ffffff;
+    --border: #d0d7de;
+    --ink: #1f2328;
+    --muted: #59636e;
+    --accent: #0969da;
+    --accent-fill: #0969da;
+    --accent-teal: #1b7c83;
+    --warn: #9a6700;
+    --ok: #1a7f37;
+    --json-key: #0550ae;
+    --json-str: #0a3069;
+    --json-lit: #953800;
+    --shadow-popover: 0 8px 24px rgba(140, 149, 159, 0.3);
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+  body {
+    background: var(--canvas);
+    color: var(--ink);
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+    line-height: 1.5;
+    margin: 0 auto;
+    max-width: 60rem;
+    padding: 2rem 1.25rem 4rem;
+  }
+  a {
+    color: var(--accent);
+  }
+
+  .eyebrow {
+    color: var(--muted);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+  h1 {
+    font-size: 1.55rem;
+    line-height: 1.25;
+    margin: 0.25rem 0 0.5rem;
+    text-wrap: balance;
+  }
+  .lede {
+    color: var(--muted);
+    margin: 0 0 1.5rem;
+    max-width: 46rem;
+  }
+
+  .verdict {
+    background: color-mix(in srgb, var(--accent) 7%, var(--surface));
+    border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--border));
+    border-radius: 8px;
+    margin-bottom: 2.5rem;
+    padding: 0.9rem 1.1rem;
+  }
+  .verdict strong {
+    display: block;
+    margin-bottom: 0.3rem;
+  }
+  .verdict p {
+    margin: 0.35rem 0 0;
+  }
+
+  section.variant {
+    margin-bottom: 3rem;
+  }
+  h2 {
+    font-size: 1.1rem;
+    margin: 0 0 0.15rem;
+  }
+  h2 .tag {
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-left: 0.5rem;
+    padding: 0.15rem 0.6rem;
+    vertical-align: 0.15rem;
+  }
+  .tag.flagged {
+    background: color-mix(in srgb, var(--warn) 15%, var(--surface));
+    color: var(--warn);
+  }
+  .tag.recommended {
+    background: color-mix(in srgb, var(--ok) 15%, var(--surface));
+    color: var(--ok);
+  }
+  .tag.alt {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  .variant > .sub {
+    color: var(--muted);
+    font-size: 0.9rem;
+    margin: 0 0 1rem;
+    max-width: 46rem;
+  }
+
+  /* ---------- faithful app chrome ---------- */
+  .card {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+  }
+  .card-title {
+    align-items: baseline;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    font-weight: 600;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    position: relative;
+  }
+  .card-title-hint {
+    color: var(--muted);
+    font-weight: 400;
+  }
+  .card-title-actions {
+    margin-left: auto;
+  }
+
+  .prov-filters {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    position: relative;
+  }
+  .prov-filters input[type="text"],
+  .prov-filters select,
+  .options-row select {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: inherit;
+    font-family: inherit;
+    font-size: 0.85rem;
+    padding: 0.3rem 0.5rem;
+  }
+  .prov-filters input[type="text"] {
+    flex: 1;
+    min-width: 9rem;
+  }
+  .prov-check {
+    align-items: center;
+    color: var(--muted);
+    display: inline-flex;
+    font-size: 0.85rem;
+    gap: 0.3rem;
+    white-space: nowrap;
+  }
+  .prov-check input {
+    accent-color: var(--accent-fill);
+  }
+
+  .prov-row {
+    border-bottom: 1px solid var(--border);
+  }
+  .prov-row:last-child {
+    border-bottom: none;
+  }
+  .prov-row-head {
+    align-items: center;
+    background: none;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    display: flex;
+    font-size: 0.85rem;
+    gap: 0.5rem;
+    padding: 0.45rem 0.75rem;
+    text-align: left;
+    width: 100%;
+  }
+  .prov-row-head:hover {
+    background: color-mix(in srgb, var(--surface) 60%, var(--canvas));
+  }
+  .caret {
+    color: var(--muted);
+    font-size: 0.7rem;
+  }
+  .prov-key {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .prov-preview {
+    color: var(--muted);
+    flex: 1;
+    font-size: 0.8rem;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .badge {
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    padding: 0.05rem 0.5rem;
+    white-space: nowrap;
+  }
+  .badge.layer-repo {
+    border-color: color-mix(in srgb, var(--accent-teal) 55%, var(--border));
+    color: var(--accent-teal);
+  }
+  .badge.layer-preset {
+    border-color: color-mix(in srgb, var(--accent-purple) 55%, var(--border));
+    color: var(--accent-purple);
+  }
+  .badge.overridden {
+    border-color: color-mix(in srgb, var(--warn) 55%, var(--border));
+    color: var(--warn);
+  }
+  .badge.appended {
+    border-color: var(--border);
+    color: var(--muted);
+  }
+
+  /* segmented view switch (variant B) */
+  .segmented {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    display: inline-flex;
+    overflow: hidden;
+  }
+  .segmented button {
+    background: transparent;
+    border: 0;
+    color: var(--muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.25rem 0.7rem;
+  }
+  .segmented button + button {
+    border-left: 1px solid var(--border);
+  }
+  .segmented button[aria-pressed="true"] {
+    background: var(--accent-fill);
+    color: var(--on-accent);
+  }
+  .segmented button:focus-visible,
+  .btn:focus-visible,
+  .prov-row-head:focus-visible,
+  .menu button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  .options-row {
+    align-items: center;
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    position: relative;
+  }
+  .options-row .label {
+    color: var(--muted);
+    font-size: 0.85rem;
+  }
+  .btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: inherit;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.8rem;
+    padding: 0.25rem 0.6rem;
+  }
+  .btn.quiet {
+    border-color: transparent;
+    color: var(--muted);
+  }
+  .btn:hover {
+    background: var(--surface);
+  }
+  .push-end {
+    margin-left: auto;
+  }
+
+  pre.config-view {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.8rem;
+    line-height: 1.55;
+    margin: 0;
+    overflow-x: auto;
+    padding: 0.75rem;
+  }
+  .j-k {
+    color: var(--json-key);
+  }
+  .j-s {
+    color: var(--json-str);
+  }
+  .j-l {
+    color: var(--json-lit);
+  }
+  .j-mut {
+    color: var(--muted);
+    font-style: italic;
+  }
+
+  /* export menu (variant C) */
+  .menu {
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: var(--shadow-popover);
+    font-size: 0.83rem;
+    font-weight: 400;
+    padding: 0.3rem;
+    position: absolute;
+    right: 0.5rem;
+    top: calc(100% + 0.25rem);
+    width: 21rem;
+    z-index: 2;
+  }
+  .menu button {
+    background: none;
+    border: 0;
+    border-radius: 6px;
+    color: inherit;
+    cursor: pointer;
+    display: block;
+    font-family: inherit;
+    font-size: inherit;
+    padding: 0.4rem 0.6rem;
+    text-align: left;
+    width: 100%;
+  }
+  .menu button:hover {
+    background: var(--surface);
+  }
+  .menu .hint {
+    color: var(--muted);
+    display: block;
+    font-size: 0.75rem;
+  }
+  .mock-c-stage {
+    padding-bottom: 7.5rem;
+    position: relative;
+  }
+
+  /* annotation dots + notes */
+  .dot {
+    align-items: center;
+    background: var(--warn);
+    border-radius: 50%;
+    color: var(--canvas);
+    display: inline-flex;
+    flex: none;
+    font-size: 0.68rem;
+    font-weight: 700;
+    height: 1.05rem;
+    justify-content: center;
+    width: 1.05rem;
+  }
+  .dot.good {
+    background: var(--ok);
+  }
+  ol.notes {
+    font-size: 0.88rem;
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  ol.notes li {
+    display: flex;
+    gap: 0.55rem;
+    margin: 0.45rem 0;
+  }
+  ol.notes .dot {
+    margin-top: 0.15rem;
+  }
+  ol.notes code,
+  .sub code,
+  .verdict code,
+  .lede code {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-size: 0.85em;
+    padding: 0 0.25em;
+  }
+
+  .crosslink {
+    border-top: 1px dashed var(--border);
+    color: var(--muted);
+    font-size: 0.8rem;
+    padding: 0.5rem 0.75rem;
+  }
+
+  /* pipeline fit strip */
+  .stages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0 0;
+  }
+  .stage {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    flex: 1 1 12rem;
+    min-width: 11rem;
+    padding: 0.6rem 0.75rem;
+    position: relative;
+  }
+  .stage.new {
+    border-color: color-mix(in srgb, var(--ok) 45%, var(--border));
+  }
+  .stage .where {
+    color: var(--muted);
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .stage .doc {
+    display: block;
+    font-size: 0.88rem;
+    font-weight: 600;
+    margin: 0.15rem 0;
+  }
+  .stage .how {
+    color: var(--muted);
+    display: block;
+    font-size: 0.78rem;
+  }
+  .stage .status {
+    border-radius: 999px;
+    font-size: 0.68rem;
+    font-weight: 600;
+    padding: 0.1rem 0.5rem;
+    position: absolute;
+    right: 0.5rem;
+    top: 0.5rem;
+  }
+  .status.exists {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--muted);
+  }
+  .status.added {
+    background: color-mix(in srgb, var(--ok) 15%, var(--surface));
+    color: var(--ok);
+  }
+  .stage-arrow {
+    align-self: center;
+    color: var(--muted);
+    flex: none;
+  }
+
+  .footnote {
+    border-top: 1px solid var(--border);
+    color: var(--muted);
+    font-size: 0.85rem;
+    margin-top: 1rem;
+    max-width: 46rem;
+    padding-top: 1.25rem;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .menu {
+      transition: opacity 120ms ease;
+    }
+  }
+</style>
+
+<p class="eyebrow">UI mock · Effective Config panel</p>
+<h1>Showing the resolved config without internal presets</h1>
+<p class="lede">
+  Three ways to surface a “resolved config, internal presets kept as
+  <code>extends</code>” output in the Effective Config card — starting with the proposed checkbox,
+  then two alternatives. Amber dots flag problems, green dots mark what a variant gets right.
+</p>
+
+<div class="verdict">
+  <strong>Verdict: a checkbox is the wrong control here.</strong>
+  <p>
+    The existing checkboxes (<em>only overridden</em>, <em>show default-only</em>) filter rows of
+    the <em>same</em> document. This option produces a <em>different</em> document — a second merge
+    pass that stops at internal presets — in a different rendering (plain JSON instead of provenance
+    rows). That is a view mode, not a filter. Variant B makes the mode explicit; Variant C does it
+    with zero new chrome if preview isn’t needed.
+  </p>
+</div>
+
+<!-- ================= VARIANT A ================= -->
+<section class="variant">
+  <h2>Variant A — checkbox in the filter bar <span class="tag flagged">as proposed</span></h2>
+  <p class="sub">The new option dropped next to the existing row filters.</p>
+
+  <div class="card">
+    <div class="card-title">
+      Effective config <span class="card-title-hint">— and which layer set each option</span>
+    </div>
+    <div class="prov-filters">
+      <input type="text" placeholder="Filter keys…" aria-label="Filter keys" />
+      <select aria-label="Filter keys by layer">
+        <option>All layers</option>
+      </select>
+      <label class="prov-check"
+        ><input type="checkbox" /> only overridden <span class="dot">2</span></label
+      >
+      <label class="prov-check"><input type="checkbox" /> show default-only (382)</label>
+      <label class="prov-check"
+        ><input type="checkbox" checked /> resolved shallow config, without internal presets
+        <span class="dot">1</span><span class="dot">3</span></label
+      >
+    </div>
+    <pre class="config-view">{
+  <span class="j-k">"extends"</span>: [<span class="j-s">"config:recommended"</span>, <span class="j-s">":semanticCommits"</span>],
+  <span class="j-k">"labels"</span>: [<span class="j-s">"dependencies"</span>],
+  <span class="j-k">"rangeStrategy"</span>: <span class="j-s">"bump"</span>,
+  <span class="j-k">"automerge"</span>: <span class="j-l">true</span>  <span class="j-mut">// ← where did the chips, badges and chains go? ④</span>
+}</pre>
+  </div>
+
+  <ol class="notes">
+    <li>
+      <span class="dot">1</span
+      ><span
+        >The label bundles two axes into one boolean — “shallow” <em>and</em> “without internal
+        presets”. What does unchecking half of that mean? A checkbox can’t answer.</span
+      >
+    </li>
+    <li>
+      <span class="dot">2</span
+      ><span
+        >Checkboxes in this bar promise composition: they filter rows of the same list. Combine this
+        one with <em>only overridden</em> and the state is incoherent — the override chains
+        reference preset layers that no longer exist in the shallow document.</span
+      >
+    </li>
+    <li>
+      <span class="dot">3</span
+      ><span
+        >Negative phrasing (“without …”) means <em>checked = absence</em>, and the 6-word label
+        wraps the bar on mobile. Checkbox labels should name a positive, single thing.</span
+      >
+    </li>
+    <li>
+      <span class="dot">4</span
+      ><span
+        >Ticking it silently swaps provenance rows for plain JSON — the filter input, layer select
+        and both other checkboxes stop applying but stay enabled. Half the card’s UI becomes a
+        lie.</span
+      >
+    </li>
+  </ol>
+</section>
+
+<!-- ================= VARIANT B ================= -->
+<section class="variant">
+  <h2>
+    Variant B — explicit view switch + output options
+    <span class="tag recommended">recommended · interactive</span>
+  </h2>
+  <p class="sub">
+    A segmented control in the title bar names the two things this card can show. Row filters live
+    only in the provenance view; output options (expansion level, defaults, copy) live only in the
+    JSON view. Try it.
+  </p>
+
+  <div class="card">
+    <div class="card-title">
+      Effective config
+      <span class="card-title-hint" id="b-hint">— and which layer set each option</span>
+      <span class="card-title-actions">
+        <span class="segmented" role="group" aria-label="View">
+          <button type="button" id="b-mode-prov" aria-pressed="true">By key</button>
+          <button type="button" id="b-mode-json" aria-pressed="false">As JSON</button>
+        </span>
+        <span class="dot" style="vertical-align: middle">1</span>
+      </span>
+    </div>
+
+    <div id="b-prov-panel">
+      <div class="prov-filters">
+        <input type="text" placeholder="Filter keys…" aria-label="Filter keys" />
+        <select aria-label="Filter keys by layer">
+          <option>All layers</option>
+        </select>
+        <label class="prov-check"><input type="checkbox" /> only overridden</label>
+        <label class="prov-check"><input type="checkbox" /> show default-only (382)</label>
+        <span class="dot" style="align-self: center">2</span>
+      </div>
+      <div class="prov-row">
+        <button type="button" class="prov-row-head">
+          <span class="caret">▸</span><span class="prov-key">automerge</span
+          ><span class="prov-preview">true</span
+          ><span class="badge layer-preset">preset · secustor/renovate-config</span>
+        </button>
+      </div>
+      <div class="prov-row">
+        <button type="button" class="prov-row-head">
+          <span class="caret">▸</span><span class="prov-key">dependencyDashboard</span
+          ><span class="prov-preview">true</span
+          ><span class="badge layer-preset">preset · config:recommended</span>
+        </button>
+      </div>
+      <div class="prov-row">
+        <button type="button" class="prov-row-head">
+          <span class="caret">▸</span><span class="prov-key">labels</span
+          ><span class="prov-preview">[ 1 item ]</span
+          ><span class="badge layer-repo">repo config</span>
+        </button>
+      </div>
+      <div class="prov-row">
+        <button type="button" class="prov-row-head">
+          <span class="caret">▸</span><span class="prov-key">packageRules</span
+          ><span class="prov-preview">6 rules — 5 from presets, 1 from repo config</span
+          ><span class="badge appended">appended</span
+          ><span class="badge layer-repo">repo config</span>
+        </button>
+      </div>
+      <div class="prov-row">
+        <button type="button" class="prov-row-head">
+          <span class="caret">▸</span><span class="prov-key">rangeStrategy</span
+          ><span class="prov-preview">"bump"</span><span class="badge overridden">overridden</span
+          ><span class="badge layer-repo">repo config</span>
+        </button>
+      </div>
+    </div>
+
+    <div id="b-json-panel" hidden>
+      <div class="options-row">
+        <label class="label" for="b-expand">Expand presets:</label>
+        <select id="b-expand">
+          <option value="keep" selected>keep internal presets</option>
+          <option value="full">fully</option>
+        </select>
+        <span class="dot good">3</span>
+        <label class="prov-check"
+          ><input type="checkbox" id="b-defaults" /> include defaults (382)</label
+        >
+        <button type="button" class="btn push-end" id="b-copy">Copy JSON</button>
+        <span class="dot good">4</span>
+      </div>
+
+      <pre class="config-view" id="b-json-keep">{
+  <span class="j-k">"$schema"</span>: <span class="j-s">"https://docs.renovatebot.com/renovate-schema.json"</span>,
+  <span class="j-k">"extends"</span>: [
+    <span class="j-s">"config:recommended"</span>,
+    <span class="j-s">":semanticCommits"</span>
+  ],
+  <span class="j-k">"labels"</span>: [<span class="j-s">"dependencies"</span>],
+  <span class="j-k">"rangeStrategy"</span>: <span class="j-s">"bump"</span>,
+  <span class="j-k">"automerge"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"platformAutomerge"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"packageRules"</span>: [
+    {
+      <span class="j-k">"matchManagers"</span>: [<span class="j-s">"github-actions"</span>],
+      <span class="j-k">"groupName"</span>: <span class="j-s">"github actions"</span>
+    }
+  ]<span class="defaults-line" hidden>,
+  <span class="j-mut">… + 382 default-valued options</span></span>
+}
+<span class="j-mut">// github&gt;secustor/renovate-config inlined; internal presets stay referenced</span></pre>
+
+      <pre class="config-view" id="b-json-full" hidden>{
+  <span class="j-k">"$schema"</span>: <span class="j-s">"https://docs.renovatebot.com/renovate-schema.json"</span>,
+  <span class="j-k">"labels"</span>: [<span class="j-s">"dependencies"</span>],
+  <span class="j-k">"rangeStrategy"</span>: <span class="j-s">"bump"</span>,
+  <span class="j-k">"automerge"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"platformAutomerge"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"semanticCommits"</span>: <span class="j-s">"enabled"</span>,
+  <span class="j-k">"dependencyDashboard"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"configMigration"</span>: <span class="j-l">true</span>,
+  <span class="j-k">"minimumReleaseAge"</span>: <span class="j-s">"3 days"</span>,
+  <span class="j-k">"packageRules"</span>: [
+    <span class="j-mut">… 5 rules from config:recommended …</span>
+    {
+      <span class="j-k">"matchManagers"</span>: [<span class="j-s">"github-actions"</span>],
+      <span class="j-k">"groupName"</span>: <span class="j-s">"github actions"</span>
+    }
+  ]<span class="defaults-line" hidden>,
+  <span class="j-mut">… + 382 default-valued options</span></span>
+}
+<span class="j-mut">// every preset expanded — no extends left</span></pre>
+
+      <div class="crosslink">
+        Need the config <em>before</em> preset resolution? That document already exists:
+        <strong>Rewrites → Copy migrated config</strong>.
+      </div>
+    </div>
+  </div>
+
+  <ol class="notes">
+    <li>
+      <span class="dot">1</span
+      ><span
+        >The one honest cost: a second control surface in the title bar. It earns its place by
+        telling the truth — the whole panel changes, and the control that changes it says so.</span
+      >
+    </li>
+    <li>
+      <span class="dot good">2</span
+      ><span
+        >Row filters render only in the “By key” view, so no combination of controls can produce a
+        state the UI can’t honour.</span
+      >
+    </li>
+    <li>
+      <span class="dot good">3</span
+      ><span
+        >“Expand presets” names the axis by outcome, with exactly two values. No “as written” option
+        — that document (migrated, extends intact) is already copyable from the Rewrites tab, so
+        this view starts where Rewrites stops. And no “shallow” — that word already means
+        <code>shallow-merge</code> in the override chains.</span
+      >
+    </li>
+    <li>
+      <span class="dot good">4</span
+      ><span
+        >This view’s job is producing an artifact you paste into <code>renovate.json</code>, so Copy
+        (and later Download) belongs here — the provenance view never needed it.</span
+      >
+    </li>
+  </ol>
+</section>
+
+<!-- ================= UX FIT ================= -->
+<section class="variant">
+  <h2>How this fits the copies that already exist</h2>
+  <p class="sub">
+    Each copyable document is one stage of the pipeline the app already teaches, owned by the tab
+    that explains that stage. Variant B doesn’t duplicate the Rewrites copy — it continues the
+    progression where Rewrites stops. The tab boundary <em>is</em> preset resolution.
+  </p>
+
+  <div class="stages">
+    <div class="stage">
+      <span class="status exists">exists</span>
+      <span class="where">Editor</span>
+      <span class="doc">Config as written</span>
+      <span class="how">the source itself — select &amp; copy</span>
+    </div>
+    <span class="stage-arrow" aria-hidden="true">→</span>
+    <div class="stage">
+      <span class="status exists">exists</span>
+      <span class="where">Rewrites tab</span>
+      <span class="doc">Migrated config</span>
+      <span class="how">“Copy migrated config” — syntax modernised, extends untouched</span>
+    </div>
+    <span class="stage-arrow" aria-hidden="true">→</span>
+    <div class="stage new">
+      <span class="status added">new</span>
+      <span class="where">Effective config · As JSON</span>
+      <span class="doc">Keep internal presets</span>
+      <span class="how"
+        >hosted presets inlined, <code>config:*</code> / <code>:*</code> stay referenced</span
+      >
+    </div>
+    <span class="stage-arrow" aria-hidden="true">→</span>
+    <div class="stage new">
+      <span class="status added">new</span>
+      <span class="where">Effective config · As JSON</span>
+      <span class="doc">Fully expanded</span>
+      <span class="how">no extends left; “include defaults” hydrates the rest</span>
+    </div>
+  </div>
+
+  <ol class="notes">
+    <li>
+      <span class="dot good">·</span
+      ><span
+        ><strong>No overlap:</strong> the mock’s “as written” expansion option is dropped — that
+        artifact is Rewrites’ “Copy migrated config”. B’s JSON view now starts strictly after preset
+        resolution, and cross-links back for the pre-resolution document.</span
+      >
+    </li>
+    <li>
+      <span class="dot good">·</span
+      ><span
+        ><strong>Same pattern, per tab:</strong> Rewrites’ copy sits in its step-through chrome; B’s
+        copy sits in the JSON view’s options row. Each tab exports the document it explains — no
+        global “export” concept to invent.</span
+      >
+    </li>
+    <li>
+      <span class="dot">·</span
+      ><span
+        ><strong>One naming debt:</strong> “Copy migrated config” vs “Copy JSON” should share a
+        vocabulary once both exist — e.g. both name their document: “Copy migrated config” / “Copy
+        resolved config”. Worth aligning in the same PR.</span
+      >
+    </li>
+  </ol>
+</section>
+
+<!-- ================= VARIANT C ================= -->
+<section class="variant">
+  <h2>Variant C — export menu, zero new chrome <span class="tag alt">lighter alternative</span></h2>
+  <p class="sub">
+    The provenance view stays exactly as it is; the outputs become a quiet “Copy as…” action in the
+    title bar, following the editor card’s title-action pattern.
+  </p>
+
+  <div class="card">
+    <div class="card-title mock-c-stage">
+      Effective config <span class="card-title-hint">— and which layer set each option</span>
+      <span class="card-title-actions"
+        ><button type="button" class="btn quiet" aria-expanded="true">Copy as… ▾</button>
+        <span class="dot good">1</span></span
+      >
+      <div class="menu" role="menu">
+        <button type="button" role="menuitem">
+          Resolved config — keep internal presets
+          <span class="hint">hosted presets inlined, config:recommended stays referenced</span>
+        </button>
+        <button type="button" role="menuitem">
+          Resolved config — fully expanded
+          <span class="hint">every preset inlined, no extends left</span>
+        </button>
+        <button type="button" role="menuitem">
+          Provenance table — markdown
+          <span class="hint"
+            >key · value · winning layer, for PRs and issues
+            <span class="dot" style="vertical-align: middle">2</span></span
+          >
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <ol class="notes">
+    <li>
+      <span class="dot good">1</span
+      ><span
+        >Nothing new to learn and no mode state to reset per run — but the output isn’t previewable
+        before copying. Fine for the power user consolidating a config; weaker for the learning
+        persona this app optimises for.</span
+      >
+    </li>
+    <li>
+      <span class="dot">2</span
+      ><span
+        >Menus invite scope creep (markdown export, download, share…). If that list is wanted
+        anyway, C composes with B: the menu becomes the Copy button’s dropdown inside B’s JSON
+        view.</span
+      >
+    </li>
+  </ol>
+</section>
+
+<p class="footnote">
+  <strong>Engine note:</strong> “keep internal presets” is not a filter over the existing trace — it
+  needs a second resolution pass that stops descending at
+  <code>presetSource === "internal"</code> nodes and merges only the fetched layers over the repo
+  config. That’s also why the provenance chips can’t annotate this document: its layer set differs
+  from the traced one. Cheap to compute (the preset tree is already resolved), but it is a new
+  engine output, which is the underlying reason it deserves a mode, not a checkbox.
+</p>
+
+<script>
+  (function () {
+    var provBtn = document.getElementById("b-mode-prov");
+    var jsonBtn = document.getElementById("b-mode-json");
+    var provPanel = document.getElementById("b-prov-panel");
+    var jsonPanel = document.getElementById("b-json-panel");
+    var hint = document.getElementById("b-hint");
+    function setMode(json) {
+      provBtn.setAttribute("aria-pressed", String(!json));
+      jsonBtn.setAttribute("aria-pressed", String(json));
+      provPanel.hidden = json;
+      jsonPanel.hidden = !json;
+      hint.textContent = json
+        ? "— the resolved config as a document"
+        : "— and which layer set each option";
+    }
+    provBtn.addEventListener("click", function () {
+      setMode(false);
+    });
+    jsonBtn.addEventListener("click", function () {
+      setMode(true);
+    });
+
+    var expand = document.getElementById("b-expand");
+    var panes = {
+      keep: document.getElementById("b-json-keep"),
+      full: document.getElementById("b-json-full"),
+    };
+    var defaults = document.getElementById("b-defaults");
+    function refresh() {
+      Object.keys(panes).forEach(function (k) {
+        panes[k].hidden = k !== expand.value;
+      });
+      document.querySelectorAll(".defaults-line").forEach(function (el) {
+        el.hidden = !defaults.checked;
+      });
+    }
+    expand.addEventListener("change", refresh);
+    defaults.addEventListener("change", refresh);
+    refresh();
+
+    var copy = document.getElementById("b-copy");
+    copy.addEventListener("click", function () {
+      var text = panes[expand.value].textContent;
+      var done = function () {
+        copy.textContent = "Copied ✓";
+        setTimeout(function () {
+          copy.textContent = "Copy JSON";
+        }, 1500);
+      };
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(done, done);
+      } else {
+        done();
+      }
+    });
+  })();
+</script>


### PR DESCRIPTION
## What

The Effective config tab gains an **As JSON** rendering: the resolved config as a standalone, copyable document, with two expansion levels —

- **keep internal presets** (default): hosted/fetched presets inlined, internal presets (`config:*`, `:*`, …) kept as `extends` references — the consolidation you paste back into a `renovate.json` while still tracking upstream.
- **fully**: every preset consumed, no `extends` left, optionally hydrated with the defaults ("include defaults").

Settled through the approved mockup (`roadmap/mockups/051/effective-config-output.html`, variant B). The originally proposed filter-bar checkbox was rejected: it is a mode (a different document in a different rendering), not a filter, and would leave the row filters hanging over a document they cannot filter.

## Engine

`computeResolvedConfig(result, mode)` in `packages/engine/src/trace/resolved-config.ts` — the document counterpart to `computeProvenance`: same trace data, same `mergeChildConfig` replay, same availability guards. Only positively-non-internal, successfully-resolved presets are inlined; internal/errored/ignored/unclassifiable nodes stay referenced, and `ignorePresets` is preserved.

**Merge-order honesty:** a kept reference resolves before the emitted body even when it was written after an inlined preset. The replay runs in both orders and reports every top-level key that changes as `divergingKeys`; the UI shows a warn-tinted caveat naming them. The shimmed test proves a reported divergence is real by re-running the pipeline on the emitted document and watching the key flip — and that an empty list round-trips to an identical `finalConfig`.

## App

- Segmented **By key / As JSON** switch in the card title (036 grammar: label the state), reset per run.
- Options row in the `.prov-filters` chrome: expansion select, full-only defaults checkbox (with explanatory title — defaults written into a body that still extends presets would override them), and **Copy resolved config** (naming aligned with Rewrites' *Copy migrated config*).
- Cross-link to Rewrites for the pre-resolution document — each tab exports the pipeline stage it explains; the tab boundary is preset resolution.

## Verification

- Engine: `resolved-config.shimmed.test.ts` (7 tests — keep/inline split, concat order, pipeline round-trip, real-divergence flip, ignored presets, nested extends preserved, defaults hydration, unavailability).
- e2e `15-resolved-config.spec.ts` against the default `config:recommended` config.
- Full suite green: lint, format, typecheck, 228 app + 164 engine unit tests, build, 60 Playwright e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ