### PR TITLE
refactor(app): single kv subgrid primitive, adopted by the effective-config ledger (054 layer 8)

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -212,8 +212,8 @@ test("the merge timeline walks the matching rules one stop at a time", async ({ 
 });
 
 /**
- * Roadmap 047/053 — a cross-link opens what it targets. The step link now
- * lives inside a THREAD (053: the ledger row expands into that key's causal
+ * Roadmap 047/054 — a cross-link opens what it targets. The step link now
+ * lives inside a THREAD (054: the ledger row expands into that key's causal
  * story), and it points at a stop inside the collapsed merge drawer — so
  * clicking it must open the drawer AND land on that exact stop, not merely
  * scroll to a closed row.

--- a/packages/app/e2e/06-error-states-and-filters.spec.ts
+++ b/packages/app/e2e/06-error-states-and-filters.spec.ts
@@ -64,7 +64,7 @@ test("the simulator 'my rules only' filter shows repo rules with clause evidence
   // The repo rule row is shown, pre-expanded, with its clause evidence visible.
   const expandedRow = simulator.locator(".sim-rule.expanded").first();
   await expect(expandedRow).toBeVisible();
-  // 053 layer 7: the drawer reads clause evidence through the SAME grid the
+  // 054 layer 7: the drawer reads clause evidence through the SAME grid the
   // threads and the evidence card use — one clause renderer, one grammar.
   await expect(expandedRow.locator(".sim-clause-grid .sim-clause-row").first()).toBeVisible();
 });

--- a/packages/app/e2e/17-verdict-threads.spec.ts
+++ b/packages/app/e2e/17-verdict-threads.spec.ts
@@ -48,7 +48,7 @@ async function expandThread(page: Page, key: string): Promise<Locator> {
 }
 
 /**
- * Roadmap 053 — the thread answers "who set this, and what did they beat?" in
+ * Roadmap 054 — the thread answers "who set this, and what did they beat?" in
  * one place. Collapsed, the row still says two rules wrote the key; expanded,
  * the winner writes first with its clause evidence in aligned columns, and the
  * value it overrode is struck through under the rule that wrote it.
@@ -106,7 +106,7 @@ test("expanding a contested thread names its winner, its clause evidence and the
 });
 
 /**
- * Roadmap 053 layer 3 — the second (and last) disclosure level. A thread names
+ * Roadmap 054 layer 3 — the second (and last) disclosure level. A thread names
  * the rule whose value it beat; that reference opens the losing rule's own
  * card, which answers the only question the thread leaves open about it: what
  * ELSE did it do? The card is navigation-free, so it light-dismisses and hands
@@ -157,7 +157,7 @@ test("the losing writer's reference opens its evidence card, and Escape gives fo
 });
 
 /**
- * Roadmap 053 layer 3 — the card's one link out. "open in matched rules →" is
+ * Roadmap 054 layer 3 — the card's one link out. "open in matched rules →" is
  * navigation, not a third fold: it opens the (demoted) rules drawer and lands
  * on that rule's row through the 013 focus wiring, closing the card behind it.
  */
@@ -183,7 +183,7 @@ test("the evidence card's matched-rules link opens the drawer on that rule's row
 });
 
 /**
- * Roadmap 053 layer 4 — the way back. A thread's own jumps land the reader
+ * Roadmap 054 layer 4 — the way back. A thread's own jumps land the reader
  * somewhere the thread is off-screen, so both leave a pill naming it. The pill
  * re-expands that thread, flashes it, and then has nothing left to say.
  */
@@ -226,7 +226,7 @@ test("a thread's step jump leaves a return pill that re-expands and flashes the 
 });
 
 /**
- * Roadmap 053 layer 4 — a link says where to look. `simThread` (the expanded
+ * Roadmap 054 layer 4 — a link says where to look. `simThread` (the expanded
  * key) rides the sim descriptor beside `autoSimulate`, `simStep` restores the
  * replay's stop, and opening the link reproduces the run with both in place —
  * no clicking, no scrolling to find what the sender meant.

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -30,7 +30,7 @@ export interface ShareViewInput {
   node?: string;
   step?: number;
   tab?: string;
-  /** Roadmap 044/053: the merge replay's stop index — restored next to a `sim`
+  /** Roadmap 044/054: the merge replay's stop index — restored next to a `sim`
    *  descriptor that reproduces the run whose replay it indexes. */
   simStep?: number;
 }
@@ -253,7 +253,7 @@ export const AUTHORED_BLOCK_CONFIG = `{
 `;
 
 /**
- * Roadmap 053: a CONTESTED key. Two rules the "npm dependency" quick-fill
+ * Roadmap 054: a CONTESTED key. Two rules the "npm dependency" quick-fill
  * (lodash, patch) matches both write `groupName` with DIFFERENT values, so the
  * later one wins and the earlier one's value never reaches the final config —
  * the override cascade a verdict thread exists to show. The `react` rule never

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -325,6 +325,65 @@ function FinalValueBlock({ value }: { value: unknown }) {
   );
 }
 
+/** The key cell of a ledger row: the disclosure caret and the option name,
+ *  with its docs hover card intact (`OptionKey` is a plain span, safe inside
+ *  the button). Its own component so `KeyRow` keeps its cells one level from
+ *  the row, exactly as the simulator's thread ledger does. */
+function KeyRowKey({ name, expanded }: { name: string; expanded: boolean }) {
+  return (
+    <span className="prov-key-name">
+      <span className="caret">{expanded ? "▾" : "▸"}</span>
+      <OptionKey name={name} flagUnknown />
+    </span>
+  );
+}
+
+/** The value cell: what the merged config ends up with — or, for the one row
+ *  whose value is a list of rules, how many of them came from where. */
+function KeyRowPreview({
+  entry,
+  rules,
+  ruleAttribution,
+}: {
+  entry: KeyProvenance;
+  rules: unknown[] | null;
+  ruleAttribution?: RuleAttribution[] | null;
+}) {
+  return (
+    <span className="prov-key-preview">
+      {rules ? (
+        <RuleFramingText
+          total={rules.length}
+          attribution={ruleAttribution ?? null}
+          variant="full"
+        />
+      ) : (
+        preview(entry.finalValue)
+      )}
+    </span>
+  );
+}
+
+/** The origin cell — the multi-contributor badge (an `explained` chip since
+ *  053 layer 6) and the winning layer's chip, as ONE cell so the ledger's
+ *  third column holds on rows that carry neither. */
+function KeyRowOrigin({
+  entry,
+  winner,
+  onSelectPreset,
+}: {
+  entry: KeyProvenance;
+  winner?: ProvenanceStep;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <span className="prov-row-origin">
+      <MultiContribBadgeChip entry={entry} />
+      {winner ? <ProvenanceChip layer={winner.layer} onSelectPreset={onSelectPreset} /> : null}
+    </span>
+  );
+}
+
 function KeyRow({
   entry,
   expanded,
@@ -344,25 +403,16 @@ function KeyRow({
   const rules =
     entry.key === "packageRules" && Array.isArray(entry.finalValue) ? entry.finalValue : null;
   return (
-    <div className={`prov-row${expanded ? " expanded" : ""}`}>
-      <button type="button" className="prov-row-head" onClick={onToggle} aria-expanded={expanded}>
-        <span className="caret">{expanded ? "▾" : "▸"}</span>
-        <span className="prov-key-name">
-          <OptionKey name={entry.key} flagUnknown />
-        </span>
-        <span className="prov-key-preview">
-          {rules ? (
-            <RuleFramingText
-              total={rules.length}
-              attribution={ruleAttribution ?? null}
-              variant="full"
-            />
-          ) : (
-            preview(entry.finalValue)
-          )}
-        </span>
-        <MultiContribBadgeChip entry={entry} />
-        {winner ? <ProvenanceChip layer={winner.layer} onSelectPreset={onSelectPreset} /> : null}
+    <div className={`kv-row prov-row${expanded ? " expanded" : ""}`}>
+      <button
+        type="button"
+        className="kv-row prov-row-head"
+        onClick={onToggle}
+        aria-expanded={expanded}
+      >
+        <KeyRowKey name={entry.key} expanded={expanded} />
+        <KeyRowPreview entry={entry} rules={rules} ruleAttribution={ruleAttribution} />
+        <KeyRowOrigin entry={entry} winner={winner} onSelectPreset={onSelectPreset} />
       </button>
       {expanded ? (
         <div className="prov-detail">
@@ -794,7 +844,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
             onShowDefaultsChange={setShowDefaults}
             hiddenDefaults={hiddenDefaults}
           />
-          <div className="prov-list">
+          <div className="kv prov-list">
             {filtered.length === 0 ? (
               <p className="empty-note">
                 No keys match.{" "}

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -365,7 +365,7 @@ function KeyRowPreview({
 }
 
 /** The origin cell — the multi-contributor badge (an `explained` chip since
- *  053 layer 6) and the winning layer's chip, as ONE cell so the ledger's
+ *  054 layer 6) and the winning layer's chip, as ONE cell so the ledger's
  *  third column holds on rows that carry neither. */
 function KeyRowOrigin({
   entry,

--- a/packages/app/src/components/ProvenanceChip.tsx
+++ b/packages/app/src/components/ProvenanceChip.tsx
@@ -24,7 +24,7 @@ export function ProvenanceChip({
   layer: ProvenanceLayer;
   onSelectPreset?: (nodeId: string) => void;
   /**
-   * Roadmap 053: inside an evidence layer the same chip repeats on every row,
+   * Roadmap 054: inside an evidence layer the same chip repeats on every row,
    * where it is a column of colored labels competing with the evidence itself.
    * `dot` keeps the hue (the thing a reader scans for) and hands the label to
    * the hover card and the tooltip, which is where a reader who cares looks

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -17,7 +17,7 @@ import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
 function ClauseGridRow({ clause }: { clause: ClauseEvaluation }) {
   const evaluated = clauseEvaluated(clause);
   return (
-    <div className={`sim-clause-row state-${clause.state}`}>
+    <div className={`kv-row sim-clause-row state-${clause.state}`}>
       <span className="sim-clause-mark">{clauseIcon(clause.state)}</span>
       <code className="sim-clause-key">{clause.key}</code>
       <span className="sim-clause-checks">
@@ -38,7 +38,7 @@ function ClauseGridRow({ clause }: { clause: ClauseEvaluation }) {
  *  022 explanation (so this grid also serves rules that did NOT match). */
 export function ClauseGrid({ clauses }: { clauses: ClauseEvaluation[] }) {
   return (
-    <div className="sim-clause-grid">
+    <div className="kv sim-clause-grid">
       {clauses.map((clause) => (
         <ClauseGridRow key={clause.key} clause={clause} />
       ))}

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -2,7 +2,7 @@ import type { ClauseEvaluation } from "@renovate-config-visualizer/engine";
 import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
 
 /**
- * Roadmap 053 (variant A): a rule's clause evidence as ALIGNED columns —
+ * Roadmap 054 (variant A): a rule's clause evidence as ALIGNED columns —
  * mark · matcher · what it checks · what this update actually is. The prose
  * form this replaced (layer 7 retired it from the rules drawer too, so there is
  * one clause renderer now) restated "matched against x = y" per row; read as a

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -99,7 +99,7 @@ function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) 
     <div className="sim-compare-config">
       <div className="sim-merged-title">Final per-dependency config changes</div>
       {configDelta.length > 0 ? (
-        <div className="sim-writes">
+        <div className="kv sim-writes">
           {configDelta.map((d) => (
             <WriteRow
               key={d.key}

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -91,7 +91,7 @@ function RuleDeltaList({
 
 /** Roadmap 018: the final-config key delta — the settings A and B actually
  *  disagree on, or an explicit "only the matched-rule set differs". Each row is
- *  the shared write row (053 layer 7); a key that exists on only one side keeps
+ *  the shared write row (054 layer 7); a key that exists on only one side keeps
  *  this panel's own sentinels, since `(unset)` and `(removed)` are words, not
  *  values the config carries. */
 function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) {

--- a/packages/app/src/features/simulator/ReturnPill.tsx
+++ b/packages/app/src/features/simulator/ReturnPill.tsx
@@ -1,7 +1,7 @@
 import { createPortal } from "react-dom";
 
 /**
- * Roadmap 053 (layer 4): the way back. A thread's own jumps — the step link
+ * Roadmap 054 (layer 4): the way back. A thread's own jumps — the step link
  * into the demoted replay, the popover's "open in matched rules" — are the only
  * navigation variant A has, and both land the reader somewhere the thread they
  * came from is off-screen. This pill sits on the app's existing bottom-pill

--- a/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
@@ -4,7 +4,7 @@ import type { RuleEvidence } from "./rule-evidence";
 import { RuleEvidenceAnchor } from "./RuleEvidenceCard";
 
 /**
- * Roadmap 053 layer 3 — the popover's interaction contract, the part that is
+ * Roadmap 054 layer 3 — the popover's interaction contract, the part that is
  * not the derivation: it opens from the rule reference, it light-dismisses
  * (Escape, click outside), and dismissing hands focus BACK to the reference
  * rather than dropping it on <body>. The e2e suite (layer 5) drives the same

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -11,7 +11,7 @@ import type { RuleEvidence, RuleWrite } from "./rule-evidence";
 import { WriteRow } from "./WriteRow";
 
 /**
- * Roadmap 053 (variant A), layer 3: the second — and last — disclosure level.
+ * Roadmap 054 (variant A), layer 3: the second — and last — disclosure level.
  * A thread names the rules whose values it beat; clicking one of those
  * references opens THIS card, which answers the only question the thread
  * leaves open about a losing rule: what else did it do? Its clause evidence,
@@ -30,7 +30,7 @@ const CARD_WIDTH = 576;
 /** Roughly the card's own height: below this much room, it flips above. */
 const CARD_FLIP_MARGIN = 320;
 
-/** One key the rule merged, as the shared write row (053 layer 7). A write that
+/** One key the rule merged, as the shared write row (054 layer 7). A write that
  *  lost keeps this step's add tint — it IS what this step added — and is struck
  *  through, naming the stop that took it away; that pairing is the whole reason
  *  the card exists. */

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -120,7 +120,7 @@ function RuleEvidenceBody({
       <RuleEvidenceHead evidence={evidence} onSelectPreset={onSelectPreset} />
       {evidence.clauses.length > 0 ? <ClauseGrid clauses={evidence.clauses} /> : null}
       <RuleEvidenceSummary evidence={evidence} />
-      <div className="sim-writes">
+      <div className="kv sim-writes">
         {evidence.writes.map((write) => (
           <RuleWriteRow key={write.key} write={write} />
         ))}

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -10,7 +10,7 @@ import { ClauseGrid } from "./ClauseGrid";
 import { ruleAppliedMarkdown, ruleLabel, VERDICT_LABEL, writeMark } from "./rule-format";
 import { WriteRow } from "./WriteRow";
 
-/** Roadmap 018/040/053: what a matching rule applied to the dependency config,
+/** Roadmap 018/040/054: what a matching rule applied to the dependency config,
  *  as the shared write rows plus the copy-as-markdown export of the same. */
 function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: MergedKey[] }) {
   return (

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -23,7 +23,7 @@ function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: Merg
           code={ruleAppliedMarkdown(merged)}
         />
       </div>
-      <div className="sim-writes">
+      <div className="kv sim-writes">
         {merged.map((m) => (
           <WriteRow
             key={m.key}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -116,7 +116,7 @@ export const RuleSimulator = memo(function RuleSimulator({
     simulate,
     simulateRef,
   } = useSimulationRun({ result, onMergeStepChange });
-  // Roadmap 053 layer 4: thread expansion + the return pill. Declared BEFORE
+  // Roadmap 054 layer 4: thread expansion + the return pill. Declared BEFORE
   // the share-link request so its reset effect (keyed on the run) is
   // registered first: a link arms the thread it wants, the auto-run it starts
   // produces the sim, and the reset effect is what applies the armed key.
@@ -238,14 +238,14 @@ export const RuleSimulator = memo(function RuleSimulator({
     () => (sim ? consumedAuthoredBlocks(sim, ruleAttribution) : []),
     [sim, ruleAttribution],
   );
-  // Roadmap 053: the verdict card's threads — one per changed key, each
+  // Roadmap 054: the verdict card's threads — one per changed key, each
   // carrying its whole cascade. Same memo discipline as the ledger it replaces:
   // derived from the last RUN only, so typing in the form never re-walks it.
   const verdictThreads = useMemo(
     () => buildVerdictThreads(changedKeys, mergeStops, layerByIndex, sim),
     [changedKeys, mergeStops, layerByIndex, sim],
   );
-  // Roadmap 053 layer 3: derived on demand — one popover is open at a time, and
+  // Roadmap 054 layer 3: derived on demand — one popover is open at a time, and
   // a run can have hundreds of rules, so deriving every rule's evidence up
   // front would be work for a card nobody opens.
   const evidenceFor = useCallback(
@@ -277,7 +277,7 @@ export const RuleSimulator = memo(function RuleSimulator({
     if (effectiveUpdateType && effectiveUpdateType.trim() !== "") {
       shareForm.updateType = effectiveUpdateType;
     }
-    // Roadmap 053: the link also carries the thread the sender was reading —
+    // Roadmap 054: the link also carries the thread the sender was reading —
     // but only when exactly ONE is open, since two would make the app pick
     // which of the sender's questions the link is about. Still never a token:
     // a thread key is one of the config's own option names.
@@ -289,7 +289,7 @@ export const RuleSimulator = memo(function RuleSimulator({
     await onCopySimLink(share);
   }
 
-  /** Roadmap 053: the verdict foot's "build replay, K stops" link — the
+  /** Roadmap 054: the verdict foot's "build replay, K stops" link — the
    *  demoted drawer opens where the reader last left it (the first stop on a
    *  fresh run), not at a stop they never asked for. */
   function jumpToReplay() {
@@ -443,7 +443,7 @@ export const RuleSimulator = memo(function RuleSimulator({
               onPin={pin}
             />
 
-            {/* Roadmap 053 layer 4: the way back from a thread's own jump.
+            {/* Roadmap 054 layer 4: the way back from a thread's own jump.
                 Portalled to <body> (see ReturnPill), so where it sits in this
                 tree decides nothing but its lifetime — which is the run's. */}
             {threadNav.returnKey !== null ? (

--- a/packages/app/src/features/simulator/SimVerdictBlock.tsx
+++ b/packages/app/src/features/simulator/SimVerdictBlock.tsx
@@ -9,7 +9,7 @@ import type { VerdictSegment } from "./verdict-sentence";
 import { type ThreadNavigation, VerdictThreads } from "./VerdictThreads";
 
 /**
- * Roadmap 053 (variant A): the two full-trace links the evidence drawers
+ * Roadmap 054 (variant A): the two full-trace links the evidence drawers
  * demote to. The card answers the question; the drawers below it are where
  * someone goes to audit the whole run, so they get one quiet line — and "N of
  * M" is stated ONCE on the card, here.
@@ -44,10 +44,10 @@ function VerdictTraceLinks({
 }
 
 /**
- * Roadmap 012/018/040/046/053: the answer first — the verdict CARD directly
+ * Roadmap 012/018/040/046/054: the answer first — the verdict CARD directly
  * under the Simulate button. An answer band (eyebrow naming the simulated
  * update, then the sentence with the modal verbs badged), the THREAD ledger of
- * settings the rules changed (053: each row expands into that key's own causal
+ * settings the rules changed (054: each row expands into that key's own causal
  * story), the consumed-blocks aside when an AUTHORED update-type block was
  * consumed without applying (047 — default-only consumption says nothing and
  * renders nothing), and a footer with the two full-trace links and the
@@ -78,9 +78,9 @@ export function SimVerdictBlock({
   matchedCount: number;
   totalRules: number;
   segments: VerdictSegment[];
-  /** Roadmap 053: one thread per setting the rules changed. */
+  /** Roadmap 054: one thread per setting the rules changed. */
   threads: ThreadModel[];
-  /** Roadmap 053 layer 4: which threads are expanded, and where a jump out of
+  /** Roadmap 054 layer 4: which threads are expanded, and where a jump out of
    *  one is recorded (the return pill's origin). */
   threadNav: ThreadNavigation;
   flattened: SimulationResult["flattened"];
@@ -89,17 +89,17 @@ export function SimVerdictBlock({
   consumed: ConsumedBlock[];
   /** The flatten stop's position on the merge timeline, when it renders. */
   flattenStopIndex?: number;
-  /** Roadmap 053: how many stops the build replay has, for its trace link. */
+  /** Roadmap 054: how many stops the build replay has, for its trace link. */
   replayStops: number;
   /** The simulated update, for the card's eyebrow line. */
   dep: { manager?: string; packageName?: string; currentValue?: string; newValue?: string } | null;
   onSelectPreset?: (nodeId: string) => void;
   onJumpToStep?: (stopIndex: number) => void;
   onJumpToRules: () => void;
-  /** Roadmap 053: open the build replay where it currently stands — absent
+  /** Roadmap 054: open the build replay where it currently stands — absent
    *  when this run has no timeline to open. */
   onJumpToReplay?: () => void;
-  /** Roadmap 053 layer 3: the rule-evidence popover's model, and the jump its
+  /** Roadmap 054 layer 3: the rule-evidence popover's model, and the jump its
    *  footer offers into the matched-rules drawer. */
   evidenceFor?: (ruleIndex: number) => RuleEvidence;
   onOpenRule?: (ruleIndex: number) => void;

--- a/packages/app/src/features/simulator/ThreadBody.tsx
+++ b/packages/app/src/features/simulator/ThreadBody.tsx
@@ -6,7 +6,7 @@ import type { ThreadEntry, ThreadModel, ThreadVerb, ThreadWinner } from "./verdi
 import { WriteRow } from "./WriteRow";
 
 /**
- * Roadmap 053 (variant A): the expanded thread — the causal story of ONE
+ * Roadmap 054 (variant A): the expanded thread — the causal story of ONE
  * setting. The winner writes first (the verb carries the merge semantics, so
  * the thread needs no explanatory aside), its clause evidence follows as an
  * aligned grid, and every writer it beat is struck through underneath, newest
@@ -21,7 +21,7 @@ const VERB_LABEL: Record<ThreadVerb, string> = {
 };
 
 /**
- * Roadmap 053: the callbacks a thread's body needs to reach the rest of the
+ * Roadmap 054: the callbacks a thread's body needs to reach the rest of the
  * simulator. Bundled because every level between the ledger and the override
  * line forwards all of them unchanged.
  */
@@ -91,7 +91,7 @@ function ThreadWriterLine({
  * One value the winner beat — struck through in place, with whoever wrote it.
  * The cascade's last entry is the pre-rules value, which has no writer.
  *
- * Roadmap 053 layer 7: this IS the shared write row (`⊘` mark, a struck value,
+ * Roadmap 054 layer 7: this IS the shared write row (`⊘` mark, a struck value,
  * a trailing note), so a lost value looks the same here as in the evidence
  * card's digest. The row states only a `before` — a beaten write has no "and
  * then it became": that is the winner line at the top of the thread.

--- a/packages/app/src/features/simulator/ThreadBody.tsx
+++ b/packages/app/src/features/simulator/ThreadBody.tsx
@@ -168,7 +168,7 @@ export function ThreadBody({ thread, actions }: { thread: ThreadModel; actions: 
         <p className="sim-thread-line">No merge step names this setting.</p>
       )}
       {winner && winner.clauses.length > 0 ? <ClauseGrid clauses={winner.clauses} /> : null}
-      <div className="sim-writes">
+      <div className="kv sim-writes">
         {thread.overrides.map((entry) => (
           <ThreadOverrideLine
             key={entry.kind === "base" ? "base" : `stop-${entry.stopIndex}`}

--- a/packages/app/src/features/simulator/VerdictThreads.tsx
+++ b/packages/app/src/features/simulator/VerdictThreads.tsx
@@ -7,7 +7,7 @@ import { threadHeadId } from "./use-thread-nav";
 import type { ThreadModel } from "./verdict-threads";
 
 /**
- * Roadmap 053 (variant A): the verdict card's ledger IS the trace. Collapsed,
+ * Roadmap 054 (variant A): the verdict card's ledger IS the trace. Collapsed,
  * it reads as the 046 ledger did — the settings the rules changed, their final
  * values, where each came from — but every row expands into that key's own
  * causal thread (`ThreadBody`), so the three grains the 047 layout re-stated
@@ -48,7 +48,7 @@ function ThreadHeadValue({ thread }: { thread: ThreadModel }) {
 }
 
 /** The origin cell — kept as a cell even when empty so the column holds.
- *  Roadmap 053 layer 3: a DOT here, not the full chip. Collapsed, the column
+ *  Roadmap 054 layer 3: a DOT here, not the full chip. Collapsed, the column
  *  is read as "same origin or not?" down the ledger, which is exactly what a
  *  hue answers; the label stays one hover (or one expansion, where the writer
  *  line wears the full chip) away. */
@@ -69,7 +69,7 @@ function ThreadHeadOrigin({
 }
 
 /**
- * Roadmap 053 layer 4: expansion moved OUT of the row. Two things outside a
+ * Roadmap 054 layer 4: expansion moved OUT of the row. Two things outside a
  * row now open one — a share link's `simThread` and the return pill — and the
  * copy-link affordance has to know which thread is open to encode it, so the
  * state belongs to the simulator (see `use-thread-nav`). A re-simulation still

--- a/packages/app/src/features/simulator/VerdictThreads.tsx
+++ b/packages/app/src/features/simulator/VerdictThreads.tsx
@@ -125,7 +125,7 @@ function ThreadRow({
       <button
         type="button"
         id={threadHeadId(thread.key)}
-        className="sim-thread-head"
+        className="kv-row sim-thread-head"
         aria-expanded={open}
         onClick={() => nav.onToggle(thread.key, !open)}
       >
@@ -150,7 +150,7 @@ export function VerdictThreads({
   nav: ThreadNavigation;
 }) {
   return (
-    <ul className="sim-thread-list">
+    <ul className="kv sim-thread-list">
       {threads.map((thread) => (
         <ThreadRow key={thread.key} thread={thread} actions={actions} nav={nav} />
       ))}

--- a/packages/app/src/features/simulator/WriteRow.test.tsx
+++ b/packages/app/src/features/simulator/WriteRow.test.tsx
@@ -5,7 +5,7 @@ import { writeMark } from "./rule-format";
 import { WriteRow } from "./WriteRow";
 
 /**
- * Roadmap 053 layer 7 — the one write row, and the prop matrix the four
+ * Roadmap 054 layer 7 — the one write row, and the prop matrix the four
  * surfaces that share it actually exercise: a changed key (before → after), an
  * added one (no before), a removed one (a sentinel where a value would be), a
  * write that lost (struck `after` plus the stop that took it), and a thread's

--- a/packages/app/src/features/simulator/WriteRow.tsx
+++ b/packages/app/src/features/simulator/WriteRow.tsx
@@ -3,7 +3,7 @@ import { OptionKey } from "@/components/option-docs";
 import { previewValue } from "./rule-format";
 
 /**
- * Roadmap 053 layer 7: THE row for "something wrote this key". Four surfaces
+ * Roadmap 054 layer 7: THE row for "something wrote this key". Four surfaces
  * used to say the same `key: before → after` sentence in four dialects — the
  * matched-rule drawer's list, the A/B config delta, the evidence popover's
  * digest, and a thread's struck-through override line — each with its own

--- a/packages/app/src/features/simulator/WriteRow.tsx
+++ b/packages/app/src/features/simulator/WriteRow.tsx
@@ -11,7 +11,7 @@ import { previewValue } from "./rule-format";
  * the option-docs hover card (only two of the four gave it one).
  *
  * One component, one grammar: `mark · key · before → after · note`, on shared
- * grid columns (`.sim-writes`) so a column of writes reads straight down its
+ * grid columns (`.kv.sim-writes`) so a column of writes reads straight down its
  * value edge. The mark, the strike and the note are the only knobs, because
  * they are the only things the four surfaces actually disagreed about.
  */
@@ -56,7 +56,7 @@ export function WriteRow({
   max?: number;
 }) {
   return (
-    <div className="sim-write-row">
+    <div className="kv-row sim-write-row">
       <span className="sim-write-mark">{mark ?? ""}</span>
       <span className="sim-write-key">
         <OptionKey name={name} flagUnknown />

--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -1,5 +1,5 @@
 /**
- * Roadmap 053 (variant A), layer 3: the rule popover's model. The claim under
+ * Roadmap 054 (variant A), layer 3: the rule popover's model. The claim under
  * test is the classification — which of a rule's writes reached the final
  * config and which a later stop took away, and WHICH stop that was — because
  * that is the sentence the card prints next to a struck-through value, and

--- a/packages/app/src/features/simulator/rule-evidence.ts
+++ b/packages/app/src/features/simulator/rule-evidence.ts
@@ -8,7 +8,7 @@ import type { MergeStop } from "./merge-stops";
 import { stopLabels } from "./verdict-threads";
 
 /**
- * Roadmap 053 (variant A), layer 3: everything the rule popover states about
+ * Roadmap 054 (variant A), layer 3: everything the rule popover states about
  * ONE rule — its clause evidence, where it merged, and what each of its writes
  * was worth by the end of the run.
  *

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -26,7 +26,7 @@ export function ruleAppliedMarkdown(merged: MergedKey[]): string {
     .join("\n");
 }
 
-/** Roadmap 053 layer 7: `~` changed · `+` added · `−` removed — the mark a
+/** Roadmap 054 layer 7: `~` changed · `+` added · `−` removed — the mark a
  *  {@link WriteRow} leads with, so a write reads without re-parsing its
  *  before/after pair. Here rather than beside the component because a module
  *  that renders may only export components (Fast Refresh). */
@@ -66,7 +66,7 @@ export function clauseIcon(state: ClauseEvaluation["state"]): string {
  * engine's note) rather than reading like the clause was never evaluated; a
  * null-returning matcher reads "not applicable (skipped)".
  *
- * Roadmap 053 layer 7: no longer exported — the prose clause list that read it
+ * Roadmap 054 layer 7: no longer exported — the prose clause list that read it
  * directly is gone, and every clause now arrives through `clauseEvaluated`.
  */
 function clauseExplanation(clause: ClauseEvaluation): string {
@@ -88,7 +88,7 @@ function clauseExplanation(clause: ClauseEvaluation): string {
   }
 }
 
-/** Roadmap 053: the clause grid's last column — the value side of the
+/** Roadmap 054: the clause grid's last column — the value side of the
  *  comparison, split so the grid can style the value itself. */
 export interface ClauseEvaluated {
   text: string;
@@ -98,7 +98,7 @@ export interface ClauseEvaluated {
 }
 
 /**
- * Roadmap 053 (variant A): a matched clause reads as a two-part sentence
+ * Roadmap 054 (variant A): a matched clause reads as a two-part sentence
  * across the grid — `checks ["npm"] · this update is "npm"` — because in a
  * thread the reader is comparing the two value columns, not reading prose.
  * Every other state keeps `clauseExplanation`'s precise wording: a fail-closed

--- a/packages/app/src/features/simulator/rule-pop-dom.ts
+++ b/packages/app/src/features/simulator/rule-pop-dom.ts
@@ -1,5 +1,5 @@
 /**
- * Roadmap 053: the rule-evidence card's DOM identity, in one place.
+ * Roadmap 054: the rule-evidence card's DOM identity, in one place.
  *
  * The card is portalled to `<body>`, so its class is not only a style hook —
  * it is the ONLY way anything can ask "is the card open?" or "is this node

--- a/packages/app/src/features/simulator/use-share-link-request.ts
+++ b/packages/app/src/features/simulator/use-share-link-request.ts
@@ -33,7 +33,7 @@ export function useShareLinkRequest({
   setForm: Dispatch<SetStateAction<FormState>>;
   setUpdateTypeTouched: Dispatch<SetStateAction<boolean>>;
   simulateRef: RefObject<Simulate | null>;
-  /** Roadmap 053: the verdict thread the link asked to open, armed BEFORE the
+  /** Roadmap 054: the verdict thread the link asked to open, armed BEFORE the
    *  auto-run below so the run that arrives can expand it (see
    *  `use-thread-nav`, which consumes it in its own reset effect). */
   onThreadRequest?: (key: string | null) => void;

--- a/packages/app/src/features/simulator/use-thread-nav.ts
+++ b/packages/app/src/features/simulator/use-thread-nav.ts
@@ -4,7 +4,7 @@ import { flashTarget, motionScrollOptions } from "@/lib/motion";
 import { RULE_POP_SELECTOR } from "./rule-pop-dom";
 
 /**
- * Roadmap 053 (layer 4): thread expansion and the way back from a jump, as one
+ * Roadmap 054 (layer 4): thread expansion and the way back from a jump, as one
  * concern — because they are one concern. Expansion was local to each
  * `ThreadRow` in layer 2, which was right until two things outside a row
  * needed to open one: a share link's `simThread`, and the return pill, whose

--- a/packages/app/src/features/simulator/verdict-threads.test.ts
+++ b/packages/app/src/features/simulator/verdict-threads.test.ts
@@ -1,5 +1,5 @@
 /**
- * Roadmap 053 (variant A): the thread derivation is the simulator's single
+ * Roadmap 054 (variant A): the thread derivation is the simulator's single
  * source of truth about who wrote a setting — layer 2's thread ledger is its
  * only reader — so it is tested directly, on hand-written
  * `SimulationResult`/`MergeStop` fixtures rather than by running the engine.

--- a/packages/app/src/features/simulator/verdict-threads.ts
+++ b/packages/app/src/features/simulator/verdict-threads.ts
@@ -7,7 +7,7 @@ import type {
 import type { MergeStop } from "./merge-stops";
 
 /**
- * Roadmap 053 (variant A): the causal thread behind every setting the rules
+ * Roadmap 054 (variant A): the causal thread behind every setting the rules
  * changed. The engine already records everything a thread needs — each
  * `mergeSteps[i].merged` names the keys that merge set/changed WITH their
  * before/after, the steps are contiguous snapshots in merge order, and
@@ -201,7 +201,7 @@ function buildOverrides(
 }
 
 /**
- * Roadmap 053: one thread per changed key. `changedKeys` is the caller's
+ * Roadmap 054: one thread per changed key. `changedKeys` is the caller's
  * base→final diff (a key can be changed without any stop naming it — e.g. one
  * the flatten pass merely dropped), so a thread may legitimately have no
  * winner and an empty cascade.

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -42,7 +42,7 @@ import { ENDPOINT_KEY, persistLocal, PLATFORM_KEY } from "@/platform/storage";
 export interface SimRequest {
   form: Record<string, string>;
   autoSimulate: boolean;
-  /** Roadmap 053: the verdict thread the link asked to open, applied to the
+  /** Roadmap 054: the verdict thread the link asked to open, applied to the
    *  run this request triggers (absent = every thread starts collapsed). */
   simThread?: string;
   nonce: number;
@@ -267,7 +267,7 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
       setSimRequest({
         form: payload.sim.form,
         autoSimulate: payload.sim.autoSimulate === true,
-        // Roadmap 053: rides along with the form rather than through `view`
+        // Roadmap 054: rides along with the form rather than through `view`
         // (where `simStep` lives) because it is only meaningful for the
         // simulation this descriptor reproduces — see ShareSimulator.
         simThread: payload.sim.simThread,

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -67,7 +67,7 @@
 
   /* The stacking ladder, stated in ONE place and in the order the app means:
      a floating pill hovers over the PAGE, a popover hovers over what the
-     reader is reading right now (so it must clear the pills — 053's evidence
+     reader is reading right now (so it must clear the pills — 054's evidence
      card opened low in the viewport was landing behind the return pill), and a
      toast, which speaks for the app itself and dismisses itself, is above
      both. Rungs are 10 apart so a future in-between plane needs no renumbering. */
@@ -1410,9 +1410,9 @@ textarea.layer-editor:focus {
   color: var(--muted);
 }
 
-/* ---------- the shared key/value grid (053 layer 8) ----------
+/* ---------- the shared key/value grid (054 layer 8) ----------
    ONE primitive for every ledger in the app that reads as `key · value ·
-   origin`. Roadmap 053 planned exactly this and then grew three copies of it
+   origin`. Roadmap 054 planned exactly this and then grew three copies of it
    (the thread ledger, the clause grid, the writes grid), each re-declaring the
    same `display: grid` + child `grid-column: 1 / -1; grid-template-columns:
    subgrid` shape with near-identical gaps; the effective config's key list,
@@ -1505,7 +1505,7 @@ textarea.layer-editor:focus {
   padding: 0.5rem 0.75rem;
 }
 
-/* 053 layer 8: the key list is a `.kv` ledger — key · value preview · origin,
+/* 054 layer 8: the key list is a `.kv` ledger — key · value preview · origin,
    on ONE set of columns, so previews start on a common edge instead of
    wherever each option name happens to end (this list had the ragged-column
    problem the simulator's thread ledger was built to fix).
@@ -1594,7 +1594,7 @@ textarea.layer-editor:focus {
   cursor: pointer;
 }
 
-/* 053: the hue rules are shared with the dot variant below — the dot IS the
+/* 054: the hue rules are shared with the dot variant below — the dot IS the
    chip's color with the label moved into the hover card, so the two must never
    be able to disagree about which hue a layer wears. */
 .badge.prov-defaults,
@@ -1623,7 +1623,7 @@ textarea.layer-editor:focus {
   color: var(--accent-pink);
 }
 
-/* 053: inside an evidence layer the chip repeats on every row, where a column
+/* 054: inside an evidence layer the chip repeats on every row, where a column
    of colored labels competes with the evidence itself. The dot keeps the one
    thing that column is scanned for — same origin as the row above, or not —
    and hands the label to the tooltip and the chip's own hover card. */
@@ -2200,7 +2200,7 @@ pre.config-view.prov-before {
   padding: 0.5rem 0.75rem 0.6rem 1.9rem;
 }
 
-/* ONE clause-state → hue mapping for the ONE form a clause is read in (053
+/* ONE clause-state → hue mapping for the ONE form a clause is read in (054
    layer 7 retired the prose list the rules drawer used to have its own copy
    of). Every state is named explicitly on purpose — the grid used to inherit
    green as a fall-through, so a state the list did not know about rendered as
@@ -2242,7 +2242,7 @@ pre.config-view.prov-before {
 }
 
 /* A value that never reached the final config, wherever it is read: what a
-   write replaced, and — since 053 layer 7 — the beaten value a thread's
+   write replaced, and — since 054 layer 7 — the beaten value a thread's
    override row states, which is the same fact in the same grammar. */
 .sim-merged-before {
   color: var(--muted);
@@ -2368,7 +2368,7 @@ pre.config-view.prov-before {
   padding: 0.6rem 0.85rem 0.7rem;
 }
 
-/* ---------- 053: the thread ledger (variant A) ----------
+/* ---------- 054: the thread ledger (variant A) ----------
    The ledger IS the trace. Collapsed it reads as the 046 ledger did, but every
    row expands into that key's own causal story, so the three grains 047 kept
    re-stating (ledger, per-rule applied list, step diff) have one home each.
@@ -2478,7 +2478,7 @@ pre.config-view.prov-before {
   margin-left: 0;
 }
 
-/* 053: clause evidence as COLUMNS — mark · matcher · what it checks · what
+/* 054: clause evidence as COLUMNS — mark · matcher · what it checks · what
    this update actually is. Rows are subgrid so both value columns line up
    straight down the grid; the comparison IS the evidence, and the prose form
    this replaced (layer 7 retired it) hid the comparison in a sentence. */
@@ -2496,7 +2496,7 @@ pre.config-view.prov-before {
 }
 
 /* The matcher name, in the same mono the digest and the merge drawer set their
-   keys in — a key column is a key column wherever a 053 grid puts one. */
+   keys in — a key column is a key column wherever a 054 grid puts one. */
 .sim-clause-key {
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -2515,7 +2515,7 @@ pre.config-view.prov-before {
   font-size: 0.78rem;
 }
 
-/* 053 layer 3: the rule-evidence popover. The plane is the app's existing
+/* 054 layer 3: the rule-evidence popover. The plane is the app's existing
    hover-card plane (.option-card: raised surface, popover shadow, fixed
    placement clamped to the viewport by lib/anchored-card) — this only sets the
    shape the mockup asked for. Nothing here animates: the card is opened by a
@@ -2578,7 +2578,7 @@ pre.config-view.prov-before {
   margin: 0.4rem 0 0;
 }
 
-/* 053 layer 7: ONE grammar for "something wrote this key", on shared columns
+/* 054 layer 7: ONE grammar for "something wrote this key", on shared columns
    (mark · key · values) so a column of writes reads down its value edge — the
    evidence card's digest, a thread's beaten values, the matched rule's applied
    diff and the A/B config delta are all this grid. */
@@ -2604,7 +2604,7 @@ pre.config-view.prov-before {
 
 /* A write that happened here but lost to a later stop: it IS this step's
    addition, so it keeps the add tint, and it is struck like every other value
-   in 053 that never reached the final config. */
+   in 054 that never reached the final config. */
 .sim-merged-after.overridden {
   text-decoration: line-through;
 }
@@ -2682,7 +2682,7 @@ pre.config-view.prov-before {
   text-decoration: underline;
 }
 
-/* 053: the demoted evidence drawers' only mention on the card — one quiet
+/* 054: the demoted evidence drawers' only mention on the card — one quiet
    line, with "N of M" stated here and nowhere else on it. Both of its links
    ARE `.sim-jump`; they are the same affordance saying two things. */
 .sim-trace-links {
@@ -3052,7 +3052,7 @@ pre.config-view.prov-before {
   animation: rcv-flash 1.6s ease-out;
 }
 
-/* Roadmap 053: the same "you are here", without the motion — the target still
+/* Roadmap 054: the same "you are here", without the motion — the target still
    has to be markable for a reader who asked for less animation, so the flash
    becomes a static highlight for the same duration (the class is removed on
    the callers' timeout either way). Same HUE as the animation's first frame:
@@ -3260,7 +3260,7 @@ pre.config-view.prov-before {
 
 /* Any badge/stat given a glossary hover card (see glossary.tsx's `Explained`)
    gets a quiet affordance; more-specific rules elsewhere (e.g. the clickable
-   dup/elided badges' own `cursor: pointer`) still win by specificity. The 053
+   dup/elided badges' own `cursor: pointer`) still win by specificity. The 054
    provenance DOT carries the same class and states its own form of this next
    to `.prov-dot`, where the ordering against the clickable case is visible. */
 .badge.explained,
@@ -3313,7 +3313,7 @@ pre.config-view.prov-before {
   filter: brightness(1.1);
 }
 
-/* Roadmap 053: the return pill — the same bottom-of-the-viewport plane as
+/* Roadmap 054: the return pill — the same bottom-of-the-viewport plane as
    .back-to-top and .rcv-toast (same offset, same float shadow, the same
    --z-float rung), but centered and quiet: it answers a jump the reader made
    one click ago, so it must be findable without competing with the page it

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1410,6 +1410,48 @@ textarea.layer-editor:focus {
   color: var(--muted);
 }
 
+/* ---------- the shared key/value grid (053 layer 8) ----------
+   ONE primitive for every ledger in the app that reads as `key · value ·
+   origin`. Roadmap 053 planned exactly this and then grew three copies of it
+   (the thread ledger, the clause grid, the writes grid), each re-declaring the
+   same `display: grid` + child `grid-column: 1 / -1; grid-template-columns:
+   subgrid` shape with near-identical gaps; the effective config's key list,
+   older than all three, still had the ragged-column problem the primitive
+   exists to solve.
+
+   A surface configures it with two custom properties and nothing else:
+   `--kv-cols` (its track list) and, when the default gap is wrong, `--kv-gap`
+   / `--kv-row-gap`. Everything surface-specific — a hover fill, a state hue, a
+   column's own typography — stays a small delta on the surface's own classes.
+
+   Why subgrid and not one fixed template per surface: the tracks are sized
+   from ALL the rows at once, so the value column starts on one edge down the
+   whole ledger instead of wherever each row's key happened to end — the
+   alignment IS the feature, and a fixed template cannot size `max-content`
+   across siblings. */
+.kv {
+  column-gap: var(--kv-gap, 0.45rem);
+  display: grid;
+  grid-template-columns: var(--kv-cols);
+  row-gap: var(--kv-row-gap, 0);
+}
+
+/* Anything placed directly in a kv grid spans all of its columns: the rows,
+   and the full-width blocks (an expanded body, an empty note) between them. */
+.kv > * {
+  grid-column: 1 / -1;
+}
+
+/* A ROW re-uses the grid's own tracks. Applied at whatever depth the row
+   actually lives at — a row nested inside another `.kv-row` (a button inside
+   its bordered wrapper) passes the tracks straight through. */
+.kv-row {
+  align-items: baseline;
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+}
+
 /* ---------- merge provenance view (005) ---------- */
 
 .prov-filters {
@@ -1463,11 +1505,25 @@ textarea.layer-editor:focus {
   padding: 0.5rem 0.75rem;
 }
 
+/* 053 layer 8: the key list is a `.kv` ledger — key · value preview · origin,
+   on ONE set of columns, so previews start on a common edge instead of
+   wherever each option name happens to end (this list had the ragged-column
+   problem the simulator's thread ledger was built to fix).
+
+   The key track is `minmax(0, max-content)` rather than the thread ledger's
+   bare `max-content`: this list is filtered, not curated, so it can hold every
+   option Renovate has, and the longest of those must be allowed to wrap in a
+   narrow panel instead of pushing the preview column off the edge. */
 .prov-list {
+  --kv-cols: minmax(0, max-content) minmax(0, 1fr) auto;
+  --kv-gap: 0.5rem;
+
   max-height: 40rem;
   overflow: auto;
 }
 
+/* The row wrapper carries the separator and passes the ledger's tracks down to
+   the head button, which is the cell-bearing row. */
 .prov-row {
   border-bottom: 1px solid var(--border);
 }
@@ -1477,14 +1533,11 @@ textarea.layer-editor:focus {
 }
 
 .prov-row-head {
-  align-items: center;
   background: transparent;
   border: none;
   color: inherit;
   cursor: pointer;
-  display: flex;
   font: inherit;
-  gap: 0.5rem;
   padding: 0.4rem 0.75rem;
   text-align: left;
   width: 100%;
@@ -1494,9 +1547,11 @@ textarea.layer-editor:focus {
   background: var(--surface);
 }
 
+/* Inside the key cell, as in the thread ledger: a fixed width so the option
+   names still start on one edge whichever way the triangle points. */
 .prov-row-head .caret {
   color: var(--muted);
-  flex: none;
+  display: inline-block;
   font-size: 0.75rem;
   width: 0.9rem;
 }
@@ -1504,16 +1559,28 @@ textarea.layer-editor:focus {
 .prov-key-name {
   font-family: var(--font-mono);
   font-size: 0.85rem;
+  overflow-wrap: anywhere;
 }
 
+/* The preview is already truncated in JS (80 chars), so the ellipsis this used
+   to need was a second truncation; what is left wraps like every other value
+   column in the app rather than being clipped mid-token. */
 .prov-key-preview {
   color: var(--muted);
-  flex: 1;
   font-family: var(--font-mono);
   font-size: 0.8rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+/* Both chips a row can wear — the multi-contributor badge and the winning
+   layer — are ONE cell, so the origin column holds even on rows that have
+   neither. */
+.prov-row-origin {
+  align-items: baseline;
+  display: flex;
+  gap: 0.4rem;
+  justify-self: end;
 }
 
 .badge.prov-layer {
@@ -1592,7 +1659,10 @@ textarea.layer-editor:focus {
   color: var(--warn);
 }
 
+/* The expanded detail is a block, not a row: it spans the ledger's columns
+   rather than sharing them. */
 .prov-detail {
+  grid-column: 1 / -1;
   padding: 0 0.75rem 0.75rem 1.65rem;
 }
 
@@ -2305,11 +2375,12 @@ pre.config-view.prov-before {
    Rows share ONE set of columns — key · value · origin — through `subgrid`, so
    values start on a common edge instead of wherever the key happens to end;
    the head button IS the subgrid row, which is why the <li> around it
-   disappears into `display: contents`. */
+   disappears into `display: contents`. Columns come from the shared `.kv`
+   primitive; only the track list and the list reset are this surface's. */
 .sim-thread-list {
-  column-gap: 0.6rem;
-  display: grid;
-  grid-template-columns: max-content minmax(0, 1fr) auto;
+  --kv-cols: max-content minmax(0, 1fr) auto;
+  --kv-gap: 0.6rem;
+
   list-style: none;
   margin: 0;
   padding: 0;
@@ -2319,19 +2390,16 @@ pre.config-view.prov-before {
   display: contents;
 }
 
+/* The head IS the row (`.kv-row`); this is only the button reset it needs to
+   stop looking like a button. */
 .sim-thread-head {
-  align-items: baseline;
   background: none;
   border: none;
   border-radius: 6px;
   color: inherit;
-  column-gap: 0.6rem;
   cursor: pointer;
-  display: grid;
   font: inherit;
   font-size: 0.83rem;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
   padding: 0.2rem 0.4rem;
   text-align: left;
 }
@@ -2415,17 +2483,10 @@ pre.config-view.prov-before {
    straight down the grid; the comparison IS the evidence, and the prose form
    this replaced (layer 7 retired it) hid the comparison in a sentence. */
 .sim-clause-grid {
-  column-gap: 0.45rem;
-  display: grid;
-  grid-template-columns: max-content max-content minmax(0, 1fr) auto;
-  margin: 0.3rem 0;
-  row-gap: 0.2rem;
-}
+  --kv-cols: max-content max-content minmax(0, 1fr) auto;
+  --kv-row-gap: 0.2rem;
 
-.sim-clause-row {
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
+  margin: 0.3rem 0;
 }
 
 /* The neutral default; the state hues come from the per-state mapping above. */
@@ -2522,16 +2583,8 @@ pre.config-view.prov-before {
    evidence card's digest, a thread's beaten values, the matched rule's applied
    diff and the A/B config delta are all this grid. */
 .sim-writes {
-  column-gap: 0.45rem;
-  display: grid;
-  grid-template-columns: max-content max-content minmax(0, 1fr);
-  row-gap: 0.2rem;
-}
-
-.sim-write-row {
-  display: grid;
-  grid-column: 1 / -1;
-  grid-template-columns: subgrid;
+  --kv-cols: max-content max-content minmax(0, 1fr);
+  --kv-row-gap: 0.2rem;
 }
 
 .sim-write-mark {

--- a/packages/app/src/lib/anchored-card.ts
+++ b/packages/app/src/lib/anchored-card.ts
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 
 /**
- * Roadmap 025/053: where a floating card anchored to an element goes. The
+ * Roadmap 025/054: where a floating card anchored to an element goes. The
  * cards render `position: fixed` and are portalled to `<body>` (035), so the
  * numbers below are viewport coordinates; two rules matter and were duplicated
  * per card before this module: clamp the width to the VIEWPORT rather than to

--- a/packages/app/src/lib/input-schemas-zod.ts
+++ b/packages/app/src/lib/input-schemas-zod.ts
@@ -139,12 +139,12 @@ export function sanitizeShareView(raw: unknown): SanitizedShareView | undefined 
 export interface SanitizedShareSimulator {
   form: Record<string, string>;
   autoSimulate?: boolean;
-  /** Roadmap 053: the expanded verdict thread's key. */
+  /** Roadmap 054: the expanded verdict thread's key. */
   simThread?: string;
 }
 
 /**
- * Roadmap 053: a verdict thread's key — a config option name the opener looks
+ * Roadmap 054: a verdict thread's key — a config option name the opener looks
  * up as a DOM id and scrolls to. Bounded for the same reason every other
  * string that reaches the DOM is: a hand-edited monster value is dropped on
  * its own (the link still opens, just without expanding a thread), never
@@ -179,7 +179,7 @@ export function sanitizeShareSim(raw: unknown): SanitizedShareSimulator | undefi
   if (raw.autoSimulate === true) {
     out.autoSimulate = true;
   }
-  // Roadmap 053: kept only next to a form — a thread key names a row of a
+  // Roadmap 054: kept only next to a form — a thread key names a row of a
   // simulation's verdict, so on its own (no form to reproduce the run) there
   // is nothing for it to point at.
   const thread = threadKeySchema.safeParse(raw.simThread);

--- a/packages/app/src/lib/motion.ts
+++ b/packages/app/src/lib/motion.ts
@@ -1,5 +1,5 @@
 /**
- * Roadmap 053 — the two motion-bearing gestures every cross-link in this app
+ * Roadmap 054 — the two motion-bearing gestures every cross-link in this app
  * makes: scroll the target into view, then flash it so the eye can find it.
  * Both were spelled out inline at each call site (013's rule focus, 047's
  * drawer jumps), which is how the scroll came to ignore

--- a/packages/app/src/lib/share.test.ts
+++ b/packages/app/src/lib/share.test.ts
@@ -643,12 +643,12 @@ describe("untrustedGuardForPolicy", () => {
 });
 
 /**
- * Roadmap 053 (layer 4): `sim.simThread` — the expanded verdict thread's key —
+ * Roadmap 054 (layer 4): `sim.simThread` — the expanded verdict thread's key —
  * is additive within v2 exactly like `autoSimulate` was, so the tests are the
  * same two questions: does a link that carries it round-trip, and does a link
  * from before it existed still decode as it always did?
  */
-describe("053: sim.simThread round-trips and stays additive", () => {
+describe("054: sim.simThread round-trips and stays additive", () => {
   test("a simulation link carrying an expanded thread round-trips", async () => {
     const token = await encodeShare(
       minimalState({
@@ -690,7 +690,7 @@ describe("053: sim.simThread round-trips and stays additive", () => {
     }
   });
 
-  test("a pre-053 link (no simThread) decodes exactly as before", async () => {
+  test("a pre-054 link (no simThread) decodes exactly as before", async () => {
     const token = await rawEncodeToken(
       taggedPayload({ sim: { form: { packageName: "lodash" }, autoSimulate: true } }),
     );

--- a/packages/app/src/lib/share.ts
+++ b/packages/app/src/lib/share.ts
@@ -62,10 +62,10 @@ export interface ShareSimulator {
   form: Record<string, string>;
   autoSimulate?: boolean;
   /**
-   * Roadmap 053 (layer 4): the verdict thread — a changed setting's KEY — that
+   * Roadmap 054 (layer 4): the verdict thread — a changed setting's KEY — that
    * was expanded when the link was made, so "look at what happened to
    * `groupName`" survives the copy. Additive within v2 exactly like
-   * `autoSimulate`: a pre-053 link simply lacks it, a pre-053 reader ignores
+   * `autoSimulate`: a pre-054 link simply lacks it, a pre-054 reader ignores
    * the unknown key, and it only means anything next to a `form` that
    * reproduces the run whose threads it names. Never a token — it is one of
    * the config's own option names.

--- a/roadmap/054-simulator-results-readability.md
+++ b/roadmap/054-simulator-results-readability.md
@@ -3,6 +3,10 @@
 Milestone: — · Status: **variant A implemented** (2026-08-02), shipped as the
 five-layer stack below; variants B and C remain proposed
 
+Renumbered from 053 (2026-08-03): main took that number for the analytics
+localhost-exclusion item while this stack was in review. The `feat/053-*`
+branch names predate the renumber and stay as-is.
+
 Mockup (three variants; revised 2026-08-02 after review — the scenario now
 includes a contested field, `groupName` written by two matched rules with the
 later one winning, and every key/value ledger aligns its columns):
@@ -162,7 +166,7 @@ evidence per rule. A new `verdict-threads.ts` derives, per changed key:
 4. `ReturnPill` + `simThread` fragment state + jump wiring —
    `feat/053-04-return-pill-fragment`.
 5. e2e suite + roadmap status flip — `feat/053-05-e2e-and-docs`
-   (`packages/app/e2e/16-verdict-threads.spec.ts`, five scenarios over the
+   (`packages/app/e2e/17-verdict-threads.spec.ts`, five scenarios over the
    new `CONTESTED_KEY_CONFIG` fixture: expand a contested thread, the
    popover's evidence + Escape-restores-focus, its "open in matched
    rules →" jump, the step jump's return pill, and a `simThread` +

--- a/roadmap/054-simulator-results-readability.md
+++ b/roadmap/054-simulator-results-readability.md
@@ -195,3 +195,21 @@ rule.
   misfires in practice).
 - No third disclosure level: thread → popover is level two; the popover's
   "open in matched rules" is navigation, not another fold.
+
+### Follow-ups (2026-08-02 audit)
+
+Three layers landed after the plan above, from an audit of what shipped:
+
+6. **Consistency fixes** — `feat/053-06-design-consistency`: the thread
+   ledger's own grammar reconciled with the app's (actionable text, the
+   `explained` affordance on the dot, one clause-state → hue mapping with
+   every state named instead of a green fall-through).
+7. **One `WriteRow`, one `ClauseGrid`** — `feat/053-07-write-row`: four
+   surfaces said `key: before → after` in four dialects and two rendered
+   clause evidence as prose; both collapsed into one component each, so the
+   evidence reads the same wherever it is met.
+8. **One `.kv` subgrid primitive** — `feat/053-08-kv-primitive`: the plan
+   asked for ONE shared-column primitive and got three near-identical grid
+   systems; they are now `--kv-cols` configurations of a single `.kv` /
+   `.kv-row` pair, and the effective config's key list — older than all
+   three, and still ragged — adopted it as well.


### PR DESCRIPTION
Roadmap 054 planned ONE shared-column subgrid primitive and shipped three
near-identical ones: the thread ledger, the clause grid and the writes grid
each re-declared `display: grid` plus a child `grid-column: 1 / -1;
grid-template-columns: subgrid` with near-identical gaps. Meanwhile the
effective config's key list — older than all three — still had the ragged
value column the primitive exists to remove.

There is now one `.kv` / `.kv-row` pair. A surface configures it with
`--kv-cols` (its track list) and, when the default gap is wrong, `--kv-gap`
/ `--kv-row-gap`; everything surface-specific stays a small delta on the
surface's own classes — the thread head's hover fill and button reset, the
clause row's state hues, each grid's mark-column width. The three simulator
families keep their class names (e2e addresses them) as secondary classes.

The effective config's rows adopt it: key · value preview · origin, with
both chips a row can wear (the multi-contributor `explained` badge and the
winning layer's chip) as ONE cell so the third column holds on rows that
carry neither. The key track is `minmax(0, max-content)` rather than the
thread ledger's bare `max-content` — this list is filtered, not curated, so
it can hold every option Renovate has and the longest of those must wrap in
a narrow panel instead of pushing the preview column off the edge. The
preview loses its ellipsis, which was a second truncation over the 80-char
one `preview()` already applies.

Measured on the fully hydrated config (402 rows): a forced full relayout of
the list costs ~4.9 ms under subgrid against ~1.3 ms under the old flex
rows. Well inside a frame, and it is not on the scroll path, so subgrid
stays rather than falling back to a fixed template.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
