### PR TITLE
fix(app): never report analytics from a local hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ otherwise the shipped stub stays and the feature is off.
 | `RCV_GITHUB_APP_SLUG`   | no                   | The App's slug; enables a direct "install on repositories" link.    |
 | `RCV_GA_MEASUREMENT_ID` | no                   | GA4 measurement id (`G-…`); enables Google Analytics. Off unset.    |
 
+`RCV_GA_MEASUREMENT_ID` names **your** property, so it is honoured on any
+hostname — including a container reached at `localhost:8080`. The hosted
+build's own id is the opposite: it is ignored on loopback hostnames, so a local
+preview or a browser test of this repo never reports to it.
+
 <details>
 <summary>Sign in with GitHub, self-hosted</summary>
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,6 @@ otherwise the shipped stub stays and the feature is off.
 | `RCV_GITHUB_APP_SLUG`   | no                   | The App's slug; enables a direct "install on repositories" link.    |
 | `RCV_GA_MEASUREMENT_ID` | no                   | GA4 measurement id (`G-…`); enables Google Analytics. Off unset.    |
 
-`RCV_GA_MEASUREMENT_ID` names **your** property, so it is honoured on any
-hostname — including a container reached at `localhost:8080`. The hosted
-build's own id is the opposite: it is ignored on loopback hostnames, so a local
-preview or a browser test of this repo never reports to it.
-
 <details>
 <summary>Sign in with GitHub, self-hosted</summary>
 

--- a/packages/app/e2e/16-analytics-localhost.spec.ts
+++ b/packages/app/e2e/16-analytics-localhost.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+import { runAndAwaitResult, setEditorContent } from "./helpers";
+
+/**
+ * Roadmap 053 — the suite must not be a traffic source.
+ *
+ * CI serves the Pages `dist` (measurement id inlined by the build job) on
+ * localhost, and every Playwright context is cookie-less, so before the
+ * hostname guard each test in this suite registered as a new GA user. This
+ * spec asserts the guard from the outside: no request ever leaves for Google's
+ * analytics hosts, and gtag's `dataLayer` is never created.
+ *
+ * Against a locally built `dist` the assertion is vacuous — no id is inlined
+ * without `VITE_GA_MEASUREMENT_ID`, so nothing would load either way. It bites
+ * exactly where the bug lived: CI, and a deliberate local repro
+ * (`VITE_GA_MEASUREMENT_ID=G-TEST1234 pnpm --filter …/app build`), where it
+ * fails without the guard.
+ */
+
+const ANALYTICS_HOSTS = ["googletagmanager.com", "google-analytics.com", "analytics.google.com"];
+
+test("never loads analytics when served from localhost", async ({ page }) => {
+  const analyticsRequests: string[] = [];
+  page.on("request", (request) => {
+    const { hostname } = new URL(request.url());
+    if (ANALYTICS_HOSTS.some((host) => hostname === host || hostname.endsWith(`.${host}`))) {
+      analyticsRequests.push(request.url());
+    }
+  });
+
+  await page.goto("/");
+  // A full run, not just first paint: the injector runs at module scope, but a
+  // regression that moved it behind the pipeline would still be caught. The
+  // config resolves without fetching any preset, so the only requests that can
+  // leave the page are the app's own.
+  await setEditorContent(
+    page,
+    '{\n  "packageRules": [{ "matchPackageNames": ["react"], "groupName": "react" }]\n}',
+  );
+  await runAndAwaitResult(page);
+
+  expect(analyticsRequests).toEqual([]);
+  const hasDataLayer = await page.evaluate(() => "dataLayer" in window);
+  expect(hasDataLayer).toBe(false);
+});

--- a/packages/app/src/platform/analytics-config.test.ts
+++ b/packages/app/src/platform/analytics-config.test.ts
@@ -15,7 +15,7 @@ import { getMeasurementId, isTrackableHostname } from "./analytics";
  */
 
 /** A hostname that stands in for a real deployment. */
-const DEPLOYED = "renovate.secustor.dev";
+const DEPLOYED = "rcd.example.com";
 
 function setEnv(id: string | undefined): void {
   vi.stubEnv("VITE_GA_MEASUREMENT_ID", id);

--- a/packages/app/src/platform/analytics-config.test.ts
+++ b/packages/app/src/platform/analytics-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { getMeasurementId } from "./analytics";
+import { getMeasurementId, isTrackableHostname } from "./analytics";
 
 /**
  * `getMeasurementId` mirrors `getOAuthConfig` (roadmap 043): a deployment-time
@@ -8,7 +8,14 @@ import { getMeasurementId } from "./analytics";
  * be validated — a malformed global falls through to the var, and an id that
  * is not `G-` + alphanumerics never loads gtag at all (it would end up in the
  * script URL).
+ *
+ * Roadmap 053 adds the hostname to that resolution. The hostname is a
+ * parameter rather than a `location` read precisely so these stay pure-module
+ * tests in the node-environment "unit" project.
  */
+
+/** A hostname that stands in for a real deployment. */
+const DEPLOYED = "renovate.secustor.dev";
 
 function setEnv(id: string | undefined): void {
   vi.stubEnv("VITE_GA_MEASUREMENT_ID", id);
@@ -26,18 +33,18 @@ afterEach(() => {
 describe("getMeasurementId", () => {
   test("is null when neither source is configured", () => {
     setEnv(undefined);
-    expect(getMeasurementId()).toBeNull();
+    expect(getMeasurementId(DEPLOYED)).toBeNull();
   });
 
   test("reads the build-time var when there is no runtime global", () => {
     setEnv("G-ENV123");
-    expect(getMeasurementId()).toBe("G-ENV123");
+    expect(getMeasurementId(DEPLOYED)).toBe("G-ENV123");
   });
 
   test("the runtime global wins over the build-time var", () => {
     setEnv("G-ENV123");
     setGlobal({ measurementId: "  G-RUNTIME1  " });
-    expect(getMeasurementId()).toBe("G-RUNTIME1");
+    expect(getMeasurementId(DEPLOYED)).toBe("G-RUNTIME1");
   });
 
   test.for([
@@ -49,12 +56,62 @@ describe("getMeasurementId", () => {
   ] as const)("a global that is %s falls through to the var", ([, value]) => {
     setEnv("G-ENV123");
     setGlobal(value);
-    expect(getMeasurementId()).toBe("G-ENV123");
+    expect(getMeasurementId(DEPLOYED)).toBe("G-ENV123");
   });
 
   test("an id that could break out of the script URL is rejected", () => {
     setEnv(undefined);
     setGlobal({ measurementId: "G-1&injected=x" });
-    expect(getMeasurementId()).toBeNull();
+    expect(getMeasurementId(DEPLOYED)).toBeNull();
+  });
+});
+
+/**
+ * The hostname guard (roadmap 053). The bug it exists for: the Pages build's
+ * inlined id, running in the e2e job's `vite preview` on localhost, reported
+ * every Playwright context as a new user.
+ */
+describe("getMeasurementId on a local hostname", () => {
+  test.for(["localhost", "127.0.0.1", "0.0.0.0", "[::1]", "app.localhost", ""] as const)(
+    "the build-time var is ignored on %s",
+    (hostname) => {
+      setEnv("G-ENV123");
+      expect(getMeasurementId(hostname)).toBeNull();
+    },
+  );
+
+  test("a self-host's own runtime id still tracks there", () => {
+    // The one case the guard must not break: `RCV_GA_MEASUREMENT_ID` names the
+    // deployer's property, and their container may well be reached on
+    // localhost.
+    setGlobal({ measurementId: "G-SELFHOST1" });
+    expect(getMeasurementId("localhost")).toBe("G-SELFHOST1");
+  });
+});
+
+describe("isTrackableHostname", () => {
+  test.for(["localhost", "LOCALHOST", "127.0.0.1", "0.0.0.0", "::1", "[::1]", ""] as const)(
+    "%s is not trackable",
+    (hostname) => {
+      expect(isTrackableHostname(hostname)).toBe(false);
+    },
+  );
+
+  test.for(["app.localhost", "rcv.internal.localhost"] as const)(
+    "the reserved .localhost TLD is not trackable: %s",
+    (hostname) => {
+      expect(isTrackableHostname(hostname)).toBe(false);
+    },
+  );
+
+  test.for([
+    "renovate.secustor.dev",
+    // Matching must be exact or dot-suffixed, never a substring: these are
+    // somebody's real hosts.
+    "localhost-mirror.example.com",
+    "mylocalhost.example.com",
+    "127.0.0.1.example.com",
+  ] as const)("%s is trackable", (hostname) => {
+    expect(isTrackableHostname(hostname)).toBe(true);
   });
 });

--- a/packages/app/src/platform/analytics.ts
+++ b/packages/app/src/platform/analytics.ts
@@ -7,6 +7,14 @@
  * `VITE_GA_MEASUREMENT_ID` var (what the Pages build inlines). With no usable
  * id from either source gtag.js is never loaded — `vite dev`, previews and
  * unconfigured self-hosts send nothing.
+ *
+ * Roadmap 053: the build-time id additionally requires a non-local hostname.
+ * The Pages `dist` is also the artifact the e2e job serves on
+ * `http://localhost:4322/`, and Playwright gives every test a fresh browser
+ * context — no `_ga` cookie to reuse, so each test counted as a brand-new user
+ * and CI came to dominate the property's traffic. The runtime id is exempt: it
+ * belongs to whoever set `RCV_GA_MEASUREMENT_ID`, and a self-host reached at
+ * `localhost:8080` is a real deployment of theirs, not our test rig.
  */
 
 declare global {
@@ -38,14 +46,36 @@ function runtimeMeasurementId(): string | null {
   return toMeasurementId((raw as Record<string, unknown>).measurementId);
 }
 
+/**
+ * Hostnames that serve a development, test or preview copy rather than a
+ * deployment: the loopback names plus the reserved `.localhost` TLD, and the
+ * empty hostname a `file://` page reports. Matched exactly or as a dot-suffix,
+ * never as a substring — `localhost-mirror.example.com` is somebody's real
+ * host. IPv6 literals arrive from `location.hostname` bracketed.
+ */
+const LOCAL_HOSTNAMES = new Set(["", "localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"]);
+
+/** Whether a hostname is a real deployment, i.e. worth reporting traffic for. */
+export function isTrackableHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return !LOCAL_HOSTNAMES.has(host) && !host.endsWith(".localhost");
+}
+
 /** The measurement id to track with, or null when analytics is off. */
-export function getMeasurementId(): string | null {
-  return runtimeMeasurementId() ?? toMeasurementId(import.meta.env.VITE_GA_MEASUREMENT_ID);
+export function getMeasurementId(hostname: string): string | null {
+  const runtime = runtimeMeasurementId();
+  if (runtime) {
+    return runtime;
+  }
+  if (!isTrackableHostname(hostname)) {
+    return null;
+  }
+  return toMeasurementId(import.meta.env.VITE_GA_MEASUREMENT_ID);
 }
 
 /** Loads gtag.js and sends the initial page_view — a no-op without an id. */
 export function initAnalytics(): void {
-  const id = getMeasurementId();
+  const id = getMeasurementId(window.location.hostname);
   if (!id) {
     return;
   }

--- a/packages/app/src/platform/analytics.ts
+++ b/packages/app/src/platform/analytics.ts
@@ -7,14 +7,6 @@
  * `VITE_GA_MEASUREMENT_ID` var (what the Pages build inlines). With no usable
  * id from either source gtag.js is never loaded — `vite dev`, previews and
  * unconfigured self-hosts send nothing.
- *
- * Roadmap 053: the build-time id additionally requires a non-local hostname.
- * The Pages `dist` is also the artifact the e2e job serves on
- * `http://localhost:4322/`, and Playwright gives every test a fresh browser
- * context — no `_ga` cookie to reuse, so each test counted as a brand-new user
- * and CI came to dominate the property's traffic. The runtime id is exempt: it
- * belongs to whoever set `RCV_GA_MEASUREMENT_ID`, and a self-host reached at
- * `localhost:8080` is a real deployment of theirs, not our test rig.
  */
 
 declare global {

--- a/roadmap/053-analytics-localhost-exclusion.md
+++ b/roadmap/053-analytics-localhost-exclusion.md
@@ -1,0 +1,87 @@
+# 053 — Analytics: CI is not an audience
+
+Milestone: M14 · Status: done
+
+## Summary
+
+User-reported (2026-08-02, with screenshot): the GA4 "top hostname by active
+users" report for Jul 26 – Aug 1 2026 shows ~5,300 users on `localhost`,
+dwarfing both `renovate.secustor.dev` and `secustor.dev`. The traffic is our
+own CI, not people:
+
+1. The `build` job inlines the repo variable `VITE_GA_MEASUREMENT_ID` (set
+   2026-07-28) into the bundle, and `main.tsx` calls `initAnalytics()`
+   unconditionally.
+2. That same `dist` is the `app-dist` artifact the `e2e` job downloads and
+   serves with `vite preview` on `http://localhost:4322/` — analytics fully
+   live, because nothing about the build knows it is being tested.
+3. Playwright gives every test a fresh browser context, so there is no `_ga`
+   cookie to reuse. Each test is a brand-new user.
+
+60 e2e tests × 88 successful CI runs since the variable was set ≈ 5,280, which
+is the number in the report. Renovate PR churn (168 CI runs that week) is what
+makes it swamp the real domains. The property's hostname dimension is now the
+only thing separating signal from test rig, and every added e2e test makes it
+worse.
+
+## User story
+
+As the operator of the hosted deployment, I want the analytics property to
+count visitors, so that a week of dependency bumps does not read as a traffic
+spike — without taking tracking away from a self-hoster who configured their
+own property.
+
+## Scope
+
+- The build-time measurement id (`VITE_GA_MEASUREMENT_ID` — the hosted
+  property's) is used only when the page is served from a real hostname.
+  Loopback names, the reserved `.localhost` TLD and the empty `file://`
+  hostname never load gtag.js.
+- The runtime id (`globalThis.__RCV_ANALYTICS__`, from `RCV_GA_MEASUREMENT_ID`
+  via `/rcv-config.js`) is deliberately exempt and keeps its short-circuit
+  ahead of the guard. It names the deployer's own property, and a container
+  reached at `localhost:8080` is a real deployment of theirs, not our test rig.
+- Hostname matching is exact or dot-suffixed, never a substring:
+  `localhost-mirror.example.com` is somebody's host.
+
+## Out of scope
+
+- CI changes. The id still ships in every build artifact; the guard is what
+  makes that harmless. (Considered and rejected as the primary fix: building
+  clean and injecting the id into `dist/rcv-config.js` only for the Pages
+  deploy. It would leave a local `vite preview` of a GA-enabled build
+  reporting, which is the same class of bug.)
+- The GA-side cleanup, which cannot be done from the repo: a data filter
+  excluding hostname `localhost` going forward (filters are not retroactive)
+  and a segment excluding it when reading the existing rows.
+
+## Dependencies
+
+- 043 (the dual-source config rule this extends), 020 (the e2e suite whose
+  every test was being counted).
+
+## Delivered
+
+- `isTrackableHostname` in `src/platform/analytics.ts`: a pure predicate over
+  a `LOCAL_HOSTNAMES` set (`""`, `localhost`, `127.0.0.1`, `0.0.0.0`, `::1`,
+  `[::1]` — `location.hostname` reports IPv6 literals bracketed) plus a
+  `.localhost` suffix test, lowercased first.
+- `getMeasurementId` now takes the hostname as a parameter — a parameter and
+  not a `location` read, so the resolution logic stays testable in the
+  node-environment "unit" project. `initAnalytics()` is the one injector and
+  passes `window.location.hostname`, matching the module's existing "pure
+  logic + one injector" shape.
+- Unit coverage (`analytics-config.test.ts`): the build-time id suppressed on
+  every local hostname, the self-host runtime id still honoured on
+  `localhost`, and the substring trap (`localhost-mirror.example.com`,
+  `mylocalhost.example.com`, `127.0.0.1.example.com` all trackable).
+- New permanent e2e assertion (`e2e/16-analytics-localhost.spec.ts`): a full
+  load-and-run records zero requests to Google's analytics hosts and asserts
+  `dataLayer` is never created. Vacuous against a local build (no id is
+  inlined), non-vacuous in CI and under the documented local repro
+  (`VITE_GA_MEASUREMENT_ID=G-TEST1234 pnpm --filter …/app build`), where it
+  fails without the guard.
+
+## Deferred
+
+- None.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -57,6 +57,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement       | M13                  | done   |
 | [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document   | M14                  | done   |
 | [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity) | M14                  | done   |
+| [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost | M14                  | done   |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
## Why

GA4's hostname report for Jul 26 – Aug 1 showed ~5,300 "active users" on `localhost`, dwarfing `renovate.secustor.dev`. It is our own CI:

1. The `build` job inlines `VITE_GA_MEASUREMENT_ID` (repo variable, set 2026-07-28) into the bundle; `main.tsx` calls `initAnalytics()` unconditionally.
2. That same `dist` is the `app-dist` artifact the `e2e` job serves with `vite preview` on `http://localhost:4322/` — analytics fully live.
3. Playwright gives every test a fresh browser context, so there is no `_ga` cookie to reuse: each test counts as a brand-new user.

60 e2e tests × 88 successful CI runs since the variable was set ≈ 5,280 — the number in the report. 168 CI runs that week (Renovate churn) is what makes it swamp the real domains.

## What

- `isTrackableHostname()` in `packages/app/src/platform/analytics.ts`: loopback names, the reserved `.localhost` TLD and the empty `file://` hostname are not deployments. Exact/dot-suffix matching, never a substring — `localhost-mirror.example.com` is somebody's real host.
- `getMeasurementId()` takes the hostname as a parameter (not a `location` read) so the resolution stays testable in the node-environment `unit` project; `initAnalytics()` is the one injector and passes `window.location.hostname`.
- **The runtime id is deliberately exempt.** `RCV_GA_MEASUREMENT_ID` names the self-hoster's own property and their container may well be reached at `localhost:8080`, so it keeps its short-circuit ahead of the guard.
- No CI changes: the id still ships in every artifact, the guard is what makes that harmless.

## Verification

- `analytics-config.test.ts`: build-time id suppressed on every local hostname, runtime id still honoured on `localhost`, and the substring trap covered. 29 assertions.
- New `e2e/16-analytics-localhost.spec.ts` asserts zero requests to Google's analytics hosts and no `dataLayer`. Proven non-vacuous by reproducing CI's regime locally:
  - `VITE_GA_MEASUREMENT_ID=G-TEST1234 pnpm --filter …/app build` + pre-fix `analytics.ts` → **fails** with `https://www.googletagmanager.com/gtag/js?id=G-TEST1234` among 4 captured requests.
  - Same build with the guard → **passes**.
- Full suite green: 61 e2e, 266 vitest, `pnpm lint`, `pnpm format:check`, `pnpm -r typecheck`.

## Not covered here (GA console, manual)

Data filters are not retroactive: a hostname filter stops future stray traffic, and the existing rows need a segment excluding `hostname = localhost` when read. Worth breaking the localhost line down by day too — the variable was only set Jul 28, so Jul 26–27 should be zero; if it is not, a second source exists.