### PR TITLE
refactor(app): one WriteRow and one ClauseGrid for all rule evidence (054 layer 7)

### DIFF
--- a/packages/app/e2e/06-error-states-and-filters.spec.ts
+++ b/packages/app/e2e/06-error-states-and-filters.spec.ts
@@ -64,5 +64,7 @@ test("the simulator 'my rules only' filter shows repo rules with clause evidence
   // The repo rule row is shown, pre-expanded, with its clause evidence visible.
   const expandedRow = simulator.locator(".sim-rule.expanded").first();
   await expect(expandedRow).toBeVisible();
-  await expect(expandedRow.locator(".sim-clause").first()).toBeVisible();
+  // 053 layer 7: the drawer reads clause evidence through the SAME grid the
+  // threads and the evidence card use — one clause renderer, one grammar.
+  await expect(expandedRow.locator(".sim-clause-grid .sim-clause-row").first()).toBeVisible();
 });

--- a/packages/app/e2e/16-verdict-threads.spec.ts
+++ b/packages/app/e2e/16-verdict-threads.spec.ts
@@ -79,16 +79,19 @@ test("expanding a contested thread names its winner, its clause evidence and the
   await expect(clauses.filter({ hasText: "matchPackageNames" })).toContainText("lodash");
   await expect(clauses.filter({ hasText: "matchUpdateTypes" })).toContainText("patch");
 
-  // The cascade: the beaten value, struck through, under the rule that wrote it.
-  const lostLine = body.locator(".sim-thread-line", { hasText: "written by" });
+  // The cascade: the beaten value, struck through, under the rule that wrote
+  // it. Layer 7: a beaten value is a write like any other, so it is the shared
+  // `.sim-write-row` — `⊘ key  <struck value> · written by …`.
+  const lostLine = body.locator(".sim-write-row", { hasText: "written by" });
   await expect(lostLine).toContainText("packageRules[0]");
-  const overridden = lostLine.locator(".sim-thread-old");
+  await expect(lostLine.locator(".sim-write-mark")).toHaveText("⊘");
+  const overridden = lostLine.locator(".sim-merged-before");
   await expect(overridden).toHaveText('"all npm dependencies"');
   await expect(overridden).toHaveCSS("text-decoration-line", "line-through");
 
   // …and it terminates in the value the key held before any rule ran — here
   // Renovate's own `groupName: null`.
-  await expect(body.locator(".sim-thread-line", { hasText: "before any rule" })).toContainText(
+  await expect(body.locator(".sim-write-row", { hasText: "before any rule" })).toContainText(
     "null",
   );
 
@@ -96,8 +99,8 @@ test("expanding a contested thread names its winner, its clause evidence and the
   // same terminating base line, no manufactured override.
   const automerge = await expandThread(page, "automerge");
   await expect(automerge.locator(".sim-thread-line").first()).toContainText("packageRules[2]");
-  await expect(automerge.locator(".sim-thread-line", { hasText: "written by" })).toHaveCount(0);
-  await expect(automerge.locator(".sim-thread-line", { hasText: "before any rule" })).toContainText(
+  await expect(automerge.locator(".sim-write-row", { hasText: "written by" })).toHaveCount(0);
+  await expect(automerge.locator(".sim-write-row", { hasText: "before any rule" })).toContainText(
     "false",
   );
 });
@@ -133,12 +136,17 @@ test("the losing writer's reference opens its evidence card, and Escape gives fo
 
   // The write the thread came from, struck through and naming the stop that
   // took it; and the write that survived, plain.
-  const lost = card.locator(".sim-digest-row", { hasText: "groupName" });
+  const lost = card.locator(".sim-write-row", { hasText: "groupName" });
   await expect(lost.locator(".sim-merged-after")).toHaveClass(/overridden/);
   await expect(lost).toContainText("overridden in step 2 of 2");
-  const survived = card.locator(".sim-digest-row", { hasText: "addLabels" });
+  const survived = card.locator(".sim-write-row", { hasText: "addLabels" });
   await expect(survived.locator(".sim-merged-after")).not.toHaveClass(/overridden/);
   await expect(survived).toContainText("from-managers-rule");
+
+  // Layer 7: the evidence surfaces export like the drawer they demoted — the
+  // digest is copyable as markdown, and its keys carry the option-docs hook.
+  await expect(card.getByRole("button", { name: "Copy as markdown" })).toBeVisible();
+  await expect(card.locator(".sim-write-key .opt-key").first()).toBeVisible();
 
   // Light dismiss: Escape closes, and focus is back on the reference — the card
   // took it on open, so the reader is where they left off, not at the top.
@@ -239,7 +247,7 @@ test("a share link carrying a thread and a replay stop restores both", async ({ 
   // the run's own reset can neither fold it nor race it.
   const row = thread(page, "groupName");
   await expect(threadHead(page, "groupName")).toHaveAttribute("aria-expanded", "true");
-  await expect(row.locator(".sim-thread-line", { hasText: "written by" })).toContainText(
+  await expect(row.locator(".sim-write-row", { hasText: "written by" })).toContainText(
     '"all npm dependencies"',
   );
 

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -4,10 +4,11 @@ import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
 /**
  * Roadmap 053 (variant A): a rule's clause evidence as ALIGNED columns —
  * mark · matcher · what it checks · what this update actually is. The prose
- * form (`.sim-clauses`, still what the rules drawer uses) restates "matched
- * against x = y" per row; read as a thread's evidence, three or four of those
- * in a column are a wall. The columns do the restating instead, so the eye
- * compares the two value columns straight down.
+ * form this replaced (layer 7 retired it from the rules drawer too, so there is
+ * one clause renderer now) restated "matched against x = y" per row; read as a
+ * thread's evidence, three or four of those in a column are a wall. The columns
+ * do the restating instead, so the eye compares the two value columns straight
+ * down.
  *
  * The row is its own grid element sharing the list's tracks (`subgrid`) rather
  * than four loose cells: a row keeps its own box for state styling, and the

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -4,10 +4,10 @@ import type {
   RuleRef,
   SimulationComparison,
 } from "@renovate-config-visualizer/engine";
-import { OptionKey } from "@/components/option-docs";
 import { toDescriptor } from "./form";
-import { previewValue } from "./rule-format";
+import { previewValue, writeMark } from "./rule-format";
 import type { PinnedRun } from "./use-ab-comparison";
+import { WriteRow } from "./WriteRow";
 
 /**
  * Roadmap 021: the fields two descriptors disagree on, sorted for a stable
@@ -89,36 +89,27 @@ function RuleDeltaList({
   );
 }
 
-/** Roadmap 018: one changed key of the final per-dependency config (A → B). */
-function ConfigDeltaRow({ delta }: { delta: ConfigKeyDelta }) {
-  return (
-    <li>
-      <span className="sim-merged-key">
-        <OptionKey name={delta.key} flagUnknown />
-      </span>{" "}
-      <span className="sim-merged-before">
-        {delta.inA ? previewValue(delta.before) : "(unset)"}
-      </span>
-      {" → "}
-      <span className="sim-merged-after">
-        {delta.inB ? previewValue(delta.after) : "(removed)"}
-      </span>
-    </li>
-  );
-}
-
 /** Roadmap 018: the final-config key delta — the settings A and B actually
- *  disagree on, or an explicit "only the matched-rule set differs". */
+ *  disagree on, or an explicit "only the matched-rule set differs". Each row is
+ *  the shared write row (053 layer 7); a key that exists on only one side keeps
+ *  this panel's own sentinels, since `(unset)` and `(removed)` are words, not
+ *  values the config carries. */
 function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) {
   return (
     <div className="sim-compare-config">
       <div className="sim-merged-title">Final per-dependency config changes</div>
       {configDelta.length > 0 ? (
-        <ul>
+        <div className="sim-writes">
           {configDelta.map((d) => (
-            <ConfigDeltaRow key={d.key} delta={d} />
+            <WriteRow
+              key={d.key}
+              name={d.key}
+              mark={writeMark(d.inA, d.inB)}
+              before={d.inA ? { json: d.before } : { text: "(unset)" }}
+              after={d.inB ? { json: d.after } : { text: "(removed)" }}
+            />
           ))}
-        </ul>
+        </div>
       ) : (
         <p className="empty-note">
           Final per-dependency config is identical — only the matched-rule set differs.

--- a/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
@@ -66,6 +66,16 @@ describe("RuleEvidenceCard", () => {
     expect(dialog.querySelectorAll(".sim-merged-after.overridden")).toHaveLength(1);
   });
 
+  // Layer 7 — the two affordances the popover lost by not being the matched-
+  // rules drawer: every written key is an option-docs hook, and the digest is
+  // exportable as markdown like the drawer's applied diff always was.
+  it("gives every written key the option-docs hook and offers the markdown export", () => {
+    const { view } = open();
+    const dialog = view.getByRole("dialog", { name: "packageRules[201] — rule evidence" });
+    expect(dialog.querySelectorAll(".sim-write-key .opt-key")).toHaveLength(2);
+    expect(view.getByRole("button", { name: "Copy as markdown" })).toBeTruthy();
+  });
+
   it("closes on Escape and gives focus back to the anchor", () => {
     const { view, anchor } = open();
     expect(document.activeElement?.getAttribute("role")).toBe("dialog");

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import type { MergedKey } from "@renovate-config-visualizer/engine";
+import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";
 import { ClauseGrid } from "./ClauseGrid";
 import { RULE_POP_CLASS, RULE_POP_SELECTOR } from "./rule-pop-dom";
-import { previewValue, VERDICT_LABEL } from "./rule-format";
+import { ruleAppliedMarkdown, VERDICT_LABEL, writeMark } from "./rule-format";
 import type { RuleEvidence, RuleWrite } from "./rule-evidence";
+import { WriteRow } from "./WriteRow";
 
 /**
  * Roadmap 053 (variant A), layer 3: the second — and last — disclosure level.
@@ -27,40 +30,39 @@ const CARD_WIDTH = 576;
 /** Roughly the card's own height: below this much room, it flips above. */
 const CARD_FLIP_MARGIN = 320;
 
-/** `~` changed · `+` added · `−` removed — stated once per write so the digest
- *  reads without re-parsing the before/after pair. */
-function writeMark(write: RuleWrite): string {
-  if (!write.hadAfter) {
-    return "−";
-  }
-  return write.hadBefore ? "~" : "+";
-}
-
-/** One key the rule merged. A write that lost keeps this step's add tint — it
- *  IS what this step added — and is struck through, naming the stop that took
- *  it away; that pairing is the whole reason the card exists. */
+/** One key the rule merged, as the shared write row (053 layer 7). A write that
+ *  lost keeps this step's add tint — it IS what this step added — and is struck
+ *  through, naming the stop that took it away; that pairing is the whole reason
+ *  the card exists. */
 function RuleWriteRow({ write }: { write: RuleWrite }) {
   return (
-    <div className="sim-digest-row">
-      <span className="sim-digest-mark">{writeMark(write)}</span>
-      <code className="sim-digest-key">{write.key}</code>
-      <span className="sim-digest-values">
-        {write.hadBefore ? (
-          <span className="sim-merged-before">{previewValue(write.before, 60)}</span>
-        ) : null}
-        {write.hadBefore ? " → " : null}
-        <span className={`sim-merged-after${write.survived ? "" : " overridden"}`}>
-          {write.hadAfter ? previewValue(write.after, 60) : "removed"}
-        </span>
-        {write.survived ? null : (
-          <span className="sim-digest-note"> · ⊘ overridden in {write.overriddenAtLabel}</span>
-        )}
-      </span>
-    </div>
+    <WriteRow
+      name={write.key}
+      mark={writeMark(write.hadBefore, write.hadAfter)}
+      before={write.hadBefore ? { json: write.before } : undefined}
+      after={write.hadAfter ? { json: write.after } : { text: "removed" }}
+      struck={!write.survived}
+      note={write.survived ? undefined : `· ⊘ overridden in ${write.overriddenAtLabel}`}
+    />
   );
 }
 
-/** The rule's name, its verdict, and where it came from. */
+/**
+ * The digest's writes as the engine's own `MergedKey`, whose optional
+ * `before`/`after` say exactly what a `RuleWrite`'s presence flags do — so the
+ * card exports through the SAME markdown builder the matched-rules drawer uses
+ * (roadmap 018), rather than a second rendering of the same rows.
+ */
+function asMergedKeys(writes: RuleWrite[]): MergedKey[] {
+  return writes.map((write) => ({
+    key: write.key,
+    ...(write.hadBefore ? { before: write.before } : {}),
+    ...(write.hadAfter ? { after: write.after } : {}),
+  }));
+}
+
+/** The rule's name, its verdict, where it came from — and, when it wrote
+ *  anything, the copy-as-markdown export of what it wrote. */
 function RuleEvidenceHead({
   evidence,
   onSelectPreset,
@@ -68,6 +70,7 @@ function RuleEvidenceHead({
   evidence: RuleEvidence;
   onSelectPreset?: (nodeId: string) => void;
 }) {
+  const verdict = evidence.verdict ? ` — ${VERDICT_LABEL[evidence.verdict]}` : "";
   return (
     <p className="sim-rule-pop-head">
       <code className="sim-rule-pop-id">packageRules[{evidence.ruleIndex}]</code>
@@ -78,6 +81,13 @@ function RuleEvidenceHead({
       ) : null}
       {evidence.layer ? (
         <ProvenanceChip layer={evidence.layer} onSelectPreset={onSelectPreset} />
+      ) : null}
+      {evidence.writes.length > 0 ? (
+        <CopyMarkdownButton
+          className="inline"
+          header={`\`packageRules[${evidence.ruleIndex}]\`${verdict}${evidence.stopLabel ? ` — merged in ${evidence.stopLabel}` : ""}`}
+          code={ruleAppliedMarkdown(asMergedKeys(evidence.writes))}
+        />
       ) : null}
     </p>
   );
@@ -110,7 +120,7 @@ function RuleEvidenceBody({
       <RuleEvidenceHead evidence={evidence} onSelectPreset={onSelectPreset} />
       {evidence.clauses.length > 0 ? <ClauseGrid clauses={evidence.clauses} /> : null}
       <RuleEvidenceSummary evidence={evidence} />
-      <div className="sim-digest">
+      <div className="sim-writes">
         {evidence.writes.map((write) => (
           <RuleWriteRow key={write.key} write={write} />
         ))}

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -1,63 +1,17 @@
 import { useEffect, useState } from "react";
 import type {
-  ClauseEvaluation,
   MergedKey,
   ProvenanceLayer,
   RuleEvaluation,
 } from "@renovate-config-visualizer/engine";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
-import { OptionKey } from "@/components/option-docs";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
-import {
-  clauseExplanation,
-  clauseIcon,
-  previewValue,
-  ruleAppliedMarkdown,
-  ruleLabel,
-  VERDICT_LABEL,
-} from "./rule-format";
+import { ClauseGrid } from "./ClauseGrid";
+import { ruleAppliedMarkdown, ruleLabel, VERDICT_LABEL, writeMark } from "./rule-format";
+import { WriteRow } from "./WriteRow";
 
-/** Roadmap 006/040: a rule's clause-by-clause evidence — one row per `match*`
- *  selector, with the value it was compared against and why it did or didn't
- *  match. */
-function SimClauseList({ clauses }: { clauses: ClauseEvaluation[] }) {
-  return (
-    <ul className="sim-clauses">
-      {clauses.map((clause) => (
-        <li key={clause.key} className={`sim-clause state-${clause.state}`}>
-          <span className="sim-clause-icon">{clauseIcon(clause.state)}</span>
-          <span className="sim-clause-text">
-            <code>{clause.key}</code>: {previewValue(clause.value, 60)} —{" "}
-            {clauseExplanation(clause)}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-/** One `key: before → after` row of what a matching rule applied. */
-function MergedKeyRow({ merged }: { merged: MergedKey }) {
-  return (
-    <li>
-      <span className="sim-merged-key">
-        <OptionKey name={merged.key} flagUnknown />
-      </span>
-      {"before" in merged ? (
-        <>
-          {" "}
-          <span className="sim-merged-before">{previewValue(merged.before)}</span> →{" "}
-        </>
-      ) : (
-        " → "
-      )}
-      <span className="sim-merged-after">{previewValue(merged.after)}</span>
-    </li>
-  );
-}
-
-/** Roadmap 018/040: what a matching rule applied to the dependency config, as
- *  `key: before → after` rows plus the copy-as-markdown export of the same. */
+/** Roadmap 018/040/053: what a matching rule applied to the dependency config,
+ *  as the shared write rows plus the copy-as-markdown export of the same. */
 function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: MergedKey[] }) {
   return (
     <div className="sim-merged">
@@ -69,11 +23,17 @@ function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: Merg
           code={ruleAppliedMarkdown(merged)}
         />
       </div>
-      <ul>
+      <div className="sim-writes">
         {merged.map((m) => (
-          <MergedKeyRow key={m.key} merged={m} />
+          <WriteRow
+            key={m.key}
+            name={m.key}
+            mark={writeMark("before" in m, "after" in m)}
+            before={"before" in m ? { json: m.before } : undefined}
+            after={"after" in m ? { json: m.after } : { text: "removed" }}
+          />
         ))}
-      </ul>
+      </div>
     </div>
   );
 }
@@ -121,7 +81,7 @@ export function RuleRow({
           {rule.clauses.length === 0 ? (
             <p className="empty-note">No match* clauses — the rule applies to everything.</p>
           ) : (
-            <SimClauseList clauses={rule.clauses} />
+            <ClauseGrid clauses={rule.clauses} />
           )}
           {rule.notes.map((note) => (
             <p key={note} className="sim-note">

--- a/packages/app/src/features/simulator/ThreadBody.tsx
+++ b/packages/app/src/features/simulator/ThreadBody.tsx
@@ -2,8 +2,8 @@ import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { ClauseGrid } from "./ClauseGrid";
 import type { RuleEvidence } from "./rule-evidence";
 import { RuleEvidenceAnchor } from "./RuleEvidenceCard";
-import { previewValue } from "./rule-format";
 import type { ThreadEntry, ThreadModel, ThreadVerb, ThreadWinner } from "./verdict-threads";
+import { WriteRow } from "./WriteRow";
 
 /**
  * Roadmap 053 (variant A): the expanded thread — the causal story of ONE
@@ -87,26 +87,48 @@ function ThreadWriterLine({
   );
 }
 
-/** One value the winner beat — struck through in place, with whoever wrote it.
- *  The cascade's last entry is the pre-rules value, which has no writer. */
-function ThreadOverrideLine({ entry, actions }: { entry: ThreadEntry; actions: ThreadActions }) {
+/**
+ * One value the winner beat — struck through in place, with whoever wrote it.
+ * The cascade's last entry is the pre-rules value, which has no writer.
+ *
+ * Roadmap 053 layer 7: this IS the shared write row (`⊘` mark, a struck value,
+ * a trailing note), so a lost value looks the same here as in the evidence
+ * card's digest. The row states only a `before` — a beaten write has no "and
+ * then it became": that is the winner line at the top of the thread.
+ */
+function ThreadOverrideLine({
+  threadKey,
+  entry,
+  actions,
+}: {
+  threadKey: string;
+  entry: ThreadEntry;
+  actions: ThreadActions;
+}) {
   if (entry.kind === "base") {
-    if (!entry.present) {
-      return <p className="sim-thread-line">nothing was set before any rule</p>;
-    }
     return (
-      <p className="sim-thread-line">
-        <b>overrode</b> <span className="sim-thread-old">{previewValue(entry.value, 80)}</span>{" "}
-        <span className="sim-thread-note">before any rule</span>
-      </p>
+      <WriteRow
+        name={threadKey}
+        mark="⊘"
+        max={80}
+        before={entry.present ? { json: entry.value } : undefined}
+        note={entry.present ? "before any rule" : "nothing was set before any rule"}
+      />
     );
   }
   return (
-    <p className="sim-thread-line">
-      <b>overrode</b> <span className="sim-thread-old">{previewValue(entry.value, 80)}</span>{" "}
-      written by{" "}
-      <WriterRef ruleIndex={entry.ruleIndex} stopLabel={entry.stopLabel} evidence={actions} />
-    </p>
+    <WriteRow
+      name={threadKey}
+      mark="⊘"
+      max={80}
+      before={{ json: entry.value }}
+      note={
+        <>
+          written by{" "}
+          <WriterRef ruleIndex={entry.ruleIndex} stopLabel={entry.stopLabel} evidence={actions} />
+        </>
+      }
+    />
   );
 }
 
@@ -146,13 +168,16 @@ export function ThreadBody({ thread, actions }: { thread: ThreadModel; actions: 
         <p className="sim-thread-line">No merge step names this setting.</p>
       )}
       {winner && winner.clauses.length > 0 ? <ClauseGrid clauses={winner.clauses} /> : null}
-      {thread.overrides.map((entry) => (
-        <ThreadOverrideLine
-          key={entry.kind === "base" ? "base" : `stop-${entry.stopIndex}`}
-          entry={entry}
-          actions={actions}
-        />
-      ))}
+      <div className="sim-writes">
+        {thread.overrides.map((entry) => (
+          <ThreadOverrideLine
+            key={entry.kind === "base" ? "base" : `stop-${entry.stopIndex}`}
+            threadKey={thread.key}
+            entry={entry}
+            actions={actions}
+          />
+        ))}
+      </div>
       {winner && onJumpToStep ? (
         <ThreadStepLine winner={winner} onJumpToStep={onJumpToStep} />
       ) : null}

--- a/packages/app/src/features/simulator/WriteRow.test.tsx
+++ b/packages/app/src/features/simulator/WriteRow.test.tsx
@@ -1,0 +1,88 @@
+import type { ReactElement } from "react";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeMark } from "./rule-format";
+import { WriteRow } from "./WriteRow";
+
+/**
+ * Roadmap 053 layer 7 — the one write row, and the prop matrix the four
+ * surfaces that share it actually exercise: a changed key (before → after), an
+ * added one (no before), a removed one (a sentinel where a value would be), a
+ * write that lost (struck `after` plus the stop that took it), and a thread's
+ * beaten value (a `before` alone). What is pinned here is the CONTRACT the
+ * surfaces rely on: the two value classes are the only ones values wear, the
+ * arrow appears only between two values, and every key goes through OptionKey.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+function row(ui: ReactElement): HTMLElement {
+  const view = render(ui);
+  const el = view.container.querySelector(".sim-write-row");
+  if (!(el instanceof HTMLElement)) {
+    throw new Error("no write row rendered");
+  }
+  return el;
+}
+
+describe("WriteRow", () => {
+  it("renders a changed key as before → after, with the key as an option key", () => {
+    const el = row(
+      <WriteRow name="automerge" mark="~" before={{ json: false }} after={{ json: true }} />,
+    );
+    expect(el.querySelector(".sim-write-mark")?.textContent).toBe("~");
+    // A2.1: the key is the option-docs hook everywhere now, not bare <code>.
+    expect(el.querySelector(".sim-write-key .opt-key")?.textContent).toBe("automerge");
+    expect(el.querySelector(".sim-merged-before")?.textContent).toBe("false");
+    expect(el.querySelector(".sim-merged-after")?.textContent).toBe("true");
+    expect(el.textContent).toContain("→");
+  });
+
+  it("drops the arrow when the row states only one side", () => {
+    const added = row(<WriteRow name="schedule" after={{ json: ["before 6am"] }} />);
+    expect(added.querySelector(".sim-merged-before")).toBeNull();
+    expect(added.textContent).not.toContain("→");
+
+    const beaten = row(<WriteRow name="groupName" mark="⊘" before={{ json: "npm" }} />);
+    expect(beaten.querySelector(".sim-merged-after")).toBeNull();
+    expect(beaten.querySelector(".sim-merged-before")?.textContent).toBe('"npm"');
+    expect(beaten.textContent).not.toContain("→");
+  });
+
+  it("prints a sentinel as words rather than JSON-quoting it", () => {
+    const el = row(
+      <WriteRow name="labels" before={{ json: ["a"] }} after={{ text: "(removed)" }} />,
+    );
+    expect(el.querySelector(".sim-merged-after")?.textContent).toBe("(removed)");
+  });
+
+  it("strikes a write a later stop took away and states the note", () => {
+    const el = row(
+      <WriteRow
+        name="groupName"
+        mark="+"
+        after={{ json: "npm minor+patch" }}
+        struck
+        note="· ⊘ overridden in step 3 of 3"
+      />,
+    );
+    expect(el.querySelector(".sim-merged-after")?.className).toContain("overridden");
+    expect(el.querySelector(".sim-write-note")?.textContent).toContain("overridden in step 3 of 3");
+  });
+
+  it("truncates a value to the surface's own budget", () => {
+    const long = "x".repeat(200);
+    const short = row(<WriteRow name="k" after={{ json: long }} />);
+    const wide = row(<WriteRow name="k" after={{ json: long }} max={80} />);
+    // JSON quotes count toward the budget, and the ellipsis is added after it.
+    expect(short.querySelector(".sim-merged-after")?.textContent).toHaveLength(61);
+    expect(wide.querySelector(".sim-merged-after")?.textContent).toHaveLength(81);
+  });
+
+  it("marks a write by what it did to the key", () => {
+    expect(writeMark(true, true)).toBe("~");
+    expect(writeMark(false, true)).toBe("+");
+    expect(writeMark(true, false)).toBe("−");
+  });
+});

--- a/packages/app/src/features/simulator/WriteRow.tsx
+++ b/packages/app/src/features/simulator/WriteRow.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { OptionKey } from "@/components/option-docs";
+import { previewValue } from "./rule-format";
+
+/**
+ * Roadmap 053 layer 7: THE row for "something wrote this key". Four surfaces
+ * used to say the same `key: before → after` sentence in four dialects — the
+ * matched-rule drawer's list, the A/B config delta, the evidence popover's
+ * digest, and a thread's struck-through override line — each with its own
+ * markup, its own value classes, and its own idea of whether the key deserved
+ * the option-docs hover card (only two of the four gave it one).
+ *
+ * One component, one grammar: `mark · key · before → after · note`, on shared
+ * grid columns (`.sim-writes`) so a column of writes reads straight down its
+ * value edge. The mark, the strike and the note are the only knobs, because
+ * they are the only things the four surfaces actually disagreed about.
+ */
+
+/**
+ * One side of a write. A JSON value the row previews itself, or a literal the
+ * caller already has words for — `(unset)`, `removed` — which must NOT be
+ * JSON-quoted into a value that looks like a string the config carries.
+ */
+export type WriteValue = { json: unknown } | { text: string };
+
+function valueText(value: WriteValue, max: number): string {
+  return "text" in value ? value.text : previewValue(value.json, max);
+}
+
+export function WriteRow({
+  name,
+  before,
+  after,
+  mark,
+  struck = false,
+  note,
+  max = 60,
+}: {
+  /** The config key this row is about; carries the option-docs hover card.
+   *  (`key` is React's own prop, hence `name` — the callers still key rows on
+   *  the config key itself.) */
+  name: string;
+  /** The value the key held going in; omitted when it had none. */
+  before?: WriteValue;
+  /** What this write left behind; omitted when the row states a value that was
+   *  taken away rather than one that landed (a thread's override line). */
+  after?: WriteValue;
+  /** Leading glyph — `~`/`+`/`−` for what a write did, `⊘` for a value that
+   *  lost. Absent leaves the column empty, keeping the rows aligned. */
+  mark?: string;
+  /** Struck `after`: this write happened here, but a later stop took it away. */
+  struck?: boolean;
+  /** Trailing aside — who wrote the lost value, which step overrode it. */
+  note?: ReactNode;
+  /** Value truncation, per surface. */
+  max?: number;
+}) {
+  return (
+    <div className="sim-write-row">
+      <span className="sim-write-mark">{mark ?? ""}</span>
+      <span className="sim-write-key">
+        <OptionKey name={name} flagUnknown />
+      </span>
+      <span className="sim-write-values">
+        {before ? <span className="sim-merged-before">{valueText(before, max)}</span> : null}
+        {before && after ? " → " : null}
+        {after ? (
+          <span className={`sim-merged-after${struck ? " overridden" : ""}`}>
+            {valueText(after, max)}
+          </span>
+        ) : null}
+        {note ? <span className="sim-write-note"> {note}</span> : null}
+      </span>
+    </div>
+  );
+}

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -14,15 +14,27 @@ function fullValue(value: unknown): string {
   return JSON.stringify(value) ?? "undefined";
 }
 
-/** Roadmap 018: a matched rule's applied keys as `key: before → after` lines. */
+/** Roadmap 018: a matched rule's applied keys as `key: before → after` lines.
+ *  A merge that took a key away has no `after` at all — the export says so in
+ *  words, the same way the rows do, rather than pasting `undefined`. */
 export function ruleAppliedMarkdown(merged: MergedKey[]): string {
   return merged
-    .map((m) =>
-      "before" in m
-        ? `${m.key}: ${fullValue(m.before)} → ${fullValue(m.after)}`
-        : `${m.key}: ${fullValue(m.after)}`,
-    )
+    .map((m) => {
+      const after = "after" in m ? fullValue(m.after) : "(removed)";
+      return "before" in m ? `${m.key}: ${fullValue(m.before)} → ${after}` : `${m.key}: ${after}`;
+    })
     .join("\n");
+}
+
+/** Roadmap 053 layer 7: `~` changed · `+` added · `−` removed — the mark a
+ *  {@link WriteRow} leads with, so a write reads without re-parsing its
+ *  before/after pair. Here rather than beside the component because a module
+ *  that renders may only export components (Fast Refresh). */
+export function writeMark(hadBefore: boolean, hadAfter: boolean): string {
+  if (!hadAfter) {
+    return "−";
+  }
+  return hadBefore ? "~" : "+";
 }
 
 function inputsPreview(clause: ClauseEvaluation): string {
@@ -53,8 +65,11 @@ export function clauseIcon(state: ClauseEvaluation["state"]): string {
  * sourceUrl (Renovate treats a missing value as a non-match)", from the
  * engine's note) rather than reading like the clause was never evaluated; a
  * null-returning matcher reads "not applicable (skipped)".
+ *
+ * Roadmap 053 layer 7: no longer exported — the prose clause list that read it
+ * directly is gone, and every clause now arrives through `clauseEvaluated`.
  */
-export function clauseExplanation(clause: ClauseEvaluation): string {
+function clauseExplanation(clause: ClauseEvaluation): string {
   const hasInputs = Object.keys(clause.inputValues).length > 0;
   switch (clause.state) {
     case "matched":

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2130,53 +2130,25 @@ pre.config-view.prov-before {
   padding: 0.5rem 0.75rem 0.6rem 1.9rem;
 }
 
-.sim-clauses {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.sim-clause {
-  display: flex;
-  font-size: 0.82rem;
-  gap: 0.45rem;
-  padding: 0.15rem 0;
-}
-
-.sim-clause-icon {
-  width: 1rem;
-}
-
-/* ONE clause-state → hue mapping, worn by both forms a clause is read in: the
-   prose list (`.sim-clause`, the rules drawer) and 053's evidence grid
-   (`.sim-clause-row`). Every state is named explicitly on purpose — the grid
-   used to inherit green as a fall-through, so a state neither list knew about
-   rendered as "matched". Anything unmapped is muted (see `.sim-clause-mark`),
-   which says nothing rather than the wrong thing. */
-.sim-clause.state-matched .sim-clause-icon,
+/* ONE clause-state → hue mapping for the ONE form a clause is read in (053
+   layer 7 retired the prose list the rules drawer used to have its own copy
+   of). Every state is named explicitly on purpose — the grid used to inherit
+   green as a fall-through, so a state the list did not know about rendered as
+   "matched". Anything unmapped is muted (see `.sim-clause-mark`), which says
+   nothing rather than the wrong thing. */
 .sim-clause-row.state-matched .sim-clause-mark {
   color: var(--ok);
 }
 
-.sim-clause.state-no-match .sim-clause-icon,
-.sim-clause.state-error .sim-clause-icon,
 .sim-clause-row.state-no-match .sim-clause-mark,
 .sim-clause-row.state-error .sim-clause-mark {
   color: var(--error);
 }
 
-.sim-clause.state-no-input .sim-clause-icon,
-.sim-clause.state-not-applicable .sim-clause-icon,
-.sim-clause.state-not-simulated .sim-clause-icon,
 .sim-clause-row.state-no-input .sim-clause-mark,
 .sim-clause-row.state-not-applicable .sim-clause-mark,
 .sim-clause-row.state-not-simulated .sim-clause-mark {
   color: var(--warn);
-}
-
-.sim-clause-text {
-  min-width: 0;
-  overflow-wrap: anywhere;
 }
 
 .sim-merged {
@@ -2187,15 +2159,8 @@ pre.config-view.prov-before {
   padding: 0.5rem 0.7rem;
 }
 
-.sim-merged ul {
-  list-style: none;
-  margin: 0.25rem 0 0;
-  padding: 0;
-}
-
-.sim-merged li {
-  overflow-wrap: anywhere;
-  padding: 0.1rem 0;
+.sim-merged .sim-writes {
+  margin-top: 0.25rem;
 }
 
 .sim-merged-title {
@@ -2206,16 +2171,10 @@ pre.config-view.prov-before {
   text-transform: uppercase;
 }
 
-.sim-merged-key {
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-}
-
-/* A value that never reached the final config, wherever it is read: the merge
-   drawer's `before`, and 053's `.sim-thread-old` (which keeps its own class as
-   the thread's DOM hook, but not a second copy of this rule body). */
-.sim-merged-before,
-.sim-thread-old {
+/* A value that never reached the final config, wherever it is read: what a
+   write replaced, and — since 053 layer 7 — the beaten value a thread's
+   override row states, which is the same fact in the same grammar. */
+.sim-merged-before {
   color: var(--muted);
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -2447,10 +2406,6 @@ pre.config-view.prov-before {
   margin-left: 0.4rem;
 }
 
-.sim-thread-note {
-  font-size: 0.78rem;
-}
-
 .sim-thread-body .sim-step-link {
   margin-left: 0;
 }
@@ -2458,7 +2413,7 @@ pre.config-view.prov-before {
 /* 053: clause evidence as COLUMNS — mark · matcher · what it checks · what
    this update actually is. Rows are subgrid so both value columns line up
    straight down the grid; the comparison IS the evidence, and the prose form
-   (.sim-clauses, still what the rules drawer uses) hides it in a sentence. */
+   this replaced (layer 7 retired it) hid the comparison in a sentence. */
 .sim-clause-grid {
   column-gap: 0.45rem;
   display: grid;
@@ -2473,8 +2428,7 @@ pre.config-view.prov-before {
   grid-template-columns: subgrid;
 }
 
-/* The neutral default; the state hues come from the shared mapping the prose
-   form declares (`.sim-clause-icon`, above). */
+/* The neutral default; the state hues come from the per-state mapping above. */
 .sim-clause-mark {
   color: var(--muted);
   font-family: var(--font-mono);
@@ -2563,32 +2517,34 @@ pre.config-view.prov-before {
   margin: 0.4rem 0 0;
 }
 
-/* One row per key the rule wrote, on shared columns (mark · key · values) so
-   the digest reads down the value edge like every other 053 ledger. */
-.sim-digest {
+/* 053 layer 7: ONE grammar for "something wrote this key", on shared columns
+   (mark · key · values) so a column of writes reads down its value edge — the
+   evidence card's digest, a thread's beaten values, the matched rule's applied
+   diff and the A/B config delta are all this grid. */
+.sim-writes {
   column-gap: 0.45rem;
   display: grid;
   grid-template-columns: max-content max-content minmax(0, 1fr);
   row-gap: 0.2rem;
 }
 
-.sim-digest-row {
+.sim-write-row {
   display: grid;
   grid-column: 1 / -1;
   grid-template-columns: subgrid;
 }
 
-.sim-digest-mark {
+.sim-write-mark {
   color: var(--muted);
   font-family: var(--font-mono);
 }
 
-.sim-digest-key {
+.sim-write-key {
   font-family: var(--font-mono);
   font-size: 0.78rem;
 }
 
-.sim-digest-values {
+.sim-write-values {
   min-width: 0;
   overflow-wrap: anywhere;
 }
@@ -2600,7 +2556,10 @@ pre.config-view.prov-before {
   text-decoration: line-through;
 }
 
-.sim-digest-note {
+/* The trailing aside — who wrote a beaten value, which step took a write away.
+   Muted, so the references inside it (`.sim-thread-rule`, the popover link)
+   stay the only full-strength ink on the row. */
+.sim-write-note {
   color: var(--muted);
 }
 
@@ -2836,16 +2795,9 @@ pre.config-view.prov-before {
   margin-top: 0.6rem;
 }
 
-.sim-compare-config ul {
-  list-style: none;
-  margin: 0.3rem 0 0;
-  padding: 0;
-}
-
-.sim-compare-config li {
+.sim-compare-config .sim-writes {
   font-size: 0.82rem;
-  overflow-wrap: anywhere;
-  padding: 0.1rem 0;
+  margin-top: 0.3rem;
 }
 
 .sim-rules-head {


### PR DESCRIPTION
The simulator had TWO clause renderers and FOUR before→after dialects for the
same engine data: the rules drawer's prose clause list vs 053's clause grid,
and `key: before → after` written four different ways (the matched rule's
applied diff, the A/B config delta, the evidence card's digest, a thread's
struck override line) — each with its own markup, its own value classes, and
its own idea of whether a key deserved the option-docs hover card.

Consolidate in the new→old direction: `WriteRow` is THE write row
(`mark · key · before → after · note`, on the shared `.sim-writes` columns),
`ClauseGrid` is THE clause renderer, and the prose list plus `.sim-clauses`
are gone. Two affordances the newer surfaces had lost come back with it: the
evidence card's digest keys are now `OptionKey`s like the drawer's always
were, and the card carries the copy-as-markdown export through the same
`ruleAppliedMarkdown` builder (which now says "(removed)" rather than pasting
`undefined` for a key a merge took away).

The thread body's copy stays popover-only: its rows are prose with live rule
references, not a value table a markdown fence could carry.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>