### PR TITLE
build(deps): inline pnpm catalog versions into package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "build": "pnpm -r build"
   },
   "devDependencies": {
-    "oxfmt": "catalog:",
-    "oxlint": "catalog:",
-    "oxlint-tsgolint": "catalog:",
+    "oxfmt": "0.60.0",
+    "oxlint": "1.75.0",
+    "oxlint-tsgolint": "7.0.2001",
     "stylelint": "^17.14.1",
     "stylelint-declaration-strict-value": "^1.11.1",
     "stylelint-value-no-unknown-custom-properties": "^6.1.1",
-    "typescript": "catalog:"
+    "typescript": "7.0.2"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -24,7 +24,7 @@
     "react": "19.2.8",
     "react-diff-view": "3.3.3",
     "react-dom": "19.2.8",
-    "zod": "catalog:"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@playwright/test": "1.62.0",
@@ -36,8 +36,8 @@
     "@vitejs/plugin-react": "6.0.4",
     "jsdom": "30.0.1",
     "rollup-plugin-visualizer": "7.0.1",
-    "typescript": "catalog:",
-    "vite": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "7.0.2",
+    "vite": "8.1.5",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -22,8 +22,8 @@
     "renovate": "43.275.0"
   },
   "devDependencies": {
-    "typescript": "catalog:",
-    "vite": "catalog:",
-    "vitest": "catalog:"
+    "typescript": "7.0.2",
+    "vite": "8.1.5",
+    "vitest": "4.1.10"
   }
 }

--- a/packages/oauth-worker/package.json
+++ b/packages/oauth-worker/package.json
@@ -9,8 +9,8 @@
     "deploy": "wrangler deploy"
   },
   "devDependencies": {
-    "typescript": "catalog:",
-    "vitest": "catalog:",
+    "typescript": "7.0.2",
+    "vitest": "4.1.10",
     "wrangler": "4.115.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,30 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    oxfmt:
-      specifier: 0.60.0
-      version: 0.60.0
-    oxlint:
-      specifier: 1.75.0
-      version: 1.75.0
-    oxlint-tsgolint:
-      specifier: 7.0.2001
-      version: 7.0.2001
-    typescript:
-      specifier: 7.0.2
-      version: 7.0.2
-    vite:
-      specifier: 8.1.5
-      version: 8.1.5
-    vitest:
-      specifier: 4.1.10
-      version: 4.1.10
-    zod:
-      specifier: 4.4.3
-      version: 4.4.3
-
 patchedDependencies:
   codemirror-json-schema@0.8.1: cd887b4a6a4b99c759ce92bc254ab43ecc65d797bd6a53e55f71aaf567bbab47
 
@@ -36,13 +12,13 @@ importers:
   .:
     devDependencies:
       oxfmt:
-        specifier: 'catalog:'
+        specifier: 0.60.0
         version: 0.60.0
       oxlint:
-        specifier: 'catalog:'
+        specifier: 1.75.0
         version: 1.75.0(oxlint-tsgolint@7.0.2001)
       oxlint-tsgolint:
-        specifier: 'catalog:'
+        specifier: 7.0.2001
         version: 7.0.2001
       stylelint:
         specifier: ^17.14.1
@@ -54,7 +30,7 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(stylelint@17.14.1(supports-color@10.2.2)(typescript@7.0.2))
       typescript:
-        specifier: 'catalog:'
+        specifier: 7.0.2
         version: 7.0.2
 
   packages/app:
@@ -93,7 +69,7 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
       zod:
-        specifier: 'catalog:'
+        specifier: 4.4.3
         version: 4.4.3
     devDependencies:
       '@playwright/test':
@@ -124,13 +100,13 @@ importers:
         specifier: 7.0.1
         version: 7.0.1(rolldown@1.1.5)
       typescript:
-        specifier: 'catalog:'
+        specifier: 7.0.2
         version: 7.0.2
       vite:
-        specifier: 'catalog:'
+        specifier: 8.1.5
         version: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0)
       vitest:
-        specifier: 'catalog:'
+        specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/engine:
@@ -149,22 +125,22 @@ importers:
         version: 43.275.0(supports-color@10.2.2)(typanion@3.14.0)
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: 7.0.2
         version: 7.0.2
       vite:
-        specifier: 'catalog:'
+        specifier: 8.1.5
         version: 8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0)
       vitest:
-        specifier: 'catalog:'
+        specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))
 
   packages/oauth-worker:
     devDependencies:
       typescript:
-        specifier: 'catalog:'
+        specifier: 7.0.2
         version: 7.0.2
       vitest:
-        specifier: 'catalog:'
+        specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))
       wrangler:
         specifier: 4.115.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,15 +10,6 @@ allowBuilds:
   re2: false
   workerd: false
 
-catalog:
-  typescript: 7.0.2
-  oxlint: 1.75.0
-  oxlint-tsgolint: 7.0.2001
-  oxfmt: 0.60.0
-  vite: 8.1.5
-  vitest: 4.1.10
-  zod: 4.4.3
-
 ignoredBuiltDependencies:
   - core-js-pure
   - dtrace-provider


### PR DESCRIPTION
## Why

Renovate assigns `depType` based on which `package.json` section a dependency lives in; entries resolved through the pnpm catalog all surface as `pnpm.catalog` instead of `dependencies`/`devDependencies`, so packageRules matching on depType miss them.

## What

- Pin the 7 catalog versions (`typescript`, `oxlint`, `oxlint-tsgolint`, `oxfmt`, `vite`, `vitest`, `zod`) directly in the referencing `package.json` files
- Remove the `catalog:` block from `pnpm-workspace.yaml`
- Regenerated `pnpm-lock.yaml` — only specifier lines changed, resolved versions are byte-identical

## Verification

- `pnpm typecheck` and `pnpm lint` pass
- Lockfile diff contains no resolved-version changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)