### PR TITLE
security: fix OpenSSF Scorecard findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+# CodeQL static analysis — satisfies OpenSSF Scorecard's "SAST" check, which
+# requires a SAST tool running on every commit/PR. `actions` is included
+# because CodeQL (and Scorecard's credit for it) now also scans GitHub Actions
+# workflow YAML for injection-style issues, not just application code.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, offset from scorecard.yml's Monday 04:30 run so the two don't
+    # contend for runners.
+    - cron: "30 5 * * 3"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # Upload results to the code-scanning dashboard.
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # build-mode: none — both languages here are interpreted/analyzed from
+      # source (JS/TS and workflow YAML), so there is nothing to compile and
+      # no pnpm install is needed.
+      - uses: github/codeql-action/init@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - uses: github/codeql-action/analyze@d1ba80a13dd99fba24a470575428917156a28b43 # v4.37.5
+        with:
+          category: /language:${{ matrix.language }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # builds each architecture on a runner of that architecture and never hits
 # this, but it keeps a local `docker build --platform linux/amd64,linux/arm64`
 # from running pnpm install and the vite build a second time under QEMU.
-FROM --platform=$BUILDPLATFORM node:26.5.1-alpine AS build
+FROM --platform=$BUILDPLATFORM node:26.5.1-alpine@sha256:233761595746769ebfdb6090f44fc7cdf818ae0ce62d2b37e0367723b9823e36 AS build
 WORKDIR /repo
 
 # Matches the root package.json `packageManager` field — kept in step by
@@ -42,7 +42,7 @@ RUN pnpm --filter @renovate-config-visualizer/app build
 # --- oauth-proxy -------------------------------------------------------------
 # The OAuth token exchange (roadmap 009) without Cloudflare. Only needed by a
 # self-hoster who wants "Sign in with GitHub"; the app works without it.
-FROM node:26.5.1-alpine AS oauth-proxy
+FROM node:26.5.1-alpine@sha256:233761595746769ebfdb6090f44fc7cdf818ae0ce62d2b37e0367723b9823e36 AS oauth-proxy
 WORKDIR /app
 
 # The Worker's own manifest, for its `"type": "module"` — nothing is installed
@@ -62,7 +62,7 @@ CMD ["node", "server.mjs"]
 # --- app (default target) ----------------------------------------------------
 # LAST stage on purpose: a bare `docker build .` must produce the app, because
 # Docker builds the final stage when no --target is given.
-FROM nginx:alpine AS app
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752 AS app
 
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker/40-rcv-config.sh /docker-entrypoint.d/40-rcv-config.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues via
+[GitHub private vulnerability reporting](https://github.com/secustor/renovate-config-debugger/security/advisories/new)
+rather than a public issue — the advisory form is the only reporting channel.
+
+This is a spare-time, single-maintainer project: there's no formal SLA, but
+expect an acknowledgement within a few days. Coordinated disclosure (giving a
+fix time to land before details go public) is appreciated.
+
+## Supported versions
+
+Only the latest release / `main` is supported. There's no long-term
+maintenance branch — the Docker `latest` tags and the hosted site
+(https://renovate.secustor.dev) roll forward continuously, and fixes land
+there rather than being backported.
+
+## Scope
+
+- Configs never leave the browser except for the preset fetches they
+  themselves declare; those go browser → host API directly, with nothing
+  proxying configs or presets.
+- Tokens (OAuth or personal access token) live in `sessionStorage`/memory
+  only and are cleared when the tab closes.
+- Share links carry state in the URL fragment only, never a token.
+- `packages/oauth-worker` does nothing but the OAuth `code → token` exchange;
+  it never sees a config, a preset, or an API request.
+
+Reports about any of the above guarantees not holding, or about the
+`oauth-worker` itself, are especially welcome.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2047,15 +2047,15 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2537,8 +2537,8 @@ packages:
   fast-json-patch@3.1.1:
     resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
@@ -6325,7 +6325,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6392,17 +6392,17 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
     optional: true
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6892,7 +6892,7 @@ snapshots:
 
   fast-json-patch@3.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -7935,16 +7935,16 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
     optional: true
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
Stacked on #107. Fixes the code-fixable findings from a local `scorecard` CLI run (overall score 5.4/10):

- **Security-Policy (0/10)** → `SECURITY.md`: private vulnerability reporting via GitHub advisories, supported-versions and scope statements consistent with the README's privacy guarantees.
- **SAST (0/10)** → `codeql.yml`: CodeQL on pushes/PRs to `main` + weekly, `javascript-typescript` and `actions` languages, SHA-pinned, least-privilege.
- **Pinned-Dependencies (7/10)** → Dockerfile `FROM` lines pinned to registry-verified multi-arch index digests (Renovate maintains `tag@digest` natively). The flagged `npm install -g pnpm` was already exact-version-pinned via a Renovate-managed `ARG`.
- **Vulnerabilities (2/10)** → a one-off lockfile refresh picks up the in-range patches for the brace-expansion ReDoS (GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 — this one actually reaches the browser bundle via renovate `util/string-match` → minimatch) and fast-uri (GHSA-7p8r-x3mc-p8w7, lint-only). No `pnpm.overrides` — going forward this is Renovate's job (`config:best-practices` in secustor/renovate-config). The five undici advisories stay open for now: miniflare pins `undici@7.28.0` exactly, so they resolve with the next wrangler bump (dev-only, not in any shipped artifact).

`renovate` itself stays pinned; golden/shimmed tests still match byte-identically, tests + typecheck green.

Not addressable from the repo: Branch-Protection (repo settings), Code-Review (needs reviewed PRs), Maintained (repo <90 days old), Fuzzing / CII-Best-Practices / Signed-Releases (external programs).