### PR TITLE
feat(009): surface GitHub auth failures where the run is read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 node_modules/
 dist/
 coverage/
+
+# Local env (e.g. packages/app/.env — GitHub OAuth vars for local testing)
+.env
+.env.*
 *.log
 .DS_Store
 stats.html

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -144,11 +144,6 @@ type InjectionMap = Record<string, Record<string, unknown>>;
 // them.
 const parseLayerText = parseLayerJson;
 
-/** Starts the redirect sign-in, stashing the current fragment to restore it. */
-function onSignIn(): void {
-  void beginSignIn(window.location.hash);
-}
-
 export function App() {
   const [content, setContent] = useState(DEFAULT_CONFIG);
   // Roadmap 016: the text last loaded from an authoritative source (the
@@ -302,26 +297,29 @@ export function App() {
   // layer's `applyInheritedText`, which the hook below owns) reached through an
   // arrow that only runs after this render — and the share hook re-reads the
   // host object every render, so nothing goes stale.
-  const { shareError, simRequest, buildShareLinkAndCopy } = useShareLink(oauthConfig, {
-    onRun: (inputs, opts) => onRun(undefined, inputs, opts),
-    loadConfigText,
-    setFileName,
-    setPlatform,
-    setEndpoint,
-    setGlobalText,
-    setInheritedText: (text) => applyInheritedText(text),
-    setPlatformOverride,
-    setAdvancedOpen,
-    setHostSectionOpen,
-    setNotice,
-    setSignedIn,
-    setAuthUser,
-    applyUntrustedGuard,
-    pendingViewRef,
-    contentRef,
-    loadedContentRef,
-    buildShareState,
-  });
+  const { shareError, simRequest, buildShareLinkAndCopy, buildSignInReturnHash } = useShareLink(
+    oauthConfig,
+    {
+      onRun: (inputs, opts) => onRun(undefined, inputs, opts),
+      loadConfigText,
+      setFileName,
+      setPlatform,
+      setEndpoint,
+      setGlobalText,
+      setInheritedText: (text) => applyInheritedText(text),
+      setPlatformOverride,
+      setAdvancedOpen,
+      setHostSectionOpen,
+      setNotice,
+      setSignedIn,
+      setAuthUser,
+      applyUntrustedGuard,
+      pendingViewRef,
+      contentRef,
+      loadedContentRef,
+      buildShareState,
+    },
+  );
   // Roadmap 013: rule identity cross-links. The editor is an imperative jump
   // target (CodeMirror has no declarative "scroll to offset X" prop); the
   // simulator's target rule is prop-driven since it is a sibling component.
@@ -807,6 +805,63 @@ export function App() {
       ? "signed-in"
       : "signed-out";
 
+  /**
+   * Roadmap 009 (auth-failure surfacing): starts the redirect sign-in — and
+   * decides what the user comes BACK to. Signing in is a full-page navigation
+   * to GitHub, so everything on screen is gone by the time they return,
+   * including the run whose private preset they signed in FOR: the pre-009
+   * behavior handed `beginSignIn` the bare fragment, which for anyone who had
+   * not also copied a share link meant returning to the DEFAULT config with
+   * their work — and the failure they were acting on — silently discarded.
+   *
+   * So once a run exists, the return fragment is the CURRENT state encoded as
+   * a share token. `beginSignIn` stashes it in sessionStorage (never in the
+   * URL handed to GitHub, so nothing is exposed by encoding it) and the
+   * callback restores it before the share path reads the hash — which then
+   * decodes, populates state and auto-runs through the one path that already
+   * does exactly that. THAT is the "run again once signed in" loop: the preset
+   * that 401'd is re-fetched with the new token, with no second re-run
+   * mechanism to keep in step with the first. Before the first run there is
+   * nothing to carry and the plain fragment is kept, exactly as before.
+   *
+   * Deliberately not narrowed to runs that HAD an auth failure: the failure
+   * set lives in the tree this redirect is about to destroy, and a sign-in
+   * that quietly threw away a clean run's config would be the same bug in a
+   * case that is merely less annoying.
+   */
+  const signInRef = useRef<(() => Promise<void>) | undefined>(undefined);
+  signInRef.current = async () => {
+    let returnHash = window.location.hash;
+    if (result) {
+      try {
+        returnHash = await buildSignInReturnHash();
+      } catch {
+        // Best-effort: an encode failure costs the round trip's state, never
+        // the sign-in itself.
+      }
+    }
+    await beginSignIn(returnHash);
+  };
+  // Roadmap 032: identity-stable (latest-ref idiom) — this prop reaches the
+  // memoized results panels, and it reads `result`, which changes per run.
+  const onSignIn = useCallback(() => {
+    void signInRef.current?.();
+  }, []);
+
+  /**
+   * Roadmap 009 (auth-failure surfacing): the banner's "Run again" — the same
+   * pipeline run the Run button performs, for the case sign-in cannot fix by
+   * itself (signed in already, access granted on GitHub in another tab). It
+   * keeps the tab and the scroll position because the banner sits above every
+   * panel: the user is looking at the thing they just acted on, and a run that
+   * bounced them to the Overview would hide its own answer.
+   */
+  const onRunAgainRef = useRef<(() => void) | undefined>(undefined);
+  onRunAgainRef.current = () => {
+    void onRun(undefined, undefined, { preserveScroll: true, keepTab: true });
+  };
+  const onRunAgain = useCallback(() => onRunAgainRef.current?.(), []);
+
   function onSignOut() {
     signOut();
     setSignedIn(false);
@@ -1036,6 +1091,7 @@ export function App() {
               authState={authState}
               onSignIn={onSignIn}
               installUrl={INSTALL_URL}
+              onRunAgain={onRunAgain}
               onEffectiveStats={setEffectiveStats}
               effectiveFilterNonce={effectiveFilterNonce}
               pendingRuleFocus={pendingRuleFocus}

--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -6,6 +6,8 @@ import type {
   TraceEvent,
   TraceResult,
 } from "@renovate-config-visualizer/engine";
+import { AuthFailureBanner } from "@/components/AuthFailureBanner";
+import { collectGithubAuthFailures } from "@/features/presets/tree-shared";
 import { EffectiveConfig, type EffectiveStats } from "@/components/EffectiveConfig";
 import type { AuthState } from "@/components/GithubAuthHint";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
@@ -83,6 +85,9 @@ export interface ResultsColumnProps {
   authState: AuthState;
   onSignIn: () => void;
   installUrl: string;
+  /** Roadmap 009: re-runs the pipeline with the inputs currently on screen —
+   *  the auth-failure banner's "Run again", for access granted mid-session. */
+  onRunAgain: () => void;
 
   // —— effective ——
   onEffectiveStats: (stats: EffectiveStats) => void;
@@ -161,6 +166,7 @@ export function ResultsColumn({
   authState,
   onSignIn,
   installUrl,
+  onRunAgain,
   onEffectiveStats,
   effectiveFilterNonce,
   pendingRuleFocus,
@@ -199,6 +205,32 @@ export function ResultsColumn({
       el.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   }, [result, focusResultsRef, resultsColRef]);
+
+  // Roadmap 009: one walk of the finished run's tree per result — the banner
+  // below is the only consumer, and the tree is a per-run value, so this must
+  // never be recomputed on a keystroke (032's contract) even though the walk
+  // itself is cheap.
+  const authFailures = useMemo(
+    () => collectGithubAuthFailures(result.presetTree),
+    [result.presetTree],
+  );
+  // Rendered by the tab shell above ALL panels rather than inside one: the
+  // failure is a property of the run, and the tab a run lands on depends on
+  // which stage errored — a preset-stage failure lands on Problems, so an
+  // Overview-only banner would be exactly invisible in its own main case.
+  const banner = useMemo(
+    () => (
+      <AuthFailureBanner
+        failures={authFailures.failures}
+        rateLimited={authFailures.rateLimited}
+        authState={authState}
+        onSignIn={onSignIn}
+        installUrl={installUrl}
+        onRunAgain={onRunAgain}
+      />
+    ),
+    [authFailures, authState, onSignIn, installUrl, onRunAgain],
+  );
 
   // Roadmap 032: the seven tab panels render RUN RESULTS — they change when a
   // run completes or a view-state jump lands, never while the user types. So
@@ -376,6 +408,7 @@ export function ResultsColumn({
       onSelect={onSelectTab}
       back={backTab}
       onBack={onBack}
+      banner={banner}
       panels={panels}
     />
   );

--- a/packages/app/src/components/AuthFailureBanner.tsx
+++ b/packages/app/src/components/AuthFailureBanner.tsx
@@ -1,0 +1,87 @@
+/**
+ * Roadmap 009 (auth-failure surfacing) — the run-level half of the error-path
+ * UX. {@link GithubAuthHint} already turns ONE failed node into its likely next
+ * action, but only inside the detail panel of a preset the user has to go
+ * looking for: a run whose private preset never loaded otherwise reads as a
+ * quietly incomplete result. This says it once, where the run's outcome is
+ * read, and carries the same hint plus the one action that closes the loop
+ * without a redirect — "Run again", for the case where access was granted in
+ * another tab (the signed-in "the app isn't installed on this repo" path).
+ *
+ * Deliberately as decoupled as the hint it wraps: the failures are found by
+ * `collectGithubAuthFailures` (pure, in the presets feature) and arrive here as
+ * plain names + flavors — roadmap 048 keeps a shared component off a feature
+ * module, and a banner that only prints a sentence never needed the tree nodes
+ * anyway.
+ */
+import { type AuthState, GithubAuthHint } from "@/components/GithubAuthHint";
+
+/** One failing preset, already deduped and named by the caller. */
+export interface AuthFailureSummary {
+  /** Display form, e.g. `github>secustor/private-presets`. */
+  name: string;
+  /** This particular failure was a rate limit rather than a not-found. */
+  rateLimited: boolean;
+}
+
+/**
+ * The failure sentence. Named from the FIRST failure's own flavor (that is the
+ * one the sentence is about), while the hint below it takes the aggregate — a
+ * run that hit the rate limit anywhere is a run where signing in raises it.
+ * Only the first repo is named: the list is already deduped by repo, and a
+ * banner that enumerates ten of them stops being one sentence to act on.
+ */
+function failureLine(failures: readonly AuthFailureSummary[]): string | null {
+  const first = failures[0];
+  if (!first) {
+    return null;
+  }
+  const rest = failures.length - 1;
+  const name = rest > 0 ? `${first.name} and ${rest} more` : first.name;
+  return first.rateLimited
+    ? `Rate limit exceeded while resolving ${name}.`
+    : `Could not load preset ${name} — repo not found, or private and not accessible.`;
+}
+
+export function AuthFailureBanner({
+  failures,
+  rateLimited,
+  authState,
+  onSignIn,
+  installUrl,
+  onRunAgain,
+}: {
+  failures: readonly AuthFailureSummary[];
+  /** ANY failure in the run was a rate limit — tunes the hint's copy. */
+  rateLimited: boolean;
+  authState: AuthState;
+  onSignIn: () => void;
+  installUrl: string;
+  /** Re-runs the pipeline with the inputs that are on screen right now. */
+  onRunAgain: () => void;
+}) {
+  const line = failureLine(failures);
+  // Mirrors GithubAuthHint's own guard: with sign-in unconfigured there is no
+  // action to offer, and a banner that only restates the tree's error badges
+  // is noise. The failed nodes still say what happened where they happened.
+  if (line === null || authState === "unconfigured") {
+    return null;
+  }
+  return (
+    <div className="auth-failure-banner" role="alert">
+      <p className="auth-failure-banner-line">{line}</p>
+      <GithubAuthHint
+        authState={authState}
+        rateLimited={rateLimited}
+        onSignIn={onSignIn}
+        installUrl={installUrl}
+      />
+      {/* The signed-in path sends the user to GitHub to install the app on the
+          repo — they come back to a page whose result predates that grant, so
+          the loop only closes if re-running is one click away and right here. */}
+      <button type="button" className="auth-failure-rerun" onClick={onRunAgain}>
+        Run again
+      </button>
+    </div>
+  );
+}

--- a/packages/app/src/components/ResultsPanel.tsx
+++ b/packages/app/src/components/ResultsPanel.tsx
@@ -21,6 +21,11 @@ interface Props {
    *  pill). null = the current tab was reached by an explicit tab click. */
   back: ResultsTabId | null;
   onBack: () => void;
+  /** Roadmap 009: a run-level banner shown above the panels, on every tab —
+   *  the auth-failure notice describes the RUN, not one instrument, and a run
+   *  that failed on a preset lands the user on Problems rather than on the
+   *  Overview whose own `banner` slot the 023 hypothetical notice occupies. */
+  banner?: ReactNode;
   panels: Record<ResultsTabId, ReactNode>;
 }
 
@@ -30,7 +35,7 @@ interface Props {
  * (tree expansion and search, effective-config filters, the stepper index,
  * simulation results, scroll positions) survives switching for free.
  */
-export function ResultsPanel({ tabs, active, onSelect, back, onBack, panels }: Props) {
+export function ResultsPanel({ tabs, active, onSelect, back, onBack, banner, panels }: Props) {
   return (
     <div className="results-panel">
       <div className="tab-bar" role="tablist" aria-label="Results">
@@ -59,6 +64,7 @@ export function ResultsPanel({ tabs, active, onSelect, back, onBack, panels }: P
         ))}
       </div>
       <div className="tab-body">
+        {banner}
         {back ? (
           <button type="button" className="tab-back" onClick={onBack}>
             ← Back to {RESULTS_TAB_LABELS[back]}

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -11,7 +11,7 @@ import {
   nodeInjectionKey,
   ROW_HEIGHT,
   sourceKindEntry,
-  STATE_LABELS,
+  stateBadge,
 } from "./tree-shared";
 
 function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed: boolean }) {
@@ -69,7 +69,9 @@ export function TreeRow({
   dupCount: number;
 }) {
   const { node, stats } = row;
-  const stateLabel = STATE_LABELS[node.state];
+  // Roadmap 009: `failed` for every error except the two a user can act on —
+  // see `stateBadge`, which owns that decision.
+  const badge = stateBadge(node);
   const key = nodeInjectionKey(node.source, injectionKey);
   const userSupplied = key !== null && usedInjections.has(key);
   const style: CSSProperties = {
@@ -174,7 +176,7 @@ export function TreeRow({
           )}
         </Explained>
       ) : null}
-      {stateLabel ? <span className={`badge state state-${node.state}`}>{stateLabel}</span> : null}
+      {badge ? <span className={`badge state ${badge.className}`}>{badge.label}</span> : null}
       {node.state === "error" && node.error ? (
         <span className="preset-row-error" title={node.error.message}>
           {node.error.message}

--- a/packages/app/src/features/presets/tree-shared.test.ts
+++ b/packages/app/src/features/presets/tree-shared.test.ts
@@ -62,7 +62,8 @@ describe("collectGithubAuthFailures", () => {
       name: "repo config",
       children: [
         node({
-          name: "config:recommended",
+          name: "github>org/shared-config",
+          source: { presetSource: "github", repo: "org/shared-config" },
           children: [githubFailure("org/private-presets", NOT_FOUND_MESSAGE)],
         }),
       ],
@@ -72,6 +73,23 @@ describe("collectGithubAuthFailures", () => {
     expect(failures[0]?.name).toBe("github>org/private-presets");
     expect(failures[0]?.rateLimited).toBe(false);
     expect(rateLimited).toBe(false);
+  });
+
+  test("prunes internal subtrees — internal presets never reference external ones", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        node({
+          name: "config:recommended",
+          source: { presetSource: "internal" },
+          // Cannot happen on a real run (internal presets only reference other
+          // internal presets); the fixture pins that the walk RELIES on that
+          // invariant instead of re-checking every internal node.
+          children: [githubFailure("org/private-presets", NOT_FOUND_MESSAGE)],
+        }),
+      ],
+    });
+    expect(collectGithubAuthFailures(root).failures).toEqual([]);
   });
 
   test("matches renovate's rewritten not-found message (the shape real runs carry)", () => {

--- a/packages/app/src/features/presets/tree-shared.test.ts
+++ b/packages/app/src/features/presets/tree-shared.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Roadmap 009 (auth-failure surfacing) — the two decisions the feature rests
+ * on, both pure and both tested here rather than through the UI that renders
+ * them: WHICH failures a run-level banner should name
+ * ({@link collectGithubAuthFailures}) and WHAT a failing row's badge says
+ * ({@link stateBadge}).
+ *
+ * The fixtures spell the engine's real messages ("… — rate limit or missing
+ * token" from the github preset shim, renovate's own "dep not found") because
+ * the match IS a pair of regexes over those strings: a fixture paraphrasing
+ * them would keep passing after the engine's wording moved on.
+ */
+import type { PresetNode } from "@renovate-config-visualizer/engine";
+import { describe, expect, test } from "vitest";
+import { collectGithubAuthFailures, githubPresetDisplayName, stateBadge } from "./tree-shared";
+
+const RATE_LIMIT_MESSAGE =
+  "GitHub API rejected the request (HTTP 403) — rate limit or missing token";
+const NOT_FOUND_MESSAGE = "dep not found";
+// What a not-found ACTUALLY looks like on a real run's node: renovate rewrites
+// the fetcher's message into its validation copy before throwing, and the
+// engine mirrors that rewrite onto the node — see githubAuthFailure's docs.
+const NOT_FOUND_REWRITTEN_MESSAGE = "Cannot find preset's package (github>org/private-presets)";
+
+let nextId = 0;
+
+/** A tree node with only the fields these two functions read. */
+function node(partial: Partial<PresetNode> & { name: string }): PresetNode {
+  return {
+    id: `n${++nextId}`,
+    state: "resolved",
+    children: [],
+    ...partial,
+  } as PresetNode;
+}
+
+/** A failed `github>owner/repo` preset in one of the two auth flavors. */
+function githubFailure(repo: string, message: string, name = `github>${repo}`): PresetNode {
+  return node({
+    name,
+    state: "error",
+    source: { presetSource: "github", repo },
+    error: { topic: "Preset", message },
+  });
+}
+
+describe("collectGithubAuthFailures", () => {
+  test("an absent tree has no failures", () => {
+    expect(collectGithubAuthFailures(undefined)).toEqual({ failures: [], rateLimited: false });
+  });
+
+  test("a clean run has no failures", () => {
+    const root = node({
+      name: "repo config",
+      children: [node({ name: "config:recommended" }), node({ name: "github>org/presets" })],
+    });
+    expect(collectGithubAuthFailures(root).failures).toEqual([]);
+  });
+
+  test("finds a not-found github failure nested anywhere in the tree", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        node({
+          name: "config:recommended",
+          children: [githubFailure("org/private-presets", NOT_FOUND_MESSAGE)],
+        }),
+      ],
+    });
+    const { failures, rateLimited } = collectGithubAuthFailures(root);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.name).toBe("github>org/private-presets");
+    expect(failures[0]?.rateLimited).toBe(false);
+    expect(rateLimited).toBe(false);
+  });
+
+  test("matches renovate's rewritten not-found message (the shape real runs carry)", () => {
+    const root = node({
+      name: "repo config",
+      children: [githubFailure("org/private-presets", NOT_FOUND_REWRITTEN_MESSAGE)],
+    });
+    const { failures, rateLimited } = collectGithubAuthFailures(root);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.rateLimited).toBe(false);
+    expect(rateLimited).toBe(false);
+  });
+
+  test("ignores errors that are not sign-in-fixable github fetches", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        // A github preset that failed for an unrelated reason.
+        githubFailure("org/presets", "Invalid JSON in preset"),
+        // The right message, but not a github source.
+        node({
+          name: "gitlab>org/presets",
+          state: "error",
+          source: { presetSource: "gitlab", repo: "org/presets" },
+          error: { topic: "Preset", message: RATE_LIMIT_MESSAGE },
+        }),
+        // The right message and source, but the node did not fail.
+        node({ name: "github>org/ok", source: { presetSource: "github", repo: "org/ok" } }),
+      ],
+    });
+    expect(collectGithubAuthFailures(root).failures).toEqual([]);
+  });
+
+  test("dedupes by repository — one unreachable repo is one thing to fix", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        githubFailure("org/private", NOT_FOUND_MESSAGE, "github>org/private:base"),
+        githubFailure("org/private", NOT_FOUND_MESSAGE, "github>org/private:extra"),
+        githubFailure("org/other", NOT_FOUND_MESSAGE),
+      ],
+    });
+    const { failures } = collectGithubAuthFailures(root);
+    expect(failures.map((f) => f.name)).toEqual(["github>org/private:base", "github>org/other"]);
+  });
+
+  test("reports failures in tree order, so the banner names the first one", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        node({ name: "config:recommended", children: [githubFailure("org/a", NOT_FOUND_MESSAGE)] }),
+        githubFailure("org/b", NOT_FOUND_MESSAGE),
+      ],
+    });
+    expect(collectGithubAuthFailures(root).failures.map((f) => f.name)).toEqual([
+      "github>org/a",
+      "github>org/b",
+    ]);
+  });
+
+  test("the aggregate is rate-limited when ANY failure was", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        githubFailure("org/a", NOT_FOUND_MESSAGE),
+        githubFailure("org/b", RATE_LIMIT_MESSAGE),
+      ],
+    });
+    const { failures, rateLimited } = collectGithubAuthFailures(root);
+    expect(rateLimited).toBe(true);
+    expect(failures.map((f) => f.rateLimited)).toEqual([false, true]);
+  });
+
+  test("a duplicated rate limit still flips the aggregate, dedupe notwithstanding", () => {
+    const root = node({
+      name: "repo config",
+      children: [
+        githubFailure("org/a", NOT_FOUND_MESSAGE),
+        githubFailure("org/a", RATE_LIMIT_MESSAGE),
+      ],
+    });
+    expect(collectGithubAuthFailures(root)).toMatchObject({ rateLimited: true });
+    expect(collectGithubAuthFailures(root).failures).toHaveLength(1);
+  });
+});
+
+describe("githubPresetDisplayName", () => {
+  test("keeps the preset as it was written when it names the repo", () => {
+    const failure = githubFailure("org/presets", NOT_FOUND_MESSAGE, "github>org/presets:base");
+    expect(githubPresetDisplayName(failure)).toBe("github>org/presets:base");
+  });
+
+  test("synthesizes the writable form when the raw name drifted from the repo", () => {
+    const failure = githubFailure("org/presets", NOT_FOUND_MESSAGE, "local>renovate-config");
+    expect(githubPresetDisplayName(failure)).toBe("github>org/presets");
+  });
+
+  test("falls back to the raw name when there is no structured repo", () => {
+    const bare = node({ name: "some-preset", state: "error" });
+    expect(githubPresetDisplayName(bare)).toBe("some-preset");
+  });
+});
+
+describe("stateBadge", () => {
+  test("a resolved node wears no badge", () => {
+    expect(stateBadge(node({ name: "config:recommended" }))).toBeNull();
+  });
+
+  test("an ordinary error is still just `failed`", () => {
+    const badge = stateBadge(githubFailure("org/presets", "Invalid JSON in preset"));
+    expect(badge).toEqual({ label: "failed", className: "state-error" });
+  });
+
+  test("a private/not-found github preset says `no access`", () => {
+    const badge = stateBadge(githubFailure("org/private", NOT_FOUND_MESSAGE));
+    expect(badge).toEqual({ label: "no access", className: "state-error auth-no-access" });
+  });
+
+  test("a throttled github preset says `rate limited`", () => {
+    const badge = stateBadge(githubFailure("org/presets", RATE_LIMIT_MESSAGE));
+    expect(badge).toEqual({ label: "rate limited", className: "state-error auth-rate-limited" });
+  });
+
+  test("non-error states keep their own wording", () => {
+    expect(stateBadge(node({ name: "x", state: "ignored" }))?.label).toBe(
+      "ignored via ignorePresets",
+    );
+    expect(stateBadge(node({ name: "x", state: "aborted" }))?.className).toBe("state-aborted");
+  });
+});

--- a/packages/app/src/features/presets/tree-shared.ts
+++ b/packages/app/src/features/presets/tree-shared.ts
@@ -4,7 +4,14 @@ import { GLOSSARY, type GlossaryEntry } from "@/data/glossary-data";
 /**
  * A failed GitHub preset node whose error is the private-repo (not-found) or
  * auth/rate-limit kind — the cases where signing in is the likely fix (009).
- * Matches the exact strings the engine's github fetcher emits.
+ *
+ * Two message shapes per flavor, because renovate rewrites one of them: the
+ * fetcher's raw `dep not found` is replaced by renovate's validation copy
+ * ("Cannot find preset's package (…)") when the preset error is thrown, and
+ * the engine mirrors that rewrite onto the node (preset-tree.ts, "Throwing
+ * preset error") — so by the time the app reads the node, only the rewritten
+ * form remains. Rate-limit errors are rethrown by renovate WITHOUT a rewrite
+ * and keep the fetcher's `rate limit or missing token` wording.
  */
 export function githubAuthFailure(node: PresetNode): { match: boolean; rateLimited: boolean } {
   if (node.state !== "error" || node.source?.presetSource !== "github") {
@@ -12,8 +19,82 @@ export function githubAuthFailure(node: PresetNode): { match: boolean; rateLimit
   }
   const msg = node.error?.message ?? "";
   const rateLimited = /rate limit or missing token/i.test(msg);
-  const notFound = /dep not found/i.test(msg);
+  const notFound = /dep not found|Cannot find preset's package/i.test(msg);
   return { match: rateLimited || notFound, rateLimited };
+}
+
+/**
+ * Roadmap 009 (auth-failure surfacing): the preset as the user would WRITE it,
+ * rebuilt from the node's structured source when its raw `name` isn't already
+ * that form. The tree's `name` is the raw `extends` entry, which for a github
+ * preset is normally exactly `github>owner/repo[:preset]` — so it is preferred
+ * whenever it still mentions the repo, and only a node whose name drifted (a
+ * bare `owner/repo` shorthand, a `local>` rewrite) gets the synthesized form.
+ */
+export function githubPresetDisplayName(node: PresetNode): string {
+  const repo = node.source?.repo;
+  if (!repo) {
+    return node.name;
+  }
+  return node.name.includes(repo) ? node.name : `github>${repo}`;
+}
+
+/** One failing GitHub preset, as the run-level banner (009) names it. Carries
+ *  the naming, not the node: the banner is a shared component and may not
+ *  reach into this feature (048), so what crosses that line is a sentence's
+ *  worth of data. */
+export interface GithubAuthFailureNode {
+  /** Display form, e.g. `github>secustor/private-presets`. */
+  name: string;
+  rateLimited: boolean;
+}
+
+/** Every sign-in-fixable GitHub failure in a run, plus the aggregate flavor. */
+export interface GithubAuthFailures {
+  /** Deduped by repository — one unreachable repo extended from five places is
+   *  ONE thing to fix, and naming it five times reads as five problems. */
+  failures: GithubAuthFailureNode[];
+  /** Any failure was a rate limit — tunes the hint's copy toward "sign in to
+   *  raise the limit" rather than "sign in to reach a private repo". */
+  rateLimited: boolean;
+}
+
+/**
+ * Roadmap 009 (auth-failure surfacing): walks a finished run's preset tree for
+ * the failures signing in could fix, so the app can say so ONCE at run level
+ * instead of only inside the detail panel of a node the user has to find first.
+ * Pure (no React, no engine) — the whole decision is unit-testable.
+ */
+export function collectGithubAuthFailures(root: PresetNode | undefined): GithubAuthFailures {
+  const failures: GithubAuthFailureNode[] = [];
+  const seenRepos = new Set<string>();
+  let rateLimited = false;
+  // Iterative walk: `config:recommended` alone expands to ~1,100 nodes, and a
+  // recursive one would also be at the mercy of a pathological chain depth.
+  const stack: PresetNode[] = root ? [root] : [];
+  for (let node = stack.pop(); node !== undefined; node = stack.pop()) {
+    // Children pushed in reverse so the walk still reports them left-to-right —
+    // the banner names the FIRST failure, which must be the first one the user
+    // would find in the tree.
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      const child = node.children[i];
+      if (child) {
+        stack.push(child);
+      }
+    }
+    const failure = githubAuthFailure(node);
+    if (!failure.match) {
+      continue;
+    }
+    rateLimited ||= failure.rateLimited;
+    const dedupeKey = node.source?.repo ?? node.name;
+    if (seenRepos.has(dedupeKey)) {
+      continue;
+    }
+    seenRepos.add(dedupeKey);
+    failures.push({ name: githubPresetDisplayName(node), rateLimited: failure.rateLimited });
+  }
+  return { failures, rateLimited };
 }
 
 export type InjectionKeyFn = (id: {
@@ -54,6 +135,36 @@ export const STATE_LABELS: Record<PresetNode["state"], string | null> = {
   "already-seen": "skipped — already in its own ancestor chain",
   aborted: "not resolved — run aborted by an earlier error",
 };
+
+/** A row's state badge: the word it wears and the modifier that colors it. */
+export interface StateBadge {
+  label: string;
+  /** Appended to the shared `badge state` base classes. */
+  className: string;
+}
+
+/**
+ * Roadmap 009 (auth-failure surfacing): what a row's state badge says. Plain
+ * `failed` covers every error EXCEPT the two the user can act on — a GitHub
+ * preset that signing in would reach (`no access`) and one that ran into the
+ * unauthenticated rate limit (`rate limited`). Naming the cause in the badge
+ * is what lets the tree be scanned for "which of these is about my token?"
+ * without opening a single node. Lives here, next to {@link githubAuthFailure},
+ * so TreeRow stays a renderer. Null = this state wears no badge at all.
+ */
+export function stateBadge(node: PresetNode): StateBadge | null {
+  const label = STATE_LABELS[node.state];
+  if (label === null) {
+    return null;
+  }
+  const failure = githubAuthFailure(node);
+  if (!failure.match) {
+    return { label, className: `state-${node.state}` };
+  }
+  return failure.rateLimited
+    ? { label: "rate limited", className: `state-${node.state} auth-rate-limited` }
+    : { label: "no access", className: `state-${node.state} auth-no-access` };
+}
 
 /** Fixed row height keeps the windowing math trivial; rows never wrap. */
 export const ROW_HEIGHT = 26;

--- a/packages/app/src/features/presets/tree-shared.ts
+++ b/packages/app/src/features/presets/tree-shared.ts
@@ -73,6 +73,14 @@ export function collectGithubAuthFailures(root: PresetNode | undefined): GithubA
   // recursive one would also be at the mercy of a pathological chain depth.
   const stack: PresetNode[] = root ? [root] : [];
   for (let node = stack.pop(); node !== undefined; node = stack.pop()) {
+    // An internal preset (`config:*`, `group:*`, …) is a static definition
+    // inside renovate itself and can only reference other internal presets —
+    // nothing sign-in-fixable can live below one, so the whole subtree is
+    // skipped (review, PR #61). Only an EXPLICIT "internal" prunes: the root
+    // user-config node has no parsed source and must always descend.
+    if (node.source?.presetSource === "internal") {
+      continue;
+    }
     // Children pushed in reverse so the walk still reports them left-to-right —
     // the banner names the FIRST failure, which must be the first one the user
     // would find in the tree.

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -107,6 +107,11 @@ export interface ShareLink {
    *  pipeline run this link triggered has produced its result. */
   simRequest: SimRequest | null;
   buildShareLinkAndCopy: (sim?: ShareSimulator) => Promise<void>;
+  /** Roadmap 009 (auth-failure surfacing): the `#config=…` fragment a sign-in
+   *  redirect should return to — the current state as a share token, so the
+   *  round trip through GitHub keeps the config (and re-runs it on arrival).
+   *  See App.tsx's `signInRef` for why the sign-in path needs one at all. */
+  buildSignInReturnHash: () => Promise<string>;
 }
 
 export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHost): ShareLink {
@@ -301,11 +306,24 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
           // the mount latch (not the decode generation) — a hashchange
           // superseding the DECODE must not strand the chip nameless.
           hostRef.current.setSignedIn(true);
-          writeHash(window.location.pathname + returnHash, readShareToken(returnHash));
+          // Roadmap 009 (auth-failure surfacing): a token on the return
+          // fragment means step 2 below is about to re-run the config the user
+          // signed in FROM — the auto-rerun that closes the auth-failure loop.
+          // It happens exactly once per callback (this effect is one-shot),
+          // and only when a run existed to encode (App.tsx's `signInRef`).
+          const returnToken = readShareToken(returnHash);
+          writeHash(window.location.pathname + returnHash, returnToken);
           void (async () => {
             const user = await userPromise;
             if (user && mountedRef.current) {
               hostRef.current.setAuthUser(user);
+              // Said only once the login is known — a nameless "running
+              // again…" would be the app narrating itself; with the login it
+              // is the confirmation that the sign-in took, which is the
+              // question a user who just came back from GitHub actually has.
+              if (returnToken) {
+                hostRef.current.setNotice(`Signed in as ${user.login} — running again…`);
+              }
             }
           })();
         } catch (err) {
@@ -396,5 +414,22 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
     [],
   );
 
-  return { shareError, simRequest, buildShareLinkAndCopy };
+  /**
+   * Roadmap 009 (auth-failure surfacing): the same encode, WITHOUT the copy or
+   * the address-bar write — the caller hands the result to `beginSignIn`,
+   * which stashes it in sessionStorage and restores it after the callback.
+   * Reusing `buildShareUrl` rather than re-spelling `#config=` keeps the one
+   * definition of the wire format in share.ts.
+   */
+  async function buildSignInReturnHashImpl(): Promise<string> {
+    return new URL(buildShareUrl(await encodeShare(await host.buildShareState()))).hash;
+  }
+  // Same latest-ref reason as above: the impl closes over this render's `host`
+  // (it must — the return hash IS the current state), and the identity handed
+  // out reaches App's own stable `onSignIn`.
+  const buildSignInReturnHashRef = useRef(buildSignInReturnHashImpl);
+  buildSignInReturnHashRef.current = buildSignInReturnHashImpl;
+  const buildSignInReturnHash = useCallback(() => buildSignInReturnHashRef.current(), []);
+
+  return { shareError, simRequest, buildShareLinkAndCopy, buildSignInReturnHash };
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -628,6 +628,22 @@ pre.config-view {
   color: var(--error);
 }
 
+/* Roadmap 009 (auth-failure surfacing): the two failures a user can act on say
+   so in the badge, and wear their own hue so the tree can be scanned for
+   "which of these is about my access?" without opening a node. Violet is
+   already the app's remote-source hue (`.badge.src-github` and friends — this
+   IS a github fetch that did not happen); amber is its "throttled, come back"
+   hue. Both declare `color` only, per the 036 chip rule that derives the fill
+   from it. Placed after `.state-error` deliberately: same specificity, and
+   these nodes still carry `state-error`, so source order is the override. */
+.badge.state.auth-no-access {
+  color: var(--accent-purple);
+}
+
+.badge.state.auth-rate-limited {
+  color: var(--warn);
+}
+
 .badge.via {
   color: var(--accent);
 }
@@ -1820,6 +1836,48 @@ pre.config-view.prov-before {
   font: inherit;
   padding: 0;
   text-decoration: underline;
+}
+
+/* Roadmap 009 (auth-failure surfacing): the run-level counterpart of the hint
+   above — it sits inside the results shell, above every tab panel, so it takes
+   the same tint-on-a-card treatment as 023's hypothetical banner rather than
+   the full-bleed page banners (`.share-error-banner`), which belong to the
+   page and not to a result. */
+.auth-failure-banner {
+  background: var(--error-bg);
+  border: 1px solid var(--error-border);
+  border-left: 3px solid var(--error);
+  border-radius: 6px;
+  color: inherit;
+  margin: 0 0 0.6rem;
+  padding: 0.5rem 0.7rem;
+}
+
+.auth-failure-banner-line {
+  color: var(--error);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+/* The hint sits directly under the sentence it qualifies — its own default
+   margins would read as a second, unrelated paragraph. */
+.auth-failure-banner .gh-auth-hint {
+  margin: 0.2rem 0 0;
+}
+
+.auth-failure-rerun {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin-top: 0.35rem;
+  padding: 0.25rem 0.7rem;
+}
+
+.auth-failure-rerun:hover {
+  border-color: var(--accent);
 }
 
 /* ---------- packageRules simulator (006) ---------- */

--- a/packages/app/src/platform/oauth-config.test.ts
+++ b/packages/app/src/platform/oauth-config.test.ts
@@ -10,10 +10,15 @@ import { getOAuthConfig } from "./oauth";
  * because it is a served file a deployment can get wrong.
  */
 
-/** `vi.stubEnv` covers `import.meta.env` too, so both sources are drivable. */
+/** `vi.stubEnv` covers `import.meta.env` too, so both sources are drivable.
+ *  ALL three vars are stubbed — vitest loads a developer's gitignored
+ *  `packages/app/.env` (the local-testing OAuth config) into
+ *  `import.meta.env`, so any var left unstubbed leaks that machine's value
+ *  into the fixture. */
 function setEnv(clientId: string | undefined, workerUrl: string | undefined): void {
   vi.stubEnv("VITE_GITHUB_CLIENT_ID", clientId);
   vi.stubEnv("VITE_OAUTH_WORKER_URL", workerUrl);
+  vi.stubEnv("VITE_GITHUB_APP_SLUG", undefined);
 }
 
 function setGlobal(value: unknown): void {

--- a/packages/app/src/platform/oauth.ts
+++ b/packages/app/src/platform/oauth.ts
@@ -379,8 +379,31 @@ export function readCallbackParams(search: string): { code: string; state: strin
  * promise the caller consumes whenever it lands instead of gating the
  * sign-in (and, downstream, a share link's decode and auto-run). Throws on
  * state mismatch or exchange failure (caller stays signed out).
+ *
+ * Single-flight per callback (like `getValidToken`'s refresh below): the
+ * pending stash is consume-once and the `code` is single-use at GitHub, but
+ * React's StrictMode mounts the completing effect twice in dev — the second
+ * invocation of the SAME code+state must join the first's exchange, not find
+ * an empty stash and paint "sign-in failed" over a sign-in that succeeded.
+ * A genuinely new callback (fresh redirect, different code) starts fresh.
  */
-export async function completeCallback(
+let callbackInFlight: {
+  key: string;
+  promise: Promise<{ userPromise: Promise<StoredUser | null>; returnHash: string }>;
+} | null = null;
+
+export function completeCallback(
+  code: string,
+  state: string,
+): Promise<{ userPromise: Promise<StoredUser | null>; returnHash: string }> {
+  const key = `${state} ${code}`;
+  if (callbackInFlight?.key !== key) {
+    callbackInFlight = { key, promise: completeCallbackImpl(code, state) };
+  }
+  return callbackInFlight.promise;
+}
+
+async function completeCallbackImpl(
   code: string,
   state: string,
 ): Promise<{ userPromise: Promise<StoredUser | null>; returnHash: string }> {

--- a/packages/engine/src/trace/preset-tree.ts
+++ b/packages/engine/src/trace/preset-tree.ts
@@ -218,7 +218,14 @@ export class PresetTreeBuilder {
 
   private onFetchError(meta: Record<string, unknown>): void {
     const preset = typeof meta.preset === "string" ? meta.preset : "(unknown)";
-    const err = meta.err;
+    // Renovate wraps host failures in ExternalHostError, whose OWN message is
+    // the constant "external-host-error" — the descriptive message (the one
+    // the app's 009 auth-failure detection reads, e.g. "… rate limit or
+    // missing token") lives on its `.err`. Unwrapped structurally, not by
+    // class: the instance comes from renovate's bundle, not our import graph.
+    const raw = meta.err;
+    const inner = (raw as { err?: unknown } | undefined)?.err;
+    const err = inner instanceof Error ? inner : raw;
     const errMsg = err instanceof Error ? err.message : String(err ?? "unknown error");
     const top = this.top();
     let node = top?.pendingChild;


### PR DESCRIPTION
## What

Makes the two GitHub auth journeys (sign in for rate limit · install for private repos) visible at the moment they fail, instead of leaving the user to discover a `failed` node deep in the preset tree.

- **Run-level `AuthFailureBanner`** above every results tab: names the failing preset from its structured `source` (e.g. `github>owner/repo`), carries the existing `GithubAuthHint` (sign-in or manage-access copy by auth state), and offers **Run again** for access granted mid-session. Rendered through a new `banner` slot in `ResultsPanel` — a preset failure lands on Problems, so an Overview-only banner would miss its own main case.
- **Tree badges name the fix**: `no access` / `rate limited` for sign-in-fixable GitHub fetches; plain `failed` stays for everything else.
- **Sign-in keeps your work**: the redirect now encodes the current state as a share token (stashed in `sessionStorage`, never in the URL handed to GitHub) and auto-reruns it on return with a "Signed in as … — running again…" notice. Previously the redirect silently discarded the config — including the failure the user signed in for.

## Bug fixes (found verifying in the live app)

All three also silently broke the *pre-existing* 009 detail-panel hint on real runs:

1. Renovate rewrites the fetcher's `dep not found` into `Cannot find preset's package (…)` before throwing, and the engine mirrors that onto the node — the detection regex never matched real not-found runs. Broadened in `tree-shared.ts`.
2. Renovate wraps host failures in `ExternalHostError`, whose own message is the constant `external-host-error` — the descriptive "rate limit or missing token" text lives on its inner `.err`. The engine's `preset-tree.ts` now unwraps it.
3. Side effect of (2): the Problems tab showed `Failed to fetch preset "…": external-host-error`; it now shows the real reason.

## Test plan

- [x] Unit: 17 new tests for `collectGithubAuthFailures` / `githubPresetDisplayName` / `stateBadge`, incl. renovate's rewritten message shape (245 app tests total)
- [x] Engine golden (65) + shimmed (111), oauth-worker (11)
- [x] Verified live against real renovate code paths: not-found run shows banner + `no access` badge; stubbed 403 shows rate-limit banner + `rate limited` badge (screenshots in session)
- [x] `pnpm lint`, `lint:css`, `format:check`, `-r typecheck`, production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LgoudxgJtoT5DxNi6wPuZ