### PR TITLE
chore(agents): add Claude Code session hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/tools/agents/hooks/pretooluse-check.ts\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/tools/agents/hooks/sessionstart-check.ts\"",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/tools/agents/hooks/cwdchanged-check.ts\"",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/tools/agents/hooks/stop-check.ts\"",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
 
       - run: pnpm lint
       - run: pnpm format:check
-      - run: pnpm -r typecheck
+      # The root script, not `pnpm -r typecheck`: it adds `tools/` (the agent
+      # hooks), which is not a workspace package and so has no `-r` entry.
+      - run: pnpm typecheck
 
   test:
     needs: setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 mise install && pnpm install   # node + pnpm versions come from mise.toml
 pnpm dev                       # app dev server (vite)
 pnpm test                      # all workspace tests (engine golden+shimmed, app unit+render, oauth-worker)
-pnpm typecheck                 # tsc across all packages
+pnpm typecheck                 # tsc across all packages, plus tools/ (the agent hooks)
 pnpm lint                      # oxlint --type-aware + stylelint (zero tolerance: any report fails CI)
 pnpm format                    # oxfmt (format:check to verify)
 pnpm build                     # all packages
@@ -29,6 +29,22 @@ pnpm --filter @renovate-config-visualizer/app exec vitest run --project unit src
 pnpm --filter @renovate-config-visualizer/app exec playwright test e2e/04-simulator.spec.ts          # single e2e
 pnpm --filter @renovate-config-visualizer/app check:dev-graph   # guards `vite dev` module graph against Node-only leaks
 ```
+
+## Session hooks
+
+`.claude/settings.json` wires four hooks in `tools/agents/hooks/` (readme
+there). They run as `node <file>.ts` and import nothing outside `node:`, since
+two of them have to work before `pnpm install` has:
+
+- **SessionStart / CwdChanged** — provision the checkout (`mise install`, then
+  `pnpm install`); CwdChanged only fires the install for a root without
+  `node_modules`, i.e. a fresh worktree.
+- **PreToolUse** — denies `npm`/`npx`/`yarn`.
+- **Stop** — runs lint, format:check, typecheck and the tests of every changed
+  package, and blocks the stop with the failing output. **The e2e suite is
+  excluded** (it needs a production build and takes minutes) — run it yourself
+  when the change warrants it. A green run is fingerprinted, so an unchanged
+  working set doesn't pay for the checks twice.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ deliberately out of scope. Put the app image behind whatever you already run.
 mise install       # node + pnpm (or use your own, see package.json engines)
 pnpm install
 pnpm dev     # dev server
-pnpm test          # golden + shimmed engine tests
-pnpm -r typecheck
+pnpm test          # every workspace test except e2e (which needs a build first)
+pnpm typecheck
 pnpm lint && pnpm format:check
 ```
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "lint:css": "stylelint \"packages/app/src/**/*.css\"",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
-    "typecheck": "pnpm -r typecheck",
+    "typecheck": "pnpm -r typecheck && tsc --noEmit -p tools/tsconfig.json",
     "test": "pnpm -r test",
     "build": "pnpm -r build"
   },
   "devDependencies": {
+    "@types/node": "26.1.2",
     "oxfmt": "0.61.0",
     "oxlint": "1.76.0",
     "oxlint-tsgolint": "7.0.2001",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,6 +9,7 @@
     "check:dev-graph": "node scripts/check-dev-module-graph.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",
+    "test": "pnpm test:unit",
     "test:unit": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: 26.1.2
+        version: 26.1.2
       oxfmt:
         specifier: 0.61.0
         version: 0.61.0

--- a/tools/agents/hooks/cwdchanged-check.ts
+++ b/tools/agents/hooks/cwdchanged-check.ts
@@ -1,0 +1,31 @@
+/**
+ * CwdChanged — provision a checkout that has never been installed.
+ *
+ * Fires on every working-directory change, `EnterWorktree` included. A fresh
+ * git worktree has no node_modules at all, so without this the first check
+ * run in it fails on a missing binary rather than on the code.
+ *
+ * Guarded on node_modules being absent: an ordinary `cd` within an installed
+ * checkout must stay free.
+ */
+import { access } from "node:fs/promises";
+import { join } from "node:path";
+import { getRepoRoot } from "./utils/git.ts";
+import { readHookInput } from "./utils/hook-input.ts";
+import { provision } from "./utils/provision.ts";
+
+const { cwd } = await readHookInput();
+const root = await getRepoRoot(cwd);
+if (!root) {
+  process.exit(0);
+}
+
+const installed = await access(join(root, "node_modules")).then(
+  () => true,
+  () => false,
+);
+if (installed) {
+  process.exit(0);
+}
+
+await provision(root);

--- a/tools/agents/hooks/pretooluse-check.ts
+++ b/tools/agents/hooks/pretooluse-check.ts
@@ -1,0 +1,20 @@
+/**
+ * PreToolUse — refuse Bash calls that would use the wrong package manager.
+ *
+ * The workspace is pnpm-only: `packageManager` is pinned, the lockfile is
+ * pnpm's, and `pnpm-workspace.yaml` carries patches plus the allowBuilds
+ * decisions. An `npm install` here silently produces a different (unpatched,
+ * unpinned) node_modules that no CI run would reproduce.
+ */
+import { readHookInput } from "./utils/hook-input.ts";
+import { deny } from "./utils/output.ts";
+
+const { bashCommand } = await readHookInput();
+
+if (bashCommand !== undefined) {
+  // Word-bounded so that `pnpm dlx`, paths and prose ("… like npm-run-all")
+  // don't trip it; `pnpm exec`/`pnpm dlx` remain the escape hatch.
+  if (/(?:^|\s)(?:npm|npx|yarn)(?:\s|$)/.test(bashCommand)) {
+    deny("This workspace is pnpm-only — use pnpm (or `pnpm dlx`) instead of npm/npx/yarn.");
+  }
+}

--- a/tools/agents/hooks/readme.md
+++ b/tools/agents/hooks/readme.md
@@ -1,0 +1,56 @@
+# Claude Code hooks
+
+Scripts Claude Code runs automatically at fixed points in a session, wired up
+in [`.claude/settings.json`](../../../.claude/settings.json). They exist so a
+session provisions itself and can't finish a turn on a red branch.
+
+They are run as `node <file>.ts` (Node ≥24 strips the types; the repo pins 26)
+and import nothing outside `node:` — SessionStart and CwdChanged have to work
+in a checkout where `pnpm install` has not run yet, which is precisely the case
+they are there to fix. `pnpm typecheck` covers them via `tools/tsconfig.json`.
+
+## The hooks
+
+### `sessionstart-check.ts` — SessionStart
+
+Runs on startup, resume, clear and compact: `mise install` (non-fatal — without
+mise the node/pnpm on PATH are used as-is) followed by `pnpm install`.
+
+### `cwdchanged-check.ts` — CwdChanged
+
+Runs on every working-directory change, `EnterWorktree` included, and
+provisions the new root only when it has no `node_modules` — a fresh worktree.
+An ordinary `cd` inside an installed checkout stays free.
+
+### `pretooluse-check.ts` — PreToolUse
+
+Denies Bash calls using `npm`, `npx` or `yarn`. The workspace is pnpm-only:
+pinned `packageManager`, pnpm lockfile, and `pnpm-workspace.yaml` carrying the
+patches and `allowBuilds` decisions that another package manager would ignore.
+
+### `stop-check.ts` — Stop
+
+Runs the checks from CI's `lint` and `test` jobs before the turn ends, and
+blocks the stop if any fail, handing back the tail of the failing output.
+
+- **Always** (when anything changed): `pnpm lint`, `pnpm format:check`,
+  `pnpm typecheck`.
+- **Per changed package**: engine tests, app unit/render tests plus the dev
+  module-graph guard, oauth-worker tests. An engine change runs the app's tests
+  too (the app imports the engine); a change outside `packages/` runs all of
+  them.
+- **Never**: the Playwright e2e suite. It needs a production build first and
+  takes minutes — running it stays a deliberate step
+  (`pnpm --filter @renovate-config-visualizer/app build` then `… test:e2e`).
+
+Markdown-only changes skip everything, since none of the checks read prose.
+
+Two things keep it from getting in the way:
+
+- **A green fingerprint.** The SHA-256 of the diff against the base ref (plus
+  untracked file contents) is stored in the worktree's git dir after a green
+  run. The checks are derived from that same content, so an unchanged
+  fingerprint means an unchanged verdict and the stop is free.
+- **A circuit breaker.** After 3 consecutive blocked stops the next one is let
+  through, with the failures written to stderr. Blocking forever on something
+  the agent cannot fix burns tokens and hides the problem from the user.

--- a/tools/agents/hooks/sessionstart-check.ts
+++ b/tools/agents/hooks/sessionstart-check.ts
@@ -1,0 +1,11 @@
+/**
+ * SessionStart — install the toolchain and the workspace deps once per
+ * session (startup, resume, clear, compact), so the first command a session
+ * runs isn't the one that discovers node_modules is missing or stale.
+ */
+import { provision } from "./utils/provision.ts";
+
+const ok = await provision();
+if (!ok) {
+  process.exit(1);
+}

--- a/tools/agents/hooks/stop-check.ts
+++ b/tools/agents/hooks/stop-check.ts
@@ -1,0 +1,163 @@
+/**
+ * Stop — the branch must be green before the turn ends.
+ *
+ * Runs the same checks CI's `lint` and `test` jobs run, minus the e2e suite:
+ * Playwright needs a production build first and takes minutes, which is the
+ * wrong trade at the end of every turn (`pnpm --filter …/app test:e2e`, after
+ * a build, stays a deliberate manual step). Everything else is ~30s in total,
+ * and less than that when only one package changed.
+ *
+ * Failures block the stop and are handed back as the reason, tail of output
+ * included, so the next turn starts from the actual error.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { exec } from "./utils/exec.ts";
+import { getGitStatePath, getRepoRoot, getWorkingSet } from "./utils/git.ts";
+import { block } from "./utils/output.ts";
+
+interface Check {
+  id: string;
+  args: string[];
+}
+
+const PACKAGES = ["engine", "app", "oauth-worker"] as const;
+type PackageName = (typeof PACKAGES)[number];
+
+function filter(pkg: PackageName, script: string): string[] {
+  return ["--filter", `@renovate-config-visualizer/${pkg}`, script];
+}
+
+/** Repo-wide and cheap (~7s together) — run whenever anything at all changed. */
+const ALWAYS: Check[] = [
+  { id: "lint", args: ["lint"] },
+  { id: "format:check", args: ["format:check"] },
+  { id: "typecheck", args: ["typecheck"] },
+];
+
+const TESTS: Record<PackageName, Check[]> = {
+  engine: [{ id: "engine tests", args: filter("engine", "test") }],
+  app: [
+    { id: "app unit/render tests", args: filter("app", "test:unit") },
+    // Cheap, and it guards a module regime (`vite dev`) that no other check
+    // exercises — see the app's scripts/check-dev-module-graph.mjs.
+    { id: "app dev module graph", args: filter("app", "check:dev-graph") },
+  ],
+  "oauth-worker": [{ id: "oauth-worker tests", args: filter("oauth-worker", "test") }],
+};
+
+/** Files no check here reads — prose only, so a docs edit shouldn't cost 30s. */
+function isCovered(file: string): boolean {
+  return !(file.endsWith(".md") || file.startsWith("docs/") || file.startsWith("roadmap/"));
+}
+
+function affectedPackages(files: string[]): Set<PackageName> {
+  const affected = new Set<PackageName>();
+  for (const file of files) {
+    if (file.startsWith("packages/engine/")) {
+      // The app imports the engine, so an engine edit has to re-run both.
+      affected.add("engine");
+      affected.add("app");
+    } else if (file.startsWith("packages/app/")) {
+      affected.add("app");
+    } else if (file.startsWith("packages/oauth-worker/")) {
+      affected.add("oauth-worker");
+    } else {
+      // Root-level: a lockfile, a tsconfig, the lint config, these hooks —
+      // anything that can change what every package compiles or resolves to.
+      return new Set(PACKAGES);
+    }
+  }
+  return affected;
+}
+
+interface State {
+  /** Fingerprint of the working set the last green run covered. */
+  green?: string;
+  /** Consecutive blocks, to break a stop → fix → stop loop that isn't converging. */
+  blocks?: number;
+}
+
+const MAX_CONSECUTIVE_BLOCKS = 3;
+
+async function readState(path: string | null): Promise<State> {
+  if (!path) {
+    return {};
+  }
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    return typeof parsed === "object" && parsed !== null ? (parsed as State) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeState(path: string | null, state: State): Promise<void> {
+  if (!path) {
+    return;
+  }
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, JSON.stringify(state));
+  } catch {
+    // State is a cache; losing it costs one redundant check run, nothing more.
+  }
+}
+
+const root = await getRepoRoot();
+if (!root) {
+  process.exit(0);
+}
+
+const { files, fingerprint } = await getWorkingSet(root);
+const relevant = files.filter(isCovered);
+if (relevant.length === 0) {
+  process.exit(0);
+}
+
+const statePath = await getGitStatePath(root, "rcv-stop-check.json");
+const state = await readState(statePath);
+// The fingerprint is the content of the changes themselves, and the checks are
+// derived from that content — so an unchanged fingerprint means an unchanged
+// verdict, and every stop after the first green one is free.
+if (state.green === fingerprint) {
+  process.exit(0);
+}
+
+const checks = [...ALWAYS, ...[...affectedPackages(relevant)].flatMap((pkg) => TESTS[pkg])];
+
+const failures: string[] = [];
+for (const check of checks) {
+  console.error(`[hooks] pnpm ${check.args.join(" ")}`);
+  const result = await exec("pnpm", check.args, { cwd: root });
+  if (!result.ok) {
+    // Tail rather than head: the summary a runner prints last is the part
+    // worth carrying back.
+    failures.push(
+      `--- ${check.id} (pnpm ${check.args.join(" ")}) ---\n${result.output.slice(-2000).trim()}`,
+    );
+  }
+}
+
+if (failures.length === 0) {
+  await writeState(statePath, { green: fingerprint });
+  process.exit(0);
+}
+
+const blocks = (state.blocks ?? 0) + 1;
+
+if (blocks > MAX_CONSECUTIVE_BLOCKS) {
+  // Let the turn end and say so plainly. Blocking forever on something the
+  // agent can't fix burns tokens and hides the problem from the user. The
+  // counter resets, so the next turn gets a full set of attempts again.
+  await writeState(statePath, {});
+  console.error(
+    `[hooks] still failing after ${MAX_CONSECUTIVE_BLOCKS} blocked stops — letting this one through:\n${failures.join("\n\n")}`,
+  );
+  process.exit(0);
+}
+
+await writeState(statePath, { blocks });
+block(
+  `Repository checks failed (e2e excluded). Fix these before finishing:\n\n${failures.join("\n\n")}`,
+);

--- a/tools/agents/hooks/utils/exec.ts
+++ b/tools/agents/hooks/utils/exec.ts
@@ -1,0 +1,58 @@
+/**
+ * Minimal `spawn` wrapper for the hook scripts.
+ *
+ * Deliberately dependency-free (node: builtins only, no execa): SessionStart
+ * and CwdChanged run *before* `pnpm install` necessarily has — provisioning a
+ * fresh worktree is what they are for — so a hook that imports from
+ * node_modules cannot bootstrap the very checkout it is meant to bootstrap.
+ *
+ * A hook's stdout is a control channel (Claude Code parses it as the hook's
+ * JSON result), so child output is captured and mirrored to stderr, never
+ * forwarded to stdout.
+ */
+import { spawn } from "node:child_process";
+
+export interface ExecResult {
+  ok: boolean;
+  output: string;
+}
+
+export interface ExecOptions {
+  cwd?: string;
+  /** Capture only — don't mirror the child's output to stderr. */
+  quiet?: boolean;
+}
+
+export function exec(
+  cmd: string,
+  args: string[] = [],
+  opts: ExecOptions = {},
+): Promise<ExecResult> {
+  return new Promise<ExecResult>((resolve) => {
+    const child = spawn(cmd, args, {
+      cwd: opts.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, RCV_AGENT_HOOK: "1" },
+    });
+
+    let output = "";
+    const collect = (chunk: Buffer): void => {
+      const text = chunk.toString();
+      output += text;
+      if (!opts.quiet) {
+        process.stderr.write(text);
+      }
+    };
+    child.stdout.on("data", collect);
+    child.stderr.on("data", collect);
+
+    // ENOENT (the tool isn't installed) resolves like a failed run rather than
+    // rejecting — every caller here already has to handle "the check failed".
+    child.on("error", (error) => {
+      resolve({ ok: false, output: `${output}${String(error)}` });
+    });
+    child.on("close", (code) => {
+      resolve({ ok: code === 0, output });
+    });
+  });
+}

--- a/tools/agents/hooks/utils/git.ts
+++ b/tools/agents/hooks/utils/git.ts
@@ -1,0 +1,77 @@
+/**
+ * The bits of git the hooks need, over `exec` — no simple-git, for the reason
+ * given in `exec.ts`.
+ */
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { isAbsolute, join } from "node:path";
+import { exec } from "./exec.ts";
+
+async function git(args: string[], cwd?: string): Promise<string> {
+  const result = await exec("git", args, { cwd, quiet: true });
+  return result.ok ? result.output.trim() : "";
+}
+
+function lines(out: string): string[] {
+  return out.split("\n").filter((line) => line.length > 0);
+}
+
+export async function getRepoRoot(cwd?: string): Promise<string | null> {
+  return (await git(["rev-parse", "--show-toplevel"], cwd)) || null;
+}
+
+/**
+ * Somewhere inside this worktree's git dir — `.git/…` in a normal checkout,
+ * `.git/worktrees/<name>/…` in a worktree, which is what makes it the right
+ * home for per-branch hook state: never committed, never wiped by an install,
+ * and not shared between two worktrees checked out at different commits.
+ */
+export async function getGitStatePath(root: string, name: string): Promise<string | null> {
+  const path = await git(["rev-parse", "--git-path", name], root);
+  if (!path) {
+    return null;
+  }
+  return isAbsolute(path) ? path : join(root, path);
+}
+
+/**
+ * The commit this branch's work is measured against: the fork point from
+ * origin/main, else the upstream branch, else HEAD — which narrows "changed"
+ * to "uncommitted", the only honest answer left when neither ref exists.
+ */
+async function getBaseRef(root: string): Promise<string> {
+  return (
+    (await git(["merge-base", "origin/main", "HEAD"], root)) ||
+    (await git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], root)) ||
+    "HEAD"
+  );
+}
+
+export interface WorkingSet {
+  /** Repo-relative paths changed since the base ref, including untracked. */
+  files: string[];
+  /** Content hash of exactly those changes — see `stop-check.ts`. */
+  fingerprint: string;
+}
+
+export async function getWorkingSet(root: string): Promise<WorkingSet> {
+  const base = await getBaseRef(root);
+  const tracked = lines(await git(["diff", "--name-only", "--diff-filter=ACMR", base], root));
+  // `git diff` only sees files git already knows about, so a brand-new source
+  // file — the case where running the tests matters most — is invisible to it.
+  const untracked = lines(await git(["ls-files", "--others", "--exclude-standard"], root));
+
+  // The patch covers committed *and* uncommitted edits to tracked files; the
+  // untracked ones have to be hashed by hand, path included so that a rename
+  // registers as a change.
+  const hash = createHash("sha256").update(await git(["diff", base], root));
+  for (const file of untracked) {
+    hash.update(file);
+    hash.update(await readFile(join(root, file)).catch(() => Buffer.alloc(0)));
+  }
+
+  return {
+    files: [...new Set([...tracked, ...untracked])],
+    fingerprint: hash.digest("hex"),
+  };
+}

--- a/tools/agents/hooks/utils/hook-input.ts
+++ b/tools/agents/hooks/utils/hook-input.ts
@@ -1,0 +1,55 @@
+/**
+ * Reads and narrows the JSON Claude Code writes to a hook's stdin.
+ *
+ * Hand-written guards rather than zod: these scripts have to run before
+ * `pnpm install` (see `exec.ts`), and the shape needed here is three optional
+ * string fields. A malformed or unexpected payload always degrades to
+ * `undefined` — a hook that can't read its input must not take a decision.
+ */
+
+function readStdin(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk: string) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => {
+      resolve(data);
+    });
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringAt(source: unknown, key: string): string | undefined {
+  if (!isRecord(source)) {
+    return undefined;
+  }
+  const value = source[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+export interface HookInput {
+  /** The session's working directory (CwdChanged: the *new* one). */
+  cwd: string | undefined;
+  /** PreToolUse only, and only for Bash calls. */
+  bashCommand: string | undefined;
+}
+
+export async function readHookInput(): Promise<HookInput> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readStdin());
+  } catch {
+    return { cwd: undefined, bashCommand: undefined };
+  }
+
+  const isBash = stringAt(parsed, "tool_name") === "Bash";
+  return {
+    cwd: stringAt(parsed, "cwd"),
+    bashCommand: isBash && isRecord(parsed) ? stringAt(parsed.tool_input, "command") : undefined,
+  };
+}

--- a/tools/agents/hooks/utils/output.ts
+++ b/tools/agents/hooks/utils/output.ts
@@ -1,0 +1,36 @@
+/**
+ * The two hook results these scripts emit. Hook output is JSON on stdout —
+ * https://code.claude.com/docs/en/hooks — so nothing else may be printed
+ * there (diagnostics go to stderr, see `exec.ts`).
+ */
+
+interface BlockOutput {
+  decision: "block";
+  reason: string;
+}
+
+interface DenyOutput {
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse";
+    permissionDecision: "deny";
+    permissionDecisionReason: string;
+  };
+}
+
+/** Stop: don't finish the turn — `reason` is handed back to the agent. */
+export function block(reason: string): void {
+  const output: BlockOutput = { decision: "block", reason };
+  console.log(JSON.stringify(output));
+}
+
+/** PreToolUse: refuse the call — `reason` is handed back to the agent. */
+export function deny(reason: string): void {
+  const output: DenyOutput = {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+  console.log(JSON.stringify(output));
+}

--- a/tools/agents/hooks/utils/provision.ts
+++ b/tools/agents/hooks/utils/provision.ts
@@ -1,0 +1,23 @@
+/**
+ * Brings a checkout to a working state: the toolchain from `mise.toml`, then
+ * the workspace's dependencies.
+ */
+import { exec } from "./exec.ts";
+
+export async function provision(cwd?: string): Promise<boolean> {
+  // Non-fatal: a session on a machine without mise still works as long as the
+  // node/pnpm on PATH satisfy `engines` — it just isn't the pinned pair.
+  // (`mise.toml`'s postinstall hook runs `pnpm install` for us when mise is
+  // present; the explicit install below is what covers the case where it
+  // isn't, and is a no-op otherwise.)
+  const mise = await exec("mise", ["install"], { cwd });
+  if (!mise.ok) {
+    console.error("[hooks] mise install failed or mise is absent — continuing");
+  }
+
+  const install = await exec("pnpm", ["install"], { cwd });
+  if (!install.ok) {
+    console.error("[hooks] pnpm install failed — the session has no deps");
+  }
+  return install.ok;
+}

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  // Not a workspace package (it has no build, no deps and nothing imports it),
+  // so `pnpm -r typecheck` never sees it — the root `typecheck` script runs
+  // this project explicitly on top.
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "types": ["node"],
+    // These files are run by `node file.ts` — type stripping, no build step —
+    // which requires the import specifiers to carry the real `.ts` extension.
+    "allowImportingTsExtensions": true
+  },
+  "include": ["agents/**/*.ts"]
+}


### PR DESCRIPTION
Mirrors the hook setup in the renovate repo, adapted to this workspace:

- SessionStart / CwdChanged provision the checkout (mise + pnpm install); CwdChanged only installs where node_modules is missing, so entering a fresh worktree no longer starts with a broken toolchain.
- PreToolUse denies npm/npx/yarn — the patches and allowBuilds decisions in pnpm-workspace.yaml only exist for pnpm.
- Stop runs lint, format:check, typecheck and the tests of every changed package, and blocks the stop with the failing output. The Playwright suite is excluded: it needs a production build first and takes minutes. A green run is fingerprinted (diff hash in the worktree's git dir) so an unchanged working set is free, and three consecutive blocks trip a circuit breaker rather than looping.

The scripts run via `node <file>.ts` and import nothing outside `node:`, because the two provisioning hooks must work before an install has happened. tools/tsconfig.json puts them under `pnpm typecheck` (which CI now calls instead of `pnpm -r typecheck`, since tools/ is not a workspace package).

Also gives packages/app a `test` script: `pnpm -r test` silently skipped it, so `pnpm test` did not mean what AGENTS.md said it meant.