### PR TITLE
test(e2e): derive the Renovate version instead of hand-copying it

### DIFF
--- a/.claude/skills/persona-test/generate-links.mjs
+++ b/.claude/skills/persona-test/generate-links.mjs
@@ -47,6 +47,7 @@
  */
 
 import { readFile, readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
@@ -62,7 +63,6 @@ const ENGINE_PKG_JSON = path.resolve(
   "engine",
   "package.json",
 );
-const FALLBACK_RENOVATE_VERSION = "43.275.0";
 
 const HELP = `Usage: node generate-links.mjs --config <path> --port <port> [options]
 
@@ -154,19 +154,24 @@ async function resolveRenovateVersion(explicit) {
   if (explicit) {
     return explicit;
   }
+  // The app embeds renovate/package.json's own `version` in every share link
+  // (engine src/version.ts), so read that same file. `renovate` is a dependency
+  // of the engine package, hence resolution anchored at its package.json.
   try {
-    const pkg = JSON.parse(await readFile(ENGINE_PKG_JSON, "utf8"));
-    const version = pkg.dependencies?.renovate;
+    const pkgPath = createRequire(ENGINE_PKG_JSON).resolve("renovate/package.json");
+    const { version } = JSON.parse(await readFile(pkgPath, "utf8"));
     if (typeof version === "string" && version.length > 0) {
-      return version.replace(/^[\^~]/, "");
+      return version;
     }
   } catch {
-    // fall through to hardcoded fallback
+    // not installed (no `pnpm install` yet) — fall back to the exact pin below
   }
-  process.stderr.write(
-    `warning: could not read renovate version from ${ENGINE_PKG_JSON}; using fallback ${FALLBACK_RENOVATE_VERSION}\n`,
-  );
-  return FALLBACK_RENOVATE_VERSION;
+  const pkg = JSON.parse(await readFile(ENGINE_PKG_JSON, "utf8"));
+  const pinned = pkg.dependencies?.renovate;
+  if (typeof pinned !== "string" || pinned.length === 0) {
+    throw new Error(`no renovate dependency declared in ${ENGINE_PKG_JSON}`);
+  }
+  return pinned.replace(/^[\^~]/, "");
 }
 
 async function deflateRaw(bytes) {

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -10,6 +10,9 @@
  * use web globals only (CompressionStream, TextEncoder, btoa — available in
  * Node 20+ and the browser), the same wire shape the codec itself writes.
  */
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 import { configChecksum, encodeShare, type ShareSimulator, type ShareView } from "../src/lib/share";
 
 export { configChecksum };
@@ -48,8 +51,26 @@ export interface SharePayloadInput {
   sim?: ShareSimulator;
 }
 
-/** The Renovate version pinned in packages/engine/package.json. */
-export const RENOVATE_VERSION = "44.4.6";
+/**
+ * The Renovate version the engine actually runs — read from the installed
+ * package, not hand-copied. The app embeds `renovateVersion` (engine
+ * `src/version.ts`, i.e. `renovate/package.json`'s own `version`) in every
+ * share link, so reading the same file is what keeps a fixture's version tag
+ * equal to the app's by construction. `renovate` is a dependency of the engine
+ * package, not of this one, so resolution is anchored at the engine's
+ * package.json rather than at this file.
+ */
+export const RENOVATE_VERSION: string = readInstalledRenovateVersion();
+
+function readInstalledRenovateVersion(): string {
+  const enginePkgJson = fileURLToPath(new URL("../../engine/package.json", import.meta.url));
+  const pkgPath = createRequire(enginePkgJson).resolve("renovate/package.json");
+  const { version } = JSON.parse(readFileSync(pkgPath, "utf8")) as { version?: string };
+  if (!version) {
+    throw new Error(`no "version" field in ${pkgPath}`);
+  }
+  return version;
+}
 
 async function pipeThrough(bytes: Uint8Array, stream: GenericTransformStream): Promise<Uint8Array> {
   // Type the stream as GenericTransformStream (writable: WritableStream) so the


### PR DESCRIPTION
## What

`packages/app/e2e/fixtures.ts` carried the pinned Renovate version as a string literal:

```ts
/** The Renovate version pinned in packages/engine/package.json. */
export const RENOVATE_VERSION = "43.275.0";
```

That was the one reference a `renovate` bump had to update **by hand** — #78 needed exactly this edit, in a file nothing else in the bump touches (`renovate.json`'s `postUpgradeTasks` already regenerate `registry-names.generated.ts` and the golden snapshots).

## How

Read it from the **installed** package instead of duplicating the pin:

```ts
const enginePkgJson = fileURLToPath(new URL("../../engine/package.json", import.meta.url));
const pkgPath = createRequire(enginePkgJson).resolve("renovate/package.json");
```

`renovate/package.json`'s own `version` is exactly what the engine's `renovateVersion` (`packages/engine/src/version.ts`) exports and what the app embeds in every share link, so the fixture's version tag now equals the app's by construction — a drift notice can no longer be caused by a stale fixture. `renovate` is a dependency of the *engine* package, not the app, hence the resolution anchor.

A custom manager was the alternative; deriving the value removes the reference altogether, so there is nothing left for a manager to keep in sync.

The persona-test link generator (`.claude/skills/persona-test/generate-links.mjs`) held the same literal as a stale fallback (`43.275.0`, i.e. already two majors behind). It already read the engine pin first; it now prefers the installed version, falls back to the engine's exact pin, and throws rather than silently embedding a hardcoded version.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` — clean
- `pnpm test` (engine golden + shimmed, app unit + render, oauth-worker) — pass
- `pnpm --filter …/app test:e2e` — 66/66 pass, including the 14 share-diagnostics specs that consume `RENOVATE_VERSION`
- `generate-links.mjs` smoke run reports `renovate 44.4.6`