### PR TITLE
test(app): e2e coverage for verdict threads navigation (054 layer 5)

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -1,20 +1,11 @@
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import {
   AUTHORED_BLOCK_CONFIG,
   encodeShareFragment,
   MERGE_STEPS_CONFIG,
   PACKAGE_RULES_CONFIG,
 } from "./fixtures";
-import { openTab } from "./helpers";
-
-/**
- * Roadmap 047: the results are staged into summary drawers — a `<details>`
- * whose summary row abstracts the body. Addressed by their visible title, the
- * way a user finds them.
- */
-function drawer(page: Page, title: string): Locator {
-  return page.locator("details.drawer", { hasText: title });
-}
+import { drawer, openTab } from "./helpers";
 
 /**
  * Journey 4 — the packageRules simulator. After a run whose config has a

--- a/packages/app/e2e/16-verdict-threads.spec.ts
+++ b/packages/app/e2e/16-verdict-threads.spec.ts
@@ -1,0 +1,274 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { CONTESTED_KEY_CONFIG, encodeShareFragment } from "./fixtures";
+import { drawer, openTab } from "./helpers";
+
+/**
+ * Roadmap 053 (variant A) — the verdict ledger IS the trace. Every row of
+ * settings the rules changed expands into that key's own causal thread: who had
+ * the last word, on what evidence, and every value that lost on the way. This
+ * suite drives the contested case end to end against the production build,
+ * because that is the case the whole variant exists for: `groupName` written by
+ * two matched rules, only one of which reaches the final config.
+ *
+ * `CONTESTED_KEY_CONFIG`'s stops, for every expectation below: base ·
+ * `packageRules[0]` (step 1 of 2) · `packageRules[2]` (step 2 of 2) · flatten ·
+ * final. The `react` rule never matches, so it is no stop at all.
+ */
+
+/** The `npm dependency` quick-fill's own fields — what a share link has to
+ *  carry to reproduce a run this suite otherwise starts by clicking. */
+const NPM_QUICK_FILL: Record<string, string> = {
+  manager: "npm",
+  datasource: "npm",
+  packageFile: "package.json",
+  packageName: "lodash",
+  depType: "dependencies",
+  currentValue: "4.17.20",
+  newValue: "4.17.21",
+  updateType: "patch",
+};
+
+/** Opens the contested config, runs the lodash quick-fill, and waits for the
+ *  verdict card the threads live on. */
+async function runContestedSimulation(page: Page): Promise<void> {
+  await page.goto(await encodeShareFragment({ config: CONTESTED_KEY_CONFIG }));
+  await openTab(page, "simulator");
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await expect(simulator).toBeVisible();
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+}
+
+/** A thread's head button — addressed by the id the app gives it (`use-thread-nav`
+ *  builds the same id for a deep link's scroll target), so no thread can be
+ *  confused with another whose value happens to mention its key. */
+function threadHead(page: Page, key: string): Locator {
+  return page.locator(`#sim-thread-${key}`);
+}
+
+/** The thread row for one changed setting, by its key. */
+function thread(page: Page, key: string): Locator {
+  return page.locator(".sim-thread", { has: threadHead(page, key) });
+}
+
+/** Expands a thread and hands back its body. */
+async function expandThread(page: Page, key: string): Promise<Locator> {
+  const head = threadHead(page, key);
+  await expect(head).toHaveAttribute("aria-expanded", "false");
+  await head.click();
+  await expect(head).toHaveAttribute("aria-expanded", "true");
+  return thread(page, key).locator(".sim-thread-body");
+}
+
+/**
+ * Roadmap 053 — the thread answers "who set this, and what did they beat?" in
+ * one place. Collapsed, the row still says two rules wrote the key; expanded,
+ * the winner writes first with its clause evidence in aligned columns, and the
+ * value it overrode is struck through under the rule that wrote it.
+ */
+test("expanding a contested thread names its winner, its clause evidence and the value it struck out", async ({
+  page,
+}) => {
+  await runContestedSimulation(page);
+
+  // Collapsed, the contested row already says the key had more than one writer
+  // — the 046 ledger's blind spot, and the reason to open this row first.
+  const row = thread(page, "groupName");
+  await expect(row.locator(".sim-thread-writers")).toHaveText("2 writers");
+  await expect(row.locator(".sim-thread-final")).toHaveText('"lodash updates"');
+
+  const body = await expandThread(page, "groupName");
+
+  // The winner line: the verb carries the merge semantics, and the reference is
+  // the LAST rule to write the key.
+  const writer = body.locator(".sim-thread-line").first();
+  await expect(writer).toContainText("set by");
+  await expect(writer).toContainText("packageRules[2]");
+
+  // Its clause evidence, as the aligned grid — one row per matcher, each
+  // stating what it checks and what this update actually is.
+  const clauses = body.locator(".sim-clause-grid .sim-clause-row");
+  await expect(clauses).toHaveCount(2);
+  await expect(clauses.filter({ hasText: "matchPackageNames" })).toContainText("lodash");
+  await expect(clauses.filter({ hasText: "matchUpdateTypes" })).toContainText("patch");
+
+  // The cascade: the beaten value, struck through, under the rule that wrote it.
+  const lostLine = body.locator(".sim-thread-line", { hasText: "written by" });
+  await expect(lostLine).toContainText("packageRules[0]");
+  const overridden = lostLine.locator(".sim-thread-old");
+  await expect(overridden).toHaveText('"all npm dependencies"');
+  await expect(overridden).toHaveCSS("text-decoration-line", "line-through");
+
+  // …and it terminates in the value the key held before any rule ran — here
+  // Renovate's own `groupName: null`.
+  await expect(body.locator(".sim-thread-line", { hasText: "before any rule" })).toContainText(
+    "null",
+  );
+
+  // An UNCONTESTED key's thread has no lost writer at all — same disclosure,
+  // same terminating base line, no manufactured override.
+  const automerge = await expandThread(page, "automerge");
+  await expect(automerge.locator(".sim-thread-line").first()).toContainText("packageRules[2]");
+  await expect(automerge.locator(".sim-thread-line", { hasText: "written by" })).toHaveCount(0);
+  await expect(automerge.locator(".sim-thread-line", { hasText: "before any rule" })).toContainText(
+    "false",
+  );
+});
+
+/**
+ * Roadmap 053 layer 3 — the second (and last) disclosure level. A thread names
+ * the rule whose value it beat; that reference opens the losing rule's own
+ * card, which answers the only question the thread leaves open about it: what
+ * ELSE did it do? The card is navigation-free, so it light-dismisses and hands
+ * focus straight back to the reference that opened it.
+ */
+test("the losing writer's reference opens its evidence card, and Escape gives focus back", async ({
+  page,
+}) => {
+  await runContestedSimulation(page);
+  const body = await expandThread(page, "groupName");
+
+  const anchor = body.getByRole("button", { name: "packageRules[0]" });
+  await expect(anchor).toHaveAttribute("aria-expanded", "false");
+  await anchor.click();
+
+  const card = page.getByRole("dialog", { name: "packageRules[0] — rule evidence" });
+  await expect(card).toBeVisible();
+
+  // The losing rule's own clause evidence, in the same aligned grid the thread
+  // uses — one grammar for evidence, wherever it is read.
+  await expect(card.locator(".sim-clause-grid .sim-clause-row")).toHaveCount(1);
+  await expect(card.locator(".sim-clause-row")).toContainText("matchManagers");
+
+  // The digest: this rule wrote two keys, one of which survived.
+  await expect(card.locator(".sim-rule-pop-line")).toContainText("merged in step 1 of 2");
+  await expect(card.locator(".sim-rule-pop-line")).toContainText("2 writes, 1 survived");
+
+  // The write the thread came from, struck through and naming the stop that
+  // took it; and the write that survived, plain.
+  const lost = card.locator(".sim-digest-row", { hasText: "groupName" });
+  await expect(lost.locator(".sim-merged-after")).toHaveClass(/overridden/);
+  await expect(lost).toContainText("overridden in step 2 of 2");
+  const survived = card.locator(".sim-digest-row", { hasText: "addLabels" });
+  await expect(survived.locator(".sim-merged-after")).not.toHaveClass(/overridden/);
+  await expect(survived).toContainText("from-managers-rule");
+
+  // Light dismiss: Escape closes, and focus is back on the reference — the card
+  // took it on open, so the reader is where they left off, not at the top.
+  await page.keyboard.press("Escape");
+  await expect(card).toHaveCount(0);
+  await expect(anchor).toBeFocused();
+  await expect(anchor).toHaveAttribute("aria-expanded", "false");
+});
+
+/**
+ * Roadmap 053 layer 3 — the card's one link out. "open in matched rules →" is
+ * navigation, not a third fold: it opens the (demoted) rules drawer and lands
+ * on that rule's row through the 013 focus wiring, closing the card behind it.
+ */
+test("the evidence card's matched-rules link opens the drawer on that rule's row", async ({
+  page,
+}) => {
+  await runContestedSimulation(page);
+  const body = await expandThread(page, "groupName");
+
+  const rulesDrawer = drawer(page, "Matched rules");
+  await expect(rulesDrawer).toHaveJSProperty("open", false);
+
+  await body.getByRole("button", { name: "packageRules[0]" }).click();
+  const card = page.getByRole("dialog", { name: "packageRules[0] — rule evidence" });
+  await card.getByRole("button", { name: "open in matched rules →" }).click();
+
+  // The card is gone, the drawer it targeted is open, and the row is there.
+  await expect(card).toHaveCount(0);
+  await expect(rulesDrawer).toHaveJSProperty("open", true);
+  const row = page.locator("#sim-rule-0");
+  await expect(row).toBeVisible();
+  await expect(row).toContainText("matchManagers");
+});
+
+/**
+ * Roadmap 053 layer 4 — the way back. A thread's own jumps land the reader
+ * somewhere the thread is off-screen, so both leave a pill naming it. The pill
+ * re-expands that thread, flashes it, and then has nothing left to say.
+ */
+test("a thread's step jump leaves a return pill that re-expands and flashes the thread", async ({
+  page,
+}) => {
+  await runContestedSimulation(page);
+  const body = await expandThread(page, "groupName");
+
+  const mergeDrawer = drawer(page, "How the final config was built");
+  await expect(mergeDrawer).toHaveJSProperty("open", false);
+  await expect(page.locator(".sim-return-pill")).toHaveCount(0);
+
+  // The winner merged at the second rule stop, so that is where the replay opens.
+  const stepLink = body.locator(".sim-step-link");
+  await expect(stepLink).toContainText("step 2 of 2");
+  await stepLink.click();
+  await expect(mergeDrawer).toHaveJSProperty("open", true);
+  await expect(page.locator(".sim-merge-steps .migration-step-counter")).toHaveText("Step 2 of 2");
+
+  // The pill names the thread the reader left, by key.
+  const pill = page.locator(".sim-return-pill");
+  await expect(pill).toBeVisible();
+  await expect(pill).toContainText("groupName");
+
+  // Collapsing the thread from down here proves the return does more than
+  // scroll: it puts the reader back INSIDE the story they walked away from.
+  const head = threadHead(page, "groupName");
+  await head.click();
+  await expect(head).toHaveAttribute("aria-expanded", "false");
+
+  await pill.click();
+  await expect(head).toHaveAttribute("aria-expanded", "true");
+  await expect(head).toHaveClass(/rcv-flash/);
+  // Ephemeral: it answered the jump it was created for.
+  await expect(pill).toHaveCount(0);
+  // And the jump it undid stays undone — the drawer the reader opened is still
+  // open, at the stop they were sent to.
+  await expect(mergeDrawer).toHaveJSProperty("open", true);
+});
+
+/**
+ * Roadmap 053 layer 4 — a link says where to look. `simThread` (the expanded
+ * key) rides the sim descriptor beside `autoSimulate`, `simStep` restores the
+ * replay's stop, and opening the link reproduces the run with both in place —
+ * no clicking, no scrolling to find what the sender meant.
+ */
+test("a share link carrying a thread and a replay stop restores both", async ({ page }) => {
+  const fragment = await encodeShareFragment({
+    config: CONTESTED_KEY_CONFIG,
+    view: { tab: "simulator", simStep: 2 },
+    sim: { form: NPM_QUICK_FILL, autoSimulate: true, simThread: "groupName" },
+  });
+  await page.goto(fragment);
+
+  await openTab(page, "simulator");
+  const verdict = page.locator(".sim-verdict-block");
+  await expect(verdict).toBeVisible({ timeout: 30_000 });
+
+  // The link's thread arrives EXPANDED, with its cascade already on screen —
+  // the run's own reset can neither fold it nor race it.
+  const row = thread(page, "groupName");
+  await expect(threadHead(page, "groupName")).toHaveAttribute("aria-expanded", "true");
+  await expect(row.locator(".sim-thread-line", { hasText: "written by" })).toContainText(
+    '"all npm dependencies"',
+  );
+
+  // Every other thread is collapsed: the link carries one question, not a state
+  // dump of the sender's screen.
+  await expect(verdict.locator(".sim-thread.open")).toHaveCount(1);
+
+  // The replay stop the link named is restored, and the drawer holding it is
+  // open — a link may not point INTO a closed drawer.
+  const mergeDrawer = drawer(page, "How the final config was built");
+  await expect(mergeDrawer).toHaveJSProperty("open", true);
+  await expect(page.locator(".sim-merge-steps .migration-step-counter")).toHaveText("Step 2 of 2");
+  await expect(page.locator(".sim-merge-steps .migration-step-head")).toContainText(
+    "packageRules[2]",
+  );
+
+  // The pill is not link state: nobody jumped anywhere.
+  await expect(page.locator(".sim-return-pill")).toHaveCount(0);
+});

--- a/packages/app/e2e/16-verdict-threads.spec.ts
+++ b/packages/app/e2e/16-verdict-threads.spec.ts
@@ -2,19 +2,6 @@ import { expect, type Locator, type Page, test } from "@playwright/test";
 import { CONTESTED_KEY_CONFIG, encodeShareFragment } from "./fixtures";
 import { drawer, openTab } from "./helpers";
 
-/**
- * Roadmap 053 (variant A) — the verdict ledger IS the trace. Every row of
- * settings the rules changed expands into that key's own causal thread: who had
- * the last word, on what evidence, and every value that lost on the way. This
- * suite drives the contested case end to end against the production build,
- * because that is the case the whole variant exists for: `groupName` written by
- * two matched rules, only one of which reaches the final config.
- *
- * `CONTESTED_KEY_CONFIG`'s stops, for every expectation below: base ·
- * `packageRules[0]` (step 1 of 2) · `packageRules[2]` (step 2 of 2) · flatten ·
- * final. The `react` rule never matches, so it is no stop at all.
- */
-
 /** The `npm dependency` quick-fill's own fields — what a share link has to
  *  carry to reproduce a run this suite otherwise starts by clicking. */
 const NPM_QUICK_FILL: Record<string, string> = {

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -30,6 +30,9 @@ export interface ShareViewInput {
   node?: string;
   step?: number;
   tab?: string;
+  /** Roadmap 044/053: the merge replay's stop index — restored next to a `sim`
+   *  descriptor that reproduces the run whose replay it indexes. */
+  simStep?: number;
 }
 
 export interface SharePayloadInput {
@@ -244,6 +247,36 @@ export const AUTHORED_BLOCK_CONFIG = `{
     {
       "matchPackageNames": ["lodash"],
       "addLabels": ["from-lodash-rule"]
+    }
+  ]
+}
+`;
+
+/**
+ * Roadmap 053: a CONTESTED key. Two rules the "npm dependency" quick-fill
+ * (lodash, patch) matches both write `groupName` with DIFFERENT values, so the
+ * later one wins and the earlier one's value never reaches the final config —
+ * the override cascade a verdict thread exists to show. The `react` rule never
+ * matches, so it contributes no stop; `addLabels` (written only by the first
+ * rule) gives its popover a surviving write to sit beside the lost one.
+ */
+export const CONTESTED_KEY_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "groupName": "all npm dependencies",
+      "addLabels": ["from-managers-rule"]
+    },
+    {
+      "matchPackageNames": ["react"],
+      "groupName": "never-applied"
+    },
+    {
+      "matchPackageNames": ["lodash"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "lodash updates",
+      "automerge": true
     }
   ]
 }

--- a/packages/app/e2e/helpers.ts
+++ b/packages/app/e2e/helpers.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 import type { ResultsTabId } from "../src/data/results-tabs";
 
 /**
@@ -70,6 +70,15 @@ export async function openTab(page: Page, id: TabId): Promise<void> {
   await expect(resultsPanel(page)).toBeVisible({ timeout: 30_000 });
   await tabButton(page, id).click();
   await expect(tabPanel(page, id)).toBeVisible();
+}
+
+/**
+ * Roadmap 047: the results are staged into summary drawers — a `<details>`
+ * whose summary row abstracts the body. Addressed by their visible title, the
+ * way a user finds them.
+ */
+export function drawer(page: Page, title: string): Locator {
+  return page.locator("details.drawer", { hasText: title });
 }
 
 /** Clicks Run and waits for the pipeline to produce a result (the results

--- a/roadmap/054-simulator-results-readability.md
+++ b/roadmap/054-simulator-results-readability.md
@@ -1,7 +1,7 @@
 # 054 — Simulator: results readability
 
-Milestone: — · Status: proposed (2026-08-01) · variant A planned in detail
-after mockup review (2026-08-02, see below)
+Milestone: — · Status: **variant A implemented** (2026-08-02), shipped as the
+five-layer stack below; variants B and C remain proposed
 
 Mockup (three variants; revised 2026-08-02 after review — the scenario now
 includes a contested field, `groupName` written by two matched rules with the
@@ -33,7 +33,8 @@ against 719 rules):
 
 ## Proposed variants (see mockup)
 
-- **A — the ledger is the trace.** Each changed setting on the verdict card
+- **A — the ledger is the trace** (shipped, see below)**.** Each changed
+  setting on the verdict card
   expands into its own causal thread: writing rule with predicate/evaluated
   clause evidence inline, the overridden value struck through, a replay jump.
   Rules/merge drawers demote to one "full trace" line. (DevTools
@@ -126,7 +127,8 @@ evidence per rule. A new `verdict-threads.ts` derives, per changed key:
 - Thread expansion is uncontrolled locally, but the share fragment gains
   `simThread?: string` (the expanded key) beside `simStep`, and jumps
   push fragment updates — browser Back and deep links work (mockup's
-  recorded model). Cross-link into the rules drawer reuses
+  recorded model). **Shipped without the history half** — see the layer-4
+  deviation below. Cross-link into the rules drawer reuses
   `use-rule-focus`'s focus/highlight wiring.
 - CSS: the `.kv` subgrid system and `.clause-grid` land in `index.css`
   with existing tokens only (stylelint: no raw colors); flash animation
@@ -148,14 +150,41 @@ evidence per rule. A new `verdict-threads.ts` derives, per changed key:
   shipped — success criterion: the contested-field question ("who else
   wrote groupName?") answerable by entry personas.
 
-### Sequencing (one PR each)
+### Sequencing (one PR each) — as built
 
-1. `verdict-threads.ts` derivation + unit tests (no UI change).
+1. `verdict-threads.ts` derivation + unit tests (no UI change) —
+   `feat/053-01-verdict-threads`.
 2. Thread ledger UI + `.kv`/`.clause-grid` CSS + drawer demotion
-   (replaces the 046 ledger; `verdict-changes.ts` deleted).
-3. `RuleEvidenceCard` popover + `ProvenanceChip` dot variant.
-4. `ReturnPill` + `simThread` fragment state + jump wiring.
-5. e2e suite + persona replay + roadmap status flip.
+   (replaces the 046 ledger; `verdict-changes.ts` deleted) —
+   `feat/053-02-thread-ledger-ui`.
+3. `RuleEvidenceCard` popover + `ProvenanceChip` dot variant —
+   `feat/053-03-rule-evidence-card`.
+4. `ReturnPill` + `simThread` fragment state + jump wiring —
+   `feat/053-04-return-pill-fragment`.
+5. e2e suite + roadmap status flip — `feat/053-05-e2e-and-docs`
+   (`packages/app/e2e/16-verdict-threads.spec.ts`, five scenarios over the
+   new `CONTESTED_KEY_CONFIG` fixture: expand a contested thread, the
+   popover's evidence + Escape-restores-focus, its "open in matched
+   rules →" jump, the step jump's return pill, and a `simThread` +
+   `simStep` deep link). The persona replay is the one piece not run yet
+   — it is a live-app study, not a suite, so it stays a follow-up.
+
+### Deviation recorded in layer 4 — `simThread` is a decode-time one-shot
+
+The plan above says "jumps push fragment updates — browser Back and deep
+links work". Deep links do; **browser Back does not undo a jump, and no jump
+pushes a history entry**. Thread expansion is a SET, meaningful only for the
+last run's evidence and read by nothing outside the simulator, so App does
+not own it the way it owns `mergeStepIndex` (a controlled stepper's index
+that a link must restore). `simThread` is therefore armed on the existing
+`simRequest` nonce at decode time and applied by the run's own reset effect,
+once.
+
+The `ReturnPill` — not the browser's Back button — is what undoes a jump.
+That is consistent with the app's standing rule that the fragment is written
+on **Copy link only** (`useShareLink`): pushing history from a jump would
+have traded a documented limitation for an undocumented exception to that
+rule.
 
 ### Non-goals
 


### PR DESCRIPTION
Variant A's last layer: the browser proof, against the production build,
that the thread ledger IS the trace — and the roadmap status flip that
says so.

`16-verdict-threads.spec.ts` drives the case the whole variant exists for:
a new `CONTESTED_KEY_CONFIG` fixture whose lodash update matches two rules
that both write `groupName`, so one value reaches the final config and the
other is struck through under the rule that wrote it. Five scenarios —
expanding the contested thread (writer line, aligned clause grid, override
cascade down to Renovate's own `groupName: null`), the losing writer's
reference opening the evidence card (clause grid + per-write digest, the
lost write naming the stop that took it) with Escape handing focus back to
the anchor, the card's "open in matched rules →" landing on that rule's row
in the drawer it opens, the step jump's return pill re-expanding and
flashing the thread it came from, and a `simThread` + `simStep` link
restoring thread and replay stop together.

The suite's `drawer()` locator moves from 04-simulator into `helpers.ts`
rather than being copied a second time — two specs now address drawers by
their visible title.

Roadmap 054 flips to "variant A implemented", lists the five layer
branches, and records layer 4's deviation where the plan promised
otherwise: `simThread` is a decode-time one-shot on the existing
`simRequest` nonce, so a jump pushes NO history entry — the return pill,
not browser Back, is what undoes one. That keeps the app's standing rule
intact (the fragment is written on Copy link only) instead of trading a
documented limitation for an undocumented exception.

The persona replay named in the plan's test list stays a follow-up: it is a
live-app study, not a suite.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
