### PR TITLE
test(engine): raise shimmed project timeout to 30s

### DIFF
--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
         plugins: [renovateShims()],
         test: {
           name: "shimmed",
+          // the first test to resolve a large internal preset (e.g.
+          // config:recommended) pays the lazy vite-node transform+import of
+          // renovate's preset data modules — 4-6s on 2-core CI runners
+          testTimeout: 30_000,
           include: [
             "test/global-inherit.shimmed.test.ts",
             "test/pipeline.shimmed.test.ts",


### PR DESCRIPTION
## Why

CI has been flaking on `resolved-config.shimmed.test.ts` > "handles the renovatebot/.github shape…" with `Test timed out in 5000ms` (e.g. [this run](https://github.com/secustor/renovate-config-debugger/actions/runs/30700640893/job/91370964481) and the concurrent node.js-bump run — both unrelated toolchain-only PRs).

The test isn't hanging: it's the first test in its worker to resolve `config:recommended`, which lazily pulls renovate's internal preset data modules (monorepo groupings, replacements, workarounds) through the vite-node transform pipeline (`server.deps.inline: [/renovate/]`). On GitHub's 2-core runners that one-time per-worker cost is 4–6s — a green run 20 minutes before the failure showed the same test passing at 4311ms, ~700ms under vitest's 5s default.

## What

Set `testTimeout: 30_000` on the shimmed vitest project (mirrors the app render project's long timeout). Project-level rather than per-test because `pipeline.shimmed.test.ts`'s first test (3430ms) is drifting toward the same cliff. The cost is bounded module-graph import time and only grows with the pinned renovate package, so this is a durable fix.

Verified: `pnpm --filter @renovate-config-visualizer/engine test:shimmed` — 114/114 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)