### PR TITLE
feat(app): persist GitHub sign-in across tab closures (roadmap 065)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,6 @@ The app's vitest config also has a `render` project (`src/**/*.test.tsx`, jsdom 
 ## Other constraints worth knowing
 
 - `matchCurrentVersion` uses Renovate's real versioning modules for every ecosystem **except `conda`** (its ~3 MB WASM parser is excluded; such clauses report an honest error).
-- Share links carry state in the URL _fragment_ only (never reaches server logs) and must never carry tokens or manually injected presets. Tokens live in `sessionStorage`/memory only.
+- Share links carry state in the URL _fragment_ only (never reaches server logs) and must never carry tokens or manually injected presets. Tokens live in `sessionStorage`/memory only — except the OAuth refresh token, which (roadmap 065, opt-in per deployment) lives in an `HttpOnly` cookie scoped to the oauth-worker; `localStorage` never holds a secret, only the non-secret cookie-session marker.
 - `public/` is deployment payload copied verbatim, not app source; `rcv-config.js` there is a stub that the Docker entrypoint may overwrite at container start (runtime `RCV_*` config).
 - CI must not install via mise hooks — the `postinstall` hook in `mise.toml` is local-only convenience (see the comment there before touching caching in workflows).

--- a/docs/Auth-Flow.md
+++ b/docs/Auth-Flow.md
@@ -1,0 +1,105 @@
+# Auth flow
+
+How "Sign in with GitHub" works: the SPA drives GitHub's authorization-code
+flow with PKCE, and the only server piece is the stateless oauth-worker that
+turns a `code` (or a refresh token) into a GitHub user token. The browser
+cannot do that exchange itself: GitHub's token endpoint requires the
+`client_secret` and serves no CORS. Every GitHub _content_ request still goes
+browser → `api.github.com` directly; the worker never sees a config, a preset,
+or an API call.
+
+Design decisions live in [roadmap 009](../roadmap/009-github-oauth-sign-in.md)
+(the flow) and [roadmap 065](../roadmap/065-persistent-sign-in.md) (the
+refresh-token cookie). Provisioning is in the
+[oauth-worker README](../packages/oauth-worker/README.md).
+
+## Where credentials live
+
+| Credential                                           | Location                                      | Lifetime          |
+| ---------------------------------------------------- | --------------------------------------------- | ----------------- |
+| Access token (~8 h)                                  | memory + `sessionStorage`                     | tab               |
+| Refresh token, 009 protocol                          | memory + `sessionStorage`                     | tab               |
+| Refresh token, cookie mode                           | `HttpOnly` cookie, scoped to the worker mount | ~6 months         |
+| Cookie-session marker (non-secret horizon timestamp) | `localStorage`                                | until the horizon |
+| `client_secret`                                      | worker secret store                           | n/a               |
+
+`localStorage` never holds a secret. In cookie mode, XSS can use the session
+while a page is open but cannot exfiltrate the long-lived refresh token: the
+browser's cookie jar has it, and JS never does.
+
+## Sign-in
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SPA
+    participant GitHub as github.com
+    participant Worker as oauth-worker
+    SPA->>SPA: stash {state, PKCE verifier, return hash} in sessionStorage
+    SPA->>GitHub: redirect to /login/oauth/authorize (client_id, state, code_challenge)
+    GitHub->>SPA: redirect back with ?code=&state=
+    SPA->>SPA: validate state against the stash (CSRF gate)
+    SPA->>Worker: POST /exchange {code, code_verifier}
+    Worker->>GitHub: POST /login/oauth/access_token (+ client_secret)
+    GitHub-->>Worker: access + refresh token JSON
+    alt cookie mode (REFRESH_COOKIE=true, not *.workers.dev)
+        Worker-->>SPA: body without refresh_token, refresh_token_cookie: true<br/>+ Set-Cookie: __Secure-rcv-refresh (HttpOnly, SameSite=Strict)
+        SPA->>SPA: store access token (sessionStorage),<br/>marker → localStorage
+    else 009 protocol
+        Worker-->>SPA: tokens in the body, verbatim
+        SPA->>SPA: store both tokens (sessionStorage)
+    end
+```
+
+A deployment opts into cookie mode with `REFRESH_COOKIE=true`, and the mode is
+only correct same-site, so the worker refuses to engage it on a
+`*.workers.dev` host. That URL is only ever reached cross-site, where the
+browser would drop the cookie.
+The production deployment routes the worker at
+`renovate.secustor.dev/oauth/*`, the app's own hostname.
+
+## Session lifetime: refresh and boot restore
+
+Closing the tab drops `sessionStorage`. In cookie mode the session survives:
+on boot, a live marker triggers one silent `/refresh` whose empty body tells
+the worker to read the cookie. When an access token expires mid-session,
+`getValidToken` runs the same refresh; on the 009 protocol the body carries
+the in-JS refresh token instead of staying empty.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant SPA
+    participant Worker as oauth-worker
+    participant GitHub as github.com
+    SPA->>SPA: boot: signed out, marker still live?
+    SPA->>Worker: POST /refresh {} (credentials: include → cookie rides along)
+    Worker->>GitHub: refresh_token grant (+ client_secret)
+    alt success
+        GitHub-->>Worker: new access + rotated refresh token
+        Worker-->>SPA: access token + rotated Set-Cookie
+        SPA->>SPA: signed in, marker horizon moves forward
+    else definitive rejection (4xx, grant is dead)
+        Worker-->>SPA: 400 + clearing Set-Cookie (Max-Age=0)
+        SPA->>SPA: drop the marker — later boots stop probing
+    else transient failure (offline, 5xx)
+        Worker--xSPA: unreachable / 502
+        SPA->>SPA: stay signed out THIS boot, keep the marker — next boot retries
+    end
+```
+
+GitHub rotates the refresh token on every use, which is why the restore and
+refresh paths are single-flight: a second concurrent `/refresh` would post the
+cookie the first one already burned.
+
+Only a definitive 4xx ends the session; a transient failure never destroys
+state, because signing out fires `/logout` and could burn a still-good cookie
+over a network blip.
+
+## Sign-out
+
+`signOut()` clears memory, every `rcv.oauth.*` storage key, and the marker,
+then fires a best-effort `POST /logout`, since only the worker can clear the
+`HttpOnly` cookie (the answer carries a clearing `Max-Age=0`). True revocation of the GitHub
+grant can only be done on
+[github.com/settings/apps/authorizations](https://github.com/settings/apps/authorizations).

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -15,8 +15,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { TraceResult } from "@renovate-config-debugger/engine";
 import {
   completeCallback,
+  isSignedIn,
   type OAuthConfig,
   readCallbackParams,
+  restoreSession,
   type StoredUser,
 } from "@/platform/oauth";
 import { getRenovateVersion } from "@/platform/run";
@@ -285,9 +287,10 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
   loadShareTokenRef.current = loadShareToken;
 
   // On mount: first complete an OAuth callback if the URL carries one (QUERY
-  // params ?code&state), then — reading the possibly-restored fragment — decode
-  // a shared config, populate state and auto-run. OAuth runs before the share
-  // decode so a share link survives a sign-in round-trip. Still runs once:
+  // params ?code&state) — or, when there is none, try roadmap 065's silent
+  // cookie restore — then, reading the possibly-restored fragment, decode a
+  // shared config, populate state and auto-run. Both auth steps run before the
+  // share decode so a share link survives a sign-in round-trip. Still runs once:
   // `oauthConfig` is a `useMemo(…, [])` over build-time env (App.tsx), so it
   // is a constant for the app's lifetime — it is in the deps only because it
   // is read here, not because this is meant to re-run.
@@ -345,7 +348,28 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
         }
       }
 
-      // 2. Shared config (007) from the URL fragment (survives the OAuth strip).
+      // 2. Roadmap 065 — no callback, but a previous tab may have left a live
+      // `HttpOnly` refresh cookie: one silent /refresh restores the session.
+      // Ordered here for the same reason the callback branch is (and awaited
+      // for the same reason): step 3's decode can auto-run a link whose
+      // presets are private, and that run must see the restored token rather
+      // than a 404 it would have to be re-run to fix. `restoreSession` is
+      // single-flight and returns without a round trip when there is nothing
+      // to restore, so the cost on the ordinary signed-out boot is nil.
+      if (!callback && oauthConfig && !isSignedIn()) {
+        const user = await restoreSession();
+        // The session, not the chip, decides `signedIn`: the profile fetch is
+        // cosmetic and yields null on failure, so a nameless-but-restored
+        // session must still read as signed in (same contract as above).
+        if (!isCancelled() && isSignedIn()) {
+          hostRef.current.setSignedIn(true);
+          if (user) {
+            hostRef.current.setAuthUser(user);
+          }
+        }
+      }
+
+      // 3. Shared config (007) from the URL fragment (survives the OAuth strip).
       const shareToken = readShareToken(window.location.hash);
       if (!shareToken) {
         return;

--- a/packages/app/src/lib/input-schemas-zod.ts
+++ b/packages/app/src/lib/input-schemas-zod.ts
@@ -250,6 +250,11 @@ export const tokenResponseSchema = z.object({
   expires_in: z.optional(z.number()),
   refresh_token: z.optional(tokenSchema),
   refresh_token_expires_in: z.optional(z.number()),
+  // Roadmap 065 — the worker's cookie mode strips `refresh_token` from the
+  // body and says so with this flag (keeping `refresh_token_expires_in`,
+  // which feeds the localStorage marker). Absent on a 009 deployment, so it
+  // is optional here and oauth.ts treats absent exactly as `false`.
+  refresh_token_cookie: z.optional(z.boolean()),
   token_type: z.optional(z.string()),
   scope: z.optional(z.string()),
   error: z.optional(z.string()),

--- a/packages/app/src/lib/input-schemas.test.ts
+++ b/packages/app/src/lib/input-schemas.test.ts
@@ -629,4 +629,29 @@ describe("Worker token-exchange response", () => {
       tokenResponseSchema.safeParse({ access_token: "gho_x", expires_in: "soon" }).success,
     ).toBe(false);
   });
+
+  // Roadmap 065: cookie mode's body — no `refresh_token` at all, the flag
+  // instead, and `refresh_token_expires_in` kept (it feeds the marker).
+  test("accepts a cookie-mode success response", () => {
+    expect(
+      tokenResponseSchema.safeParse({
+        access_token: "gho_abc123",
+        expires_in: 28800,
+        refresh_token_cookie: true,
+        refresh_token_expires_in: 15552000,
+      }).success,
+    ).toBe(true);
+  });
+  test("a 009 body without the flag still parses (the field is optional)", () => {
+    expect(
+      tokenResponseSchema.safeParse({ access_token: "gho_abc123", refresh_token: "ghr_def456" })
+        .success,
+    ).toBe(true);
+  });
+  test("rejects a wrong-typed refresh_token_cookie", () => {
+    expect(
+      tokenResponseSchema.safeParse({ access_token: "gho_x", refresh_token_cookie: "true" })
+        .success,
+    ).toBe(false);
+  });
 });

--- a/packages/app/src/platform/oauth-session.test.ts
+++ b/packages/app/src/platform/oauth-session.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * Roadmap 065 — the cookie-session half of oauth.ts: the localStorage marker
+ * (the ONE thing that outlives the tab, and no secret), the silent boot
+ * restore built on it, and sign-out's cookie teardown. The refresh token
+ * itself is in an `HttpOnly` cookie, so nothing here can (or tries to) see
+ * it — the browser's cookie jar is stubbed out entirely and the assertions
+ * are about WHAT is requested: an empty `/refresh` body, `credentials:
+ * "include"`, and exactly one round trip no matter how many callers.
+ *
+ * Every test re-imports the module (`vi.resetModules`) because the restore is
+ * single-flight through module-level state, and a session restored in one
+ * test must not read as "already signed in" in the next.
+ */
+
+const COOKIE_SESSION_KEY = "rcv.oauth.cookieSession";
+const WORKER_URL = "https://worker.example";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function memoryStorage(): StorageLike & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+}
+
+const g = globalThis as { localStorage?: StorageLike; sessionStorage?: StorageLike };
+let local = memoryStorage();
+let session = memoryStorage();
+
+/** The Worker + GitHub responses the paths below reach for. `refresh` decides
+ *  what `POST /refresh` answers; everything else is fixed. */
+let refreshResponse: () => Response = () => jsonResponse({});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function baseFetch(input: unknown, init?: RequestInit): Promise<Response> {
+  const url = String(input);
+  if (url === `${WORKER_URL}/refresh`) {
+    return Promise.resolve(refreshResponse());
+  }
+  if (url === `${WORKER_URL}/logout`) {
+    return Promise.resolve(new Response(null, { status: 204 }));
+  }
+  if (url === "https://api.github.com/user") {
+    return Promise.resolve(jsonResponse({ login: "octocat", avatar_url: "https://ex.test/a.png" }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url} ${String(init?.method)}`));
+}
+
+const fetchMock = vi.fn(baseFetch);
+
+function fetchCalls(path: string) {
+  return fetchMock.mock.calls.filter(([input]) => String(input) === path);
+}
+
+/** A fresh module instance, with the same env in force as a deployment that
+ *  has sign-in configured (all three vars stubbed — vitest would otherwise
+ *  leak a developer's gitignored `.env`, exactly as oauth-config.test.ts
+ *  documents). */
+async function freshOAuth() {
+  vi.resetModules();
+  return import("./oauth");
+}
+
+beforeEach(() => {
+  local = memoryStorage();
+  g.localStorage = local;
+  session = memoryStorage();
+  g.sessionStorage = session;
+  vi.stubEnv("VITE_GITHUB_CLIENT_ID", "client");
+  vi.stubEnv("VITE_OAUTH_WORKER_URL", WORKER_URL);
+  vi.stubEnv("VITE_GITHUB_APP_SLUG", undefined);
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(baseFetch);
+});
+
+afterEach(() => {
+  delete g.localStorage;
+  delete g.sessionStorage;
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("restoreSession", () => {
+  test("no marker: answers null without a round trip", async () => {
+    const { restoreSession, isSignedIn } = await freshOAuth();
+    expect(await restoreSession()).toBeNull();
+    expect(isSignedIn()).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a hand-edited marker is dropped and reads as absent (roadmap 030)", async () => {
+    local.map.set(COOKIE_SESSION_KEY, "tomorrow");
+    const { restoreSession } = await freshOAuth();
+    expect(await restoreSession()).toBeNull();
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("an expired marker is not probed", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() - 1000));
+    const { restoreSession } = await freshOAuth();
+    expect(await restoreSession()).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a live marker restores through the cookie: empty body, credentials, new horizon", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    refreshResponse = () =>
+      jsonResponse({
+        access_token: "gho_restored",
+        expires_in: 28_800,
+        refresh_token_cookie: true,
+        refresh_token_expires_in: 15_552_000,
+      });
+    const { restoreSession, isSignedIn } = await freshOAuth();
+    const user = await restoreSession();
+
+    expect(user).toEqual({ login: "octocat", avatarUrl: "https://ex.test/a.png" });
+    expect(isSignedIn()).toBe(true);
+    const [, init] = fetchCalls(`${WORKER_URL}/refresh`)[0] ?? [];
+    // The SPA has no copy of the refresh token to offer — the cookie is it.
+    expect(init?.body).toBe("{}");
+    expect(init?.credentials).toBe("include");
+    // The rotated cookie's horizon replaces the old one, and it is STILL the
+    // only oauth key in localStorage — no token followed it there.
+    expect(Number(local.map.get(COOKIE_SESSION_KEY))).toBeGreaterThan(Date.now() + 15_000_000_000);
+    expect([...local.map.keys()]).toEqual([COOKIE_SESSION_KEY]);
+  });
+
+  test("concurrent restores share ONE /refresh (StrictMode + GitHub's rotation)", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    refreshResponse = () =>
+      jsonResponse({ access_token: "gho_restored", refresh_token_cookie: true });
+    const { restoreSession } = await freshOAuth();
+    // The second call is the StrictMode remount: it must JOIN the first, not
+    // post a cookie the first one already burned.
+    const [first, second] = await Promise.all([restoreSession(), restoreSession()]);
+
+    expect(first).toEqual(second);
+    expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(1);
+  });
+
+  test("a rejected cookie drops the marker and stays signed out", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    refreshResponse = () => jsonResponse({ error: "bad_refresh_token" }, 400);
+    const { restoreSession, isSignedIn } = await freshOAuth();
+
+    expect(await restoreSession()).toBeNull();
+    expect(isSignedIn()).toBe(false);
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(false);
+  });
+
+  test("an unreachable Worker keeps the marker for the next boot", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    fetchMock.mockImplementation((input: unknown) =>
+      String(input) === `${WORKER_URL}/refresh`
+        ? Promise.reject(new TypeError("network down"))
+        : baseFetch(input),
+    );
+    const { restoreSession, isSignedIn } = await freshOAuth();
+
+    // This boot stays signed out — but a flaky-wifi boot says nothing about
+    // the cookie, so the marker survives and the NEXT boot retries instead of
+    // stranding a still-good session.
+    expect(await restoreSession()).toBeNull();
+    expect(isSignedIn()).toBe(false);
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(true);
+  });
+
+  test("a Worker 5xx (GitHub unreachable) keeps the marker too", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    refreshResponse = () => jsonResponse({ error: "github_unreachable" }, 502);
+    const { restoreSession } = await freshOAuth();
+
+    expect(await restoreSession()).toBeNull();
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(true);
+  });
+
+  test("a failed profile fetch still leaves the session signed in", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    refreshResponse = () =>
+      jsonResponse({ access_token: "gho_restored", refresh_token_cookie: true });
+    const { restoreSession, isSignedIn } = await freshOAuth();
+    // The token round trip succeeds, the cosmetic profile fetch does not.
+    fetchMock.mockImplementation((input: unknown) =>
+      String(input) === `${WORKER_URL}/refresh`
+        ? Promise.resolve(refreshResponse())
+        : Promise.reject(new Error("profile unavailable")),
+    );
+    // …the chip is nameless, the session is not thrown away (the same
+    // contract completeCallback's userPromise has).
+    expect(await restoreSession()).toBeNull();
+    expect(isSignedIn()).toBe(true);
+  });
+});
+
+describe("getValidToken (cookie-session refresh)", () => {
+  /** A signed-in cookie-mode session whose access token has already expired,
+   *  so the next getValidToken() must go through the cookie refresh. */
+  function seedExpiredCookieSession() {
+    session.map.set("rcv.oauth.token", "gho_expired");
+    session.map.set("rcv.oauth.tokenExpiresAt", String(Date.now() - 1000));
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+  }
+
+  test("a transient refresh failure answers null but keeps the session", async () => {
+    seedExpiredCookieSession();
+    refreshResponse = () => jsonResponse({ error: "github_unreachable" }, 502);
+    const { getValidToken, isSignedIn } = await freshOAuth();
+
+    expect(await getValidToken()).toBeNull();
+    // Not signed out: the cookie may be fine, and the next call retries.
+    // Crucially NO /logout went out — with a reachable Worker behind an
+    // unreachable GitHub it would burn the still-good cookie.
+    expect(isSignedIn()).toBe(true);
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(true);
+    expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(0);
+  });
+
+  test("a definitive rejection signs out: marker dropped, /logout fired", async () => {
+    seedExpiredCookieSession();
+    refreshResponse = () => jsonResponse({ error: "bad_refresh_token" }, 400);
+    const { getValidToken, isSignedIn } = await freshOAuth();
+
+    expect(await getValidToken()).toBeNull();
+    expect(isSignedIn()).toBe(false);
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(false);
+    expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(1);
+  });
+});
+
+describe("signOut", () => {
+  test("drops the marker and asks the Worker to clear the cookie", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    const { signOut } = await freshOAuth();
+    expect(() => signOut()).not.toThrow();
+
+    expect(local.map.has(COOKIE_SESSION_KEY)).toBe(false);
+    const [, init] = fetchCalls(`${WORKER_URL}/logout`)[0] ?? [];
+    expect(init?.method).toBe("POST");
+    expect(init?.credentials).toBe("include");
+  });
+
+  test("a failing /logout never surfaces (sign-out is synchronous and total)", async () => {
+    fetchMock.mockImplementation(() => Promise.reject(new Error("offline")));
+    const { signOut, isSignedIn } = await freshOAuth();
+    expect(() => signOut()).not.toThrow();
+    expect(isSignedIn()).toBe(false);
+  });
+});

--- a/packages/app/src/platform/oauth.ts
+++ b/packages/app/src/platform/oauth.ts
@@ -11,6 +11,15 @@
  * never a URL) so a reload inside the token lifetime does not force re-auth but
  * closing the tab clears them. GitHub Apps issue 8 h user tokens with a 6-month
  * refresh token; refreshing is a Worker round-trip.
+ *
+ * Roadmap 065 — a deployment may run the Worker in cookie mode, where the
+ * refresh token never reaches JS at all: it lives in an `HttpOnly` cookie the
+ * Worker sets, and the only thing this module persists across tabs is the
+ * non-secret {@link K.cookieSession} marker ("a cookie session exists until
+ * \<epoch ms\>"). Access tokens are unchanged. Everything below therefore has
+ * two shapes — with an in-JS refresh token (009, and any cookie-off
+ * deployment) and without one — and the mode is read from the Worker's own
+ * `refresh_token_cookie` flag, never assumed.
  */
 import {
   isHttpUrl,
@@ -21,7 +30,7 @@ import {
 // Roadmap 033: storage access goes through the safe wrappers — a
 // storage-disabled browser reads "signed out" (get → null) and writes are
 // no-ops, instead of a throw taking down whatever called into this module.
-import { sessionGet, sessionRemove, sessionSet } from "./storage";
+import { localGet, localRemove, localSet, sessionGet, sessionRemove, sessionSet } from "./storage";
 
 export interface OAuthConfig {
   clientId: string;
@@ -41,7 +50,7 @@ export const REVOKE_URL = "https://github.com/settings/apps/authorizations";
 const AUTHORIZE_URL = "https://github.com/login/oauth/authorize";
 const USER_API = "https://api.github.com/user";
 
-/** sessionStorage keys, all under the `rcv.oauth.*` prefix. */
+/** The `rcv.oauth.*` keys — sessionStorage, except {@link K.cookieSession}. */
 const K = {
   pending: "rcv.oauth.pending",
   token: "rcv.oauth.token",
@@ -49,7 +58,41 @@ const K = {
   refreshToken: "rcv.oauth.refreshToken",
   refreshTokenExpiresAt: "rcv.oauth.refreshTokenExpiresAt",
   user: "rcv.oauth.user",
+  /** Roadmap 065 — the ONE oauth key in localStorage, and the only oauth
+   *  state that outlives the tab. It holds no secret: just the refresh
+   *  horizon as epoch ms, so boot knows whether a silent cookie refresh is
+   *  worth a round trip. The token it refers to is in the `HttpOnly` cookie,
+   *  out of JS's reach entirely. */
+  cookieSession: "rcv.oauth.cookieSession",
 } as const;
+
+/**
+ * Roadmap 065 — the marker's horizon, or null when there is none. Validated
+ * like every other stored value (roadmap 030): a hand-edited/non-numeric
+ * value is dropped and read as absent, rather than poisoning every later
+ * boot with a NaN comparison.
+ */
+function readCookieSession(): number | null {
+  const raw = localGet(K.cookieSession);
+  if (raw === null) {
+    return null;
+  }
+  const horizon = Number(raw);
+  if (!Number.isFinite(horizon)) {
+    localRemove(K.cookieSession);
+    return null;
+  }
+  return horizon;
+}
+
+/** True while the marker says the cookie's refresh token is still good — the
+ *  only evidence in JS that a cookie session exists at all (the cookie itself
+ *  is `HttpOnly` and unreadable). An expired marker reads as "no session":
+ *  the refresh would fail anyway, and probing costs a round trip. */
+function hasLiveCookieSession(): boolean {
+  const horizon = readCookieSession();
+  return horizon !== null && Date.now() < horizon;
+}
 
 /**
  * The one validity rule, shared by both config sources: a client id AND a
@@ -227,22 +270,53 @@ interface TokenResponse {
   expires_in?: number;
   refresh_token?: string;
   refresh_token_expires_in?: number;
+  /** Roadmap 065 — set by a cookie-mode Worker: the refresh token is NOT in
+   *  this body, it is in the `HttpOnly` cookie the same response set. */
+  refresh_token_cookie?: boolean;
   token_type?: string;
   scope?: string;
   error?: string;
   error_description?: string;
 }
 
+/**
+ * A failed Worker round trip. `transient` says the failure MAY be a blip —
+ * a fetch rejection, a 5xx (the Worker itself couldn't reach GitHub), a
+ * malformed body — rather than a definitive 4xx rejection of the credentials
+ * that were sent. Callers must not destroy session state over a transient
+ * failure: dropping the cookie-session marker (or worse, signing out, which
+ * fires `/logout`) on a flaky boot would orphan — or actively burn — a
+ * still-good refresh cookie, the exact session roadmap 065 exists to keep.
+ */
+class WorkerError extends Error {
+  readonly transient: boolean;
+
+  constructor(message: string, transient: boolean) {
+    super(message);
+    this.transient = transient;
+  }
+}
+
 async function postWorker(path: string, body: unknown): Promise<TokenResponse> {
   const cfg = getOAuthConfig();
   if (!cfg) {
-    throw new Error("Sign-in is not configured.");
+    throw new WorkerError("Sign-in is not configured.", false);
   }
-  const res = await fetch(`${cfg.workerUrl}${path}`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${cfg.workerUrl}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      // Roadmap 065: the refresh cookie must ride along on every Worker call
+      // (it is what `/refresh` reads in cookie mode and what `/exchange` sets).
+      // Harmless when no cookie exists or the deployment is cookie-off, and the
+      // Worker always answers with `access-control-allow-credentials: true`.
+      credentials: "include",
+    });
+  } catch {
+    throw new WorkerError("Could not reach the sign-in service.", true);
+  }
   const raw: unknown = await res.json().catch(() => ({}));
   // Roadmap 030: the Worker's response is network input — a structurally
   // invalid body (wrong types, or an access_token that couldn't safely go
@@ -254,8 +328,12 @@ async function postWorker(path: string, body: unknown): Promise<TokenResponse> {
   const parsed = tokenResponseSchema.safeParse(raw);
   const data: TokenResponse = parsed.success ? parsed.data : {};
   if (!res.ok || data.error || !data.access_token) {
-    throw new Error(
+    throw new WorkerError(
       data.error_description || data.error || `Token exchange failed (HTTP ${res.status}).`,
+      // Only a 4xx is a definitive rejection of what was sent (the Worker
+      // passes GitHub's bad-grant errors through as 400); a 5xx or an
+      // OK-but-malformed body may well resolve on retry.
+      !(res.status >= 400 && res.status < 500),
     );
   }
   return data;
@@ -265,16 +343,30 @@ function applyTokenResponse(data: TokenResponse): void {
   const now = Date.now();
   const tokenExpiresAt =
     typeof data.expires_in === "number" ? now + data.expires_in * 1000 : Number.MAX_SAFE_INTEGER;
+  const refreshExpiresAt =
+    typeof data.refresh_token_expires_in === "number"
+      ? now + data.refresh_token_expires_in * 1000
+      : undefined;
   storeTokenState({
     // access_token presence is guaranteed by postWorker.
     token: data.access_token as string,
     tokenExpiresAt,
-    refreshToken: data.refresh_token,
-    refreshTokenExpiresAt:
-      typeof data.refresh_token_expires_in === "number"
-        ? now + data.refresh_token_expires_in * 1000
-        : undefined,
+    // Roadmap 065: in cookie mode there IS no refresh token to store — the
+    // Worker kept it in the cookie, which is the whole point (XSS can use the
+    // session while the page is open, but cannot exfiltrate the 6-month
+    // token). GitHub rotates on every refresh, so the Worker re-sets the
+    // cookie each time and the horizon below moves with it.
+    refreshToken: data.refresh_token_cookie ? undefined : data.refresh_token,
+    refreshTokenExpiresAt: refreshExpiresAt,
   });
+  if (data.refresh_token_cookie) {
+    localSet(K.cookieSession, String(refreshExpiresAt ?? Number.MAX_SAFE_INTEGER));
+  } else {
+    // Mode-switch hygiene: a deployment that turned cookie mode back off (or
+    // a 009 Worker answering a browser that still carries a marker) must not
+    // leave a marker behind promising a cookie session that nothing refreshes.
+    localRemove(K.cookieSession);
+  }
 }
 
 async function fetchUser(token: string): Promise<StoredUser> {
@@ -448,6 +540,66 @@ async function completeCallbackImpl(
   return { userPromise, returnHash: pending.returnHash ?? "" };
 }
 
+/**
+ * Roadmap 065 — the boot restore: turns a surviving `HttpOnly` refresh cookie
+ * back into a signed-in session, or resolves null (signed out, the 009
+ * fallback). Cheap when there is nothing to restore — an already-loaded token
+ * (a plain reload inside the access token's lifetime) and a missing/expired
+ * marker both answer without touching the network.
+ *
+ * The resolved user is the toolbar chip's, not the session: the profile fetch
+ * is cosmetic and its failure yields null, so {@link isSignedIn} may be true
+ * after this resolves even when the returned user is null — the same contract
+ * `completeCallback`'s `userPromise` has (a nameless chip beats a session
+ * thrown away over a cosmetic fetch).
+ *
+ * Single-flight, and this one MUST be: StrictMode double-mounts the effect
+ * that calls it, and GitHub ROTATES refresh tokens — a second concurrent
+ * `/refresh` would post the cookie the first one already burned and kill the
+ * session it was restoring. Same idiom as `callbackInFlight`, minus the key:
+ * there is only ever one session to restore, so every caller joins the one
+ * promise. Clearing it on completion is safe (and keeps the module from
+ * pinning a stale result forever): by then either a token is loaded, the
+ * marker is gone (both no-network branches), or the failure was transient —
+ * and a retry is exactly what a later caller should get then.
+ */
+let restoreInFlight: Promise<StoredUser | null> | null = null;
+
+export function restoreSession(): Promise<StoredUser | null> {
+  restoreInFlight ??= restoreSessionImpl().finally(() => {
+    restoreInFlight = null;
+  });
+  return restoreInFlight;
+}
+
+async function restoreSessionImpl(): Promise<StoredUser | null> {
+  if (currentToken()) {
+    return getStoredUser();
+  }
+  if (!hasLiveCookieSession()) {
+    return null;
+  }
+  let data: TokenResponse;
+  try {
+    // Empty body: the refresh token is the cookie `credentials: "include"`
+    // sends, and the SPA has no copy of it to offer.
+    data = await postWorker("/refresh", {});
+  } catch (err) {
+    // A definitive rejection (a 4xx: the cookie is gone, expired, or was
+    // already rotated away) drops the marker so later boots stop probing. A
+    // transient failure — an offline boot, a Worker/GitHub 5xx — keeps it:
+    // the cookie may be perfectly fine, and the next boot retrying instead of
+    // stranding it is the entire persistence promise of roadmap 065. Either
+    // way this boot stays signed out.
+    if (!(err instanceof WorkerError && err.transient)) {
+      localRemove(K.cookieSession);
+    }
+    return null;
+  }
+  applyTokenResponse(data);
+  return fetchUser(data.access_token as string).catch(() => null);
+}
+
 let refreshInFlight: Promise<string | null> | null = null;
 
 /**
@@ -466,18 +618,38 @@ export async function getValidToken(): Promise<string | null> {
   }
   const refreshExpired =
     typeof state.refreshTokenExpiresAt === "number" && Date.now() >= state.refreshTokenExpiresAt;
-  if (!state.refreshToken || refreshExpired) {
+  // Roadmap 065: no in-JS refresh token is not the end of the session any
+  // more — in cookie mode there never was one, and a live marker says the
+  // `HttpOnly` cookie still carries a good token, so the refresh goes out
+  // with an EMPTY body for the Worker to fill from the cookie. Without a
+  // marker (009, or an expired horizon) this is the unchanged signOut path.
+  const viaCookie = !state.refreshToken && hasLiveCookieSession();
+  if ((!state.refreshToken && !viaCookie) || refreshExpired) {
     signOut();
     return null;
   }
+  // Both paths share the ONE in-flight refresh: they are mutually exclusive
+  // per session, and a second concurrent cookie refresh would post the
+  // already-rotated (burned) cookie and kill the session it is renewing.
   if (!refreshInFlight) {
     refreshInFlight = (async () => {
       try {
-        const data = await postWorker("/refresh", { refresh_token: state.refreshToken });
+        const data = await postWorker(
+          "/refresh",
+          viaCookie ? {} : { refresh_token: state.refreshToken },
+        );
         applyTokenResponse(data);
         return currentToken()?.token ?? null;
-      } catch {
-        signOut();
+      } catch (err) {
+        // Same split as the boot restore: only a definitive 4xx ends the
+        // session. A transient failure answers null for THIS call (the
+        // caller acts unauthenticated once) but keeps the session so the
+        // next call retries — signOut() here would fire /logout, and with a
+        // reachable Worker behind an unreachable GitHub that would burn a
+        // still-good refresh cookie over a blip.
+        if (!(err instanceof WorkerError && err.transient)) {
+          signOut();
+        }
         return null;
       } finally {
         refreshInFlight = null;
@@ -490,11 +662,28 @@ export async function getValidToken(): Promise<string | null> {
 /**
  * Drops all `rcv.oauth.*` state. Revocation itself cannot be done from the
  * browser — the sign-out UI links to {@link REVOKE_URL} for true revocation.
+ *
+ * Roadmap 065: the refresh cookie has to die with the session too, and only
+ * the Worker can clear it — hence the fire-and-forget `POST /logout`. It is
+ * best-effort by design: this function is synchronous (every caller, down to
+ * `loadTokenState`'s corrupted-state path, relies on that) and must never
+ * throw, so a failed or blocked request costs nothing but the cookie's
+ * server-side lifetime, which the dropped marker already stops the app from
+ * using. `postWorker` is deliberately NOT reused: it expects a token JSON
+ * body and throws on anything that isn't one.
  */
 export function signOut(): void {
   memToken = null;
   memLoaded = true;
   for (const key of Object.values(K)) {
     sessionRemove(key);
+  }
+  // The one localStorage key: the loop above is a no-op for it.
+  localRemove(K.cookieSession);
+  const cfg = getOAuthConfig();
+  if (cfg) {
+    void fetch(`${cfg.workerUrl}/logout`, { method: "POST", credentials: "include" }).catch(
+      () => {},
+    );
   }
 }


### PR DESCRIPTION
## What

The app half of persistent sign-in (roadmap 065): closing the tab no longer signs the user out. Stacked on #146, which owns the worker protocol and the design doc; the refresh token never reaches JS, and the only thing the app persists across tabs is a non-secret marker.

## How

- Worker calls send `credentials: "include"`.
- A `refresh_token_cookie` response stores no refresh token; `localStorage` gets only `rcv.oauth.cookieSession` (the refresh horizon as epoch ms), validated like every stored value.
- Boot: signed out + live marker triggers one silent `/refresh` that restores the session. Single-flight (StrictMode double-mounts the effect, and GitHub rotation would burn the session), and ordered before the share-link decode so a private-preset auto-run sees the restored token.
- `getValidToken()` refreshes through the cookie when no in-JS refresh token exists; `signOut()` drops the marker and fires a best-effort `POST /logout`.
- Only a definitive 4xx destroys session state; a transient failure (offline boot, a 5xx) keeps the marker and session so the next attempt retries instead of stranding, or burning via `/logout`, a still-good cookie (ultrareview finding).
- `docs/Auth-Flow.md`: concise auth-flow doc with mermaid sequence diagrams.

## Compatibility

The mode is read per-response from the worker's `refresh_token_cookie` flag, never assumed: an old or cookie-off worker keeps this app on the 009 protocol unchanged, so merge order relative to #146 only matters for when the feature turns on, not for correctness.

## Testing

- app unit/render: 313/313 (cookie-session suite: marker validation, single-flight restore, transient-vs-definitive failure splits for both restore and `getValidToken`, signOut teardown)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)