### PR TITLE
feat(app): rule evidence popover and provenance dots (054 layer 3)

### DIFF
--- a/packages/app/src/components/ProvenanceChip.tsx
+++ b/packages/app/src/components/ProvenanceChip.tsx
@@ -19,12 +19,24 @@ import { layerClass, layerLabel, provenanceGlossaryEntry } from "./provenance-la
 export function ProvenanceChip({
   layer,
   onSelectPreset,
+  variant = "chip",
 }: {
   layer: ProvenanceLayer;
   onSelectPreset?: (nodeId: string) => void;
+  /**
+   * Roadmap 053: inside an evidence layer the same chip repeats on every row,
+   * where it is a column of colored labels competing with the evidence itself.
+   * `dot` keeps the hue (the thing a reader scans for) and hands the label to
+   * the hover card and the tooltip, which is where a reader who cares looks
+   * anyway. Writer lines — where the layer is part of the sentence — keep the
+   * full chip.
+   */
+  variant?: "chip" | "dot";
 }) {
   const clickable = layer.kind === "preset" && onSelectPreset;
-  const className = `badge prov-layer ${layerClass(layer)}`;
+  const dot = variant === "dot";
+  const label = layerLabel(layer);
+  const className = dot ? `prov-dot ${layerClass(layer)}` : `badge prov-layer ${layerClass(layer)}`;
   const entry = provenanceGlossaryEntry(layer);
   return (
     <Explained entry={entry}>
@@ -37,6 +49,8 @@ export function ProvenanceChip({
             role="button"
             tabIndex={0}
             className={className}
+            title={dot ? label : undefined}
+            aria-label={dot ? label : undefined}
             onClick={(e) => {
               e.stopPropagation();
               onSelectPreset(layer.nodeId);
@@ -50,11 +64,17 @@ export function ProvenanceChip({
             }}
             {...handlers}
           >
-            {layerLabel(layer)}
+            {dot ? null : label}
           </span>
         ) : (
-          <span className={className} tabIndex={0} {...handlers}>
-            {layerLabel(layer)}
+          <span
+            className={className}
+            tabIndex={0}
+            title={dot ? label : undefined}
+            aria-label={dot ? label : undefined}
+            {...handlers}
+          >
+            {dot ? null : label}
           </span>
         )
       }

--- a/packages/app/src/components/glossary.tsx
+++ b/packages/app/src/components/glossary.tsx
@@ -2,21 +2,16 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom";
 import { GLOSSARY, type GlossaryEntry, type TermId } from "@/data/glossary-data";
 import { useMoveGatedHover } from "@/hooks/hover-gate";
+import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";
 
 /**
  * The hover/focus card UI for the glossary. The entries themselves live in
  * glossary-data.ts.
  */
 
-interface CardPos {
-  left: number;
-  top: number;
-  bottom: number;
-}
-
 interface CardState {
   entry: GlossaryEntry;
-  pos: CardPos;
+  pos: AnchorRect;
 }
 
 /** Module-level singleton so only one glossary card is ever open. */
@@ -43,8 +38,7 @@ function useHoverCard(entry: GlossaryEntry) {
       }
       activeHide = hideNow;
       window.clearTimeout(hideTimer.current);
-      const rect = el.getBoundingClientRect();
-      setCard({ entry, pos: { left: rect.left, top: rect.top, bottom: rect.bottom } });
+      setCard({ entry, pos: anchorRectOf(el) });
     },
     [entry, hideNow],
   );
@@ -81,14 +75,7 @@ function GlossaryCard({
   onLeave: () => void;
 }) {
   const { entry, pos } = card;
-  // Clamp to the viewport, not just a fixed constant — a 320px card doesn't
-  // fit an under-320px viewport (roadmap 025).
-  const width = Math.min(320, window.innerWidth - 32);
-  const left = Math.max(8, Math.min(pos.left, window.innerWidth - width - 16));
-  const openUpward = pos.bottom > window.innerHeight - 200;
-  const style: React.CSSProperties = openUpward
-    ? { left, bottom: window.innerHeight - pos.top + 6, maxWidth: width }
-    : { left, top: pos.bottom + 6, maxWidth: width };
+  const style = anchoredCardStyle(pos, 320, 200);
   // Roadmap 035: portalled to <body>. The coordinates above are viewport
   // coordinates, which only hold while no ancestor is a containing block for
   // fixed-position descendants — and CSS containment creates exactly that, so

--- a/packages/app/src/components/option-docs.tsx
+++ b/packages/app/src/components/option-docs.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import type { OptionDoc, OptionIndex } from "@renovate-config-visualizer/engine";
 import { useMoveGatedHover } from "@/hooks/hover-gate";
 import { OptionDocsContext, useOptionDocs } from "@/hooks/option-docs-hooks";
+import { type AnchorRect, anchoredCardStyle } from "@/lib/anchored-card";
 
 /**
  * Inline documentation for renovate options (roadmap 003): a context carrying
@@ -14,7 +15,7 @@ import { OptionDocsContext, useOptionDocs } from "@/hooks/option-docs-hooks";
 interface CardState {
   name: string;
   doc?: OptionDoc;
-  anchor: { left: number; top: number; bottom: number };
+  anchor: AnchorRect;
 }
 
 export function OptionDocsProvider({
@@ -87,14 +88,7 @@ function OptionCard({
   onLeave: () => void;
 }) {
   const { doc, name, anchor } = card;
-  // Clamp to the viewport, not just a fixed constant — a 340px card doesn't
-  // fit an under-340px viewport (roadmap 025).
-  const width = Math.min(340, window.innerWidth - 32);
-  const left = Math.max(8, Math.min(anchor.left, window.innerWidth - width - 16));
-  const openUpward = anchor.bottom > window.innerHeight - 280;
-  const style: React.CSSProperties = openUpward
-    ? { left, bottom: window.innerHeight - anchor.top + 6, maxWidth: width }
-    : { left, top: anchor.bottom + 6, maxWidth: width };
+  const style = anchoredCardStyle(anchor, 340, 280);
 
   return (
     <div className="option-card" style={style} onMouseEnter={onEnter} onMouseLeave={onLeave}>

--- a/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
@@ -1,0 +1,105 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuleEvidence } from "./rule-evidence";
+import { RuleEvidenceAnchor } from "./RuleEvidenceCard";
+
+/**
+ * Roadmap 053 layer 3 — the popover's interaction contract, the part that is
+ * not the derivation: it opens from the rule reference, it light-dismisses
+ * (Escape, click outside), and dismissing hands focus BACK to the reference
+ * rather than dropping it on <body>. The e2e suite (layer 5) drives the same
+ * flow against the production build; this is the fast guard.
+ */
+
+const EVIDENCE: RuleEvidence = {
+  ruleIndex: 201,
+  verdict: "matched",
+  clauses: [],
+  stopIndex: 2,
+  stopOrdinal: 2,
+  stopLabel: "step 2 of 3",
+  writes: [
+    {
+      key: "schedule",
+      before: ["at any time"],
+      hadBefore: true,
+      after: ["before 6am"],
+      hadAfter: true,
+      survived: true,
+    },
+    {
+      key: "groupName",
+      before: undefined,
+      hadBefore: false,
+      after: "npm minor+patch",
+      hadAfter: true,
+      survived: false,
+      overriddenAtStopIndex: 3,
+      overriddenAtOrdinal: 3,
+      overriddenAtLabel: "step 3 of 3",
+    },
+  ],
+  survivedCount: 1,
+};
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+function open(onOpenRule?: (ruleIndex: number) => void) {
+  const view = render(
+    <RuleEvidenceAnchor ruleIndex={201} evidenceFor={() => EVIDENCE} onOpenRule={onOpenRule} />,
+  );
+  const anchor = view.getByRole("button", { name: "packageRules[201]" });
+  act(() => {
+    fireEvent.click(anchor);
+  });
+  return { view, anchor };
+}
+
+describe("RuleEvidenceCard", () => {
+  it("opens from the rule reference and digests the rule's writes", () => {
+    const { view } = open();
+    const dialog = view.getByRole("dialog", { name: "packageRules[201] — rule evidence" });
+    expect(dialog.textContent).toContain("merged in step 2 of 3 — 2 writes, 1 survived");
+    // The lost write names the stop that took it; the surviving one does not.
+    expect(dialog.textContent).toContain("⊘ overridden in step 3 of 3");
+    expect(dialog.querySelectorAll(".sim-merged-after.overridden")).toHaveLength(1);
+  });
+
+  it("closes on Escape and gives focus back to the anchor", () => {
+    const { view, anchor } = open();
+    expect(document.activeElement?.getAttribute("role")).toBe("dialog");
+    act(() => {
+      fireEvent.keyDown(document, { key: "Escape" });
+    });
+    expect(view.queryByRole("dialog")).toBeNull();
+    expect(document.activeElement).toBe(anchor);
+    expect(anchor.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("closes on a click outside", () => {
+    const { view } = open();
+    act(() => {
+      fireEvent.mouseDown(document.body);
+    });
+    expect(view.queryByRole("dialog")).toBeNull();
+  });
+
+  it("stays open while the card itself is clicked", () => {
+    const { view } = open();
+    act(() => {
+      fireEvent.mouseDown(view.getByRole("dialog"));
+    });
+    expect(view.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("hands the rule to the matched-rules jump and closes", () => {
+    const onOpenRule = vi.fn();
+    const { view } = open(onOpenRule);
+    act(() => {
+      fireEvent.click(view.getByRole("button", { name: "open in matched rules →" }));
+    });
+    expect(onOpenRule).toHaveBeenCalledWith(201);
+    expect(view.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -1,0 +1,273 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { ProvenanceChip } from "@/components/ProvenanceChip";
+import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";
+import { ClauseGrid } from "./ClauseGrid";
+import { previewValue, VERDICT_LABEL } from "./rule-format";
+import type { RuleEvidence, RuleWrite } from "./rule-evidence";
+
+/**
+ * Roadmap 053 (variant A), layer 3: the second — and last — disclosure level.
+ * A thread names the rules whose values it beat; clicking one of those
+ * references opens THIS card, which answers the only question the thread
+ * leaves open about a losing rule: what else did it do? Its clause evidence,
+ * where it merged, and a per-outcome digest of its writes — the ones that
+ * survived plain, the ones a later stop took away struck through, in the same
+ * grammar the threads use for a lost value.
+ *
+ * The card is navigation-free (its footer link is the exception, and that is a
+ * jump, not another fold), so it is light-dismiss: Escape or a click outside
+ * closes it and focus goes back to the reference that opened it.
+ */
+
+/** The card's preferred width — the mockup's 36rem, in px, clamped to the
+ *  viewport by `anchoredCardStyle`. */
+const CARD_WIDTH = 576;
+/** Roughly the card's own height: below this much room, it flips above. */
+const CARD_FLIP_MARGIN = 320;
+
+/** `~` changed · `+` added · `−` removed — stated once per write so the digest
+ *  reads without re-parsing the before/after pair. */
+function writeMark(write: RuleWrite): string {
+  if (!write.hadAfter) {
+    return "−";
+  }
+  return write.hadBefore ? "~" : "+";
+}
+
+/** One key the rule merged. A write that lost keeps this step's add tint — it
+ *  IS what this step added — and is struck through, naming the stop that took
+ *  it away; that pairing is the whole reason the card exists. */
+function RuleWriteRow({ write }: { write: RuleWrite }) {
+  return (
+    <div className="sim-digest-row">
+      <span className="sim-digest-mark">{writeMark(write)}</span>
+      <code className="sim-digest-key">{write.key}</code>
+      <span className="sim-digest-values">
+        {write.hadBefore ? (
+          <span className="sim-merged-before">{previewValue(write.before, 60)}</span>
+        ) : null}
+        {write.hadBefore ? " → " : null}
+        <span className={`sim-merged-after${write.survived ? "" : " overridden"}`}>
+          {write.hadAfter ? previewValue(write.after, 60) : "removed"}
+        </span>
+        {write.survived ? null : (
+          <span className="sim-digest-note"> · ⊘ overridden in {write.overriddenAtLabel}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+/** The rule's name, its verdict, and where it came from. */
+function RuleEvidenceHead({
+  evidence,
+  onSelectPreset,
+}: {
+  evidence: RuleEvidence;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <p className="sim-rule-pop-head">
+      <code className="sim-rule-pop-id">packageRules[{evidence.ruleIndex}]</code>
+      {evidence.verdict ? (
+        <span className={`badge sim-verdict verdict-${evidence.verdict}`}>
+          {VERDICT_LABEL[evidence.verdict]}
+        </span>
+      ) : null}
+      {evidence.layer ? (
+        <ProvenanceChip layer={evidence.layer} onSelectPreset={onSelectPreset} />
+      ) : null}
+    </p>
+  );
+}
+
+/** "merged in step N — X writes, Y survived": the counts the digest below
+ *  then spells out one row at a time. */
+function RuleEvidenceSummary({ evidence }: { evidence: RuleEvidence }) {
+  if (evidence.stopLabel === undefined) {
+    return <p className="sim-rule-pop-line">This rule merged nothing into the config.</p>;
+  }
+  const { writes, survivedCount } = evidence;
+  return (
+    <p className="sim-rule-pop-line">
+      merged in {evidence.stopLabel} — {writes.length} write{writes.length === 1 ? "" : "s"},{" "}
+      {survivedCount} survived
+    </p>
+  );
+}
+
+function RuleEvidenceBody({
+  evidence,
+  onSelectPreset,
+}: {
+  evidence: RuleEvidence;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <>
+      <RuleEvidenceHead evidence={evidence} onSelectPreset={onSelectPreset} />
+      {evidence.clauses.length > 0 ? <ClauseGrid clauses={evidence.clauses} /> : null}
+      <RuleEvidenceSummary evidence={evidence} />
+      <div className="sim-digest">
+        {evidence.writes.map((write) => (
+          <RuleWriteRow key={write.key} write={write} />
+        ))}
+      </div>
+    </>
+  );
+}
+
+/**
+ * The popover itself: portalled to `<body>` on the app's existing hover-card
+ * plane (`.option-card` — raised surface, popover shadow, viewport-clamped
+ * placement), because an in-place card would be clipped by the thread's own
+ * box and would re-anchor to any ancestor that gains containment (035).
+ */
+export function RuleEvidenceCard({
+  evidence,
+  anchor,
+  onClose,
+  onOpenRule,
+  onSelectPreset,
+}: {
+  evidence: RuleEvidence;
+  anchor: AnchorRect;
+  onClose: () => void;
+  /** The footer's jump into the (demoted) matched-rules drawer. */
+  onOpenRule?: (ruleIndex: number) => void;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  // The card is opened by a click, so focus belongs inside it: its footer link
+  // is then the next thing Tab reaches, and Escape hands focus back.
+  useEffect(() => {
+    cardRef.current?.focus({ preventScroll: true });
+  }, []);
+  return createPortal(
+    <div
+      className="option-card sim-rule-pop"
+      role="dialog"
+      aria-label={`packageRules[${evidence.ruleIndex}] — rule evidence`}
+      tabIndex={-1}
+      ref={cardRef}
+      style={anchoredCardStyle(anchor, CARD_WIDTH, CARD_FLIP_MARGIN)}
+    >
+      <RuleEvidenceBody evidence={evidence} onSelectPreset={onSelectPreset} />
+      <p className="sim-rule-pop-foot">
+        <button
+          type="button"
+          className="sim-step-link"
+          onClick={() => {
+            onClose();
+            onOpenRule?.(evidence.ruleIndex);
+          }}
+        >
+          open in matched rules →
+        </button>
+      </p>
+    </div>,
+    document.body,
+  );
+}
+
+/**
+ * The `packageRules[N]` reference that opens the card. It owns the open state
+ * and the light-dismiss listeners, because it is the one place that knows both
+ * boxes: a pointer press inside EITHER the anchor or the card must not close
+ * (otherwise the toggle would close and reopen on its own click).
+ */
+export function RuleEvidenceAnchor({
+  ruleIndex,
+  evidenceFor,
+  onOpenRule,
+  onSelectPreset,
+}: {
+  ruleIndex: number;
+  evidenceFor: (ruleIndex: number) => RuleEvidence;
+  onOpenRule?: (ruleIndex: number) => void;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const wrapRef = useRef<HTMLSpanElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [anchor, setAnchor] = useState<AnchorRect | null>(null);
+  const open = anchor !== null;
+
+  // Closing takes the focus back to the reference that opened the card —
+  // except when the click that dismissed it already moved focus somewhere the
+  // user picked themselves. Never scrolls: focus is being restored, not given.
+  const close = useCallback(() => {
+    const restore = document.activeElement?.closest(".sim-rule-pop") != null;
+    setAnchor(null);
+    if (restore) {
+      buttonRef.current?.focus({ preventScroll: true });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        close();
+      }
+    }
+    function onPointerDown(e: MouseEvent) {
+      const target = e.target;
+      if (target instanceof Node && wrapRef.current?.contains(target)) {
+        return;
+      }
+      // The card lives in a portal, so "inside" is not a DOM-ancestor test
+      // against the anchor — ask the card's own element.
+      if (target instanceof Element && target.closest(".sim-rule-pop")) {
+        return;
+      }
+      close();
+    }
+    // Re-anchor rather than hide: the card is click-opened, so it has to
+    // survive the scroll that reading it may cause. Capture, to also catch
+    // scrolling inside the page's own scroll containers.
+    function reposition() {
+      if (buttonRef.current) {
+        setAnchor(anchorRectOf(buttonRef.current));
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    document.addEventListener("mousedown", onPointerDown);
+    window.addEventListener("scroll", reposition, { capture: true, passive: true });
+    window.addEventListener("resize", reposition, { passive: true });
+    return () => {
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("mousedown", onPointerDown);
+      window.removeEventListener("scroll", reposition, { capture: true });
+      window.removeEventListener("resize", reposition);
+    };
+  }, [open, close]);
+
+  return (
+    <span className="sim-rule-pop-anchor" ref={wrapRef}>
+      <button
+        type="button"
+        className="sim-rule-pop-link"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        ref={buttonRef}
+        onClick={() =>
+          setAnchor(open || !buttonRef.current ? null : anchorRectOf(buttonRef.current))
+        }
+      >
+        packageRules[{ruleIndex}]
+      </button>
+      {anchor ? (
+        <RuleEvidenceCard
+          evidence={evidenceFor(ruleIndex)}
+          anchor={anchor}
+          onClose={close}
+          onOpenRule={onOpenRule}
+          onSelectPreset={onSelectPreset}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 import type { ProvenanceLayer, TraceResult } from "@renovate-config-visualizer/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
@@ -10,6 +10,7 @@ import { ComparisonPanel } from "./ComparisonPanel";
 import { consumedAuthoredBlocks } from "./consumed-blocks";
 import { EMPTY_FORM, type FormState, hasMeaningfulInput } from "./form";
 import { buildMergeStops } from "./merge-stops";
+import { buildRuleEvidence } from "./rule-evidence";
 import { SimMergeDrawer } from "./SimMergeDrawer";
 import { SimMessages } from "./SimMessages";
 import { SimRulesDrawer } from "./SimRulesDrawer";
@@ -230,6 +231,13 @@ export const RuleSimulator = memo(function RuleSimulator({
     () => buildVerdictThreads(changedKeys, mergeStops, layerByIndex, sim),
     [changedKeys, mergeStops, layerByIndex, sim],
   );
+  // Roadmap 053 layer 3: derived on demand — one popover is open at a time, and
+  // a run can have hundreds of rules, so deriving every rule's evidence up
+  // front would be work for a card nobody opens.
+  const evidenceFor = useCallback(
+    (ruleIndex: number) => buildRuleEvidence(ruleIndex, mergeStops, layerByIndex, sim),
+    [mergeStops, layerByIndex, sim],
+  );
 
   if (!finalConfig) {
     return null;
@@ -397,6 +405,11 @@ export const RuleSimulator = memo(function RuleSimulator({
               onJumpToStep={showTimeline ? jumpToStep : undefined}
               onJumpToRules={jumpToRules}
               onJumpToReplay={showTimeline ? jumpToReplay : undefined}
+              evidenceFor={evidenceFor}
+              // The popover's footer lands on the rule ROW itself — the 013
+              // focus wiring opens the drawer, clears whatever filter hides
+              // the row, scrolls to it and flashes it.
+              onOpenRule={focusRule}
               copySimLink={onCopySimLink ? copySimLink : null}
               pinned={pinned !== null}
               onUnpin={unpin}

--- a/packages/app/src/features/simulator/SimVerdictBlock.tsx
+++ b/packages/app/src/features/simulator/SimVerdictBlock.tsx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 import type { SimulationResult } from "@renovate-config-visualizer/engine";
 import { CopyButton } from "@/components/CopyButton";
 import type { ConsumedBlock } from "./consumed-blocks";
+import type { RuleEvidence } from "./rule-evidence";
 import { SimConsumedBlock } from "./SimConsumedBlock";
 import type { ThreadModel } from "./verdict-threads";
 import type { VerdictSegment } from "./verdict-sentence";
@@ -66,6 +67,8 @@ export function SimVerdictBlock({
   onJumpToStep,
   onJumpToRules,
   onJumpToReplay,
+  evidenceFor,
+  onOpenRule,
   copySimLink,
   pinned,
   onUnpin,
@@ -92,6 +95,10 @@ export function SimVerdictBlock({
   /** Roadmap 053: open the build replay where it currently stands — absent
    *  when this run has no timeline to open. */
   onJumpToReplay?: () => void;
+  /** Roadmap 053 layer 3: the rule-evidence popover's model, and the jump its
+   *  footer offers into the matched-rules drawer. */
+  evidenceFor?: (ruleIndex: number) => RuleEvidence;
+  onOpenRule?: (ruleIndex: number) => void;
   /** null when the host gave no share-link callback — no button then. */
   copySimLink: (() => Promise<void>) | null;
   pinned: boolean;
@@ -135,8 +142,7 @@ export function SimVerdictBlock({
         ) : (
           <VerdictThreads
             threads={threads}
-            onSelectPreset={onSelectPreset}
-            onJumpToStep={onJumpToStep}
+            actions={{ onSelectPreset, onJumpToStep, evidenceFor, onOpenRule }}
           />
         )}
         {consumed.map((block) => (

--- a/packages/app/src/features/simulator/ThreadBody.tsx
+++ b/packages/app/src/features/simulator/ThreadBody.tsx
@@ -1,5 +1,7 @@
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { ClauseGrid } from "./ClauseGrid";
+import type { RuleEvidence } from "./rule-evidence";
+import { RuleEvidenceAnchor } from "./RuleEvidenceCard";
 import { previewValue } from "./rule-format";
 import type { ThreadEntry, ThreadModel, ThreadVerb, ThreadWinner } from "./verdict-threads";
 
@@ -18,13 +20,46 @@ const VERB_LABEL: Record<ThreadVerb, string> = {
   removed: "removed by",
 };
 
+/**
+ * Roadmap 053: the callbacks a thread's body needs to reach the rest of the
+ * simulator. Bundled because every level between the ledger and the override
+ * line forwards all of them unchanged.
+ */
+export interface ThreadActions {
+  onSelectPreset?: (nodeId: string) => void;
+  onJumpToStep?: (stopIndex: number) => void;
+  /** Layer 3: the popover's model for a rule, derived off the last run. */
+  evidenceFor?: (ruleIndex: number) => RuleEvidence;
+  /** Layer 3: the popover footer's jump into the matched-rules drawer. */
+  onOpenRule?: (ruleIndex: number) => void;
+}
+
 /** How a stop is named in prose: a rule by its canonical `packageRules[N]`
  *  reference (the same text validators and cross-links use), a stop without a
- *  rule by its timeline name. Roadmap 053 layer 3 turns the rule reference
- *  into the popover anchor; until then it is plain text. */
-function WriterRef({ ruleIndex, stopLabel }: { ruleIndex?: number; stopLabel: string }) {
+ *  rule by its timeline name. On an OVERRIDE line the reference is also the
+ *  popover anchor (layer 3) — that rule's story is elsewhere, unlike the
+ *  winner's, whose evidence is already open right below it. */
+function WriterRef({
+  ruleIndex,
+  stopLabel,
+  evidence,
+}: {
+  ruleIndex?: number;
+  stopLabel: string;
+  evidence?: ThreadActions;
+}) {
   if (ruleIndex === undefined) {
     return <span className="sim-thread-stop">the {stopLabel}</span>;
+  }
+  if (evidence?.evidenceFor) {
+    return (
+      <RuleEvidenceAnchor
+        ruleIndex={ruleIndex}
+        evidenceFor={evidence.evidenceFor}
+        onOpenRule={evidence.onOpenRule}
+        onSelectPreset={evidence.onSelectPreset}
+      />
+    );
   }
   return <code className="sim-thread-rule">packageRules[{ruleIndex}]</code>;
 }
@@ -54,7 +89,7 @@ function ThreadWriterLine({
 
 /** One value the winner beat — struck through in place, with whoever wrote it.
  *  The cascade's last entry is the pre-rules value, which has no writer. */
-function ThreadOverrideLine({ entry }: { entry: ThreadEntry }) {
+function ThreadOverrideLine({ entry, actions }: { entry: ThreadEntry; actions: ThreadActions }) {
   if (entry.kind === "base") {
     if (!entry.present) {
       return <p className="sim-thread-line">nothing was set before any rule</p>;
@@ -69,7 +104,8 @@ function ThreadOverrideLine({ entry }: { entry: ThreadEntry }) {
   return (
     <p className="sim-thread-line">
       <b>overrode</b> <span className="sim-thread-old">{previewValue(entry.value, 80)}</span>{" "}
-      written by <WriterRef ruleIndex={entry.ruleIndex} stopLabel={entry.stopLabel} />
+      written by{" "}
+      <WriterRef ruleIndex={entry.ruleIndex} stopLabel={entry.stopLabel} evidence={actions} />
     </p>
   );
 }
@@ -95,20 +131,17 @@ function ThreadStepLine({
   );
 }
 
-export function ThreadBody({
-  thread,
-  onSelectPreset,
-  onJumpToStep,
-}: {
-  thread: ThreadModel;
-  onSelectPreset?: (nodeId: string) => void;
-  onJumpToStep?: (stopIndex: number) => void;
-}) {
+export function ThreadBody({ thread, actions }: { thread: ThreadModel; actions: ThreadActions }) {
   const { winner } = thread;
+  const { onJumpToStep } = actions;
   return (
     <div className="sim-thread-body">
       {winner ? (
-        <ThreadWriterLine winner={winner} verb={thread.verb} onSelectPreset={onSelectPreset} />
+        <ThreadWriterLine
+          winner={winner}
+          verb={thread.verb}
+          onSelectPreset={actions.onSelectPreset}
+        />
       ) : (
         <p className="sim-thread-line">No merge step names this setting.</p>
       )}
@@ -117,6 +150,7 @@ export function ThreadBody({
         <ThreadOverrideLine
           key={entry.kind === "base" ? "base" : `stop-${entry.stopIndex}`}
           entry={entry}
+          actions={actions}
         />
       ))}
       {winner && onJumpToStep ? (

--- a/packages/app/src/features/simulator/VerdictThreads.tsx
+++ b/packages/app/src/features/simulator/VerdictThreads.tsx
@@ -3,7 +3,7 @@ import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
 import { OptionKey } from "@/components/option-docs";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { previewValue } from "./rule-format";
-import { ThreadBody } from "./ThreadBody";
+import { ThreadBody, type ThreadActions } from "./ThreadBody";
 import type { ThreadModel } from "./verdict-threads";
 
 /**
@@ -47,7 +47,11 @@ function ThreadHeadValue({ thread }: { thread: ThreadModel }) {
   );
 }
 
-/** The origin cell — kept as a cell even when empty so the column holds. */
+/** The origin cell — kept as a cell even when empty so the column holds.
+ *  Roadmap 053 layer 3: a DOT here, not the full chip. Collapsed, the column
+ *  is read as "same origin or not?" down the ledger, which is exactly what a
+ *  hue answers; the label stays one hover (or one expansion, where the writer
+ *  line wears the full chip) away. */
 function ThreadHeadOrigin({
   layer,
   onSelectPreset,
@@ -57,7 +61,9 @@ function ThreadHeadOrigin({
 }) {
   return (
     <span className="sim-thread-origin">
-      {layer ? <ProvenanceChip layer={layer} onSelectPreset={onSelectPreset} /> : null}
+      {layer ? (
+        <ProvenanceChip layer={layer} onSelectPreset={onSelectPreset} variant="dot" />
+      ) : null}
     </span>
   );
 }
@@ -65,15 +71,7 @@ function ThreadHeadOrigin({
 /** One thread: the collapsed head button, and the body it discloses.
  *  Expansion is local and uncontrolled — a re-simulation replaces the rows and
  *  collapses them, which is the honest state for a new run's evidence. */
-function ThreadRow({
-  thread,
-  onSelectPreset,
-  onJumpToStep,
-}: {
-  thread: ThreadModel;
-  onSelectPreset?: (nodeId: string) => void;
-  onJumpToStep?: (stopIndex: number) => void;
-}) {
+function ThreadRow({ thread, actions }: { thread: ThreadModel; actions: ThreadActions }) {
   const [open, setOpen] = useState(false);
   return (
     <li className={`sim-thread${open ? " open" : ""}`}>
@@ -85,33 +83,24 @@ function ThreadRow({
       >
         <ThreadHeadKey name={thread.key} open={open} />
         <ThreadHeadValue thread={thread} />
-        <ThreadHeadOrigin layer={thread.winner?.layer} onSelectPreset={onSelectPreset} />
+        <ThreadHeadOrigin layer={thread.winner?.layer} onSelectPreset={actions.onSelectPreset} />
       </button>
-      {open ? (
-        <ThreadBody thread={thread} onSelectPreset={onSelectPreset} onJumpToStep={onJumpToStep} />
-      ) : null}
+      {open ? <ThreadBody thread={thread} actions={actions} /> : null}
     </li>
   );
 }
 
 export function VerdictThreads({
   threads,
-  onSelectPreset,
-  onJumpToStep,
+  actions,
 }: {
   threads: ThreadModel[];
-  onSelectPreset?: (nodeId: string) => void;
-  onJumpToStep?: (stopIndex: number) => void;
+  actions: ThreadActions;
 }) {
   return (
     <ul className="sim-thread-list">
       {threads.map((thread) => (
-        <ThreadRow
-          key={thread.key}
-          thread={thread}
-          onSelectPreset={onSelectPreset}
-          onJumpToStep={onJumpToStep}
-        />
+        <ThreadRow key={thread.key} thread={thread} actions={actions} />
       ))}
     </ul>
   );

--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Roadmap 053 (variant A), layer 3: the rule popover's model. The claim under
+ * test is the classification — which of a rule's writes reached the final
+ * config and which a later stop took away, and WHICH stop that was — because
+ * that is the sentence the card prints next to a struck-through value, and
+ * getting it wrong would accuse the wrong rule.
+ *
+ * Fixtures are hand-written `MergeStop`s (same shapes as
+ * `verdict-threads.test.ts`): a `merged` entry omits `before` for a key that
+ * did not exist yet and omits `after` when the merge removed it.
+ */
+import type {
+  ClauseEvaluation,
+  MergedKey,
+  ProvenanceLayer,
+  RuleEvaluation,
+  SimulationResult,
+} from "@renovate-config-visualizer/engine";
+import { describe, expect, test } from "vitest";
+import type { MergeStop } from "./merge-stops";
+import { buildRuleEvidence } from "./rule-evidence";
+
+const PRESET_LAYER: ProvenanceLayer = { kind: "preset", nodeId: "n1", name: "config:recommended" };
+
+const MATCHED_CLAUSE: ClauseEvaluation = {
+  key: "matchDatasources",
+  value: ["npm"],
+  state: "matched",
+  inputValues: { datasource: "npm" },
+  readFields: ["datasource"],
+};
+
+function stopChrome(id: string): Pick<MergeStop, "chip" | "step"> {
+  return { chip: { label: id, ariaLabel: id }, step: { id, before: {}, after: {}, head: id } };
+}
+
+function ruleStop(ruleIndex: number, merged: MergedKey[]): MergeStop {
+  return { kind: "rule", ruleIndex, merged, ...stopChrome(`rule-${ruleIndex}`) };
+}
+
+function flattenStop(merged: MergedKey[]): MergeStop {
+  return { kind: "flatten", merged, ...stopChrome("flatten") };
+}
+
+function matchedRule(index: number): RuleEvaluation {
+  return { index, verdict: "matched", clauses: [MATCHED_CLAUSE], notes: [] };
+}
+
+function simFixture(rules: RuleEvaluation[]): SimulationResult {
+  return {
+    rules,
+    rawFinalConfig: {},
+    finalDependencyConfig: {},
+    flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    mergeSteps: [],
+    errors: [],
+    warnings: [],
+    notes: [],
+  };
+}
+
+/** The mockup's scenario: rule 201 writes two keys in step 2; `schedule`
+ *  survives, `groupName` is taken by rule 458 in step 3. */
+const STOPS: MergeStop[] = [
+  { kind: "base", ...stopChrome("base") },
+  ruleStop(12, [{ key: "labels", before: [], after: ["deps"] }]),
+  ruleStop(201, [
+    { key: "schedule", before: ["at any time"], after: ["before 6am on monday"] },
+    { key: "groupName", after: "npm minor+patch" },
+  ]),
+  ruleStop(458, [{ key: "groupName", before: "npm minor+patch", after: "oxlint monorepo" }]),
+  { kind: "final", ...stopChrome("final") },
+];
+const LAYERS = new Map<number, ProvenanceLayer>([[201, PRESET_LAYER]]);
+const SIM = simFixture([matchedRule(12), matchedRule(201), matchedRule(458)]);
+
+describe("buildRuleEvidence", () => {
+  test("classifies each write, naming the stop that overrode the lost one", () => {
+    const evidence = buildRuleEvidence(201, STOPS, LAYERS, SIM);
+    expect(evidence.stopOrdinal).toBe(2);
+    expect(evidence.stopLabel).toBe("step 2 of 3");
+    expect(evidence.stopIndex).toBe(2);
+    expect(evidence.verdict).toBe("matched");
+    expect(evidence.layer).toBe(PRESET_LAYER);
+    expect(evidence.clauses).toEqual([MATCHED_CLAUSE]);
+    expect(evidence.survivedCount).toBe(1);
+    expect(evidence.writes).toEqual([
+      {
+        key: "schedule",
+        before: ["at any time"],
+        hadBefore: true,
+        after: ["before 6am on monday"],
+        hadAfter: true,
+        survived: true,
+        overriddenAtStopIndex: undefined,
+        overriddenAtOrdinal: undefined,
+        overriddenAtLabel: undefined,
+      },
+      {
+        key: "groupName",
+        before: undefined,
+        // The key did not exist before this rule ran — a `+` write, not a `~`.
+        hadBefore: false,
+        after: "npm minor+patch",
+        hadAfter: true,
+        survived: false,
+        overriddenAtStopIndex: 3,
+        overriddenAtOrdinal: 3,
+        overriddenAtLabel: "step 3 of 3",
+      },
+    ]);
+  });
+
+  test("the LAST word is not what overrode a write — the next stop that took it is", () => {
+    const stops = [
+      ruleStop(1, [{ key: "groupName", after: "a" }]),
+      ruleStop(2, [{ key: "groupName", before: "a", after: "b" }]),
+      ruleStop(3, [{ key: "groupName", before: "b", after: "c" }]),
+    ];
+    const [write] = buildRuleEvidence(1, stops, new Map(), simFixture([])).writes;
+    expect(write?.overriddenAtOrdinal).toBe(2);
+  });
+
+  test("a flatten stop can be the overrider, and is named rather than numbered", () => {
+    const stops = [
+      ruleStop(4, [{ key: "automerge", after: true }]),
+      flattenStop([{ key: "automerge", before: true, after: false }]),
+    ];
+    const [write] = buildRuleEvidence(4, stops, new Map(), simFixture([])).writes;
+    expect(write?.survived).toBe(false);
+    expect(write?.overriddenAtLabel).toBe("flatten step");
+    expect(write?.overriddenAtOrdinal).toBeUndefined();
+  });
+
+  test("a removed key is a write like any other, and can itself be overridden", () => {
+    const stops = [
+      ruleStop(0, [{ key: "schedule", before: ["on monday"] }]),
+      ruleStop(1, [{ key: "schedule", after: ["at any time"] }]),
+    ];
+    const [write] = buildRuleEvidence(0, stops, new Map(), simFixture([])).writes;
+    expect(write?.hadAfter).toBe(false);
+    expect(write?.hadBefore).toBe(true);
+    expect(write?.survived).toBe(false);
+    expect(write?.overriddenAtLabel).toBe("step 2 of 2");
+  });
+
+  test("a rule with no merge stop keeps its clause evidence and writes nothing", () => {
+    const evidence = buildRuleEvidence(
+      12,
+      [ruleStop(3, [{ key: "labels", after: [] }])],
+      new Map(),
+      {
+        ...simFixture([{ index: 12, verdict: "no-match", clauses: [MATCHED_CLAUSE], notes: [] }]),
+      },
+    );
+    expect(evidence.stopLabel).toBeUndefined();
+    expect(evidence.writes).toEqual([]);
+    expect(evidence.survivedCount).toBe(0);
+    expect(evidence.verdict).toBe("no-match");
+    expect(evidence.clauses).toEqual([MATCHED_CLAUSE]);
+  });
+
+  test("without a simulation there is no verdict and no clause evidence", () => {
+    const evidence = buildRuleEvidence(201, STOPS, LAYERS, null);
+    expect(evidence.verdict).toBeUndefined();
+    expect(evidence.clauses).toEqual([]);
+    // The stops still say what the rule merged and what became of it.
+    expect(evidence.writes).toHaveLength(2);
+    expect(evidence.survivedCount).toBe(1);
+  });
+});

--- a/packages/app/src/features/simulator/rule-evidence.ts
+++ b/packages/app/src/features/simulator/rule-evidence.ts
@@ -1,0 +1,120 @@
+import type {
+  ClauseEvaluation,
+  ProvenanceLayer,
+  RuleEvaluation,
+  SimulationResult,
+} from "@renovate-config-visualizer/engine";
+import type { MergeStop } from "./merge-stops";
+import { stopLabels } from "./verdict-threads";
+
+/**
+ * Roadmap 053 (variant A), layer 3: everything the rule popover states about
+ * ONE rule — its clause evidence, where it merged, and what each of its writes
+ * was worth by the end of the run.
+ *
+ * The popover is opened from a thread's override line, i.e. from a write that
+ * LOST; the whole point is that the reader can then see the rule's other writes
+ * too, most of which usually survived. So a write is classified against the
+ * stops that came after it: the first later stop naming the same key is the one
+ * that took it away ("overridden in step M"), and a key no later stop names
+ * reached the final config.
+ *
+ * Pure derivation over the last RUN — same discipline as `verdict-threads.ts`,
+ * and it borrows that module's `stopLabels` so a stop is never named two ways.
+ */
+
+/** One key this rule merged, and what became of it. */
+export interface RuleWrite {
+  key: string;
+  /** The value the key held going into this merge. */
+  before: unknown;
+  /** The engine omits `before` when the key did not exist yet — the difference
+   *  between "changed x" and "added x", which the digest's mark states. */
+  hadBefore: boolean;
+  after: unknown;
+  /** The engine omits `after` when the merge REMOVED the key. */
+  hadAfter: boolean;
+  /** True when no later stop wrote this key — i.e. this write is what the
+   *  final per-dependency config carries. */
+  survived: boolean;
+  /** The stop that took the key away, when one did. */
+  overriddenAtStopIndex?: number;
+  /** Its position among the rule stops (absent for the flatten stop). */
+  overriddenAtOrdinal?: number;
+  /** Its prose name ("step 3 of 4", "flatten step"). */
+  overriddenAtLabel?: string;
+}
+
+/** The popover's whole model. Stop fields are absent for a rule that never
+ *  merged anything (no stop of its own) — the card then states the clause
+ *  evidence alone. */
+export interface RuleEvidence {
+  ruleIndex: number;
+  verdict?: RuleEvaluation["verdict"];
+  layer?: ProvenanceLayer;
+  clauses: ClauseEvaluation[];
+  stopIndex?: number;
+  stopOrdinal?: number;
+  stopLabel?: string;
+  writes: RuleWrite[];
+  /** How many of `writes` reached the final config. */
+  survivedCount: number;
+}
+
+/** The first stop AFTER `stopIndex` that names `key` — the write's killer.
+ *  Later stops than that one are irrelevant here: by then the value on the
+ *  table is no longer this rule's. */
+function overriderOf(mergeStops: MergeStop[], stopIndex: number, key: string): number | undefined {
+  for (let i = stopIndex + 1; i < mergeStops.length; i += 1) {
+    if (mergeStops[i]?.merged?.some((m) => m.key === key)) {
+      return i;
+    }
+  }
+  return undefined;
+}
+
+export function buildRuleEvidence(
+  ruleIndex: number,
+  mergeStops: MergeStop[],
+  layerByIndex: Map<number, ProvenanceLayer>,
+  sim: SimulationResult | null,
+): RuleEvidence {
+  const labels = stopLabels(mergeStops);
+  const stopIndex = mergeStops.findIndex((s) => s.kind === "rule" && s.ruleIndex === ruleIndex);
+  const rule = sim?.rules.find((r) => r.index === ruleIndex);
+  const base: RuleEvidence = {
+    ruleIndex,
+    verdict: rule?.verdict,
+    layer: layerByIndex.get(ruleIndex),
+    clauses: rule?.clauses ?? [],
+    writes: [],
+    survivedCount: 0,
+  };
+  if (stopIndex === -1) {
+    return base;
+  }
+  const label = labels[stopIndex];
+  const writes: RuleWrite[] = (mergeStops[stopIndex]?.merged ?? []).map((entry) => {
+    const overriddenAt = overriderOf(mergeStops, stopIndex, entry.key);
+    const overrider = overriddenAt === undefined ? undefined : labels[overriddenAt];
+    return {
+      key: entry.key,
+      before: entry.before,
+      hadBefore: Object.hasOwn(entry, "before"),
+      after: entry.after,
+      hadAfter: Object.hasOwn(entry, "after"),
+      survived: overriddenAt === undefined,
+      overriddenAtStopIndex: overriddenAt,
+      overriddenAtOrdinal: overrider?.ordinal,
+      overriddenAtLabel: overrider?.label,
+    };
+  });
+  return {
+    ...base,
+    stopIndex,
+    stopOrdinal: label?.ordinal,
+    stopLabel: label?.label,
+    writes,
+    survivedCount: writes.filter((w) => w.survived).length,
+  };
+}

--- a/packages/app/src/features/simulator/verdict-threads.ts
+++ b/packages/app/src/features/simulator/verdict-threads.ts
@@ -92,7 +92,9 @@ export interface ThreadModel {
   writerCount: number;
 }
 
-interface StopLabel {
+/** How one merge stop is named in prose — shared with `rule-evidence.ts`, so
+ *  the popover and the thread cannot name the same stop differently. */
+export interface StopLabel {
   ordinal?: number;
   label: string;
 }
@@ -109,7 +111,7 @@ interface Writer {
  * rule stops count among themselves ("step 2 of 5"), the flatten stop is named
  * rather than numbered.
  */
-function stopLabels(mergeStops: MergeStop[]): StopLabel[] {
+export function stopLabels(mergeStops: MergeStop[]): StopLabel[] {
   const nRuleStops = mergeStops.filter((s) => s.kind === "rule").length;
   let ordinal = 0;
   return mergeStops.map((stop) => {

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1509,25 +1509,50 @@ textarea.layer-editor:focus {
   cursor: pointer;
 }
 
-.badge.prov-defaults {
+/* 053: the hue rules are shared with the dot variant below — the dot IS the
+   chip's color with the label moved into the hover card, so the two must never
+   be able to disagree about which hue a layer wears. */
+.badge.prov-defaults,
+.prov-dot.prov-defaults {
   color: var(--muted);
 }
 
-.badge.prov-repo {
+.badge.prov-repo,
+.prov-dot.prov-repo {
   color: var(--accent);
 }
 
-.badge.prov-preset {
+.badge.prov-preset,
+.prov-dot.prov-preset {
   color: var(--accent-purple);
 }
 
 /* 008 layer badges — distinct hues next to the repo blue / preset purple */
-.badge.prov-global {
+.badge.prov-global,
+.prov-dot.prov-global {
   color: var(--accent-teal);
 }
 
-.badge.prov-inherited {
+.badge.prov-inherited,
+.prov-dot.prov-inherited {
   color: var(--accent-pink);
+}
+
+/* 053: inside an evidence layer the chip repeats on every row, where a column
+   of colored labels competes with the evidence itself. The dot keeps the one
+   thing that column is scanned for — same origin as the row above, or not —
+   and hands the label to the tooltip and the chip's own hover card. */
+.prov-dot {
+  background: currentColor;
+  border-radius: 50%;
+  display: inline-block;
+  flex: none;
+  height: 0.5rem;
+  width: 0.5rem;
+}
+
+.prov-dot[role="button"] {
+  cursor: pointer;
 }
 
 .badge.prov-overridden {
@@ -2434,6 +2459,101 @@ pre.config-view.prov-before {
   color: var(--ink);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.78rem;
+}
+
+/* 053 layer 3: the rule-evidence popover. The plane is the app's existing
+   hover-card plane (.option-card: raised surface, popover shadow, fixed
+   placement clamped to the viewport by lib/anchored-card) — this only sets the
+   shape the mockup asked for. Nothing here animates: the card is opened by a
+   click and read immediately, so a transition would only delay it. */
+.sim-rule-pop {
+  font-size: 0.78rem;
+  /* The inline max-width from the placement helper wins; this is the shape
+     when the viewport is wide enough for the card's full 36rem. */
+  max-width: min(36rem, 92vw);
+  width: max-content;
+}
+
+.sim-rule-pop-anchor {
+  display: inline;
+}
+
+/* The losing writer's reference IS the link — same mono reference text the
+   thread uses elsewhere, marked as actionable rather than restated. */
+.sim-rule-pop-link {
+  background: none;
+  border: none;
+  border-bottom: 1px dotted var(--accent);
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  /* The reference reads as the same `packageRules[N]` token the winner line
+     sets in <code> — only its color and underline say it opens something. */
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  padding: 0;
+}
+
+.sim-rule-pop-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin: 0 0 0.35rem;
+}
+
+.sim-rule-pop-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+}
+
+.sim-rule-pop-line {
+  color: var(--muted);
+  margin: 0.35rem 0;
+}
+
+.sim-rule-pop-foot {
+  margin: 0.4rem 0 0;
+}
+
+/* One row per key the rule wrote, on shared columns (mark · key · values) so
+   the digest reads down the value edge like every other 053 ledger. */
+.sim-digest {
+  column-gap: 0.45rem;
+  display: grid;
+  grid-template-columns: max-content max-content minmax(0, 1fr);
+  row-gap: 0.2rem;
+}
+
+.sim-digest-row {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+}
+
+.sim-digest-mark {
+  color: var(--muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.sim-digest-key {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+}
+
+.sim-digest-values {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* A write that happened here but lost to a later stop: it IS this step's
+   addition, so it keeps the add tint, and it is struck like every other value
+   in 053 that never reached the final config. */
+.sim-merged-after.overridden {
+  text-decoration: line-through;
+}
+
+.sim-digest-note {
+  color: var(--muted);
 }
 
 .sim-step-link {

--- a/packages/app/src/lib/anchored-card.ts
+++ b/packages/app/src/lib/anchored-card.ts
@@ -1,0 +1,40 @@
+import type { CSSProperties } from "react";
+
+/**
+ * Roadmap 025/053: where a floating card anchored to an element goes. The
+ * cards render `position: fixed` and are portalled to `<body>` (035), so the
+ * numbers below are viewport coordinates; two rules matter and were duplicated
+ * per card before this module: clamp the width to the VIEWPORT rather than to
+ * a constant (a 340px card does not fit a 320px phone, roadmap 025), and flip
+ * above the anchor when there isn't room beneath it.
+ */
+
+/** The anchor's viewport box — the three edges the placement needs. */
+export interface AnchorRect {
+  left: number;
+  top: number;
+  bottom: number;
+}
+
+export function anchorRectOf(el: Element): AnchorRect {
+  const rect = el.getBoundingClientRect();
+  return { left: rect.left, top: rect.top, bottom: rect.bottom };
+}
+
+/**
+ * @param maxWidth the card's preferred width in px, clamped to the viewport
+ * @param flipMargin how much room the card wants below the anchor before it
+ *   flips above it — roughly the card's own height
+ */
+export function anchoredCardStyle(
+  anchor: AnchorRect,
+  maxWidth: number,
+  flipMargin: number,
+): CSSProperties {
+  const width = Math.min(maxWidth, window.innerWidth - 32);
+  const left = Math.max(8, Math.min(anchor.left, window.innerWidth - width - 16));
+  const openUpward = anchor.bottom > window.innerHeight - flipMargin;
+  return openUpward
+    ? { left, bottom: window.innerHeight - anchor.top + 6, maxWidth: width }
+    : { left, top: anchor.bottom + 6, maxWidth: width };
+}


### PR DESCRIPTION
Variant A's second (and last) disclosure level. A thread names the rules
whose values it beat; those references are now buttons that open a
`RuleEvidenceCard` — the losing rule's clause evidence, where it merged,
and a per-outcome digest of everything it wrote: surviving writes plain,
lost ones keeping the step's add tint but struck through and naming the
stop that took them ("⊘ overridden in step M"). Its footer jumps into the
matched-rules drawer through the existing 013 focus wiring.

`buildRuleEvidence` is the pure derivation behind it, deriving off the
last RUN like `buildVerdictThreads` and borrowing that module's
`stopLabels` so a stop is never named two ways. A write is classified
against the stops AFTER it: the first later stop naming the key is the
one that took it, not whoever happens to hold the key at the end.

The card is light-dismiss (Escape / click outside), `role="dialog"`, and
hands focus back to the reference that opened it. It rides the app's
existing hover-card plane — and the viewport-clamping that plane needs
moves into `lib/anchored-card.ts`, which the glossary and option cards
now share instead of each carrying its own copy (roadmap 025's math, one
home).

`ProvenanceChip` gains a `dot` variant, used on thread HEAD rows: that
column is read as "same origin as the row above, or not?", which is what
a hue answers — the label stays one hover (or one expansion, where the
writer line wears the full chip) away.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>