### PR TITLE
feat(app): return pill and simThread share state (054 layer 4)

### DIFF
--- a/packages/app/src/features/simulator/ReturnPill.tsx
+++ b/packages/app/src/features/simulator/ReturnPill.tsx
@@ -1,0 +1,36 @@
+import { createPortal } from "react-dom";
+
+/**
+ * Roadmap 053 (layer 4): the way back. A thread's own jumps — the step link
+ * into the demoted replay, the popover's "open in matched rules" — are the only
+ * navigation variant A has, and both land the reader somewhere the thread they
+ * came from is off-screen. This pill sits on the app's existing bottom-pill
+ * plane (`.back-to-top` / `.rcv-toast`) naming that thread, and returns to it:
+ * expanded, scrolled to, flashed.
+ *
+ * Ephemeral by construction — a click, a new run or Escape ends it — and NEVER
+ * encoded in a share link: a link says where to look, not that the reader once
+ * walked away from a row.
+ *
+ * Portalled to `<body>` for the same reason the rule-evidence popover is: a
+ * `position: fixed` box rendered inside the results column is re-anchored by
+ * any ancestor that gains containment (035), and the stale-run veil it would
+ * live under is exactly such an ancestor waiting to happen.
+ *
+ * It lives in features/simulator rather than components/ because nothing about
+ * it is app-generic: the label IS a thread key, and the plane it borrows is
+ * already shared through CSS, which is where that sharing belongs.
+ */
+export function ReturnPill({ threadKey, onReturn }: { threadKey: string; onReturn: () => void }) {
+  return createPortal(
+    <button
+      type="button"
+      className="sim-return-pill"
+      onClick={onReturn}
+      aria-label={`Back to ${threadKey}`}
+    >
+      ↩ Back to <code>{threadKey}</code>
+    </button>,
+    document.body,
+  );
+}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -10,6 +10,7 @@ import { ComparisonPanel } from "./ComparisonPanel";
 import { consumedAuthoredBlocks } from "./consumed-blocks";
 import { EMPTY_FORM, type FormState, hasMeaningfulInput } from "./form";
 import { buildMergeStops } from "./merge-stops";
+import { ReturnPill } from "./ReturnPill";
 import { buildRuleEvidence } from "./rule-evidence";
 import { SimMergeDrawer } from "./SimMergeDrawer";
 import { SimMessages } from "./SimMessages";
@@ -24,6 +25,7 @@ import { type SimRequest, useShareLinkRequest } from "./use-share-link-request";
 import { useSimulationRun } from "./use-simulation-run";
 import { useSimulatorDrawers } from "./use-simulator-drawers";
 import { useSimulatorForm } from "./use-simulator-form";
+import { useThreadNav } from "./use-thread-nav";
 import { buildVerdictSegments } from "./verdict-sentence";
 import { buildVerdictThreads } from "./verdict-threads";
 
@@ -114,7 +116,19 @@ export const RuleSimulator = memo(function RuleSimulator({
     simulate,
     simulateRef,
   } = useSimulationRun({ result, onMergeStepChange });
-  useShareLinkRequest({ simRequest, result, setForm, setUpdateTypeTouched, simulateRef });
+  // Roadmap 053 layer 4: thread expansion + the return pill. Declared BEFORE
+  // the share-link request so its reset effect (keyed on the run) is
+  // registered first: a link arms the thread it wants, the auto-run it starts
+  // produces the sim, and the reset effect is what applies the armed key.
+  const threadNav = useThreadNav(sim);
+  useShareLinkRequest({
+    simRequest,
+    result,
+    setForm,
+    setUpdateTypeTouched,
+    simulateRef,
+    onThreadRequest: threadNav.requestThread,
+  });
   const {
     moreFieldsOpen,
     setMoreFieldsOpen,
@@ -263,8 +277,16 @@ export const RuleSimulator = memo(function RuleSimulator({
     if (effectiveUpdateType && effectiveUpdateType.trim() !== "") {
       shareForm.updateType = effectiveUpdateType;
     }
+    // Roadmap 053: the link also carries the thread the sender was reading —
+    // but only when exactly ONE is open, since two would make the app pick
+    // which of the sender's questions the link is about. Still never a token:
+    // a thread key is one of the config's own option names.
+    const share: ShareSimulator = { form: shareForm, autoSimulate: true };
+    if (threadNav.shareThreadKey !== undefined) {
+      share.simThread = threadNav.shareThreadKey;
+    }
     // Roadmap 036: the copied state lives in CopyButton now.
-    await onCopySimLink({ form: shareForm, autoSimulate: true });
+    await onCopySimLink(share);
   }
 
   /** Roadmap 053: the verdict foot's "build replay, K stops" link — the
@@ -387,6 +409,11 @@ export const RuleSimulator = memo(function RuleSimulator({
               totalRules={sim.rules.length}
               segments={verdictSegments}
               threads={verdictThreads}
+              threadNav={{
+                open: threadNav.openThreads,
+                onToggle: threadNav.toggleThread,
+                onJumpFrom: threadNav.noteJump,
+              }}
               flattened={sim.flattened}
               consumed={consumedBlocks}
               flattenStopIndex={showTimeline ? flattenStopIndex : undefined}
@@ -415,6 +442,13 @@ export const RuleSimulator = memo(function RuleSimulator({
               onUnpin={unpin}
               onPin={pin}
             />
+
+            {/* Roadmap 053 layer 4: the way back from a thread's own jump.
+                Portalled to <body> (see ReturnPill), so where it sits in this
+                tree decides nothing but its lifetime — which is the run's. */}
+            {threadNav.returnKey !== null ? (
+              <ReturnPill threadKey={threadNav.returnKey} onReturn={threadNav.returnToThread} />
+            ) : null}
 
             {pinned ? (
               <ComparisonPanel

--- a/packages/app/src/features/simulator/SimVerdictBlock.tsx
+++ b/packages/app/src/features/simulator/SimVerdictBlock.tsx
@@ -6,7 +6,7 @@ import type { RuleEvidence } from "./rule-evidence";
 import { SimConsumedBlock } from "./SimConsumedBlock";
 import type { ThreadModel } from "./verdict-threads";
 import type { VerdictSegment } from "./verdict-sentence";
-import { VerdictThreads } from "./VerdictThreads";
+import { type ThreadNavigation, VerdictThreads } from "./VerdictThreads";
 
 /**
  * Roadmap 053 (variant A): the two full-trace links the evidence drawers
@@ -58,6 +58,7 @@ export function SimVerdictBlock({
   totalRules,
   segments,
   threads,
+  threadNav,
   flattened,
   consumed,
   flattenStopIndex,
@@ -79,6 +80,9 @@ export function SimVerdictBlock({
   segments: VerdictSegment[];
   /** Roadmap 053: one thread per setting the rules changed. */
   threads: ThreadModel[];
+  /** Roadmap 053 layer 4: which threads are expanded, and where a jump out of
+   *  one is recorded (the return pill's origin). */
+  threadNav: ThreadNavigation;
   flattened: SimulationResult["flattened"];
   /** Roadmap 047: authored update-type blocks flattening consumed without
    *  applying — empty on a run where only Renovate's own defaults were. */
@@ -143,6 +147,7 @@ export function SimVerdictBlock({
           <VerdictThreads
             threads={threads}
             actions={{ onSelectPreset, onJumpToStep, evidenceFor, onOpenRule }}
+            nav={threadNav}
           />
         )}
         {consumed.map((block) => (

--- a/packages/app/src/features/simulator/VerdictThreads.tsx
+++ b/packages/app/src/features/simulator/VerdictThreads.tsx
@@ -1,9 +1,9 @@
-import { useState } from "react";
 import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
 import { OptionKey } from "@/components/option-docs";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { previewValue } from "./rule-format";
 import { ThreadBody, type ThreadActions } from "./ThreadBody";
+import { threadHeadId } from "./use-thread-nav";
 import type { ThreadModel } from "./verdict-threads";
 
 /**
@@ -68,24 +68,74 @@ function ThreadHeadOrigin({
   );
 }
 
-/** One thread: the collapsed head button, and the body it discloses.
- *  Expansion is local and uncontrolled — a re-simulation replaces the rows and
- *  collapses them, which is the honest state for a new run's evidence. */
-function ThreadRow({ thread, actions }: { thread: ThreadModel; actions: ThreadActions }) {
-  const [open, setOpen] = useState(false);
+/**
+ * Roadmap 053 layer 4: expansion moved OUT of the row. Two things outside a
+ * row now open one — a share link's `simThread` and the return pill — and the
+ * copy-link affordance has to know which thread is open to encode it, so the
+ * state belongs to the simulator (see `use-thread-nav`). A re-simulation still
+ * collapses everything, which is the honest state for a new run's evidence.
+ */
+export interface ThreadNavigation {
+  open: ReadonlySet<string>;
+  onToggle: (key: string, open: boolean) => void;
+  /** A jump out of a thread — recorded so the pill can point back at it. */
+  onJumpFrom: (key: string) => void;
+}
+
+/** Every jump a thread offers records that thread as the return target first.
+ *  Wrapped once per row, so the pill's origin can never disagree with the row
+ *  the reader actually left — the alternative is each jump site remembering to
+ *  say where it is, which is the kind of thing that stays right for one
+ *  release. */
+function withJumpOrigin(
+  key: string,
+  actions: ThreadActions,
+  onJumpFrom: (key: string) => void,
+): ThreadActions {
+  const wrapped: ThreadActions = { ...actions };
+  const { onJumpToStep, onOpenRule } = actions;
+  if (onJumpToStep) {
+    wrapped.onJumpToStep = (stopIndex) => {
+      onJumpFrom(key);
+      onJumpToStep(stopIndex);
+    };
+  }
+  if (onOpenRule) {
+    wrapped.onOpenRule = (ruleIndex) => {
+      onJumpFrom(key);
+      onOpenRule(ruleIndex);
+    };
+  }
+  return wrapped;
+}
+
+/** One thread: the collapsed head button, and the body it discloses. */
+function ThreadRow({
+  thread,
+  actions,
+  nav,
+}: {
+  thread: ThreadModel;
+  actions: ThreadActions;
+  nav: ThreadNavigation;
+}) {
+  const open = nav.open.has(thread.key);
   return (
     <li className={`sim-thread${open ? " open" : ""}`}>
       <button
         type="button"
+        id={threadHeadId(thread.key)}
         className="sim-thread-head"
         aria-expanded={open}
-        onClick={() => setOpen(!open)}
+        onClick={() => nav.onToggle(thread.key, !open)}
       >
         <ThreadHeadKey name={thread.key} open={open} />
         <ThreadHeadValue thread={thread} />
         <ThreadHeadOrigin layer={thread.winner?.layer} onSelectPreset={actions.onSelectPreset} />
       </button>
-      {open ? <ThreadBody thread={thread} actions={actions} /> : null}
+      {open ? (
+        <ThreadBody thread={thread} actions={withJumpOrigin(thread.key, actions, nav.onJumpFrom)} />
+      ) : null}
     </li>
   );
 }
@@ -93,14 +143,16 @@ function ThreadRow({ thread, actions }: { thread: ThreadModel; actions: ThreadAc
 export function VerdictThreads({
   threads,
   actions,
+  nav,
 }: {
   threads: ThreadModel[];
   actions: ThreadActions;
+  nav: ThreadNavigation;
 }) {
   return (
     <ul className="sim-thread-list">
       {threads.map((thread) => (
-        <ThreadRow key={thread.key} thread={thread} actions={actions} />
+        <ThreadRow key={thread.key} thread={thread} actions={actions} nav={nav} />
       ))}
     </ul>
   );

--- a/packages/app/src/features/simulator/use-rule-focus.ts
+++ b/packages/app/src/features/simulator/use-rule-focus.ts
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import { flashTarget, motionScrollOptions } from "@/lib/motion";
 
 export interface RuleFocus {
   /** The simulator card itself — where a cross-link lands when no simulation
@@ -70,7 +71,7 @@ export function useRuleFocus({
       // No simulation has run yet, so the target row isn't rendered anywhere.
       // Land the user on the simulator and prompt them to run one, rather than
       // leaving the cross-link click looking dead (the "looks broken" finding).
-      cardRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      cardRef.current?.scrollIntoView(motionScrollOptions("start"));
       setFocusHint(scrollTarget);
       setScrollTarget(null);
       onRuleFocused?.();
@@ -101,9 +102,8 @@ export function useRuleFocus({
     }
     const el = document.getElementById(`sim-rule-${scrollTarget}`);
     if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
-      el.classList.add("rcv-flash");
-      window.setTimeout(() => el.classList.remove("rcv-flash"), 1600);
+      el.scrollIntoView(motionScrollOptions("center"));
+      flashTarget(el);
     }
     setScrollTarget(null);
     onRuleFocused?.();

--- a/packages/app/src/features/simulator/use-share-link-request.ts
+++ b/packages/app/src/features/simulator/use-share-link-request.ts
@@ -26,12 +26,17 @@ export function useShareLinkRequest({
   setForm,
   setUpdateTypeTouched,
   simulateRef,
+  onThreadRequest,
 }: {
   simRequest: SimRequest | null | undefined;
   result: TraceResult;
   setForm: Dispatch<SetStateAction<FormState>>;
   setUpdateTypeTouched: Dispatch<SetStateAction<boolean>>;
   simulateRef: RefObject<Simulate | null>;
+  /** Roadmap 053: the verdict thread the link asked to open, armed BEFORE the
+   *  auto-run below so the run that arrives can expand it (see
+   *  `use-thread-nav`, which consumes it in its own reset effect). */
+  onThreadRequest?: (key: string | null) => void;
 }) {
   // Roadmap 018: applied-once bookkeeping for an incoming share `simRequest`.
   const appliedSimNonce = useRef<number | null>(null);
@@ -53,11 +58,12 @@ export function useShareLinkRequest({
     // deliberate pin — mark it touched so derivation can't override it.
     const touched = next.updateType.trim() !== "";
     setUpdateTypeTouched(touched);
+    onThreadRequest?.(simRequest.simThread ?? null);
     if (simRequest.autoSimulate) {
       // Roadmap 044: the link's own merge-step index has already been applied
       // by App — this auto-run must not reset it back to step 0, which is the
       // whole point of a link that says "look at what THIS rule does".
       void simulateRef.current?.(next, touched, true);
     }
-  }, [simRequest, result, setForm, setUpdateTypeTouched, simulateRef]);
+  }, [simRequest, result, setForm, setUpdateTypeTouched, simulateRef, onThreadRequest]);
 }

--- a/packages/app/src/features/simulator/use-thread-nav.ts
+++ b/packages/app/src/features/simulator/use-thread-nav.ts
@@ -1,0 +1,141 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import { flashTarget, motionScrollOptions } from "@/lib/motion";
+
+/**
+ * Roadmap 053 (layer 4): thread expansion and the way back from a jump, as one
+ * concern — because they are one concern. Expansion was local to each
+ * `ThreadRow` in layer 2, which was right until two things outside a row
+ * needed to open one: a share link's `simThread`, and the return pill, whose
+ * whole job is to put the reader back inside the thread they left.
+ *
+ * The set of open keys is the simulator's, not App's (see RuleSimulator's
+ * `copySimLink`): a thread only exists for the LAST run's evidence and several
+ * can be open at once, so App owning it would mean App mirroring a Set it has
+ * no use for — unlike `mergeStepIndex`, which is a controlled stepper's index.
+ * The consequence is documented where it bites: a jump does not push a history
+ * entry, so browser Back does not undo one — the pill is what undoes it.
+ */
+
+const NO_THREADS: ReadonlySet<string> = new Set();
+
+/** The thread head's DOM id — what a return (or a deep link) scrolls to. Keys
+ *  are config option names, so this is `getElementById`-safe as written. */
+export function threadHeadId(key: string): string {
+  return `sim-thread-${key}`;
+}
+
+export interface ThreadNav {
+  /** The expanded threads, by key. */
+  openThreads: ReadonlySet<string>;
+  toggleThread: (key: string, open: boolean) => void;
+  /** Record a thread-originated jump — the pill's origin. */
+  noteJump: (key: string) => void;
+  /** The thread a jump left behind, or null when no pill is showing. */
+  returnKey: string | null;
+  /** Go back: expand the origin thread, scroll to its head, flash it. */
+  returnToThread: () => void;
+  /** A decoded link's `simThread`, applied to the NEXT run's threads. */
+  requestThread: (key: string | null) => void;
+  /** Exactly one thread open → the key a copied link should carry. */
+  shareThreadKey?: string;
+}
+
+export function useThreadNav(sim: SimulationResult | null): ThreadNav {
+  const [openThreads, setOpenThreads] = useState<ReadonlySet<string>>(NO_THREADS);
+  const [returnKey, setReturnKey] = useState<string | null>(null);
+  // The key awaiting a scroll+flash once its row has committed (same idiom as
+  // use-rule-focus's `scrollTarget`).
+  const [focusKey, setFocusKey] = useState<string | null>(null);
+  const pendingThreadRef = useRef<string | null>(null);
+  const returnKeyRef = useRef(returnKey);
+  returnKeyRef.current = returnKey;
+
+  // A new run is new evidence: its threads start collapsed, and whatever jump
+  // the previous run's threads sent the reader on is over. A link's requested
+  // thread is consumed HERE, inside the same effect, so the reset can never
+  // land after it and fold the very thread the link asked for.
+  useEffect(() => {
+    const pending = pendingThreadRef.current;
+    pendingThreadRef.current = null;
+    setOpenThreads(pending === null ? NO_THREADS : new Set([pending]));
+    setReturnKey(null);
+  }, [sim]);
+
+  // The scroll+flash itself. One pass is enough, unlike use-rule-focus: a
+  // thread's HEAD renders whether or not the thread is expanded, so nothing
+  // can be hiding the target by the time this runs.
+  useEffect(() => {
+    if (focusKey === null) {
+      return;
+    }
+    const el = document.getElementById(threadHeadId(focusKey));
+    if (el) {
+      el.scrollIntoView(motionScrollOptions("center"));
+      flashTarget(el);
+    }
+    setFocusKey(null);
+  }, [focusKey]);
+
+  // Escape dismisses the pill — but only when it is not the POPOVER's Escape.
+  // A rule-evidence card open over the page owns that key first; its own
+  // document listener closes it, and React has not yet unmounted the card when
+  // this listener runs, which is exactly what the query below tests.
+  useEffect(() => {
+    if (returnKey === null) {
+      return;
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape" && document.querySelector(".sim-rule-pop") === null) {
+        setReturnKey(null);
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [returnKey]);
+
+  const toggleThread = useCallback((key: string, open: boolean) => {
+    setOpenThreads((prev) => {
+      const next = new Set(prev);
+      if (open) {
+        next.add(key);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  }, []);
+
+  const noteJump = useCallback((key: string) => {
+    setReturnKey(key);
+  }, []);
+
+  const requestThread = useCallback((key: string | null) => {
+    pendingThreadRef.current = key;
+  }, []);
+
+  // Reads the current origin through a ref rather than a state updater: a
+  // setState updater runs in the render phase, where triggering the other two
+  // updates would be a side effect React is free to replay.
+  const returnToThread = useCallback(() => {
+    const key = returnKeyRef.current;
+    if (key === null) {
+      return;
+    }
+    setReturnKey(null);
+    setOpenThreads((prev) => (prev.has(key) ? prev : new Set(prev).add(key)));
+    setFocusKey(key);
+  }, []);
+
+  return {
+    openThreads,
+    toggleThread,
+    noteJump,
+    returnKey,
+    returnToThread,
+    requestThread,
+    // Only unambiguous when ONE thread is open: with two expanded, a link
+    // carrying either would be the app choosing for the sender.
+    shareThreadKey: openThreads.size === 1 ? [...openThreads][0] : undefined,
+  };
+}

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -42,6 +42,9 @@ import { ENDPOINT_KEY, persistLocal, PLATFORM_KEY } from "@/platform/storage";
 export interface SimRequest {
   form: Record<string, string>;
   autoSimulate: boolean;
+  /** Roadmap 053: the verdict thread the link asked to open, applied to the
+   *  run this request triggers (absent = every thread starts collapsed). */
+  simThread?: string;
   nonce: number;
 }
 
@@ -264,6 +267,10 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
       setSimRequest({
         form: payload.sim.form,
         autoSimulate: payload.sim.autoSimulate === true,
+        // Roadmap 053: rides along with the form rather than through `view`
+        // (where `simStep` lives) because it is only meaningful for the
+        // simulation this descriptor reproduces — see ShareSimulator.
+        simThread: payload.sim.simThread,
         nonce: ++simNonceRef.current,
       });
     }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -3013,6 +3013,17 @@ pre.config-view.prov-before {
   animation: rcv-flash 1.6s ease-out;
 }
 
+/* Roadmap 053: the same "you are here", without the motion — the target still
+   has to be markable for a reader who asked for less animation, so the flash
+   becomes a static highlight for the same duration (the class is removed on
+   the callers' timeout either way). */
+@media (prefers-reduced-motion: reduce) {
+  .rcv-flash {
+    animation: none;
+    background: var(--highlight);
+  }
+}
+
 .sim-rule-provenance {
   flex: none;
 }
@@ -3249,6 +3260,38 @@ pre.config-view.prov-before {
 
 .back-to-top:hover {
   filter: brightness(1.1);
+}
+
+/* Roadmap 053: the return pill — the same bottom-of-the-viewport plane as
+   .back-to-top and .rcv-toast (same offset, same float shadow, same z-index),
+   but centered and quiet: it answers a jump the reader made one click ago, so
+   it must be findable without competing with the page it floats over. */
+.sim-return-pill {
+  align-items: center;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  bottom: 1.25rem;
+  box-shadow: var(--shadow-float);
+  color: var(--accent);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-size: 0.82rem;
+  gap: 0.3rem;
+  left: 50%;
+  padding: 0.4rem 0.95rem;
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: 20;
+}
+
+.sim-return-pill:hover {
+  border-color: var(--accent);
+}
+
+.sim-return-pill code {
+  font-size: 0.95em;
 }
 
 /* ---------- post-action focus, honest error states, rule filters (023) ---------- */

--- a/packages/app/src/lib/input-schemas-zod.ts
+++ b/packages/app/src/lib/input-schemas-zod.ts
@@ -139,7 +139,18 @@ export function sanitizeShareView(raw: unknown): SanitizedShareView | undefined 
 export interface SanitizedShareSimulator {
   form: Record<string, string>;
   autoSimulate?: boolean;
+  /** Roadmap 053: the expanded verdict thread's key. */
+  simThread?: string;
 }
+
+/**
+ * Roadmap 053: a verdict thread's key — a config option name the opener looks
+ * up as a DOM id and scrolls to. Bounded for the same reason every other
+ * string that reaches the DOM is: a hand-edited monster value is dropped on
+ * its own (the link still opens, just without expanding a thread), never
+ * failing the whole link.
+ */
+const threadKeySchema = z.string().check(z.minLength(1), z.maxLength(128));
 
 /**
  * Sanitizes a decoded share payload's `sim` sub-object: keeps only
@@ -164,7 +175,18 @@ export function sanitizeShareSim(raw: unknown): SanitizedShareSimulator | undefi
   if (Object.keys(form).length === 0) {
     return undefined;
   }
-  return raw.autoSimulate === true ? { form, autoSimulate: true } : { form };
+  const out: SanitizedShareSimulator = { form };
+  if (raw.autoSimulate === true) {
+    out.autoSimulate = true;
+  }
+  // Roadmap 053: kept only next to a form — a thread key names a row of a
+  // simulation's verdict, so on its own (no form to reproduce the run) there
+  // is nothing for it to point at.
+  const thread = threadKeySchema.safeParse(raw.simThread);
+  if (thread.success) {
+    out.simThread = thread.data;
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/app/src/lib/motion.ts
+++ b/packages/app/src/lib/motion.ts
@@ -1,0 +1,40 @@
+/**
+ * Roadmap 053 — the two motion-bearing gestures every cross-link in this app
+ * makes: scroll the target into view, then flash it so the eye can find it.
+ * Both were spelled out inline at each call site (013's rule focus, 047's
+ * drawer jumps), which is how the scroll came to ignore
+ * `prefers-reduced-motion` while the flash honored it in CSS only.
+ *
+ * DOM-touching but React-free, so it sits in lib/ next to `anchored-card.ts`.
+ */
+
+const REDUCED_MOTION = "(prefers-reduced-motion: reduce)";
+
+/** Must match the `.rcv-flash` animation's own duration in index.css. */
+const FLASH_MS = 1600;
+
+/** The OS-level "don't animate" preference, read at call time (a user can flip
+ *  it mid-session, and these are one-shot gestures — nothing to subscribe to). */
+export function prefersReducedMotion(): boolean {
+  return window.matchMedia(REDUCED_MOTION).matches;
+}
+
+/**
+ * Scroll options for landing on a cross-link's target: smooth normally,
+ * instant when the reader asked for less motion — the LANDING is the point,
+ * and a long smooth scroll is exactly the vestibular trigger that preference
+ * exists for.
+ */
+export function motionScrollOptions(block: ScrollLogicalPosition): ScrollIntoViewOptions {
+  return { behavior: prefersReducedMotion() ? "auto" : "smooth", block };
+}
+
+/**
+ * The transient "you are here" flash. The animation itself lives in CSS
+ * (`.rcv-flash`), including its reduced-motion form — a static highlight for
+ * the same duration, so the target is still marked, just not animated.
+ */
+export function flashTarget(el: Element): void {
+  el.classList.add("rcv-flash");
+  window.setTimeout(() => el.classList.remove("rcv-flash"), FLASH_MS);
+}

--- a/packages/app/src/lib/share.test.ts
+++ b/packages/app/src/lib/share.test.ts
@@ -641,3 +641,88 @@ describe("untrustedGuardForPolicy", () => {
     expect(guard?.host).toBe("https://evil.example/");
   });
 });
+
+/**
+ * Roadmap 053 (layer 4): `sim.simThread` — the expanded verdict thread's key —
+ * is additive within v2 exactly like `autoSimulate` was, so the tests are the
+ * same two questions: does a link that carries it round-trip, and does a link
+ * from before it existed still decode as it always did?
+ */
+describe("053: sim.simThread round-trips and stays additive", () => {
+  test("a simulation link carrying an expanded thread round-trips", async () => {
+    const token = await encodeShare(
+      minimalState({
+        view: { stage: "merge", simStep: 2, tab: "simulator" },
+        sim: { form: { packageName: "oxlint" }, autoSimulate: true, simThread: "groupName" },
+      }),
+    );
+    const result = await decodeShareResult(token);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.sim).toEqual({
+        form: { packageName: "oxlint" },
+        autoSimulate: true,
+        simThread: "groupName",
+      });
+      // The thread rides with the SIM descriptor, not the view: it is only
+      // meaningful for the simulation the form reproduces.
+      expect(result.payload.view).toEqual({ stage: "merge", simStep: 2, tab: "simulator" });
+    }
+  });
+
+  test("re-encoding a decoded sim with a thread is a fixpoint", async () => {
+    const first = await decodeShareResult(
+      await encodeShare(
+        minimalState({ sim: { form: { depName: "lodash" }, simThread: "automerge" } }),
+      ),
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    expect(first.payload.sim).toEqual({ form: { depName: "lodash" }, simThread: "automerge" });
+    const second = await decodeShareResult(
+      await encodeShare(minimalState({ sim: first.payload.sim })),
+    );
+    expect(second.ok).toBe(true);
+    if (second.ok) {
+      expect(second.payload.sim).toEqual(first.payload.sim);
+    }
+  });
+
+  test("a pre-053 link (no simThread) decodes exactly as before", async () => {
+    const token = await rawEncodeToken(
+      taggedPayload({ sim: { form: { packageName: "lodash" }, autoSimulate: true } }),
+    );
+    const result = await decodeShareResult(token);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
+      expect(result.payload.sim?.simThread).toBeUndefined();
+    }
+  });
+
+  test("a malformed simThread is dropped alone — the link still opens and runs", async () => {
+    for (const simThread of [42, "", "x".repeat(200), { key: "groupName" }]) {
+      const token = await rawEncodeToken(
+        taggedPayload({ sim: { form: { packageName: "lodash" }, autoSimulate: true, simThread } }),
+      );
+      const result = await decodeShareResult(token);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
+      }
+    }
+  });
+
+  test("a simThread without a form is dropped with the rest of the descriptor", async () => {
+    const token = await rawEncodeToken(
+      taggedPayload({ sim: { form: {}, simThread: "groupName" } }),
+    );
+    const result = await decodeShareResult(token);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.sim).toBeUndefined();
+    }
+  });
+});

--- a/packages/app/src/lib/share.ts
+++ b/packages/app/src/lib/share.ts
@@ -61,6 +61,16 @@ export interface ShareView {
 export interface ShareSimulator {
   form: Record<string, string>;
   autoSimulate?: boolean;
+  /**
+   * Roadmap 053 (layer 4): the verdict thread — a changed setting's KEY — that
+   * was expanded when the link was made, so "look at what happened to
+   * `groupName`" survives the copy. Additive within v2 exactly like
+   * `autoSimulate`: a pre-053 link simply lacks it, a pre-053 reader ignores
+   * the unknown key, and it only means anything next to a `form` that
+   * reproduces the run whose threads it names. Never a token — it is one of
+   * the config's own option names.
+   */
+  simThread?: string;
 }
 
 /** The app-facing shape passed to encodeShare. */


### PR DESCRIPTION
Variant A's navigation half. A thread's own jumps — the step link into the
demoted replay, the popover's "open in matched rules" — leave the thread
they came from off-screen, so both now leave a `ReturnPill` on the app's
bottom-pill plane naming it: "↩ Back to `groupName`". Clicking it expands
that thread, scrolls to its head and flashes it. The pill is ephemeral —
a click, a new run, or Escape ends it (Escape only when no rule-evidence
popover is open; that card owns the key first) — and is never encoded in
a link: a link says where to look, not that the reader once walked away
from a row.

Recording the origin is wrapped once per row (`withJumpOrigin`) rather
than asked of each jump site, so the pill's origin can never disagree
with the row the reader actually left.

Thread expansion therefore moves out of `ThreadRow` into `use-thread-nav`
(the simulator's own state): the pill, a share link and the copy-link
affordance all need it, and a row's `useState` can serve none of them.
Scroll + flash gain a shared home in `lib/motion.ts`, which is also what
makes them honor `prefers-reduced-motion` — the scroll becomes instant
and `.rcv-flash` a static `--highlight` for the same duration. 013's rule
focus reuses it, so both cross-link gestures behave identically.

`ShareSimulator` gains `simThread?: string` — the expanded thread's key,
carried when EXACTLY one is open (two would make the app pick which of
the sender's questions the link is about). It rides the sim descriptor,
not `view`, because it only means anything for the simulation the form
reproduces; additive within v2 exactly like `autoSimulate`, sanitized
per-field (bounded, dropped alone on a malformed value), and a pre-053
link decodes unchanged. It carries no token: a thread key is one of the
config's own option names.

Ownership deviates from the plan's "jumps push fragment updates": unlike
`mergeStepIndex`, which App owns because a controlled stepper needs
restoring, thread expansion is a set, is meaningful only for the last
run's evidence, and is read by nothing outside the simulator — App would
be mirroring state it has no use for. `simThread` is therefore a
decode-time one-shot on the existing `simRequest` nonce, armed before the
auto-run and applied by the run's own reset effect. The consequence, and
the one thing this layer does not deliver: a jump does not push a history
entry, so browser Back does not undo one. The pill is what undoes it. The
app writes the fragment on Copy link only (see `useShareLink`), and
bypassing that to push history from a jump would trade a documented
limitation for an undocumented rule.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>