### PR TITLE
chore(deps): override undici to ^7.29.0 under miniflare

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  miniflare>undici: ^7.29.0
+
 patchedDependencies:
   codemirror-json-schema@0.8.1: cd887b4a6a4b99c759ce92bc254ab43ecc65d797bd6a53e55f71aaf567bbab47
 
@@ -4220,8 +4223,8 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   undici@8.9.0:
@@ -7863,7 +7866,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 7.28.0
+      undici: 7.29.0
       workerd: 1.20260730.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -8969,7 +8972,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   undici@8.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,5 +17,9 @@ ignoredBuiltDependencies:
   - re2
   - workerd
 
+overrides:
+  # miniflare directly pins a version so this is overwriting to an range starting with a not effected version 
+  miniflare>undici: ^7.29.0
+
 patchedDependencies:
   codemirror-json-schema@0.8.1: patches/codemirror-json-schema@0.8.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,7 +18,7 @@ ignoredBuiltDependencies:
   - workerd
 
 overrides:
-  # miniflare directly pins a version so this is overwriting to an range starting with a not effected version 
+  # miniflare directly pins a version so this is overwriting to an range starting with a not effected version
   miniflare>undici: ^7.29.0
 
 patchedDependencies:


### PR DESCRIPTION
miniflare (pulled in by wrangler) exact-pins undici 7.28.0, which sits
below the 7.29.0 that patches five Dependabot-flagged advisories (CRLF
injection via blob body type, cache-control whitespace disclosure, cookie
attribute injection, retry-interceptor response desync, and the private
cache-directive crash).

Add a scoped pnpm override so the transitive pin becomes a range,
resolving undici to 7.29.0 and keeping future patches in scope.

The selector carries no version on purpose. pnpm matches the selector's
version part with plain semver, and miniflare 5 ships as a prerelease, so
no ordinary range matches it -- `miniflare@5>undici` misses silently and
undici drops back to vulnerable 7.28.0 with no warning. Omitting the
version matches every miniflare and survives its calver bumps.
