### PR TITLE
ci: build docker images on native arm64 runners with a registry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,16 +225,10 @@ jobs:
   # `ubuntu-24.04-arm` is a native arm64 hosted runner, so nothing is emulated
   # any more and both architectures build in parallel instead of back to back.
   # Each job pushes an untagged, single-platform image and hands its digest to
-  # `docker-merge`, which stitches the tagged manifest list together.
   docker:
     needs: ci-result
     if: github.event_name == 'push'
     runs-on: ${{ matrix.runner }}
-    # Unchanged at 30 even though a native single-platform build is much cheaper
-    # than the emulated one: the timeout is here to cap the stall class that
-    # once left this job wedged for 90+ minutes, not to be tight. (The arm64
-    # runner is 4 vCPU like ubuntu-latest and free, this repo being public; in
-    # a private repo it would be 2 vCPU and the headroom would earn its keep.)
     timeout-minutes: 30
     permissions:
       contents: read
@@ -288,19 +282,7 @@ jobs:
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # push-by-digest uploads the image without a tag and returns its
-          # digest; `name-canonical` still records the repository so the blobs
-          # land in the right package.
           outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
-          # A registry cache rather than type=gha: the GitHub Actions cache is
-          # one 10 GB LRU budget shared with the pnpm store and the Playwright
-          # browsers in `checks`, and a mode=max export of the app image (whose
-          # build stage carries the whole workspace node_modules) is large
-          # enough to evict them. GHCR has no such budget, is readable from
-          # every branch rather than just the one that wrote it, and only
-          # uploads blobs it does not already hold. One ref per platform is
-          # mandatory, not tidiness: a shared ref would have each architecture
-          # overwrite the other's cache manifest.
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }}
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }},mode=max,image-manifest=true,oci-mediatypes=true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,11 +220,6 @@ jobs:
   # from a fork has no package-write token and an untagged PR image has no
   # consumer. The Dockerfile builds the app WITHOUT any VITE_* variables: these
   # images are configured at `docker run` time, not baked.
-  #
-  # One job per (image × platform), each on a runner of that architecture —
-  # `ubuntu-24.04-arm` is a native arm64 hosted runner, so nothing is emulated
-  # any more and both architectures build in parallel instead of back to back.
-  # Each job pushes an untagged, single-platform image and hands its digest to
   docker:
     needs: ci-result
     if: github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,23 +177,51 @@ jobs:
   # from a fork has no package-write token and an untagged PR image has no
   # consumer. The Dockerfile builds the app WITHOUT any VITE_* variables: these
   # images are configured at `docker run` time, not baked.
+  #
+  # One job per (image × platform), each on a runner of that architecture —
+  # `ubuntu-24.04-arm` is a native arm64 hosted runner, so nothing is emulated
+  # any more and both architectures build in parallel instead of back to back.
+  # Each job pushes an untagged, single-platform image and hands its digest to
+  # `docker-merge`, which stitches the tagged manifest list together.
   docker:
     needs: checks
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    # Normally 2–6 min; the spread is the emulated arm64 build reacting to
-    # buildkit cache hits. Generous headroom, but it caps the stall class that
-    # once left this job wedged for 90+ minutes inside the app image build.
+    runs-on: ${{ matrix.runner }}
+    # Unchanged at 30 even though a native single-platform build is much cheaper
+    # than the emulated one: arm64 hosted runners are 2 vCPU in a private repo
+    # (4 in a public one), so a cold-cache `pnpm install` + vite build there is
+    # the slow case to leave headroom for. The timeout is here to cap the stall
+    # class that once left this job wedged for 90+ minutes, not to be tight.
     timeout-minutes: 30
     permissions:
       contents: read
       packages: write
+    strategy:
+      # No fail-fast: a failure on one architecture should still show whether
+      # the other one is healthy — that difference is the whole diagnosis.
+      fail-fast: false
+      matrix:
+        target: [app, oauth-proxy]
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - target: app
+            image: ghcr.io/secustor/renovate-config-visualizer
+          - target: oauth-proxy
+            image: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy
     steps:
+      # `linux/amd64` is not usable in a cache tag or an artifact name.
+      - id: platform
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: echo "pair=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # arm64 is emulated; the app image's heavy work (pnpm install + the vite
-      # build) happens once per platform, so the gha cache below matters.
-      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      # No setup-qemu-action: every job builds only its own architecture.
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -202,42 +230,105 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: meta-app
+      # Only for the labels here — the tags are applied to the manifest list in
+      # `docker-merge`, since these builds push by digest and stay untagged.
+      - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/secustor/renovate-config-visualizer
+          images: ${{ matrix.image }}
+
+      - id: build
+        name: Build and push by digest
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # push-by-digest uploads the image without a tag and returns its
+          # digest; `name-canonical` still records the repository so the blobs
+          # land in the right package.
+          outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          # A registry cache rather than type=gha: the GitHub Actions cache is
+          # one 10 GB LRU budget shared with the pnpm store and the Playwright
+          # browsers in `checks`, and a mode=max export of the app image (whose
+          # build stage carries the whole workspace node_modules) is large
+          # enough to evict them. GHCR has no such budget, is readable from
+          # every branch rather than just the one that wrote it, and only
+          # uploads blobs it does not already hold. One ref per platform is
+          # mandatory, not tidiness: a shared ref would have each architecture
+          # overwrite the other's cache manifest.
+          cache-from: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }}
+          cache-to: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }},mode=max,image-manifest=true,oci-mediatypes=true
+
+      # An empty file named after the digest; the merge job globs the directory.
+      - name: Export the digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/digests"
+          touch "${RUNNER_TEMP}/digests/${DIGEST#sha256:}"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.target }}-${{ steps.platform.outputs.pair }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # The tagging half of `docker`: collects the per-platform digests of one image
+  # and publishes them as a single multi-platform manifest list. Cheap enough to
+  # run on amd64 — it moves no layers, only manifests.
+  docker-merge:
+    needs: docker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: app
+            image: ghcr.io/secustor/renovate-config-visualizer
+          - target: oauth-proxy
+            image: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.target }}-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ matrix.image }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=sha-,format=short
 
-      - id: meta-oauth-proxy
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy
-          tags: |
-            type=raw,value=latest
-            type=sha,prefix=sha-,format=short
+      - name: Create the manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
 
-      - name: Build and push the app image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          target: app
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta-app.outputs.tags }}
-          labels: ${{ steps.meta-app.outputs.labels }}
-          cache-from: type=gha,scope=app
-          cache-to: type=gha,scope=app,mode=max
-
-      - name: Build and push the oauth-proxy image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          target: oauth-proxy
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta-oauth-proxy.outputs.tags }}
-          labels: ${{ steps.meta-oauth-proxy.outputs.labels }}
-          cache-from: type=gha,scope=oauth-proxy
-          cache-to: type=gha,scope=oauth-proxy,mode=max
+      # Fails loudly if a platform is missing from the published list — the one
+      # failure mode of this split that a green build job would otherwise hide.
+      - name: Inspect the manifest
+        env:
+          REF: ${{ matrix.image }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect "$REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,10 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ${{ matrix.runner }}
     # Unchanged at 30 even though a native single-platform build is much cheaper
-    # than the emulated one: arm64 hosted runners are 2 vCPU in a private repo
-    # (4 in a public one), so a cold-cache `pnpm install` + vite build there is
-    # the slow case to leave headroom for. The timeout is here to cap the stall
-    # class that once left this job wedged for 90+ minutes, not to be tight.
+    # than the emulated one: the timeout is here to cap the stall class that
+    # once left this job wedged for 90+ minutes, not to be tight. (The arm64
+    # runner is 4 vCPU like ubuntu-latest and free, this repo being public; in
+    # a private repo it would be 2 vCPU and the headroom would earn its keep.)
     timeout-minutes: 30
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@
 # (/rcv-config.js, written by the entrypoint) — see docker/40-rcv-config.sh.
 
 # --- build -------------------------------------------------------------------
-FROM node:26.5.0-alpine AS build
+# Pinned to the BUILD platform, not the target one: this stage emits static
+# HTML/JS/CSS, which is byte-identical whatever architecture produced it. CI
+# builds each architecture on a runner of that architecture and never hits
+# this, but it keeps a local `docker build --platform linux/amd64,linux/arm64`
+# from running pnpm install and the vite build a second time under QEMU.
+FROM --platform=$BUILDPLATFORM node:26.5.0-alpine AS build
 WORKDIR /repo
 
 # Matches the root package.json `packageManager` field — kept in step by

--- a/roadmap/043-docker-self-host.md
+++ b/roadmap/043-docker-self-host.md
@@ -84,10 +84,14 @@ token-exchange proxy for deployments that want "Sign in with GitHub".
   as the `node` user; nothing is installed.
 - **`.dockerignore`, `docker-compose.yml`** — a lean context, and a two-service
   worked example with every optional variable present but commented.
-- **CI `docker` job** — `needs: checks`, push-only, `packages: write`; qemu +
-  buildx + ghcr login + two `metadata-action`/`build-push-action` pairs
-  publishing `linux/amd64,linux/arm64` for both targets with `latest` +
-  `sha-<short>` tags and per-target GHA layer caching.
+- **CI `docker` + `docker-merge` jobs** — `needs: checks`, push-only,
+  `packages: write`. `docker` is a (target × platform) matrix, `linux/amd64` on
+  `ubuntu-latest` and `linux/arm64` on the native `ubuntu-24.04-arm` runner —
+  no qemu, both architectures in parallel — each pushing its platform by digest
+  with a per-(target, platform) `type=registry` layer cache in GHCR
+  (`:buildcache-linux-<arch>`). `docker-merge` then joins the digests of one
+  target into the `latest` + `sha-<short>` manifest list with
+  `docker buildx imagetools create`, and inspects it.
 - **Docs** — a "Self-hosting (Docker)" section in the root README (quickstart,
   the `RCV_*` table, the sign-in story with the privacy boundary restated,
   compose, local build) and a note in the Worker README that the same handler


### PR DESCRIPTION
## What

The `docker` job built `linux/amd64,linux/arm64` for both images on one amd64 runner, so the arm64 half — including the app image's `pnpm install` and vite build — ran under QEMU, sequentially after amd64.

- **`docker` is now a (target × platform) matrix.** `linux/amd64` on `ubuntu-latest`, `linux/arm64` on the native [`ubuntu-24.04-arm`](https://github.blog/changelog/2026-01-29-arm64-standard-runners-are-now-available-in-private-repositories/) hosted runner. `setup-qemu-action` is gone; the four builds run in parallel.
- **Each build pushes by digest** (`push-by-digest=true`, untagged) and uploads the digest as an artifact.
- **New `docker-merge` job** joins one target's digests into the `latest` + `sha-<short>` manifest list via `docker buildx imagetools create`, then `imagetools inspect`s it — so a missing platform fails the run instead of shipping a half image.
- **Layer cache moves from `type=gha` to `type=registry`** in GHCR, one ref per (target, platform).
- **Dockerfile `build` stage pinned to `$BUILDPLATFORM`** — it emits static assets, identical whatever arch produced them, so a local multi-arch `docker build` no longer repeats it under QEMU. No-op in CI, where each arch already builds natively.

## Why a registry cache instead of `type=gha`

The Actions cache is a single 10 GB LRU budget for the whole repo, shared with the pnpm store and the Playwright browsers cached in `checks`. A `mode=max` export of the app image — whose build stage carries the entire workspace `node_modules` — is large enough to evict them. GHCR has no such budget, is readable from every branch rather than only the one that wrote it, and only uploads blobs it does not already hold.

One ref per platform is required, not tidiness: with a shared ref each architecture's builder overwrites the other's cache manifest ([moby/buildkit#2758](https://github.com/moby/buildkit/issues/2758)).

Side effect: two extra tags per package, `:buildcache-linux-amd64` and `:buildcache-linux-arm64`.

## Verification

Local only — the job is push-only, so the real proof is the first run on `main` after merge.

- Workflow YAML parses; matrix expansion simulated → 4 combos, each with the right `runner` and `image`.
- The `${PLATFORM//\//-}`, digest-export and `imagetools create` shell snippets dry-run to the expected commands.
- `docker buildx build --check --target app .` → "Check complete, no warnings found" with the `$BUILDPLATFORM` change.
- Roadmap 043 updated to describe the new job pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
