### PR TITLE
feat(app): derive per-key verdict threads (054 layer 1)

### DIFF
--- a/packages/app/src/features/simulator/verdict-changes.ts
+++ b/packages/app/src/features/simulator/verdict-changes.ts
@@ -1,5 +1,6 @@
 import type { ProvenanceLayer, SimulationResult } from "@renovate-config-visualizer/engine";
 import type { MergeStop } from "./merge-stops";
+import { buildVerdictThreads } from "./verdict-threads";
 
 /** Roadmap 046: one ledger entry of the verdict card — a setting the rules
  *  genuinely changed, plus where it came from and the merge stop that set it. */
@@ -15,8 +16,11 @@ export interface VerdictChange {
 }
 
 /**
- * Roadmap 046: each ledger entry carries the merge stop that last set its
- * key — later merges win, so the LAST stop naming the key is authoritative.
+ * Roadmap 046/053: the collapsed row of a key's thread. Later merges win, so
+ * the ledger names the thread's WINNER — the last stop that set the key. The
+ * walk itself lives in `verdict-threads.ts` (053) and this is a projection of
+ * it, so the row and the expanded thread can never disagree about who wrote
+ * what.
  */
 export function buildVerdictChanges(
   changedKeys: string[],
@@ -24,33 +28,12 @@ export function buildVerdictChanges(
   layerByIndex: Map<number, ProvenanceLayer>,
   sim: SimulationResult | null,
 ): VerdictChange[] {
-  const nRuleStops = mergeStops.filter((s) => s.kind === "rule").length;
-  return changedKeys.map((key) => {
-    let layer: ProvenanceLayer | undefined;
-    let stopIndex: number | undefined;
-    let stopLabel: string | undefined;
-    for (let i = mergeStops.length - 1; i >= 0; i--) {
-      const stop = mergeStops[i];
-      if (!stop?.merged?.some((m) => m.key === key)) {
-        continue;
-      }
-      stopIndex = i;
-      if (stop.kind === "rule") {
-        layer = stop.ruleIndex === undefined ? undefined : layerByIndex.get(stop.ruleIndex);
-        const ordinal = mergeStops.slice(0, i + 1).filter((s) => s.kind === "rule").length;
-        stopLabel = `step ${ordinal} of ${nRuleStops}`;
-      } else {
-        stopLabel = "flatten step";
-      }
-      break;
-    }
-    return {
-      key,
-      value: sim?.finalDependencyConfig[key],
-      present: sim ? key in sim.finalDependencyConfig : false,
-      layer,
-      stopIndex,
-      stopLabel,
-    };
-  });
+  return buildVerdictThreads(changedKeys, mergeStops, layerByIndex, sim).map((thread) => ({
+    key: thread.key,
+    value: thread.finalValue,
+    present: thread.present,
+    layer: thread.winner?.layer,
+    stopIndex: thread.winner?.stopIndex,
+    stopLabel: thread.winner?.stopLabel,
+  }));
 }

--- a/packages/app/src/features/simulator/verdict-threads.test.ts
+++ b/packages/app/src/features/simulator/verdict-threads.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Roadmap 053 (variant A, layer 1): the thread derivation is the simulator's
+ * single source of truth about who wrote a setting — the collapsed ledger row
+ * (`VerdictChange`) is a projection of it — so it is tested directly, on
+ * hand-written `SimulationResult`/`MergeStop` fixtures rather than by running
+ * the engine. The fixtures spell the shapes the engine really produces: a
+ * `merged` entry omits `before` when the key did not exist yet and omits
+ * `after` when the merge removed it (engine `diffKeys`), and merge stops are
+ * contiguous, so the earliest writer's `before` IS the pre-rules value.
+ *
+ * The `VerdictChange` expectations are the pre-053 output of the old
+ * standalone `buildVerdictChanges` walk, verified against it before the
+ * projection replaced it.
+ */
+import type {
+  ClauseEvaluation,
+  MergedKey,
+  ProvenanceLayer,
+  RuleEvaluation,
+  SimulationResult,
+} from "@renovate-config-visualizer/engine";
+import { describe, expect, test } from "vitest";
+import type { MergeStop } from "./merge-stops";
+import { buildVerdictChanges } from "./verdict-changes";
+import { buildVerdictThreads } from "./verdict-threads";
+
+const PRESET_LAYER: ProvenanceLayer = { kind: "preset", nodeId: "n1", name: "config:recommended" };
+const REPO_LAYER: ProvenanceLayer = { kind: "repo" };
+
+const MATCHED_CLAUSE: ClauseEvaluation = {
+  key: "matchPackageNames",
+  value: ["renovate"],
+  state: "matched",
+  inputValues: { packageName: "renovate" },
+  readFields: ["packageName"],
+};
+
+/** The chip/step halves of a `MergeStop` are the timeline's rendering payload;
+ *  the derivation reads only `kind`/`ruleIndex`/`merged`. */
+function stopChrome(id: string): Pick<MergeStop, "chip" | "step"> {
+  return {
+    chip: { label: id, ariaLabel: id },
+    step: { id, before: {}, after: {}, head: id },
+  };
+}
+
+function baseStop(): MergeStop {
+  return { kind: "base", ...stopChrome("base") };
+}
+
+function ruleStop(ruleIndex: number, merged: MergedKey[]): MergeStop {
+  return { kind: "rule", ruleIndex, merged, ...stopChrome(`rule-${ruleIndex}`) };
+}
+
+function flattenStop(merged: MergedKey[]): MergeStop {
+  return { kind: "flatten", merged, ...stopChrome("flatten") };
+}
+
+function finalStop(): MergeStop {
+  return { kind: "final", ...stopChrome("final") };
+}
+
+function matchedRule(
+  index: number,
+  clauses: ClauseEvaluation[] = [MATCHED_CLAUSE],
+): RuleEvaluation {
+  return { index, verdict: "matched", clauses, notes: [] };
+}
+
+function simFixture(
+  finalDependencyConfig: Record<string, unknown>,
+  rules: RuleEvaluation[] = [],
+): SimulationResult {
+  return {
+    rules,
+    rawFinalConfig: finalDependencyConfig,
+    finalDependencyConfig,
+    flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    mergeSteps: [],
+    errors: [],
+    warnings: [],
+    notes: [],
+  };
+}
+
+/** Contested `groupName`: a preset rule sets it, a repo rule later overwrites
+ *  it — the cascade the whole feature exists for. */
+const CONTESTED_STOPS: MergeStop[] = [
+  baseStop(),
+  ruleStop(0, [{ key: "groupName", before: "all dependencies", after: "front-end" }]),
+  ruleStop(3, [{ key: "groupName", before: "front-end", after: "renovate core" }]),
+  finalStop(),
+];
+const CONTESTED_LAYERS = new Map<number, ProvenanceLayer>([
+  [0, PRESET_LAYER],
+  [3, REPO_LAYER],
+]);
+const CONTESTED_SIM = simFixture({ groupName: "renovate core" }, [matchedRule(0), matchedRule(3)]);
+
+/** A flatten stop has the last word over the rule that ran before it. */
+const FLATTEN_STOPS: MergeStop[] = [
+  baseStop(),
+  ruleStop(1, [{ key: "automerge", after: true }]),
+  flattenStop([{ key: "automerge", before: true, after: false }]),
+  finalStop(),
+];
+const FLATTEN_SIM = simFixture({ automerge: false }, [matchedRule(1)]);
+
+const NO_LAYERS = new Map<number, ProvenanceLayer>();
+
+describe("buildVerdictThreads", () => {
+  test("a contested key cascades newest first, and the last stop wins", () => {
+    const [thread] = buildVerdictThreads(
+      ["groupName"],
+      CONTESTED_STOPS,
+      CONTESTED_LAYERS,
+      CONTESTED_SIM,
+    );
+    expect(thread).toEqual({
+      key: "groupName",
+      finalValue: "renovate core",
+      present: true,
+      verb: "set",
+      winner: {
+        kind: "rule",
+        ruleIndex: 3,
+        layer: REPO_LAYER,
+        clauses: [MATCHED_CLAUSE],
+        stopIndex: 2,
+        stopOrdinal: 2,
+        stopLabel: "step 2 of 2",
+      },
+      overrides: [
+        {
+          kind: "writer",
+          value: "front-end",
+          ruleIndex: 0,
+          layer: PRESET_LAYER,
+          stopIndex: 1,
+          stopLabel: "step 1 of 2",
+        },
+        { kind: "base", value: "all dependencies", present: true, origin: "base" },
+      ],
+      writerCount: 2,
+    });
+  });
+
+  test("an array key whose previous value is a strict prefix was appended", () => {
+    const stops = [
+      baseStop(),
+      ruleStop(0, [{ key: "labels", before: ["renovate"], after: ["renovate", "deps"] }]),
+      finalStop(),
+    ];
+    const [thread] = buildVerdictThreads(
+      ["labels"],
+      stops,
+      NO_LAYERS,
+      simFixture({ labels: ["renovate", "deps"] }, [matchedRule(0)]),
+    );
+    expect(thread?.verb).toBe("appended");
+  });
+
+  test("a rewritten array is set, not appended", () => {
+    const stops = [
+      baseStop(),
+      ruleStop(0, [{ key: "labels", before: ["renovate"], after: ["deps", "renovate"] }]),
+      finalStop(),
+    ];
+    const [thread] = buildVerdictThreads(
+      ["labels"],
+      stops,
+      NO_LAYERS,
+      simFixture({ labels: ["deps", "renovate"] }, [matchedRule(0)]),
+    );
+    expect(thread?.verb).toBe("set");
+  });
+
+  test("a key missing from the final config was removed", () => {
+    const stops = [
+      baseStop(),
+      ruleStop(0, [{ key: "schedule", before: ["on monday"] }]),
+      finalStop(),
+    ];
+    const [thread] = buildVerdictThreads(
+      ["schedule"],
+      stops,
+      NO_LAYERS,
+      simFixture({}, [matchedRule(0)]),
+    );
+    expect(thread?.verb).toBe("removed");
+    expect(thread?.present).toBe(false);
+    expect(thread?.finalValue).toBeUndefined();
+    expect(thread?.overrides).toEqual([
+      { kind: "base", value: ["on monday"], present: true, origin: "base" },
+    ]);
+  });
+
+  test("a flatten stop can win, and carries no clause evidence", () => {
+    const [thread] = buildVerdictThreads(["automerge"], FLATTEN_STOPS, NO_LAYERS, FLATTEN_SIM);
+    expect(thread?.winner).toEqual({
+      kind: "flatten",
+      ruleIndex: undefined,
+      layer: undefined,
+      clauses: [],
+      stopIndex: 2,
+      stopOrdinal: undefined,
+      stopLabel: "flatten step",
+    });
+    expect(thread?.writerCount).toBe(2);
+    expect(thread?.overrides[0]).toEqual({
+      kind: "writer",
+      value: true,
+      ruleIndex: 1,
+      layer: undefined,
+      stopIndex: 1,
+      stopLabel: "step 1 of 1",
+    });
+  });
+
+  test("a single writer has one writer and a bare base entry", () => {
+    const stops = [baseStop(), ruleStop(2, [{ key: "rangeStrategy", after: "bump" }]), finalStop()];
+    const [thread] = buildVerdictThreads(
+      ["rangeStrategy"],
+      stops,
+      new Map([[2, REPO_LAYER]]),
+      simFixture({ rangeStrategy: "bump" }, [matchedRule(2)]),
+    );
+    expect(thread?.writerCount).toBe(1);
+    // The key did not exist before the rules ran — `present: false` is what
+    // stops the UI from striking through a value that never was.
+    expect(thread?.overrides).toEqual([
+      { kind: "base", value: undefined, present: false, origin: "base" },
+    ]);
+    expect(thread?.winner?.stopLabel).toBe("step 1 of 1");
+  });
+
+  test("a changed key no stop names has no winner and no cascade", () => {
+    const [thread] = buildVerdictThreads(
+      ["minor"],
+      [baseStop(), ruleStop(0, [{ key: "groupName", after: "x" }]), finalStop()],
+      NO_LAYERS,
+      simFixture({ groupName: "x" }, [matchedRule(0)]),
+    );
+    expect(thread?.winner).toBeUndefined();
+    expect(thread?.overrides).toEqual([]);
+    expect(thread?.writerCount).toBe(0);
+  });
+
+  test("without a simulation nothing is present", () => {
+    const [thread] = buildVerdictThreads(["groupName"], CONTESTED_STOPS, CONTESTED_LAYERS, null);
+    expect(thread?.present).toBe(false);
+    expect(thread?.verb).toBe("removed");
+    expect(thread?.winner?.stopIndex).toBe(2);
+  });
+});
+
+describe("buildVerdictChanges (projection)", () => {
+  test("a contested key reports the WINNING rule's layer and stop", () => {
+    expect(
+      buildVerdictChanges(["groupName"], CONTESTED_STOPS, CONTESTED_LAYERS, CONTESTED_SIM),
+    ).toEqual([
+      {
+        key: "groupName",
+        value: "renovate core",
+        present: true,
+        layer: REPO_LAYER,
+        stopIndex: 2,
+        stopLabel: "step 2 of 2",
+      },
+    ]);
+  });
+
+  test("a flatten winner has no layer, and a removed key no value", () => {
+    const stops = [...FLATTEN_STOPS];
+    expect(buildVerdictChanges(["automerge", "schedule"], stops, NO_LAYERS, FLATTEN_SIM)).toEqual([
+      {
+        key: "automerge",
+        value: false,
+        present: true,
+        layer: undefined,
+        stopIndex: 2,
+        stopLabel: "flatten step",
+      },
+      {
+        key: "schedule",
+        value: undefined,
+        present: false,
+        layer: undefined,
+        stopIndex: undefined,
+        stopLabel: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/app/src/features/simulator/verdict-threads.ts
+++ b/packages/app/src/features/simulator/verdict-threads.ts
@@ -1,0 +1,242 @@
+import type {
+  ClauseEvaluation,
+  MergedKey,
+  ProvenanceLayer,
+  SimulationResult,
+} from "@renovate-config-visualizer/engine";
+import type { MergeStop } from "./merge-stops";
+
+/**
+ * Roadmap 053 (variant A): the causal thread behind every setting the rules
+ * changed. The engine already records everything a thread needs — each
+ * `mergeSteps[i].merged` names the keys that merge set/changed WITH their
+ * before/after, the steps are contiguous snapshots in merge order, and
+ * `RuleEvaluation.clauses` holds the per-rule predicate evidence — so this is
+ * pure derivation over the last RUN, no engine change and no UI knowledge.
+ *
+ * Later merges win, so per key the LAST stop naming it is the winner and every
+ * earlier one is an override it beat. `verdict-changes.ts` is a projection of
+ * this model, which is the point: the collapsed ledger row and the expanded
+ * thread can never disagree about who wrote what.
+ */
+
+/** The stop that had the last word on a key. */
+export interface ThreadWinner {
+  kind: "rule" | "flatten";
+  /** `kind: "rule"` only — the rule's position in `packageRules`. */
+  ruleIndex?: number;
+  /** The layer that owns the winning rule (never set for a flatten stop). */
+  layer?: ProvenanceLayer;
+  /** The winning rule's clause evidence; empty for a flatten stop, which has
+   *  the 047 update-type story instead. */
+  clauses: ClauseEvaluation[];
+  /** Position on the merge timeline, for the "step N of M →" jump. */
+  stopIndex: number;
+  /** `kind: "rule"` only — the stop's position among the RULE stops. */
+  stopOrdinal?: number;
+  stopLabel: string;
+}
+
+/** A writer the winner beat — its value never reached the final config. */
+export interface ThreadOverride {
+  kind: "writer";
+  /** What this stop wrote (its `merged` entry's `after`) — the lost value. */
+  value: unknown;
+  ruleIndex?: number;
+  layer?: ProvenanceLayer;
+  stopIndex: number;
+  stopLabel: string;
+}
+
+/**
+ * The value the key held before any rule ran (the earliest writer's `merged`
+ * entry's `before`), which terminates every cascade.
+ *
+ * `origin` would read `"default"` for a value that is Renovate's own default
+ * rather than something the config's layers set — but no engine surface
+ * carries the resolved default config into the app today (047's
+ * `authoredBlocks` compares against `getDefaultConfig()` INSIDE the engine and
+ * exports only the verdict, and `getOptionIndex()`'s per-option `default` is
+ * documentation metadata behind the lazily-loaded engine chunk). Until one
+ * exists, base values are labeled `"base"`.
+ */
+export interface ThreadBase {
+  kind: "base";
+  value: unknown;
+  /** False when the key did not exist at all before the rules ran. */
+  present: boolean;
+  origin: "base" | "default";
+}
+
+/** The cascade under a thread: lost writers newest first, then the base. */
+export type ThreadEntry = ThreadOverride | ThreadBase;
+
+/**
+ * How the winner wrote the key — the verb carries the merge semantics, so the
+ * thread needs no explanatory aside. `appended` is Renovate's concat-merge of
+ * array keys, detected as "before is a strict prefix of after".
+ */
+export type ThreadVerb = "set" | "appended" | "removed";
+
+/** One changed setting, with its whole causal thread. */
+export interface ThreadModel {
+  key: string;
+  /** The value in `finalDependencyConfig` (undefined when removed). */
+  finalValue: unknown;
+  present: boolean;
+  verb: ThreadVerb;
+  /** Absent only for a key no merge stop names (nothing to attribute). */
+  winner?: ThreadWinner;
+  overrides: ThreadEntry[];
+  /** How many rule/flatten stops wrote this key — `1` means uncontested. */
+  writerCount: number;
+}
+
+interface StopLabel {
+  ordinal?: number;
+  label: string;
+}
+
+/** One writer of a key: the stop, where it sits, and what it wrote. */
+interface Writer {
+  stopIndex: number;
+  stop: MergeStop;
+  entry: MergedKey;
+}
+
+/**
+ * Roadmap 046's stop naming, computed once per stop list instead of per key:
+ * rule stops count among themselves ("step 2 of 5"), the flatten stop is named
+ * rather than numbered.
+ */
+function stopLabels(mergeStops: MergeStop[]): StopLabel[] {
+  const nRuleStops = mergeStops.filter((s) => s.kind === "rule").length;
+  let ordinal = 0;
+  return mergeStops.map((stop) => {
+    if (stop.kind === "rule") {
+      ordinal += 1;
+      return { ordinal, label: `step ${ordinal} of ${nRuleStops}` };
+    }
+    return { label: stop.kind === "flatten" ? "flatten step" : stop.kind };
+  });
+}
+
+/**
+ * Renovate concat-merges array options, so a rule that "appended" leaves the
+ * previous value as a strict prefix of the new one. If this heuristic ever
+ * misfires the fix is an engine-side `MergedKey.mode` tag, not more guesswork
+ * here.
+ */
+function isAppend(entry: MergedKey): boolean {
+  const { before, after } = entry;
+  if (!Array.isArray(before) || !Array.isArray(after) || before.length >= after.length) {
+    return false;
+  }
+  return before.every((item, i) => JSON.stringify(item) === JSON.stringify(after[i]));
+}
+
+function layerOf(
+  stop: MergeStop,
+  layerByIndex: Map<number, ProvenanceLayer>,
+): ProvenanceLayer | undefined {
+  if (stop.kind !== "rule" || stop.ruleIndex === undefined) {
+    return undefined;
+  }
+  return layerByIndex.get(stop.ruleIndex);
+}
+
+function buildWinner(
+  writer: Writer,
+  labels: StopLabel[],
+  layerByIndex: Map<number, ProvenanceLayer>,
+  sim: SimulationResult | null,
+): ThreadWinner {
+  const { stop, stopIndex } = writer;
+  const label = labels[stopIndex];
+  const rule =
+    stop.ruleIndex === undefined ? undefined : sim?.rules.find((r) => r.index === stop.ruleIndex);
+  return {
+    kind: stop.kind === "flatten" ? "flatten" : "rule",
+    ruleIndex: stop.ruleIndex,
+    layer: layerOf(stop, layerByIndex),
+    clauses: stop.kind === "rule" ? (rule?.clauses ?? []) : [],
+    stopIndex,
+    stopOrdinal: label?.ordinal,
+    stopLabel: label?.label ?? "merge step",
+  };
+}
+
+function buildOverrides(
+  writers: Writer[],
+  labels: StopLabel[],
+  layerByIndex: Map<number, ProvenanceLayer>,
+): ThreadEntry[] {
+  // Every writer except the winner, newest first — each showing the value it
+  // wrote and lost.
+  const entries: ThreadEntry[] = writers
+    .slice(0, -1)
+    .toReversed()
+    .map(({ stop, stopIndex, entry }) => ({
+      kind: "writer" as const,
+      value: entry.after,
+      ruleIndex: stop.ruleIndex,
+      layer: layerOf(stop, layerByIndex),
+      stopIndex,
+      stopLabel: labels[stopIndex]?.label ?? "merge step",
+    }));
+  const first = writers[0];
+  if (first) {
+    // The steps are contiguous, so the EARLIEST writer's `before` is the value
+    // the key held when the rules started.
+    entries.push({
+      kind: "base",
+      value: first.entry.before,
+      present: Object.hasOwn(first.entry, "before"),
+      origin: "base",
+    });
+  }
+  return entries;
+}
+
+/**
+ * Roadmap 053: one thread per changed key. `changedKeys` is the caller's
+ * base→final diff (a key can be changed without any stop naming it — e.g. one
+ * the flatten pass merely dropped), so a thread may legitimately have no
+ * winner and an empty cascade.
+ */
+export function buildVerdictThreads(
+  changedKeys: string[],
+  mergeStops: MergeStop[],
+  layerByIndex: Map<number, ProvenanceLayer>,
+  sim: SimulationResult | null,
+): ThreadModel[] {
+  const labels = stopLabels(mergeStops);
+  return changedKeys.map((key) => {
+    const writers: Writer[] = [];
+    for (const [stopIndex, stop] of mergeStops.entries()) {
+      const entry = stop.merged?.find((m) => m.key === key);
+      if (entry) {
+        writers.push({ stopIndex, stop, entry });
+      }
+    }
+    const last = writers.at(-1);
+    const present = sim ? key in sim.finalDependencyConfig : false;
+    // Mutually exclusive in practice: a winner that appended left an array
+    // behind, so the key is present.
+    let verb: ThreadVerb = "set";
+    if (!present) {
+      verb = "removed";
+    } else if (last && isAppend(last.entry)) {
+      verb = "appended";
+    }
+    return {
+      key,
+      finalValue: sim?.finalDependencyConfig[key],
+      present,
+      verb,
+      winner: last ? buildWinner(last, labels, layerByIndex, sim) : undefined,
+      overrides: buildOverrides(writers, labels, layerByIndex),
+      writerCount: writers.length,
+    };
+  });
+}


### PR DESCRIPTION
Variant A's ledger is the trace: every setting the rules changed gets a
causal thread instead of a single attribution. `verdict-threads.ts`
derives, per changed key, the WINNER (the last merge stop naming it, with
its rule's clause evidence and the 046 stop label), the cascade of earlier
writers it beat — newest first, each with the value it wrote and lost —
terminated by the pre-rules base value taken from the earliest writer's
`before`, plus the verb that carries the merge semantics (`set` /
`appended` for Renovate's concat-merge of arrays / `removed`) and the
writer count that tells an uncontested key from a contested one.

Pure derivation over the last RUN: no engine change, no UI change. The
base entry is labeled `origin: "base"` — no engine surface carries the
resolved default config into the app, so "Renovate default" cannot be
claimed honestly yet (the type keeps the seam).

`buildVerdictChanges` is now a projection of this model rather than its
own stop walk, so the collapsed ledger row and the expanded thread can
never disagree about who wrote what; its signature and `VerdictChange`
shape are unchanged, so RuleSimulator/SimVerdictBlock compile untouched.
Unit tests cover the contested cascade, append detection, removed keys,
a flatten winner, a single writer, and the projection's parity with the
pre-053 behavior.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>