### PR TITLE
docs(roadmap): simulator results readability — research + 3 mockup variants (053)

### DIFF
--- a/roadmap/053-simulator-results-readability.md
+++ b/roadmap/053-simulator-results-readability.md
@@ -1,0 +1,53 @@
+# 053 — Simulator: results readability
+
+Milestone: — · Status: proposed (2026-08-01) — mockup awaiting a variant
+decision
+
+Mockup (three variants):
+[mockups/053/simulator-results-readability.html](mockups/053/simulator-results-readability.html)
+
+Research basis (commissioned for this work):
+[2026-08-simulator-readability-research.md](2026-08-simulator-readability-research.md)
+— how DevTools, Compiler Explorer, rule/policy engines (Stripe Radar, IAM
+simulator, GCP Policy Troubleshooter, LaunchDarkly), CI systems, Terraform
+plan, and tracing UIs lay out dense rule-evaluation evidence.
+
+## Problem
+
+047 staged the simulator into ask / answer / evidence and the verdict is no
+longer buried — but the evidence layers themselves still overwhelm once
+opened (reported 2026-08-01, screenshot of the oxlint 1.75.0 → 1.76.0 run
+against 719 rules):
+
+- The same three facts (the changed settings) render at three grains —
+  verdict ledger, per-rule "applied" lists, step diffs — with nothing telling
+  the reader they are re-reading the same information.
+- The merge-step diff renders the whole ~10,700-line config to show three
+  changed keys; the Prev/Next/Jump controls compensate for the layout rather
+  than serve a task.
+- Both drawers open rebuilds the pre-047 wall: ~2,000 px of equal-weight
+  monospace, four vocabularies (code, prose, chip, link) per row, and
+  "3 of 719" stated four times.
+
+## Proposed variants (see mockup)
+
+- **A — the ledger is the trace.** Each changed setting on the verdict card
+  expands into its own causal thread: writing rule with predicate/evaluated
+  clause evidence inline, the overridden value struck through, a replay jump.
+  Rules/merge drawers demote to one "full trace" line. (DevTools
+  Computed-pane model.)
+- **B — inspector.** A persistent index rail (rules grouped
+  changed / matched-inert / 716-no-match, then replay stops) beside a single
+  detail pane; constant page height, rail selection shareable via the URL
+  fragment. (Compiler Explorer / Jaeger model.)
+- **C — lenses + digest diff.** The two drawers become three mutually
+  exclusive lenses (Matched rules · Build replay · Final config) and the step
+  diff defaults to a Terraform-style changed-keys digest with a counted
+  "unchanged hidden" row. Smallest delta from the shipped architecture.
+
+Shared fixes worth shipping under any variant: the digest diff, saying
+"3 of 719" once, demoting provenance chips to dots inside evidence layers,
+and naming the "matched but changed nothing" state.
+
+The variants compose; the mockup's suggested sequencing is C-then-A, with B
+reserved for a future audit mode.

--- a/roadmap/2026-08-simulator-readability-research.md
+++ b/roadmap/2026-08-simulator-readability-research.md
@@ -1,0 +1,166 @@
+# Simulator results readability — research report (2026-08-01)
+
+Commissioned for mockup 053 (Simulator results readability). The 2026-07
+progressive-disclosure research ([2026-07-progressive-disclosure-research.md](2026-07-progressive-disclosure-research.md))
+covered the *disclosure* literature and produced 047's three-layer staging
+(ask / answer / evidence). This report covers the next question: **how do
+established tools lay out the evidence itself** — dense rule-evaluation,
+trace, and config-diff data — once the user opens it. Compiled from primary
+product documentation; the condensed, decision-mapped version lives inside
+[mockups/053/simulator-results-readability.html](mockups/053/simulator-results-readability.html).
+
+## 1. Browser DevTools — the CSS cascade in two panes
+
+- **Styles pane (default)**: every matching rule in cascade order, overridden
+  declarations struck through inline — the "loser" marking needs no
+  interaction, but finding the winner means scanning the list.
+- **Computed pane (opt-in tab)**: only the *winning* value per property.
+  Expanding a property reveals the same cascade list, winner pinned on top,
+  each entry a jump-link to its source. Two panes answer two different
+  questions cheaply: *what is happening* (Computed) vs. *why* (Styles); users
+  default to Computed and escalate only when the answer surprises them.
+- A third state exists besides won/lost: valid-but-inert declarations (e.g.
+  `float` on a grid item) render dimmed with an ⓘ hover explaining why —
+  "lost the cascade" and "had no effect" are deliberately not conflated.
+- Firefox adds a per-property filter (funnel icon) that highlights every
+  occurrence of one property across all rules — "show me only this
+  property's history".
+  Source: https://developer.chrome.com/docs/devtools/css ·
+  https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/
+
+**Transplant.** Renovate's packageRules are a sequential override, not a
+specificity cascade, but "final value per key, expandable to the ordered list
+of writers with losers struck through" maps one-to-one onto the simulator's
+changed-settings ledger.
+
+## 2. Compiler Explorer (godbolt.org) — opt-in panes
+
+Default layout is exactly two panes (source, one compiler's output). Every
+further analysis surface — AST, IR, diff-against-another-compiler, execution
+— is added via an explicit "Add new…" menu and tiled/resized by the user
+(GoldenLayout). The whole workspace (open panes, layout, flags) is encoded in
+the URL, so a fully-configured deep-dive is one link away while the landing
+experience stays at two panes. Panes are *linked views*: selecting a source
+line highlights the matching output lines.
+Source: https://github.com/compiler-explorer/compiler-explorer/blob/main/docs/UsingCompilerExplorer.md
+
+**Transplant.** The complexity floor stays fixed (verdict only) while the
+ceiling is user-controlled; pane/layout state rides the app's existing
+URL-fragment share convention.
+
+## 3. Rule/policy engines — "why did this fire"
+
+- **Stripe Radar**: evaluation order (3DS → Allow → Block → Review, Block
+  short-circuits) is shown as a literal ordered list the user can reorder —
+  order is a visible artifact, not hidden state. A charge's risk insights give
+  the verdict plus contributing signals in plain language above the raw data.
+  Source: https://docs.stripe.com/radar/rules
+- **AWS IAM policy simulator**: headline is binary allowed/denied; below it,
+  per-statement explains (matched/not-matched action, resource, condition).
+  Community tooling labels which statements were *decisive* — the trace is
+  pre-filtered to the causally relevant subset, never an undifferentiated
+  statement dump.
+  Source: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html
+- **Google Cloud Policy Troubleshooter**: deny evaluates before allow and the
+  *order* is part of the explanation — a deny hit ends the story without
+  enumerating allow policies. Verdict is separated from the hierarchy-grouped
+  policy walk.
+  Source: https://cloud.google.com/policy-intelligence/docs/troubleshoot-access
+- **Skyhigh SWG rule tracing**: each matched criterion shows two parts — the
+  *predicate* (what the rule checks) and the *evaluated value* (what the
+  runtime value actually was). Skipped-at-group-level, evaluated-but-unmatched,
+  and matched are three distinct visual states; exactly one action per trace
+  gets the "this was decisive" color.
+- **LaunchDarkly evaluation reasons**: the result is `{value, reason}` with a
+  closed reason enum (`TARGET_MATCH`, `RULE_MATCH`, `FALLTHROUGH`, …); on
+  `RULE_MATCH` the reason carries the one rule index that matched — "why"
+  drills exactly one level, no scanning.
+  Source: https://launchdarkly.com/docs/sdk/concepts/evaluation-reasons
+
+**Common thread.** The verdict is always a small fixed-vocabulary value, and
+"why" is *structured, pre-computed, decisive-subset* data — never the full
+checked-rules list left for the viewer to sift.
+
+## 4. CI systems — severity-driven default expansion
+
+GitHub Actions and Buildkite both auto-expand **failed** steps and collapse
+everything else: the default disclosure state is a function of severity, not
+of order or type. GitHub's Step Summary is a curated markdown surface
+independent of the raw log; Buildkite keeps a persistent state-colored step
+sidebar, collapses chatty log subsections into labeled bars, and deep-links
+to single log lines. "Jump to next failure" navigates by severity, not by
+scroll position.
+Sources: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary ·
+https://buildkite.com/docs/pipelines/configure/managing-log-output
+
+**Transplant.** Matched rules render open, the ~716 non-matches collapse to
+one counted row; a merge step that changed nothing visually recedes.
+
+## 5. Cloudflare WAF security events — filter the list, group the detail
+
+The event list is filterable (action, rule source, path) *before* opening any
+event; the detail view is organized by "what produced this decision" (managed
+ruleset vs. custom rule vs. rate limit); the verbose payload is a separate
+opt-in layer even inside the detail view.
+Source: https://developers.cloudflare.com/waf/analytics/security-events/
+
+## 6. Terraform plan output — the config-diff analogue
+
+Per-attribute diff with `~` / `+` / `-` prefixes and inline `old -> new` for
+**changed attributes only**; unchanged attributes are explicitly elided with
+a count — `# (12 unchanged attributes hidden)` — never silently omitted and
+never fully listed. Terraform's own documented failure mode ("plan noise" /
+phantom diffs) shows the flip side: false-positive changed fields erode the
+trust that makes a digest diff scannable at all.
+Source: https://developer.hashicorp.com/terraform/cli/commands/plan
+
+**Transplant.** This is the closest existing analogue to "which settings the
+rules changed" and is worth adopting near-verbatim for the step diff: changed
+keys only, with a counted, clickable elision row for the rest.
+
+## 7. Tracing waterfalls (Jaeger) — sequence + one detail panel
+
+The root view is a compact waterfall, one bar per span, colored by status —
+"where did the interesting thing happen" before any click. Clicking a span
+opens a detail panel *beside* the waterfall; the waterfall never leaves the
+screen, acting as a persistent spatial index. Expand-all and per-span
+collapse both exist.
+Source: https://www.jaegertracing.io/docs/frontend-ui/
+
+**Transplant.** The merge replay (base → merges → flatten → final) is a
+sequence, not a set: a persistent compact timeline with a single detail pane
+beats N stacked full diffs. (046 already chose this shape; the remaining gap
+is the size of the diff inside the pane.)
+
+## 8. Named patterns (decision shorthand for the mockup)
+
+1. **Verdict/Computed split** — default view is the winning value per key;
+   the full audit trail is one explicit switch away. Fails only for users
+   whose primary task is auditing — keep a persistent, cheap entry point.
+2. **Decisive-subset pre-filtering** — label rules matched-and-decisive /
+   matched-but-overridden (or inert) / not-matched; collapse the third to a
+   count, expand the first by default.
+3. **Severity-driven default expansion** — open/closed state derives from
+   "did it change anything", never from position.
+4. **Opt-in panes over stacked sections** — evidence surfaces are added, not
+   pre-stacked; selection rides the URL fragment.
+5. **Typed, causally-ordered "why"** — state the merge order and
+   last-writer-wins per key explicitly; note per-key exceptions (array
+   concat) rather than letting a single framing mislead.
+6. **Predicate/evaluated two-part clause** — every matcher row shows what it
+   checks *and* the runtime value it saw (047's clause list already does
+   this; keep it — the persona study called it "the money shot").
+7. **Elided-but-acknowledged collapse** — every hidden set renders as a
+   counted "N hidden — show" row. Non-negotiable wherever 2/3 collapse.
+8. **Persistent spatial index + one detail panel** — for the replay
+   specifically; a "pin this step" affordance only if comparing non-adjacent
+   steps proves common.
+
+## Evidence caveat
+
+Quantitative UX data specific to dense technical-trace tools is thin in
+public sources; the citable numbers (NN/g's task-completion gains and 2-level
+cap) are from the general progressive-disclosure literature already compiled
+in the 2026-07 report. The per-tool patterns above are validated by longevity
+under heavy technical-user scrutiny (DevTools, Actions, Terraform: 5–10+
+years of iteration), not by published A/B data.

--- a/roadmap/mockups/053/simulator-results-readability.html
+++ b/roadmap/mockups/053/simulator-results-readability.html
@@ -1,0 +1,1763 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mockup 053 — Simulator results readability</title>
+    <style>
+      /* ---- app tokens, verbatim from packages/app/src/index.css ---- */
+      :root {
+        color-scheme: light dark;
+        font-family:
+          system-ui,
+          -apple-system,
+          sans-serif;
+        --border: light-dark(#d0d7de, #3d444d);
+        --surface: light-dark(#f6f8fa, #151b23);
+        --accent: light-dark(#0969da, #4493f8);
+        --ok: #1a7f37;
+        --error: #cf222e;
+        --warn: #9a6700;
+        --muted: light-dark(#59636e, #9198a1);
+        --preset: light-dark(#8250df, #c297ff);
+        --highlight: light-dark(#fffce0, #3b2f0b);
+        --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+        --ok-bg: color-mix(in srgb, var(--ok) 10%, var(--surface));
+        --error-bg: color-mix(in srgb, var(--error) 10%, var(--surface));
+        --diff-add: light-dark(#dafbe1, #12261e);
+        --diff-del: light-dark(#ffebe9, #2b1214);
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: light-dark(#ffffff, #0d1117);
+        color: light-dark(#1f2328, #f0f6fc);
+      }
+      main {
+        margin: 0 auto;
+        max-width: 62rem;
+        padding: 1.5rem 1rem 4rem;
+      }
+      h1 {
+        font-size: 1.5rem;
+        margin: 0 0 0.25rem;
+      }
+      h2 {
+        font-size: 1.05rem;
+        margin: 2.5rem 0 0.25rem;
+      }
+      h3 {
+        font-size: 0.95rem;
+        margin: 1.75rem 0 0.25rem;
+      }
+      h2 .num,
+      h3 .num {
+        color: var(--muted);
+        font-weight: 400;
+      }
+      .section-note {
+        color: var(--muted);
+        font-size: 0.9rem;
+        margin: 0.25rem 0 1rem;
+        max-width: 56rem;
+      }
+      .section-note code,
+      p code,
+      .research code,
+      li code,
+      td code {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        font-family: var(--mono);
+        font-size: 0.85em;
+        padding: 0.05em 0.3em;
+      }
+      .mock-banner {
+        background: light-dark(#fff8c5, #3a2d00);
+        border: 1px solid var(--warn);
+        border-radius: 8px;
+        font-size: 0.85rem;
+        margin-bottom: 1rem;
+        padding: 0.5rem 0.75rem;
+      }
+      .pane-label {
+        color: var(--muted);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin: 1rem 0 0.35rem;
+        text-transform: uppercase;
+      }
+      .pane-label.now {
+        color: var(--error);
+      }
+      .problem-list,
+      .tradeoff-list {
+        color: var(--muted);
+        font-size: 0.88rem;
+        margin: 0.35rem 0 1rem;
+        max-width: 56rem;
+        padding-left: 1.25rem;
+      }
+      .problem-list li,
+      .tradeoff-list li {
+        margin: 0.25rem 0;
+      }
+      .problem-list strong {
+        color: var(--error);
+        font-weight: 600;
+      }
+      .tradeoff-list .win {
+        color: var(--ok);
+        font-weight: 600;
+      }
+      .tradeoff-list .lose {
+        color: var(--error);
+        font-weight: 600;
+      }
+      button {
+        font: inherit;
+      }
+      :focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+
+      /* ---- app chrome ---- */
+      .card {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 1rem;
+        overflow: hidden;
+      }
+      .card-body {
+        padding: 0.75rem;
+      }
+      .badge {
+        border: 1px solid;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        line-height: 1.5;
+        padding: 0 0.5rem;
+        white-space: nowrap;
+      }
+      .badge.ok {
+        border-color: var(--ok);
+        color: var(--ok);
+      }
+      .badge.muted {
+        border-color: var(--border);
+        color: var(--muted);
+      }
+      .prov {
+        border: 1px solid var(--preset);
+        border-radius: 999px;
+        color: var(--preset);
+        font-family: var(--mono);
+        font-size: 0.68rem;
+        padding: 0 0.45rem;
+        white-space: nowrap;
+      }
+      .prov-dot {
+        background: var(--preset);
+        border-radius: 50%;
+        cursor: help;
+        display: inline-block;
+        height: 0.5rem;
+        vertical-align: baseline;
+        width: 0.5rem;
+      }
+      .linkish {
+        background: none;
+        border: none;
+        color: var(--accent);
+        cursor: pointer;
+        font-size: inherit;
+        padding: 0;
+        text-align: left;
+      }
+      code,
+      .mono {
+        font-family: var(--mono);
+      }
+
+      /* ---- verdict card (as shipped by 046/047, condensed) ---- */
+      .verdict {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 0.6rem;
+        padding: 0.75rem;
+      }
+      .verdict-eyebrow {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 0.7rem;
+        letter-spacing: 0.05em;
+        margin: 0 0 0.3rem;
+        text-transform: uppercase;
+      }
+      .verdict-sentence {
+        font-size: 1.05rem;
+        margin: 0 0 0.6rem;
+      }
+      .modal-verb {
+        border: 1px solid var(--ok);
+        border-radius: 6px;
+        color: var(--ok);
+        font-size: 0.8em;
+        font-weight: 700;
+        padding: 0.05em 0.4em;
+        text-transform: uppercase;
+      }
+      .verdict-ledger-label {
+        color: var(--muted);
+        font-size: 0.72rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin: 0 0 0.35rem;
+        text-transform: uppercase;
+      }
+      .verdict-keys {
+        font-size: 0.85rem;
+        list-style: none;
+        margin: 0 0 0.6rem;
+        padding: 0;
+      }
+      .verdict-keys > li {
+        margin: 0.25rem 0;
+      }
+      .verdict-foot {
+        align-items: center;
+        border-top: 1px solid var(--border);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        justify-content: space-between;
+        margin: 0.6rem -0.75rem 0;
+        padding: 0.6rem 0.75rem 0;
+      }
+      .verdict-foot .btn-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+      .btn {
+        align-items: center;
+        background: transparent;
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        color: inherit;
+        cursor: pointer;
+        display: inline-flex;
+        font-size: 0.8rem;
+        gap: 0.35rem;
+        padding: 0.25rem 0.6rem;
+        white-space: nowrap;
+      }
+      .value {
+        color: light-dark(#0a3069, #a5d6ff);
+        font-family: var(--mono);
+        font-size: 0.82rem;
+      }
+      .value.old {
+        color: var(--muted);
+        text-decoration: line-through;
+      }
+
+      /* ---- the "now" reproduction ---- */
+      .drawer {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        margin-bottom: 0.6rem;
+      }
+      .drawer > summary {
+        align-items: baseline;
+        cursor: pointer;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem 0.6rem;
+        list-style: none;
+        padding: 0.5rem 0.75rem;
+      }
+      .drawer > summary::-webkit-details-marker {
+        display: none;
+      }
+      .drawer > summary::before {
+        color: var(--muted);
+        content: "▸";
+        font-size: 0.8rem;
+      }
+      .drawer[open] > summary::before {
+        content: "▾";
+      }
+      .drawer-title {
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      .drawer-summary {
+        color: var(--muted);
+        font-size: 0.8rem;
+      }
+      .drawer-body {
+        border-top: 1px solid var(--border);
+        padding: 0.6rem 0.75rem;
+      }
+      .filter-row {
+        color: var(--muted);
+        display: flex;
+        flex-wrap: wrap;
+        font-size: 0.78rem;
+        gap: 0.75rem;
+        margin-bottom: 0.5rem;
+      }
+      .rule-row {
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        margin: 0.3rem 0;
+      }
+      .rule-head {
+        align-items: baseline;
+        background: none;
+        border: none;
+        color: inherit;
+        cursor: pointer;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        width: 100%;
+      }
+      .rule-head .idx {
+        font-family: var(--mono);
+        font-size: 0.8rem;
+      }
+      .rule-head .label {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 0.78rem;
+      }
+      .rule-detail {
+        border-top: 1px solid var(--border);
+        font-size: 0.82rem;
+        padding: 0.5rem 0.6rem;
+      }
+      .clauses {
+        list-style: none;
+        margin: 0 0 0.5rem;
+        padding: 0;
+      }
+      .clauses li {
+        margin: 0.2rem 0;
+      }
+      .clauses .ok-mark {
+        color: var(--ok);
+      }
+      .diff {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        line-height: 1.5;
+        margin: 0.4rem 0;
+        overflow-x: auto;
+        padding: 0.4rem 0;
+      }
+      .diff .ln {
+        color: var(--muted);
+        display: inline-block;
+        padding-right: 0.75rem;
+        text-align: right;
+        user-select: none;
+        width: 6.5em;
+      }
+      .diff .row {
+        padding: 0 0.6rem;
+        white-space: pre;
+      }
+      .diff .add {
+        background: var(--diff-add);
+      }
+      .diff .del {
+        background: var(--diff-del);
+      }
+      .diff-toolbar {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        font-size: 0.78rem;
+        gap: 0.5rem;
+        justify-content: flex-end;
+        margin: 0.4rem 0;
+      }
+      .timeline {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.3rem;
+        margin: 0.4rem 0 0.6rem;
+      }
+      .seq-chip {
+        align-items: center;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        cursor: pointer;
+        display: inline-flex;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        gap: 0.3rem;
+        padding: 0.15rem 0.6rem;
+      }
+      .seq-chip.selected {
+        border-color: var(--accent);
+        box-shadow: inset 0 0 0 1px var(--accent);
+      }
+      .seq-chip .delta {
+        color: var(--muted);
+      }
+      .seq-sep {
+        color: var(--muted);
+        font-size: 0.75rem;
+      }
+
+      /* ---- variant A: ledger threads ---- */
+      .thread {
+        border-radius: 6px;
+      }
+      .thread-head {
+        align-items: baseline;
+        background: none;
+        border: none;
+        border-radius: 6px;
+        color: inherit;
+        cursor: pointer;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.45rem;
+        padding: 0.3rem 0.4rem;
+        text-align: left;
+        width: 100%;
+      }
+      .thread-head:hover {
+        background: color-mix(in srgb, var(--accent) 7%, transparent);
+      }
+      .thread-head .caret {
+        color: var(--muted);
+        font-size: 0.75rem;
+      }
+      .thread-body {
+        border-left: 2px solid var(--border);
+        display: none;
+        font-size: 0.82rem;
+        margin: 0.15rem 0 0.4rem 0.95rem;
+        padding: 0.2rem 0 0.2rem 0.75rem;
+      }
+      .thread.open .thread-body {
+        display: block;
+      }
+      .thread-line {
+        color: var(--muted);
+        margin: 0.25rem 0;
+      }
+      .thread-line b {
+        color: light-dark(#1f2328, #f0f6fc);
+        font-weight: 600;
+      }
+      .thread-line .ok-mark {
+        color: var(--ok);
+      }
+      .trace-footer {
+        color: var(--muted);
+        font-size: 0.82rem;
+        margin: 0.75rem 0 0;
+      }
+
+      /* ---- variant B: inspector ---- */
+      .inspector {
+        display: grid;
+        gap: 0;
+        grid-template-columns: 16rem minmax(0, 1fr);
+      }
+      @media (max-width: 46rem) {
+        .inspector {
+          grid-template-columns: 1fr;
+        }
+        .rail {
+          border-bottom: 1px solid var(--border);
+          border-right: none;
+        }
+      }
+      .rail {
+        border-right: 1px solid var(--border);
+        padding: 0.5rem 0;
+      }
+      .rail-group {
+        color: var(--muted);
+        font-size: 0.68rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        margin: 0.6rem 0 0.15rem;
+        padding: 0 0.75rem;
+        text-transform: uppercase;
+      }
+      .rail-group:first-child {
+        margin-top: 0;
+      }
+      .rail-item {
+        align-items: baseline;
+        background: none;
+        border: none;
+        border-left: 2px solid transparent;
+        color: inherit;
+        cursor: pointer;
+        display: flex;
+        font-size: 0.8rem;
+        gap: 0.4rem;
+        padding: 0.25rem 0.75rem;
+        text-align: left;
+        width: 100%;
+      }
+      .rail-item:hover {
+        background: color-mix(in srgb, var(--accent) 7%, transparent);
+      }
+      .rail-item[aria-selected="true"] {
+        background: color-mix(in srgb, var(--accent) 10%, transparent);
+        border-left-color: var(--accent);
+      }
+      .rail-item .idx {
+        font-family: var(--mono);
+        font-size: 0.78rem;
+      }
+      .rail-item .hint {
+        color: var(--muted);
+        font-family: var(--mono);
+        font-size: 0.72rem;
+        margin-left: auto;
+      }
+      .rail-item.elided {
+        color: var(--muted);
+      }
+      .insp-pane {
+        display: none;
+        padding: 0.75rem;
+      }
+      .insp-pane.active {
+        display: block;
+      }
+      .insp-title {
+        align-items: baseline;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 0 0 0.5rem;
+      }
+      .insp-title .idx {
+        font-family: var(--mono);
+        font-size: 0.9rem;
+        font-weight: 600;
+      }
+      .clause-table {
+        border-collapse: collapse;
+        font-size: 0.8rem;
+        margin: 0.4rem 0 0.75rem;
+        width: 100%;
+      }
+      .clause-table th {
+        color: var(--muted);
+        font-size: 0.68rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        padding: 0.25rem 0.6rem 0.25rem 0;
+        text-align: left;
+        text-transform: uppercase;
+      }
+      .clause-table td {
+        border-top: 1px solid var(--border);
+        padding: 0.3rem 0.6rem 0.3rem 0;
+        vertical-align: top;
+      }
+      .applied-list {
+        font-size: 0.82rem;
+        list-style: none;
+        margin: 0.25rem 0 0.5rem;
+        padding: 0;
+      }
+      .applied-list li {
+        margin: 0.25rem 0;
+      }
+
+      /* ---- variant C: lenses + digest diff ---- */
+      .lens-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0;
+        margin-bottom: 0.6rem;
+      }
+      .lens {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-right-width: 0;
+        color: var(--muted);
+        cursor: pointer;
+        font-size: 0.8rem;
+        padding: 0.3rem 0.8rem;
+      }
+      .lens:first-child {
+        border-radius: 6px 0 0 6px;
+      }
+      .lens:last-child {
+        border-radius: 0 6px 6px 0;
+        border-right-width: 1px;
+      }
+      .lens[aria-selected="true"] {
+        background: light-dark(#ffffff, #0d1117);
+        color: inherit;
+        font-weight: 600;
+      }
+      .lens .count {
+        font-family: var(--mono);
+        font-size: 0.72rem;
+      }
+      .lens-pane {
+        display: none;
+      }
+      .lens-pane.active {
+        display: block;
+      }
+      .elide-row {
+        background: none;
+        border: 1px dashed var(--border);
+        border-radius: 6px;
+        color: var(--muted);
+        cursor: pointer;
+        display: block;
+        font-family: var(--mono);
+        font-size: 0.75rem;
+        margin: 0.4rem 0;
+        padding: 0.3rem 0.6rem;
+        text-align: left;
+        width: 100%;
+      }
+      .elide-row:hover {
+        color: var(--accent);
+      }
+      .digest {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        font-family: var(--mono);
+        font-size: 0.78rem;
+        line-height: 1.6;
+        margin: 0.4rem 0;
+        overflow-x: auto;
+        padding: 0.5rem 0.75rem;
+      }
+      .digest .k-del {
+        background: var(--diff-del);
+      }
+      .digest .k-add {
+        background: var(--diff-add);
+      }
+      .digest .sigil {
+        display: inline-block;
+        width: 1.2em;
+      }
+      .computed {
+        font-size: 0.84rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .computed > li {
+        border-top: 1px solid var(--border);
+        padding: 0.3rem 0.2rem;
+      }
+      .computed > li:first-child {
+        border-top: none;
+      }
+
+      /* ---- comparison table ---- */
+      .compare {
+        border-collapse: collapse;
+        font-size: 0.82rem;
+        margin: 0.5rem 0 1rem;
+        width: 100%;
+      }
+      .compare th,
+      .compare td {
+        border: 1px solid var(--border);
+        padding: 0.4rem 0.6rem;
+        text-align: left;
+        vertical-align: top;
+      }
+      .compare th {
+        background: var(--surface);
+        font-size: 0.78rem;
+      }
+      .compare td:first-child {
+        color: var(--muted);
+      }
+
+      /* research + notes */
+      .research {
+        border-top: 1px solid var(--border);
+        margin-top: 3rem;
+        padding-top: 1rem;
+      }
+      .research h2 {
+        margin-top: 0.5rem;
+      }
+      .research p,
+      .research li {
+        color: var(--muted);
+        font-size: 0.88rem;
+        max-width: 56rem;
+      }
+      .research strong {
+        color: light-dark(#1f2328, #f0f6fc);
+      }
+      .research cite {
+        font-style: normal;
+        opacity: 0.8;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Mockup 053 — Simulator results readability</h1>
+      <p class="section-note">
+        047 staged the simulator into ask / answer / evidence, and it worked — the verdict is never
+        buried. The remaining problem is <strong>inside the evidence</strong>: opening both drawers
+        rebuilds the pre-047 wall, the same three facts (the changed settings) repeat at three
+        grains (ledger, per-rule "applied" lists, step diffs), and the step diff renders the whole
+        10,698-line config to show three changed keys. This mock keeps 047's layers and proposes
+        three different architectures for the evidence itself. Research notes at the bottom; full
+        report in <code>roadmap/2026-08-simulator-readability-research.md</code>.
+      </p>
+      <div class="mock-banner">
+        Mockup — app tokens from <code>packages/app/src/index.css</code>. Ledger threads (variant
+        A), the inspector rail (variant B), and the lens bar + elision rows (variant C) are
+        interactive; the rest is static. Scenario, from the reported screenshot: npm
+        <code>oxlint</code> 1.75.0 → 1.76.0 (minor), 3 of 719 rules matched —
+        <code>packageRules[0]</code> matched but changed nothing, <code>[458]</code> set
+        <code>description</code> + <code>groupName</code>, <code>[522]</code> set
+        <code>prBodyColumns</code>.
+      </div>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">0 ·</span> Now — the evidence wall</h2>
+      <p class="section-note">
+        A faithful (condensed) reproduction of the results area with both drawers open, the state
+        the screenshot shows. The drawers themselves were the 047 fix; the trouble starts when the
+        user actually opens them.
+      </p>
+
+      <p class="pane-label now">Now — verdict, then two open drawers, ~2,000&nbsp;px of it</p>
+      <div class="card">
+        <div class="card-body">
+          <div class="verdict">
+            <p class="verdict-eyebrow">Simulation · npm / oxlint · 1.75.0 → 1.76.0</p>
+            <p class="verdict-sentence">
+              This minor update <span class="modal-verb">would</span> be grouped as “oxlint
+              monorepo”.
+            </p>
+            <p class="verdict-ledger-label">Changed by the rules — 3 settings</p>
+            <ul class="verdict-keys">
+              <li>
+                <code>description</code> = <span class="value">["Enable Renovate Dependency…</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+                <button type="button" class="linkish">step 2 of 3 →</button>
+              </li>
+              <li>
+                <code>groupName</code> = <span class="value">"oxlint monorepo"</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+                <button type="button" class="linkish">step 2 of 3 →</button>
+              </li>
+              <li>
+                <code>prBodyColumns</code> =
+                <span class="value">["Package","Change","Age","Confidence"]</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+                <button type="button" class="linkish">step 3 of 3 →</button>
+              </li>
+            </ul>
+            <div class="verdict-foot">
+              <button type="button" class="linkish">3 of 719 rules matched →</button>
+              <div class="btn-row">
+                <button type="button" class="btn">⧉ Copy link with this simulation</button>
+                <button type="button" class="btn">Pin result for comparison</button>
+              </div>
+            </div>
+          </div>
+
+          <details class="drawer" open>
+            <summary>
+              <span class="drawer-title">Matched rules</span>
+              <span class="drawer-summary">3 of 719 matched</span>
+              <span class="prov">local&gt;secustor/renovate-config</span>
+              <span class="drawer-summary">×3</span>
+            </summary>
+            <div class="drawer-body">
+              <div class="filter-row">
+                <span>3 of 719 rules shown</span>
+                <button type="button" class="linkish">my rules only</button>
+                <button type="button" class="linkish">show all 719</button>
+              </div>
+              <div class="rule-row">
+                <button type="button" class="rule-head">
+                  <span>▸</span><span class="idx">packageRules[0]</span>
+                  <span class="label">matchPackageNames</span>
+                  <span class="badge ok">matched</span>
+                  <span class="prov">local&gt;secustor/renovate-config</span>
+                </button>
+              </div>
+              <div class="rule-row">
+                <button type="button" class="rule-head">
+                  <span>▸</span><span class="idx">packageRules[458]</span>
+                  <span class="label">matchPackageNames + matchUpdateTypes</span>
+                  <span class="badge ok">matched</span>
+                  <span class="prov">local&gt;secustor/renovate-config</span>
+                </button>
+              </div>
+              <div class="rule-row">
+                <button type="button" class="rule-head">
+                  <span>▾</span><span class="idx">packageRules[522]</span>
+                  <span class="label">matchDatasources + matchUpdateTypes</span>
+                  <span class="badge ok">matched</span>
+                  <span class="prov">local&gt;secustor/renovate-config</span>
+                </button>
+                <div class="rule-detail">
+                  <ul class="clauses">
+                    <li>
+                      <span class="ok-mark">✓</span>
+                      <code>matchDatasources</code>:
+                      ["go","maven","npm","nuget","packagist","pypi","rubygems"] — matched
+                      (datasource = "npm")
+                    </li>
+                    <li>
+                      <span class="ok-mark">✓</span> <code>matchUpdateTypes</code>:
+                      ["patch","minor","major"] — matched (updateType = "minor")
+                    </li>
+                  </ul>
+                  <p class="verdict-ledger-label">
+                    Applied to the dependency config
+                    <button type="button" class="btn">⧉ Copy as markdown</button>
+                  </p>
+                  <p style="font-size: 0.82rem; margin: 0.25rem 0">
+                    <code>prBodyColumns</code>
+                    <span class="value old">["Package","Type","Update","Change","Pending"]</span> →
+                    <span class="value">["Package","Change","Age","Confidence"]</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <details class="drawer" open>
+            <summary>
+              <span class="drawer-title">How the final config was built</span>
+              <span class="drawer-summary"
+                >base → 3 merges → flatten ⊘7 → final · changed <code>description</code>,
+                <code>groupName</code>, <code>prBodyColumns</code></span
+              >
+            </summary>
+            <div class="drawer-body">
+              <div class="timeline">
+                <span class="seq-chip">○ base</span><span class="seq-sep">→</span>
+                <span class="seq-chip">● packageRules[0] <span class="delta">±0</span></span>
+                <span class="seq-sep">→</span>
+                <span class="seq-chip selected"
+                  >◆ packageRules[458] <span class="delta">+2</span></span
+                >
+                <span class="seq-sep">→</span>
+                <span class="seq-chip">◆ packageRules[522] <span class="delta">+1</span></span>
+                <span class="seq-sep">→</span> <span class="seq-chip">◆ flatten ⊘7</span>
+                <span class="seq-sep">→</span> <span class="seq-chip">final config</span>
+              </div>
+              <p style="font-size: 0.85rem; margin: 0.3rem 0">
+                Step 2 of 3 <code>packageRules[458]</code> matchPackageNames + matchUpdateTypes
+                <span class="prov">local&gt;secustor/renovate-config</span>
+              </p>
+              <p style="font-size: 0.85rem; margin: 0.3rem 0">
+                This rule set <code>description</code>, <code>groupName</code>.
+              </p>
+              <div class="diff-toolbar">
+                <span class="value">+3</span> <span class="value old">−2</span>
+                <button type="button" class="btn">Unified</button>
+                <button type="button" class="btn">Side-by-side</button>
+                <button type="button" class="btn">⧉ Copy result</button>
+              </div>
+              <div class="diff">
+                <div class="row"><span class="ln">79 79</span>"Provide a link to octochangelog…</div>
+                <div class="row"><span class="ln">80 80</span>"Update `_VERSION` variables in…</div>
+                <div class="row"><span class="ln">81 81</span>"Update `_VERSION` environment…</div>
+                <div class="row del">
+                  <span class="ln">82</span>"Convert pinned GitHub Action digests to SemVer."
+                </div>
+                <div class="row add">
+                  <span class="ln">82</span>"Convert pinned GitHub Action digests to SemVer.",
+                </div>
+                <div class="row add">
+                  <span class="ln">83</span>"Group packages from oxlint monorepo together."
+                </div>
+                <div class="row"><span class="ln">83 84</span>],</div>
+                <div class="row"><span class="ln">84 85</span>"enabled": true,</div>
+                <div class="row"><span class="ln">85 86</span>"constraintsFiltering": "none",</div>
+                <div class="row"><span class="ln">10692 10693</span>}</div>
+                <div class="row"><span class="ln">10693 10694</span>},</div>
+                <div class="row">
+                  <span class="ln">10694 10695</span>"hashedBranchLength": null,
+                </div>
+                <div class="row del"><span class="ln">10695</span>"groupName": null,</div>
+                <div class="row add">
+                  <span class="ln">10696</span>"groupName": "oxlint monorepo",
+                </div>
+                <div class="row"><span class="ln">10696 10697</span>"groupSlug": null,</div>
+              </div>
+              <div class="diff-toolbar" style="justify-content: flex-start">
+                <button type="button" class="btn">‹ Prev</button>
+                <button type="button" class="btn">Next ›</button>
+                <button type="button" class="btn">Jump to end</button>
+                <label style="font-size: 0.78rem"><input type="checkbox" /> Diff vs. base config</label>
+              </div>
+            </div>
+          </details>
+        </div>
+      </div>
+      <ul class="problem-list">
+        <li>
+          <strong>The same three facts render at three grains.</strong> <code>groupName</code>
+          appears in the ledger, in rule 458's "applied" list, and twice in the step diff — the
+          reader cannot tell whether scrolling reveals new information or the same fact again, so
+          they read all of it.
+        </li>
+        <li>
+          <strong>The diff is the whole config.</strong> Three changed keys inside 10,698 lines;
+          the line-number gutter (79&nbsp;…&nbsp;10696) is visually louder than the change itself.
+          Prev/Next/Jump controls exist to survive the layout, not to serve a task.
+        </li>
+        <li>
+          <strong>Open evidence rebuilds the wall.</strong> Both drawers open is ~2,000&nbsp;px of
+          equal-weight monospace; the verdict card and the raw trace compete at the same
+          typographic rank.
+        </li>
+        <li>
+          <strong>"3 of 719" is said four times</strong> — card title, verdict footer, drawer
+          summary, filter row — and each repeat costs a line of reading.
+        </li>
+        <li>
+          <strong>Four vocabularies per row.</strong> A ledger row mixes code, prose, a provenance
+          chip, and a step link inline at equal weight; nothing tells the eye what is skippable.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">1 ·</span> Variant A — the ledger <em>is</em> the trace</h2>
+      <p class="section-note">
+        DevTools' Computed-pane model: the winning value per key is the index, and expanding a key
+        reveals <em>that key's</em> causal thread — the rule that wrote it (with its clause
+        evidence inline), the value it overrode (struck through), and a jump into the replay. The
+        rules and merge drawers demote to one quiet "full trace" line for audit-style questions.
+        Slices the data by <strong>outcome</strong> instead of by mechanism, so each fact has
+        exactly one home.
+      </p>
+
+      <p class="pane-label">Variant A — expand a changed setting to see its story (interactive)</p>
+      <div class="card">
+        <div class="card-body">
+          <div class="verdict">
+            <p class="verdict-eyebrow">Simulation · npm / oxlint · 1.75.0 → 1.76.0</p>
+            <p class="verdict-sentence">
+              This minor update <span class="modal-verb">would</span> be grouped as “oxlint
+              monorepo”.
+            </p>
+            <p class="verdict-ledger-label">Changed by the rules — 3 settings · click one for why</p>
+            <ul class="verdict-keys">
+              <li class="thread">
+                <button type="button" class="thread-head" aria-expanded="false">
+                  <span class="caret">▸</span>
+                  <code>description</code>
+                  <span class="value">[…4 items, 1 added]</span>
+                  <span class="prov-dot" title="local>secustor/renovate-config"></span>
+                </button>
+                <div class="thread-body">
+                  <p class="thread-line">
+                    <b>appended by</b> <code>packageRules[458]</code>
+                    <span class="prov">local&gt;secustor/renovate-config</span> — arrays of
+                    <code>description</code> concatenate, they don't override
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchPackageNames</code> checks
+                    <span class="value">["oxlint","oxlint-tsgolint"]</span> · this update is
+                    <span class="value">"oxlint"</span>
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchUpdateTypes</code> checks
+                    <span class="value">["patch","minor"]</span> · this update is
+                    <span class="value">"minor"</span>
+                  </p>
+                  <p class="thread-line">
+                    <b>added</b> <span class="value">"Group packages from oxlint monorepo…"</span>
+                    · <button type="button" class="linkish">step 2 of 3 in the replay →</button>
+                  </p>
+                </div>
+              </li>
+              <li class="thread">
+                <button type="button" class="thread-head" aria-expanded="false">
+                  <span class="caret">▸</span>
+                  <code>groupName</code>
+                  <span class="value">"oxlint monorepo"</span>
+                  <span class="prov-dot" title="local>secustor/renovate-config"></span>
+                </button>
+                <div class="thread-body">
+                  <p class="thread-line">
+                    <b>set by</b> <code>packageRules[458]</code>
+                    <span class="prov">local&gt;secustor/renovate-config</span> — the last of 3
+                    matched rules to write it
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchPackageNames</code> checks
+                    <span class="value">["oxlint","oxlint-tsgolint"]</span> · this update is
+                    <span class="value">"oxlint"</span>
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchUpdateTypes</code> checks
+                    <span class="value">["patch","minor"]</span> · this update is
+                    <span class="value">"minor"</span>
+                  </p>
+                  <p class="thread-line">
+                    <b>overrode</b> <span class="value old">null</span>
+                    <span style="font-size: 0.78rem">(Renovate default)</span> ·
+                    <button type="button" class="linkish">step 2 of 3 in the replay →</button>
+                  </p>
+                </div>
+              </li>
+              <li class="thread">
+                <button type="button" class="thread-head" aria-expanded="false">
+                  <span class="caret">▸</span>
+                  <code>prBodyColumns</code>
+                  <span class="value">["Package","Change","Age","Confidence"]</span>
+                  <span class="prov-dot" title="local>secustor/renovate-config"></span>
+                </button>
+                <div class="thread-body">
+                  <p class="thread-line">
+                    <b>set by</b> <code>packageRules[522]</code>
+                    <span class="prov">local&gt;secustor/renovate-config</span>
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchDatasources</code> checks
+                    <span class="value">["go","maven","npm",…7]</span> · this update is
+                    <span class="value">"npm"</span>
+                  </p>
+                  <p class="thread-line">
+                    <span class="ok-mark">✓</span> <code>matchUpdateTypes</code> checks
+                    <span class="value">["patch","minor","major"]</span> · this update is
+                    <span class="value">"minor"</span>
+                  </p>
+                  <p class="thread-line">
+                    <b>overrode</b>
+                    <span class="value old">["Package","Type","Update","Change","Pending"]</span>
+                    <span style="font-size: 0.78rem">(Renovate default)</span> ·
+                    <button type="button" class="linkish">step 3 of 3 in the replay →</button>
+                  </p>
+                </div>
+              </li>
+            </ul>
+            <div class="verdict-foot">
+              <span class="drawer-summary"
+                >Full trace: <button type="button" class="linkish">3 of 719 rules matched</button>
+                · <button type="button" class="linkish">build replay, 5 steps</button> —
+                <code>packageRules[0]</code> matched but changed nothing</span
+              >
+              <div class="btn-row">
+                <button type="button" class="btn">⧉ Copy link</button>
+                <button type="button" class="btn">Pin for comparison</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <ul class="tradeoff-list">
+        <li>
+          <span class="win">Wins:</span> "why is <code>groupName</code> set?" — the single most
+          common question — is answered in one click with zero duplication; the clause evidence
+          (the persona study's "money shot") moves <em>closer</em>, not further; nothing below the
+          verdict card exists until asked for, so the page never grows past one card.
+        </li>
+        <li>
+          <span class="win">Wins:</span> merge semantics are stated per key where they differ —
+          the <code>description</code> thread says "arrays concatenate" instead of letting a
+          last-writer-wins framing mislead (research pattern 5).
+        </li>
+        <li>
+          <span class="lose">Costs:</span> rule-centric questions ("why did
+          <code>packageRules[522]</code> match?", "which rule <em>almost</em> matched?") take two
+          hops via the demoted full-trace line; the inert rule [0] only gets a footnote.
+        </li>
+        <li>
+          <span class="lose">Costs:</span> threads repeat the clause pair per key when one rule
+          wrote several keys (458 appears twice above) — cheap for 3 settings, noisy for 15.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">2 ·</span> Variant B — inspector: index left, one detail at a time</h2>
+      <p class="section-note">
+        The Compiler-Explorer / Jaeger model: a persistent index rail (matched rules grouped by
+        consequence, then the replay stops) beside a single detail pane. Selecting anything swaps
+        the pane — the page height is constant no matter how much the user investigates. The rail
+        pre-filters to the decisive subset: rules that changed something, rules that matched but
+        changed nothing, and one counted row for the 716 that did not match.
+      </p>
+
+      <p class="pane-label">Variant B — click the rail to inspect (interactive)</p>
+      <div class="card">
+        <div class="card-body">
+          <div class="verdict" style="margin-bottom: 0.75rem">
+            <p class="verdict-eyebrow">Simulation · npm / oxlint · 1.75.0 → 1.76.0</p>
+            <p class="verdict-sentence">
+              This minor update <span class="modal-verb">would</span> be grouped as “oxlint
+              monorepo” — 3 settings changed, by 2 of the 3 matching rules.
+            </p>
+          </div>
+        </div>
+        <div class="inspector">
+          <nav class="rail" aria-label="Evidence index">
+            <p class="rail-group">Matched — changed settings</p>
+            <button type="button" class="rail-item" data-pane="pane-458" aria-selected="true">
+              <span class="idx">packageRules[458]</span><span class="hint">+2</span>
+            </button>
+            <button type="button" class="rail-item" data-pane="pane-522" aria-selected="false">
+              <span class="idx">packageRules[522]</span><span class="hint">+1</span>
+            </button>
+            <p class="rail-group">Matched — changed nothing</p>
+            <button type="button" class="rail-item" data-pane="pane-0" aria-selected="false">
+              <span class="idx">packageRules[0]</span><span class="hint">±0</span>
+            </button>
+            <p class="rail-group">Everything else</p>
+            <button type="button" class="rail-item elided" data-pane="pane-rest" aria-selected="false">
+              716 rules did not match…
+            </button>
+            <p class="rail-group">Build replay</p>
+            <button type="button" class="rail-item" data-pane="pane-step2" aria-selected="false">
+              <span class="idx">step 2 · [458] merges</span><span class="hint">+2</span>
+            </button>
+            <button type="button" class="rail-item" data-pane="pane-step4" aria-selected="false">
+              <span class="idx">step 4 · flatten</span><span class="hint">⊘7</span>
+            </button>
+            <button type="button" class="rail-item" data-pane="pane-final" aria-selected="false">
+              <span class="idx">final config</span>
+            </button>
+          </nav>
+          <div>
+            <section class="insp-pane active" id="pane-458">
+              <p class="insp-title">
+                <span class="idx">packageRules[458]</span>
+                <span class="badge ok">matched</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+              </p>
+              <table class="clause-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Matcher</th>
+                    <th scope="col">Checks for</th>
+                    <th scope="col">This update</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>matchPackageNames</code></td>
+                    <td class="mono">["oxlint","oxlint-tsgolint"]</td>
+                    <td><span class="ok-mark mono" style="color: var(--ok)">✓ "oxlint"</span></td>
+                  </tr>
+                  <tr>
+                    <td><code>matchUpdateTypes</code></td>
+                    <td class="mono">["patch","minor"]</td>
+                    <td><span class="mono" style="color: var(--ok)">✓ "minor"</span></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="verdict-ledger-label">Applied — 2 settings</p>
+              <ul class="applied-list">
+                <li>
+                  <code>groupName</code> <span class="value old">null</span> →
+                  <span class="value">"oxlint monorepo"</span>
+                </li>
+                <li>
+                  <code>description</code> <span class="value">+ "Group packages from oxlint…"</span>
+                  <span style="color: var(--muted); font-size: 0.78rem">(arrays concatenate)</span>
+                </li>
+              </ul>
+              <button type="button" class="btn">⧉ Copy as markdown</button>
+            </section>
+            <section class="insp-pane" id="pane-522">
+              <p class="insp-title">
+                <span class="idx">packageRules[522]</span>
+                <span class="badge ok">matched</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+              </p>
+              <table class="clause-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Matcher</th>
+                    <th scope="col">Checks for</th>
+                    <th scope="col">This update</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>matchDatasources</code></td>
+                    <td class="mono">["go","maven","npm","nuget","packagist","pypi","rubygems"]</td>
+                    <td><span class="mono" style="color: var(--ok)">✓ "npm"</span></td>
+                  </tr>
+                  <tr>
+                    <td><code>matchUpdateTypes</code></td>
+                    <td class="mono">["patch","minor","major"]</td>
+                    <td><span class="mono" style="color: var(--ok)">✓ "minor"</span></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="verdict-ledger-label">Applied — 1 setting</p>
+              <ul class="applied-list">
+                <li>
+                  <code>prBodyColumns</code>
+                  <span class="value old">["Package","Type","Update","Change","Pending"]</span> →
+                  <span class="value">["Package","Change","Age","Confidence"]</span>
+                </li>
+              </ul>
+              <button type="button" class="btn">⧉ Copy as markdown</button>
+            </section>
+            <section class="insp-pane" id="pane-0">
+              <p class="insp-title">
+                <span class="idx">packageRules[0]</span>
+                <span class="badge ok">matched</span>
+                <span class="badge muted">changed nothing</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+              </p>
+              <table class="clause-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Matcher</th>
+                    <th scope="col">Checks for</th>
+                    <th scope="col">This update</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td><code>matchPackageNames</code></td>
+                    <td class="mono">["*"]</td>
+                    <td><span class="mono" style="color: var(--ok)">✓ "oxlint"</span></td>
+                  </tr>
+                </tbody>
+              </table>
+              <p style="color: var(--muted); font-size: 0.82rem">
+                Every value this rule merges (<code>description</code>, <code>enabled</code>) was
+                already identical on the config — it participated, but nothing depended on it.
+              </p>
+            </section>
+            <section class="insp-pane" id="pane-rest">
+              <p class="insp-title"><span class="idx">716 rules did not match</span></p>
+              <p style="color: var(--muted); font-size: 0.82rem">
+                Filter by rule index, matcher, or source to inspect a near miss — the full list
+                never renders unfiltered.
+              </p>
+              <div class="filter-row" style="margin: 0.5rem 0">
+                <input
+                  type="search"
+                  placeholder="packageRules[12], matchConfidence, npm…"
+                  style="
+                    background: transparent;
+                    border: 1px solid var(--border);
+                    border-radius: 6px;
+                    color: inherit;
+                    font: inherit;
+                    font-size: 0.82rem;
+                    padding: 0.3rem 0.5rem;
+                    width: 100%;
+                  "
+                />
+              </div>
+              <p style="color: var(--muted); font-size: 0.82rem">
+                <button type="button" class="linkish">my rules only (1)</button> ·
+                <button type="button" class="linkish">closest misses first</button>
+              </p>
+            </section>
+            <section class="insp-pane" id="pane-step2">
+              <p class="insp-title">
+                <span class="idx">step 2 of 3 — packageRules[458] merges</span>
+                <span class="prov">local&gt;secustor/renovate-config</span>
+              </p>
+              <div class="digest">
+                <div><span class="sigil">~</span>description <span class="k-add">+ "Group packages from oxlint monorepo together."</span></div>
+                <div>
+                  <span class="sigil">~</span>groupName <span class="k-del">null</span> →
+                  <span class="k-add">"oxlint monorepo"</span>
+                </div>
+                <div style="color: var(--muted)"># 10,692 unchanged lines hidden</div>
+              </div>
+              <p style="color: var(--muted); font-size: 0.8rem">
+                <button type="button" class="linkish">open full unified diff</button> ·
+                <button type="button" class="linkish">diff vs. base config</button>
+              </p>
+            </section>
+            <section class="insp-pane" id="pane-step4">
+              <p class="insp-title"><span class="idx">step 4 — flatten update-type blocks</span></p>
+              <p style="color: var(--muted); font-size: 0.82rem">
+                Renovate deletes the 7 update-type blocks (<code>major</code>, <code>minor</code>,
+                …) after merging the one that applies. This run: the <code>minor</code> block was
+                empty, so flattening only removed — <span class="mono">⊘7</span>, nothing merged
+                up.
+              </p>
+            </section>
+            <section class="insp-pane" id="pane-final">
+              <p class="insp-title"><span class="idx">final dependency config</span></p>
+              <ul class="computed">
+                <li>
+                  <code>groupName</code> <span class="value">"oxlint monorepo"</span>
+                  <span class="prov-dot" title="packageRules[458]"></span>
+                </li>
+                <li>
+                  <code>prBodyColumns</code>
+                  <span class="value">["Package","Change","Age","Confidence"]</span>
+                  <span class="prov-dot" title="packageRules[522]"></span>
+                </li>
+                <li>
+                  <code>description</code> <span class="value">[…4 items]</span>
+                  <span class="prov-dot" title="packageRules[458] appended"></span>
+                </li>
+              </ul>
+              <button type="button" class="elide-row">Show 41 keys the rules didn't touch…</button>
+            </section>
+          </div>
+        </div>
+      </div>
+      <ul class="tradeoff-list">
+        <li>
+          <span class="win">Wins:</span> constant page height — investigating five things costs
+          zero scroll; the three-state grouping (changed / matched-inert / 716 no-match) answers
+          "what mattered" before any click (research pattern 2); scales to 719 rules because the
+          long tail is a search pane, not a list.
+        </li>
+        <li>
+          <span class="win">Wins:</span> rail selection can ride the share-link fragment the same
+          way <code>simStep</code> already does — a deep link to "look at rule 522" becomes
+          possible.
+        </li>
+        <li>
+          <span class="lose">Costs:</span> the biggest structural change (new two-column layout
+          inside an already-tabbed page); on narrow screens the rail stacks above the pane and the
+          height advantage shrinks; comparing two rules side-by-side needs a pin affordance later.
+        </li>
+        <li>
+          <span class="lose">Costs:</span> one detail at a time hides the rule list's gestalt —
+          "do several rules write <code>groupName</code>?" needs the rail hints (+2/+1) to carry
+          more weight than they visually do.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">3 ·</span> Variant C — one lens at a time + the digest diff</h2>
+      <p class="section-note">
+        The smallest structural change: keep 047's vertical flow, but the two drawers become three
+        mutually exclusive <strong>lenses</strong> (DevTools' Headers/Preview/Response model) — so
+        the wall can never rebuild itself — and the step diff becomes a Terraform-style
+        <strong>digest</strong>: changed keys only, with the elided remainder acknowledged as a
+        counted row. Matched rules render pre-expanded (severity-driven: they're the abnormal
+        ones); the 716 no-matches are one row.
+      </p>
+
+      <p class="pane-label">Variant C — switch lenses; expand elisions (interactive)</p>
+      <div class="card">
+        <div class="card-body">
+          <div class="verdict">
+            <p class="verdict-eyebrow">Simulation · npm / oxlint · 1.75.0 → 1.76.0</p>
+            <p class="verdict-sentence">
+              This minor update <span class="modal-verb">would</span> be grouped as “oxlint
+              monorepo”.
+            </p>
+            <p class="verdict-ledger-label">Changed by the rules — 3 settings</p>
+            <ul class="verdict-keys">
+              <li>
+                <code>description</code> <span class="value">[…4 items, 1 added]</span>
+                <span class="prov-dot" title="local>secustor/renovate-config"></span>
+              </li>
+              <li>
+                <code>groupName</code> <span class="value">"oxlint monorepo"</span>
+                <span class="prov-dot" title="local>secustor/renovate-config"></span>
+              </li>
+              <li>
+                <code>prBodyColumns</code>
+                <span class="value">["Package","Change","Age","Confidence"]</span>
+                <span class="prov-dot" title="local>secustor/renovate-config"></span>
+              </li>
+            </ul>
+          </div>
+
+          <div class="lens-bar" role="tablist" aria-label="Evidence lens">
+            <button type="button" class="lens" role="tab" aria-selected="true" data-lens="lens-rules">
+              Matched rules <span class="count">3 / 719</span>
+            </button>
+            <button type="button" class="lens" role="tab" aria-selected="false" data-lens="lens-build">
+              Build replay <span class="count">5 steps</span>
+            </button>
+            <button type="button" class="lens" role="tab" aria-selected="false" data-lens="lens-final">
+              Final config
+            </button>
+          </div>
+
+          <section class="lens-pane active" id="lens-rules" role="tabpanel">
+            <div class="rule-row">
+              <div class="rule-head" style="cursor: default">
+                <span class="idx">packageRules[458]</span>
+                <span class="label">matchPackageNames + matchUpdateTypes</span>
+                <span class="badge ok">matched</span>
+                <span class="prov-dot" title="local>secustor/renovate-config"></span>
+              </div>
+              <div class="rule-detail">
+                <ul class="clauses">
+                  <li>
+                    <span class="ok-mark">✓</span> <code>matchPackageNames</code> checks
+                    <span class="value">["oxlint","oxlint-tsgolint"]</span> — this update is
+                    <span class="value">"oxlint"</span>
+                  </li>
+                  <li>
+                    <span class="ok-mark">✓</span> <code>matchUpdateTypes</code> checks
+                    <span class="value">["patch","minor"]</span> — this update is
+                    <span class="value">"minor"</span>
+                  </li>
+                </ul>
+                <p style="font-size: 0.82rem; margin: 0.25rem 0">
+                  → sets <code>groupName</code>, appends to <code>description</code>
+                </p>
+              </div>
+            </div>
+            <div class="rule-row">
+              <div class="rule-head" style="cursor: default">
+                <span class="idx">packageRules[522]</span>
+                <span class="label">matchDatasources + matchUpdateTypes</span>
+                <span class="badge ok">matched</span>
+                <span class="prov-dot" title="local>secustor/renovate-config"></span>
+              </div>
+              <div class="rule-detail">
+                <ul class="clauses">
+                  <li>
+                    <span class="ok-mark">✓</span> <code>matchDatasources</code> checks
+                    <span class="value">["go","maven","npm",…7]</span> — this update is
+                    <span class="value">"npm"</span>
+                  </li>
+                  <li>
+                    <span class="ok-mark">✓</span> <code>matchUpdateTypes</code> checks
+                    <span class="value">["patch","minor","major"]</span> — this update is
+                    <span class="value">"minor"</span>
+                  </li>
+                </ul>
+                <p style="font-size: 0.82rem; margin: 0.25rem 0">
+                  → sets <code>prBodyColumns</code>
+                </p>
+              </div>
+            </div>
+            <button type="button" class="elide-row" data-toggle="inert-rule">
+              ▸ 1 rule matched but changed nothing — packageRules[0]
+            </button>
+            <div class="rule-row" id="inert-rule" hidden>
+              <div class="rule-head" style="cursor: default">
+                <span class="idx">packageRules[0]</span>
+                <span class="label">matchPackageNames</span>
+                <span class="badge ok">matched</span>
+                <span class="badge muted">changed nothing</span>
+              </div>
+            </div>
+            <button type="button" class="elide-row" data-toggle="nomatch-note">
+              ▸ 716 rules did not match — show with filters
+            </button>
+            <p id="nomatch-note" hidden style="color: var(--muted); font-size: 0.82rem">
+              (Real build: reveals the filter row — search, “my rules only”, per-matcher facets —
+              and a windowed list. Never renders 716 rows unfiltered.)
+            </p>
+          </section>
+
+          <section class="lens-pane" id="lens-build" role="tabpanel">
+            <div class="timeline">
+              <span class="seq-chip">○ base</span><span class="seq-sep">→</span>
+              <span class="seq-chip">● [0] <span class="delta">±0</span></span>
+              <span class="seq-sep">→</span>
+              <span class="seq-chip selected">◆ [458] <span class="delta">+2</span></span>
+              <span class="seq-sep">→</span>
+              <span class="seq-chip">◆ [522] <span class="delta">+1</span></span>
+              <span class="seq-sep">→</span> <span class="seq-chip">◆ flatten ⊘7</span>
+              <span class="seq-sep">→</span> <span class="seq-chip">final</span>
+            </div>
+            <p style="font-size: 0.85rem; margin: 0.3rem 0">
+              Step 2 of 3 — <code>packageRules[458]</code> merges
+              <span class="prov-dot" title="local>secustor/renovate-config"></span>
+            </p>
+            <div class="digest">
+              <div>
+                <span class="sigil">~</span>description
+                <span class="k-add">+ "Group packages from oxlint monorepo together."</span>
+              </div>
+              <div>
+                <span class="sigil">~</span>groupName <span class="k-del">null</span> →
+                <span class="k-add">"oxlint monorepo"</span>
+              </div>
+            </div>
+            <button type="button" class="elide-row" data-toggle="digest-context">
+              ▸ 10,692 unchanged lines hidden — show full unified diff
+            </button>
+            <div class="diff" id="digest-context" hidden>
+              <div class="row"><span class="ln">80</span>"Update `_VERSION` variables in…</div>
+              <div class="row"><span class="ln">81</span>"Update `_VERSION` environment…</div>
+              <div class="row del"><span class="ln">82</span>"Convert pinned GitHub Action digests…</div>
+              <div class="row add"><span class="ln">82</span>"Convert pinned GitHub Action digests…",</div>
+              <div class="row add"><span class="ln">83</span>"Group packages from oxlint monorepo…"</div>
+              <div class="row"><span class="ln">84</span>],</div>
+              <div class="row" style="color: var(--muted)"><span class="ln">⋯</span>(full diff, as today)</div>
+            </div>
+            <div class="diff-toolbar" style="justify-content: flex-start">
+              <button type="button" class="btn">‹ Prev step</button>
+              <button type="button" class="btn">Next step ›</button>
+              <label style="font-size: 0.78rem"><input type="checkbox" /> Diff vs. base config</label>
+            </div>
+          </section>
+
+          <section class="lens-pane" id="lens-final" role="tabpanel">
+            <p class="section-note" style="margin: 0.25rem 0 0.5rem">
+              The computed view — every key's winning value, its writer one hover away. What
+              Renovate would actually use for this update.
+            </p>
+            <ul class="computed">
+              <li>
+                <code>groupName</code> <span class="value">"oxlint monorepo"</span>
+                <span class="prov-dot" title="packageRules[458] · local>secustor/renovate-config"></span>
+              </li>
+              <li>
+                <code>prBodyColumns</code>
+                <span class="value">["Package","Change","Age","Confidence"]</span>
+                <span class="prov-dot" title="packageRules[522] · local>secustor/renovate-config"></span>
+              </li>
+              <li>
+                <code>description</code> <span class="value">[…4 items]</span>
+                <span class="prov-dot" title="packageRules[458] appended one item"></span>
+              </li>
+            </ul>
+            <button type="button" class="elide-row" data-toggle="final-rest">
+              ▸ 41 keys the rules didn't touch — show
+            </button>
+            <ul class="computed" id="final-rest" hidden>
+              <li><code>enabled</code> <span class="value">true</span></li>
+              <li><code>constraintsFiltering</code> <span class="value">"none"</span></li>
+              <li style="color: var(--muted)">⋯ (and 39 more, as today’s resolved view)</li>
+            </ul>
+          </section>
+        </div>
+      </div>
+      <ul class="tradeoff-list">
+        <li>
+          <span class="win">Wins:</span> cheapest to build — <code>SummaryDrawer</code> becomes a
+          lens bar, everything inside the panes is today's components; the wall is structurally
+          impossible (one lens at a time); the digest diff alone removes ~90% of the rendered
+          pixels in the screenshot's worst section and works in <em>every</em> variant.
+        </li>
+        <li>
+          <span class="win">Wins:</span> severity-driven defaults — matched rules arrive
+          pre-expanded, inert and unmatched arrive as counted rows (research patterns 3 + 7); the
+          filter machinery only renders once someone asks for the 716.
+        </li>
+        <li>
+          <span class="lose">Costs:</span> lenses hide siblings — cross-referencing a rule's
+          clauses against a build step means switching back and forth (drawers allowed both open;
+          nobody could read the result, but it was possible); lens state needs the same share-link
+          treatment <code>simStep</code> got.
+        </li>
+        <li>
+          <span class="lose">Costs:</span> "Final config" duplicates part of 051's resolved-config
+          output — needs a clear "this is per-dependency, that is repo-wide" boundary or one of
+          the two should absorb the other.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">4 ·</span> Shared fixes — worth shipping under any variant</h2>
+      <ul class="problem-list" style="color: inherit">
+        <li>
+          <strong style="color: var(--ok)">Digest diff.</strong> The step diff defaults to changed
+          keys only (<code>~ / + / −</code>, old → new inline) with
+          <code># N unchanged lines hidden — show</code>; the full unified/side-by-side diff stays
+          one click away. (Terraform's battle-tested shape for exactly this data.)
+        </li>
+        <li>
+          <strong style="color: var(--ok)">Say "3 of 719" once.</strong> The verdict owns the
+          count; drawers/lenses/rails reference it without restating it.
+        </li>
+        <li>
+          <strong style="color: var(--ok)">Demote chips in evidence.</strong> Full provenance chips
+          stay on the verdict card; inside evidence layers the same fact is a colored dot with the
+          chip on hover — all three matched rules sharing one source was worth 3 chips ×
+          28 characters in the screenshot.
+        </li>
+        <li>
+          <strong style="color: var(--ok)">Name the inert state.</strong> "Matched but changed
+          nothing" (rule [0], ±0) is today only visible as a timeline delta; every variant above
+          labels it, because an unexplained matched-rule-with-no-effect reads as a bug.
+        </li>
+      </ul>
+
+      <!-- ============================================================ -->
+      <h2><span class="num">5 ·</span> How the variants answer the actual questions</h2>
+      <table class="compare">
+        <thead>
+          <tr>
+            <th scope="col">Question</th>
+            <th scope="col">A — ledger threads</th>
+            <th scope="col">B — inspector</th>
+            <th scope="col">C — lenses</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>“Why is <code>groupName</code> set?”</td>
+            <td>1 click, inline</td>
+            <td>2 clicks (rail → rule)</td>
+            <td>1–2 clicks (rules lens)</td>
+          </tr>
+          <tr>
+            <td>“Why did rule 522 match?”</td>
+            <td>2 hops (full-trace line)</td>
+            <td>1 click, richest view</td>
+            <td>0 clicks (pre-expanded)</td>
+          </tr>
+          <tr>
+            <td>“What almost matched?” (719-rule audit)</td>
+            <td>unchanged from today</td>
+            <td>best — search pane, never a list</td>
+            <td>counted row → filters</td>
+          </tr>
+          <tr>
+            <td>Max page height while investigating</td>
+            <td>one card</td>
+            <td>constant (pane swaps)</td>
+            <td>one lens</td>
+          </tr>
+          <tr>
+            <td>Change from the shipped 047 architecture</td>
+            <td>medium — ledger grows threads; drawers demote</td>
+            <td>large — new split layout + rail state</td>
+            <td>small — drawers → lenses; diff → digest</td>
+          </tr>
+          <tr>
+            <td>Mobile (~46&nbsp;rem breakpoint)</td>
+            <td>unchanged, best</td>
+            <td>rail stacks; advantage shrinks</td>
+            <td>lens bar wraps; fine</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="section-note">
+        The variants compose: C's digest diff and elision rows are prerequisites for A and B
+        anyway (shared fixes above), and A's threads could later sit on top of either. A plausible
+        sequencing is <strong>C-then-A</strong> (ship the cheap structural fix, then grow the
+        ledger into the primary trace) with B reserved for a future "audit mode" if the 719-rule
+        population demands it.
+      </p>
+
+      <!-- ============================================================ -->
+      <div class="research">
+        <h2>Research notes (condensed)</h2>
+        <ul>
+          <li>
+            <strong>Two views, two questions.</strong> DevTools separates "what is the value"
+            (Computed pane: winner only, expandable to the ordered cascade with losers struck
+            through and jump-links to source) from "why" (Styles pane) — users default to the
+            cheap answer and escalate on surprise. Variant A is this transplanted to a sequential
+            last-writer-wins merge. <cite>developer.chrome.com/docs/devtools/css</cite>
+          </li>
+          <li>
+            <strong>Decisive subset, never a dump.</strong> IAM policy simulator, GCP Policy
+            Troubleshooter, Skyhigh rule tracing and LaunchDarkly evaluation reasons all
+            pre-compute which rules were causally relevant (typed reason codes, decisive-statement
+            labels, three visual states for matched / evaluated-unmatched / skipped) — the viewer
+            never infers relevance from a flat list. Variant B's rail grouping and the
+            "matched but changed nothing" badge.
+            <cite>docs.aws.amazon.com · cloud.google.com/policy-intelligence ·
+              launchdarkly.com/docs</cite>
+          </li>
+          <li>
+            <strong>Severity-driven expansion.</strong> GitHub Actions / Buildkite auto-expand
+            only failed steps; default disclosure state derives from "is this abnormal", never
+            from position. Variant C pre-expands the 3 matched rules and collapses the 716
+            no-matches to a counted row.
+            <cite>docs.github.com · buildkite.com/docs</cite>
+          </li>
+          <li>
+            <strong>Elided-but-acknowledged.</strong> Terraform's
+            <code># (12 unchanged attributes hidden)</code> — collapse must render as a counted
+            placeholder, or trust dies; and false-positive "changes" (plan noise) destroy diff
+            scannability, so the digest must be precise about what genuinely changed. The digest
+            diff everywhere above. <cite>developer.hashicorp.com/terraform</cite>
+          </li>
+          <li>
+            <strong>Sequence ⇒ index + one detail pane.</strong> Jaeger keeps the waterfall
+            persistent as a spatial index with a single drill-down panel beside it; Compiler
+            Explorer keeps the floor at two panes and makes depth opt-in with the whole layout in
+            the URL — matching the app's fragment-only share convention.
+            <cite>jaegertracing.io · github.com/compiler-explorer</cite>
+          </li>
+          <li>
+            <strong>Constraints carried over from 047's research:</strong> never gate the verdict;
+            two disclosure levels max; every collapsed header keeps a computed count/preview; and
+            the per-clause predicate-vs-evaluated evidence stays one interaction away — the
+            persona study called it "the single most convincing screen".
+            <cite>roadmap/2026-07-progressive-disclosure-research.md ·
+              roadmap/2026-07-persona-ux-study.md</cite>
+          </li>
+        </ul>
+      </div>
+    </main>
+
+    <script>
+      // Variant A — ledger threads
+      for (const head of document.querySelectorAll(".thread-head")) {
+        head.addEventListener("click", () => {
+          const li = head.closest(".thread");
+          const open = li.classList.toggle("open");
+          head.setAttribute("aria-expanded", String(open));
+          head.querySelector(".caret").textContent = open ? "▾" : "▸";
+        });
+      }
+      // Variant B — inspector rail
+      const rail = document.querySelectorAll(".rail-item");
+      for (const item of rail) {
+        item.addEventListener("click", () => {
+          for (const other of rail) other.setAttribute("aria-selected", "false");
+          item.setAttribute("aria-selected", "true");
+          for (const pane of document.querySelectorAll(".insp-pane")) {
+            pane.classList.toggle("active", pane.id === item.dataset.pane);
+          }
+        });
+      }
+      // Variant C — lens bar + elision toggles
+      const lenses = document.querySelectorAll(".lens");
+      for (const lens of lenses) {
+        lens.addEventListener("click", () => {
+          for (const other of lenses) other.setAttribute("aria-selected", "false");
+          lens.setAttribute("aria-selected", "true");
+          for (const pane of document.querySelectorAll(".lens-pane")) {
+            pane.classList.toggle("active", pane.id === lens.dataset.lens);
+          }
+        });
+      }
+      for (const btn of document.querySelectorAll("[data-toggle]")) {
+        btn.addEventListener("click", () => {
+          const target = document.getElementById(btn.dataset.toggle);
+          target.hidden = !target.hidden;
+          btn.textContent = btn.textContent.replace(target.hidden ? "▾" : "▸", target.hidden ? "▸" : "▾");
+        });
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What

The simulator's results area still overwhelms once the 047 evidence drawers are opened: the three changed settings repeat at three different grains (verdict ledger, per-rule "applied" lists, step diffs), the step diff renders the whole ~10,700-line config to show three changed keys, and both drawers open is a ~2,000 px wall of equal-weight monospace.

This PR is **design work only** — no app code changes:

- `roadmap/2026-08-simulator-readability-research.md` — commissioned research on how established tools lay out dense rule-evaluation evidence: DevTools CSS cascade (Computed vs. Styles), Compiler Explorer opt-in panes, Stripe Radar / AWS IAM simulator / GCP Policy Troubleshooter / Skyhigh / LaunchDarkly "why did this fire" patterns, GitHub Actions & Buildkite severity-driven expansion, Cloudflare WAF events, Terraform plan digests, Jaeger waterfalls — distilled into 8 named patterns.
- `roadmap/mockups/053/simulator-results-readability.html` — interactive mockup (open in a browser) with a faithful "Now" reproduction, five named problems, and **three variants**:
  - **A — the ledger is the trace**: each changed setting expands into its own causal thread (writing rule + clause evidence + overridden value struck through); full trace demoted to one line. DevTools Computed-pane model.
  - **B — inspector**: persistent index rail (rules grouped changed / matched-inert / 716-no-match, plus replay stops) beside a single detail pane; constant page height. Compiler Explorer / Jaeger model.
  - **C — lenses + digest diff**: the two drawers become three mutually exclusive lenses, and the step diff becomes a Terraform-style changed-keys digest with a counted "unchanged hidden" row. Smallest delta from the shipped architecture.
  - Plus the shared fixes that apply under any variant, and a question-by-question comparison table (suggested sequencing: C, then A; B as a future audit mode).
- `roadmap/053-simulator-results-readability.md` — proposal stub, status *proposed*, awaiting a variant decision.

## How to review

Open the mockup HTML locally and click around: ledger threads (A), the rail (B), the lens bar and elision rows (C) are interactive. Both themes supported via `light-dark()` app tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DPv2gqb7eVYF9Kh8CRLUnD