### PR TITLE
chore: rename Docker images and workspace packages to match the repo name

### DIFF
--- a/.claude/skills/persona-test/SKILL.md
+++ b/.claude/skills/persona-test/SKILL.md
@@ -43,7 +43,7 @@ personas) you're about to run.
 ## 2. Setup: build and serve
 
 ```sh
-pnpm --filter @renovate-config-visualizer/app build
+pnpm --filter @renovate-config-debugger/app build
 ```
 
 Then, from `packages/app`:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,17 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Golden tests (real renovate modules)
-        run: pnpm --filter @renovate-config-visualizer/engine test:golden
+        run: pnpm --filter @renovate-config-debugger/engine test:golden
       - name: Shimmed tests (browser module graph)
-        run: pnpm --filter @renovate-config-visualizer/engine test:shimmed
+        run: pnpm --filter @renovate-config-debugger/engine test:shimmed
       - name: OAuth worker tests
-        run: pnpm --filter @renovate-config-visualizer/oauth-worker test
+        run: pnpm --filter @renovate-config-debugger/oauth-worker test
       - name: App unit tests (pure modules — the run digest, …)
-        run: pnpm --filter @renovate-config-visualizer/app test:unit
+        run: pnpm --filter @renovate-config-debugger/app test:unit
       - name: Dev module graph (Node-only import leaks)
         # `vite dev` serves renovate's transitive deps raw (no CJS interop),
         # a regime neither the Node tests nor the production build exercise.
-        run: pnpm --filter @renovate-config-visualizer/app check:dev-graph
+        run: pnpm --filter @renovate-config-debugger/app check:dev-graph
 
   build:
     needs: setup
@@ -75,7 +75,7 @@ jobs:
           VITE_OAUTH_WORKER_URL: ${{ vars.VITE_OAUTH_WORKER_URL }}
           VITE_GITHUB_APP_SLUG: ${{ vars.VITE_GITHUB_APP_SLUG }}
           VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
-        run: pnpm --filter @renovate-config-visualizer/app build
+        run: pnpm --filter @renovate-config-debugger/app build
       - name: Critical-path entry-set sizes (roadmap 031)
         # Prints the gzip size of everything fetched before first paint (the
         # entry script + its modulepreload graph + the stylesheet), so a chunk
@@ -127,19 +127,19 @@ jobs:
       - name: Install Playwright chromium
         # Only chromium, with its OS deps — the e2e suite is chromium-only.
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @renovate-config-visualizer/app exec playwright install --with-deps chromium
+        run: pnpm --filter @renovate-config-debugger/app exec playwright install --with-deps chromium
 
       - name: Install Playwright OS deps
         # The cache covers ~/.cache/ms-playwright (the browser binaries) but not
         # the apt packages `--with-deps` pulls in, so those are still needed on a
         # hit. Cheap — most are already on the runner image.
         if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @renovate-config-visualizer/app exec playwright install-deps chromium
+        run: pnpm --filter @renovate-config-debugger/app exec playwright install-deps chromium
       - name: Browser e2e tests
         # Drives the production dist from the build job via `vite preview`
         # (reuses that output, never rebuilds). Base is "/" everywhere — the
         # site serves from the domain root (renovate.secustor.dev).
-        run: pnpm --filter @renovate-config-visualizer/app test:e2e
+        run: pnpm --filter @renovate-config-debugger/app test:e2e
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -204,7 +204,7 @@ jobs:
 
       # Only the worker package's deps — the deploy needs wrangler (a pinned
       # devDependency there), not the app workspace.
-      - run: pnpm install --frozen-lockfile --prefer-offline --filter @renovate-config-visualizer/oauth-worker
+      - run: pnpm install --frozen-lockfile --prefer-offline --filter @renovate-config-debugger/oauth-worker
 
       # `wrangler deploy` REPLACES dashboard-set vars on every run, so
       # GITHUB_CLIENT_ID is not committed to wrangler.jsonc; it is threaded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,9 @@ jobs:
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
           - target: app
-            image: ghcr.io/secustor/renovate-config-visualizer
+            image: ghcr.io/secustor/renovate-config-debugger
           - target: oauth-proxy
-            image: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy
+            image: ghcr.io/secustor/renovate-config-debugger-oauth-proxy
     steps:
       # `linux/amd64` is not usable in a cache tag or an artifact name.
       - id: platform
@@ -313,9 +313,9 @@ jobs:
       matrix:
         include:
           - target: app
-            image: ghcr.io/secustor/renovate-config-visualizer
+            image: ghcr.io/secustor/renovate-config-debugger
           - target: oauth-proxy
-            image: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy
+            image: ghcr.io/secustor/renovate-config-debugger-oauth-proxy
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -178,8 +178,8 @@
                 "group": [
                   "codemirror-json-schema",
                   "codemirror-json-schema/**",
-                  "@renovate-config-visualizer/engine/schema",
-                  "@renovate-config-visualizer/engine/schema/**"
+                  "@renovate-config-debugger/engine/schema",
+                  "@renovate-config-debugger/engine/schema/**"
                 ],
                 "message": "codemirror-json-schema and the engine's schema export may only be imported statically from platform/editor-schema.ts — that's the one place the ~160 kB gz schema stack is allowed into a chunk (roadmap 031)."
               }
@@ -268,8 +268,8 @@
                 "group": [
                   "codemirror-json-schema",
                   "codemirror-json-schema/**",
-                  "@renovate-config-visualizer/engine/schema",
-                  "@renovate-config-visualizer/engine/schema/**"
+                  "@renovate-config-debugger/engine/schema",
+                  "@renovate-config-debugger/engine/schema/**"
                 ],
                 "message": "codemirror-json-schema and the engine's schema export may only be imported statically from platform/editor-schema.ts — that's the one place the ~160 kB gz schema stack is allowed into a chunk (roadmap 031)."
               }
@@ -321,8 +321,8 @@
                 "group": [
                   "codemirror-json-schema",
                   "codemirror-json-schema/**",
-                  "@renovate-config-visualizer/engine/schema",
-                  "@renovate-config-visualizer/engine/schema/**"
+                  "@renovate-config-debugger/engine/schema",
+                  "@renovate-config-debugger/engine/schema/**"
                 ],
                 "message": "codemirror-json-schema and the engine's schema export may only be imported statically from platform/editor-schema.ts — that's the one place the ~160 kB gz schema stack is allowed into a chunk (roadmap 031)."
               }
@@ -360,8 +360,8 @@
                 "group": [
                   "codemirror-json-schema",
                   "codemirror-json-schema/**",
-                  "@renovate-config-visualizer/engine/schema",
-                  "@renovate-config-visualizer/engine/schema/**"
+                  "@renovate-config-debugger/engine/schema",
+                  "@renovate-config-debugger/engine/schema/**"
                 ],
                 "message": "codemirror-json-schema and the engine's schema export may only be imported statically from platform/editor-schema.ts — that's the one place the ~160 kB gz schema stack is allowed into a chunk (roadmap 031)."
               }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,13 @@ pnpm build                     # all packages
 Targeted tests:
 
 ```bash
-pnpm --filter @renovate-config-visualizer/engine test:golden    # real renovate modules, reference snapshots
-pnpm --filter @renovate-config-visualizer/engine test:shimmed   # browser module graph, must match golden
-pnpm --filter @renovate-config-visualizer/app test:unit         # pure-module unit tests (vitest "unit" project)
-pnpm --filter @renovate-config-visualizer/app test:e2e          # playwright; requires `pnpm --filter …/app build` first
-pnpm --filter @renovate-config-visualizer/app exec vitest run --project unit src/lib/share.test.ts   # single file
-pnpm --filter @renovate-config-visualizer/app exec playwright test e2e/04-simulator.spec.ts          # single e2e
-pnpm --filter @renovate-config-visualizer/app check:dev-graph   # guards `vite dev` module graph against Node-only leaks
+pnpm --filter @renovate-config-debugger/engine test:golden    # real renovate modules, reference snapshots
+pnpm --filter @renovate-config-debugger/engine test:shimmed   # browser module graph, must match golden
+pnpm --filter @renovate-config-debugger/app test:unit         # pure-module unit tests (vitest "unit" project)
+pnpm --filter @renovate-config-debugger/app test:e2e          # playwright; requires `pnpm --filter …/app build` first
+pnpm --filter @renovate-config-debugger/app exec vitest run --project unit src/lib/share.test.ts   # single file
+pnpm --filter @renovate-config-debugger/app exec playwright test e2e/04-simulator.spec.ts          # single e2e
+pnpm --filter @renovate-config-debugger/app check:dev-graph   # guards `vite dev` module graph against Node-only leaks
 ```
 
 ## Session hooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY patches/ patches/
 RUN pnpm install --frozen-lockfile
 
 COPY . .
-RUN pnpm --filter @renovate-config-visualizer/app build
+RUN pnpm --filter @renovate-config-debugger/app build
 
 # --- oauth-proxy -------------------------------------------------------------
 # The OAuth token exchange (roadmap 009) without Cloudflare. Only needed by a

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ browser. Think "compiler explorer for Renovate configs".
 **[Try it live](https://renovate.secustor.dev/)**, or run it yourself:
 
 ```bash
-docker run -p 8080:80 ghcr.io/secustor/renovate-config-visualizer   # http://localhost:8080
+docker run -p 8080:80 ghcr.io/secustor/renovate-config-debugger   # http://localhost:8080
 ```
 
 Paste this into the config editor and press _Run pipeline_ or simply [open it with the below content filled](https://renovate.secustor.dev/#config=PZDNToQwFIVfpTlxWRnHEE36Bi50YXRlZ1HKHUCnP2kvqCG8uykDLpvzfeekd8YEdS-RyIfJMEGhrqu6eoCEDf48dFCYtRdC4ybbnpzRUEKjZ45ZHQ5tsLna7SZwZYM77O_bq1F95uA15LWGfph8m0vNh95GVCIbnCPfUqtx2khnMlN6ynmkQnMaaUuisV-mo9fxQluRF0KIeZXY9s_Gm47SPuKjK617-h5bw_T2G3cZbvAhbUiXwhhfjFs3V1dssVjKzEn7RXtInIcLFQ7q_3zrT8vpoHBMj0M-NpCYBvqGmpHZdIWOiTIxJDJThLqTYNNAIUyUVnZZ_gA):
@@ -88,7 +88,7 @@ docker compose up --build    # build from this checkout instead
 ```
 
 The two services are the app image above and the optional
-`ghcr.io/secustor/renovate-config-visualizer-oauth-proxy` (token exchange, Node,
+`ghcr.io/secustor/renovate-config-debugger-oauth-proxy` (token exchange, Node,
 port 8788). Both are configured at run time, not build time, so one image serves
 an OAuth-off and an OAuth-on deployment. With both required variables set the
 container writes `/rcv-config.js` at startup and the sign-in UI appears;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   app:
-    image: ghcr.io/secustor/renovate-config-visualizer:latest
+    image: ghcr.io/secustor/renovate-config-debugger:latest
     build:
       context: .
       target: app
@@ -36,7 +36,7 @@ services:
   # does that exchange and nothing else: it never sees a config, a preset or an
   # API request.
   oauth-proxy:
-    image: ghcr.io/secustor/renovate-config-visualizer-oauth-proxy:latest
+    image: ghcr.io/secustor/renovate-config-debugger-oauth-proxy:latest
     build:
       context: .
       target: oauth-proxy

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "renovate-config-visualizer",
+  "name": "renovate-config-debugger",
   "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @renovate-config-visualizer/app dev",
+    "dev": "pnpm --filter @renovate-config-debugger/app dev",
     "lint": "oxlint --type-aware && pnpm lint:css",
     "lint:css": "stylelint \"packages/app/src/**/*.css\"",
     "format": "oxfmt",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovate-config-visualizer/app",
+  "name": "@renovate-config-debugger/app",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -17,7 +17,7 @@
     "@codemirror/lang-json": "6.0.2",
     "@codemirror/language": "6.12.4",
     "@lezer/highlight": "1.2.3",
-    "@renovate-config-visualizer/engine": "workspace:*",
+    "@renovate-config-debugger/engine": "workspace:*",
     "@uiw/react-codemirror": "4.25.11",
     "codemirror-json-schema": "0.8.1",
     "codemirror-json5": "1.0.3",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -14,7 +14,7 @@ import type {
   OptionIndex,
   StageId,
   TraceResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { AdvancedZone } from "@/features/editor/AdvancedZone";
 import { AppHeaderTools } from "@/AppHeaderTools";
 import type { ConfigEditorHandle } from "@/features/editor/ConfigEditor";

--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -5,7 +5,7 @@ import type {
   StageId,
   TraceEvent,
   TraceResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { AuthFailureBanner } from "@/components/AuthFailureBanner";
 import { collectGithubAuthFailures } from "@/features/presets/tree-shared";
 import { EffectiveConfig, type EffectiveStats } from "@/components/EffectiveConfig";

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -6,7 +6,7 @@ import type {
   ResolvedConfigOutput,
   RuleAttribution,
   TraceResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { Explained, Term } from "./glossary";
 import { GLOSSARY } from "@/data/glossary-data";
 import { OptionKey } from "./option-docs";
@@ -44,7 +44,7 @@ function useProvenance(result: TraceResult): Provenance | null | undefined {
     let live = true;
     setState(undefined);
     void (async () => {
-      const engine = await import("@renovate-config-visualizer/engine");
+      const engine = await import("@renovate-config-debugger/engine");
       if (live) {
         setState(engine.computeProvenance(result) ?? null);
       }
@@ -83,7 +83,7 @@ function useResolvedConfig(
     let live = true;
     setState(undefined);
     void (async () => {
-      const engine = await import("@renovate-config-visualizer/engine");
+      const engine = await import("@renovate-config-debugger/engine");
       if (live) {
         setState(engine.computeResolvedConfig(result, mode, { includeDefaults }) ?? null);
       }

--- a/packages/app/src/components/ErrorTranslationView.tsx
+++ b/packages/app/src/components/ErrorTranslationView.tsx
@@ -1,4 +1,4 @@
-import type { ErrorFixResult, ValidationMessage } from "@renovate-config-visualizer/engine";
+import type { ErrorFixResult, ValidationMessage } from "@renovate-config-debugger/engine";
 import type { ErrorTranslationLib } from "@/platform/run";
 
 /**

--- a/packages/app/src/components/MessagesPanel.tsx
+++ b/packages/app/src/components/MessagesPanel.tsx
@@ -2,7 +2,7 @@ import type {
   ErrorFixResult,
   RuleAttribution,
   TraceResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { memo, useMemo } from "react";
 import type { ErrorTranslationLib } from "@/platform/run";
 import { ErrorTranslationView } from "./ErrorTranslationView";

--- a/packages/app/src/components/MigrationSteps.tsx
+++ b/packages/app/src/components/MigrationSteps.tsx
@@ -1,5 +1,5 @@
 import { memo, useMemo } from "react";
-import type { TraceEvent } from "@renovate-config-visualizer/engine";
+import type { TraceEvent } from "@renovate-config-debugger/engine";
 import { CodeText } from "./CodeText";
 import { CopyButton } from "./CopyButton";
 import { StepThrough, type StepThroughStep } from "./StepThrough";

--- a/packages/app/src/components/ProjectLinks.tsx
+++ b/packages/app/src/components/ProjectLinks.tsx
@@ -10,10 +10,9 @@
  * self-hoster's fork is not where a bug report about this app belongs.
  */
 
-// The repository's CURRENT name, which is not the one `git remote -v`, the
-// package directories or the `ghcr.io/…-visualizer` images say: GitHub renamed
-// `renovate-config-visualizer` to `renovate-config-debugger` (the app's own
-// title since 016), and the old name lives on as a redirect. Verified against
+// The repository's CURRENT name: GitHub renamed `renovate-config-visualizer`
+// to `renovate-config-debugger` (the app's own title since 016), and the old
+// name lives on as a redirect. Verified against
 // `gh api repos/secustor/renovate-config-debugger`. A link a user reads before
 // clicking should carry the name they will land on.
 const REPO_URL = "https://github.com/secustor/renovate-config-debugger";

--- a/packages/app/src/components/ProvenanceChip.tsx
+++ b/packages/app/src/components/ProvenanceChip.tsx
@@ -1,4 +1,4 @@
-import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer } from "@renovate-config-debugger/engine";
 import { Explained } from "./glossary";
 import { layerClass, layerLabel, provenanceGlossaryEntry } from "./provenance-layer";
 

--- a/packages/app/src/components/RuleMessage.tsx
+++ b/packages/app/src/components/RuleMessage.tsx
@@ -1,4 +1,4 @@
-import type { RuleAttribution, ValidationMessage } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution, ValidationMessage } from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 013: one canonical rule presentation + cross-links. A validation

--- a/packages/app/src/components/StageDiff.tsx
+++ b/packages/app/src/components/StageDiff.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import type { StageId, TraceResult } from "@renovate-config-visualizer/engine";
+import type { StageId, TraceResult } from "@renovate-config-debugger/engine";
 import { JsonDiff } from "./JsonDiff";
 
 interface Props {

--- a/packages/app/src/components/StageTimeline.tsx
+++ b/packages/app/src/components/StageTimeline.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import type { StageId, TraceResult } from "@renovate-config-visualizer/engine";
+import type { StageId, TraceResult } from "@renovate-config-debugger/engine";
 import { Explained } from "./glossary";
 import { STAGE_IDS } from "@/lib/input-schemas";
 import { STAGE_EXPLAINERS, STAGE_LABELS } from "@/data/stage-copy";

--- a/packages/app/src/components/option-docs.tsx
+++ b/packages/app/src/components/option-docs.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
-import type { OptionDoc, OptionIndex } from "@renovate-config-visualizer/engine";
+import type { OptionDoc, OptionIndex } from "@renovate-config-debugger/engine";
 import { useMoveGatedHover } from "@/hooks/hover-gate";
 import { OptionDocsContext, useOptionDocs } from "@/hooks/option-docs-hooks";
 import { type AnchorRect, anchoredCardStyle } from "@/lib/anchored-card";

--- a/packages/app/src/components/preset-tree-stats.ts
+++ b/packages/app/src/components/preset-tree-stats.ts
@@ -1,4 +1,4 @@
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 
 /**
  * The preset tree's derived facts: per-node/per-subtree contribution stats,

--- a/packages/app/src/components/provenance-layer.ts
+++ b/packages/app/src/components/provenance-layer.ts
@@ -1,4 +1,4 @@
-import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer } from "@renovate-config-debugger/engine";
 import type { GlossaryEntry } from "@/data/glossary-data";
 
 /**

--- a/packages/app/src/components/rule-framing.tsx
+++ b/packages/app/src/components/rule-framing.tsx
@@ -1,4 +1,4 @@
-import type { RuleAttribution } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution } from "@renovate-config-debugger/engine";
 import type { ReactNode } from "react";
 import { layerLabel } from "./provenance-layer";
 

--- a/packages/app/src/data/host-tokens.ts
+++ b/packages/app/src/data/host-tokens.ts
@@ -5,7 +5,7 @@
  * this instead, so adding a host is a one-row change. Pure data, no React —
  * run.ts (which must stay engine-chunk-light) imports it too.
  */
-import type { PresetAuth } from "@renovate-config-visualizer/engine";
+import type { PresetAuth } from "@renovate-config-debugger/engine";
 
 export interface HostTokenDescriptor {
   /** Stable id, also the token's field prefix in the engine's PresetAuth. */

--- a/packages/app/src/data/stage-copy.ts
+++ b/packages/app/src/data/stage-copy.ts
@@ -1,4 +1,4 @@
-import type { StageId } from "@renovate-config-visualizer/engine";
+import type { StageId } from "@renovate-config-debugger/engine";
 import type { GlossaryEntry } from "./glossary-data";
 
 /**

--- a/packages/app/src/features/presets/OriginFraming.tsx
+++ b/packages/app/src/features/presets/OriginFraming.tsx
@@ -1,4 +1,4 @@
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { TreeStats } from "@/components/preset-tree-stats";
 import { Term } from "@/components/glossary";
 import { nf } from "./tree-shared";

--- a/packages/app/src/features/presets/PresetDetail.tsx
+++ b/packages/app/src/features/presets/PresetDetail.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import type { PresetNode, TraceEvent } from "@renovate-config-visualizer/engine";
+import type { PresetNode, TraceEvent } from "@renovate-config-debugger/engine";
 import { ConfigJson } from "@/components/ConfigJson";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
 import { type AuthState, GithubAuthHint } from "@/components/GithubAuthHint";

--- a/packages/app/src/features/presets/PresetListPane.tsx
+++ b/packages/app/src/features/presets/PresetListPane.tsx
@@ -1,4 +1,4 @@
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { TreeStats } from "@/components/preset-tree-stats";
 import type { Row, SortColumn, TableRow } from "./rows";
 import { type InjectionKeyFn, ROW_HEIGHT } from "./tree-shared";

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useMemo, useState } from "react";
-import type { PresetNode, TraceEvent, TraceResult } from "@renovate-config-visualizer/engine";
+import type { PresetNode, TraceEvent, TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { computeTreeStats } from "@/components/preset-tree-stats";
 import type { AuthState } from "@/components/GithubAuthHint";

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats } from "@/components/preset-tree-stats";
 import { Explained } from "@/components/glossary";
 import { GLOSSARY } from "@/data/glossary-data";

--- a/packages/app/src/features/presets/rows.ts
+++ b/packages/app/src/features/presets/rows.ts
@@ -1,4 +1,4 @@
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats, TreeStats } from "@/components/preset-tree-stats";
 
 /** Node ids whose subtree (self or any descendant) matches the query. */

--- a/packages/app/src/features/presets/tree-shared.test.ts
+++ b/packages/app/src/features/presets/tree-shared.test.ts
@@ -10,7 +10,7 @@
  * the match IS a pair of regexes over those strings: a fixture paraphrasing
  * them would keep passing after the engine's wording moved on.
  */
-import type { PresetNode } from "@renovate-config-visualizer/engine";
+import type { PresetNode } from "@renovate-config-debugger/engine";
 import { describe, expect, test } from "vitest";
 import { collectGithubAuthFailures, githubPresetDisplayName, stateBadge } from "./tree-shared";
 

--- a/packages/app/src/features/presets/tree-shared.ts
+++ b/packages/app/src/features/presets/tree-shared.ts
@@ -1,4 +1,4 @@
-import type { PresetNode, PresetSourceRef } from "@renovate-config-visualizer/engine";
+import type { PresetNode, PresetSourceRef } from "@renovate-config-debugger/engine";
 import { GLOSSARY, type GlossaryEntry } from "@/data/glossary-data";
 
 /**

--- a/packages/app/src/features/presets/use-engine-helpers.ts
+++ b/packages/app/src/features/presets/use-engine-helpers.ts
@@ -12,7 +12,7 @@ export function useEngineHelpers() {
   useEffect(() => {
     let live = true;
     void (async () => {
-      const engine = await import("@renovate-config-visualizer/engine");
+      const engine = await import("@renovate-config-debugger/engine");
       if (live) {
         setHelpers({
           merge: engine.mergeChildConfig as MergeFn,

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -1,4 +1,4 @@
-import type { ClauseEvaluation } from "@renovate-config-visualizer/engine";
+import type { ClauseEvaluation } from "@renovate-config-debugger/engine";
 import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
 
 /**

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -3,7 +3,7 @@ import type {
   DependencyDescriptor,
   RuleRef,
   SimulationComparison,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { toDescriptor } from "./form";
 import { previewValue, writeMark } from "./rule-format";
 import type { PinnedRun } from "./use-ab-comparison";

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { MergedKey } from "@renovate-config-visualizer/engine";
+import type { MergedKey } from "@renovate-config-debugger/engine";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
-import type {
-  MergedKey,
-  ProvenanceLayer,
-  RuleEvaluation,
-} from "@renovate-config-visualizer/engine";
+import type { MergedKey, ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { ClauseGrid } from "./ClauseGrid";

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useMemo } from "react";
-import type { ProvenanceLayer, TraceResult } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer, TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
 import { RuleFramingText } from "@/components/rule-framing";

--- a/packages/app/src/features/simulator/SimMergeBody.tsx
+++ b/packages/app/src/features/simulator/SimMergeBody.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useMemo, useRef } from "react";
-import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult } from "@renovate-config-debugger/engine";
 import { ConfigJson } from "@/components/ConfigJson";
 import { SequenceChip, SequenceSep, SequenceTimeline } from "@/components/SequenceTimeline";
 import { StepThrough } from "@/components/StepThrough";

--- a/packages/app/src/features/simulator/SimMergeDrawer.tsx
+++ b/packages/app/src/features/simulator/SimMergeDrawer.tsx
@@ -1,5 +1,5 @@
 import { Fragment, memo, type RefObject } from "react";
-import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult } from "@renovate-config-debugger/engine";
 import { SummaryDrawer } from "./SummaryDrawer";
 import type { MergeStop } from "./merge-stops";
 import { SimMergeBody } from "./SimMergeBody";

--- a/packages/app/src/features/simulator/SimMessages.tsx
+++ b/packages/app/src/features/simulator/SimMessages.tsx
@@ -1,4 +1,4 @@
-import type { RuleAttribution, ValidationMessage } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution, ValidationMessage } from "@renovate-config-debugger/engine";
 import { ErrorTranslationView } from "@/components/ErrorTranslationView";
 import { RuleMessage } from "@/components/RuleMessage";
 import type { ErrorTranslationLib } from "@/platform/run";

--- a/packages/app/src/features/simulator/SimRulesBody.tsx
+++ b/packages/app/src/features/simulator/SimRulesBody.tsx
@@ -1,4 +1,4 @@
-import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { RuleRow } from "./RuleRow";
 
 /**

--- a/packages/app/src/features/simulator/SimRulesDrawer.tsx
+++ b/packages/app/src/features/simulator/SimRulesDrawer.tsx
@@ -1,5 +1,5 @@
 import { memo, type RefObject } from "react";
-import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { layerId } from "@/components/provenance-layer";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { SummaryDrawer } from "./SummaryDrawer";

--- a/packages/app/src/features/simulator/SimVerdictBlock.tsx
+++ b/packages/app/src/features/simulator/SimVerdictBlock.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult } from "@renovate-config-debugger/engine";
 import { CopyButton } from "@/components/CopyButton";
 import type { ConsumedBlock } from "./consumed-blocks";
 import type { RuleEvidence } from "./rule-evidence";

--- a/packages/app/src/features/simulator/VerdictThreads.tsx
+++ b/packages/app/src/features/simulator/VerdictThreads.tsx
@@ -1,4 +1,4 @@
-import type { ProvenanceLayer } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer } from "@renovate-config-debugger/engine";
 import { OptionKey } from "@/components/option-docs";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { previewValue } from "./rule-format";

--- a/packages/app/src/features/simulator/consumed-blocks.ts
+++ b/packages/app/src/features/simulator/consumed-blocks.ts
@@ -2,7 +2,7 @@ import type {
   ProvenanceLayer,
   RuleAttribution,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 047: an update-type block the USER authored (per the engine's

--- a/packages/app/src/features/simulator/form.ts
+++ b/packages/app/src/features/simulator/form.ts
@@ -1,4 +1,4 @@
-import type { DependencyDescriptor } from "@renovate-config-visualizer/engine";
+import type { DependencyDescriptor } from "@renovate-config-debugger/engine";
 
 export interface FormState {
   manager: string;

--- a/packages/app/src/features/simulator/layer-counts.ts
+++ b/packages/app/src/features/simulator/layer-counts.ts
@@ -1,4 +1,4 @@
-import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-visualizer/engine";
+import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { layerId, layerLabel } from "@/components/provenance-layer";
 
 /** Roadmap 047: the matched rules grouped by the provenance layer that

--- a/packages/app/src/features/simulator/merge-stops.tsx
+++ b/packages/app/src/features/simulator/merge-stops.tsx
@@ -3,7 +3,7 @@ import type {
   MergedKey,
   ProvenanceLayer,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { ConfigJson } from "@/components/ConfigJson";
 import { CopyButton } from "@/components/CopyButton";
 import { Term } from "@/components/glossary";

--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -15,7 +15,7 @@ import type {
   ProvenanceLayer,
   RuleEvaluation,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { describe, expect, test } from "vitest";
 import type { MergeStop } from "./merge-stops";
 import { buildRuleEvidence } from "./rule-evidence";

--- a/packages/app/src/features/simulator/rule-evidence.ts
+++ b/packages/app/src/features/simulator/rule-evidence.ts
@@ -3,7 +3,7 @@ import type {
   ProvenanceLayer,
   RuleEvaluation,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import type { MergeStop } from "./merge-stops";
 import { stopLabels } from "./verdict-threads";
 

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -1,8 +1,4 @@
-import type {
-  ClauseEvaluation,
-  MergedKey,
-  RuleEvaluation,
-} from "@renovate-config-visualizer/engine";
+import type { ClauseEvaluation, MergedKey, RuleEvaluation } from "@renovate-config-debugger/engine";
 
 export function previewValue(value: unknown, max = 60): string {
   const text = JSON.stringify(value) ?? "undefined";

--- a/packages/app/src/features/simulator/update-type-keys.ts
+++ b/packages/app/src/features/simulator/update-type-keys.ts
@@ -1,4 +1,4 @@
-import type * as EngineModule from "@renovate-config-visualizer/engine";
+import type * as EngineModule from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 046: the update-type blocks Renovate's flattening consumes, an

--- a/packages/app/src/features/simulator/use-ab-comparison.ts
+++ b/packages/app/src/features/simulator/use-ab-comparison.ts
@@ -1,10 +1,10 @@
 import { useMemo, useState } from "react";
-import type * as EngineModule from "@renovate-config-visualizer/engine";
+import type * as EngineModule from "@renovate-config-debugger/engine";
 import type {
   DependencyDescriptor,
   SimulationComparison,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { type FormState, toDescriptor } from "./form";
 
 /** Roadmap 021: the pinned A-run plus the full form snapshot it was run

--- a/packages/app/src/features/simulator/use-engine-module.ts
+++ b/packages/app/src/features/simulator/use-engine-module.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type * as EngineModule from "@renovate-config-visualizer/engine";
+import type * as EngineModule from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 015: the engine module, loaded once up front — by the time the
@@ -14,7 +14,7 @@ export function useEngineModule(): typeof EngineModule | null {
   useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const m = await import("@renovate-config-visualizer/engine");
+      const m = await import("@renovate-config-debugger/engine");
       if (!cancelled) {
         setEngineModule(m);
       }

--- a/packages/app/src/features/simulator/use-rule-focus.ts
+++ b/packages/app/src/features/simulator/use-rule-focus.ts
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult } from "@renovate-config-debugger/engine";
 import { flashTarget, motionScrollOptions } from "@/lib/motion";
 
 export interface RuleFocus {

--- a/packages/app/src/features/simulator/use-share-link-request.ts
+++ b/packages/app/src/features/simulator/use-share-link-request.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type RefObject, type SetStateAction, useEffect, useRef } from "react";
-import type { TraceResult } from "@renovate-config-visualizer/engine";
+import type { TraceResult } from "@renovate-config-debugger/engine";
 import type { SimRequest } from "@/hooks/use-share-link";
 import { EMPTY_FORM, type FormState } from "./form";
 import type { Simulate } from "./use-simulation-run";

--- a/packages/app/src/features/simulator/use-simulation-run.ts
+++ b/packages/app/src/features/simulator/use-simulation-run.ts
@@ -7,7 +7,7 @@ import {
   useRef,
   useState,
 } from "react";
-import type { SimulationResult, TraceResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult, TraceResult } from "@renovate-config-debugger/engine";
 import { type FormState, hasMeaningfulInput, toDescriptor } from "./form";
 
 export type Simulate = (nextForm: FormState, touched: boolean, keepStep?: boolean) => Promise<void>;
@@ -132,7 +132,7 @@ export function useSimulationRun({
     setRunning(true);
     setError(null);
     try {
-      const engine = await import("@renovate-config-visualizer/engine");
+      const engine = await import("@renovate-config-debugger/engine");
       const derived = engine.deriveUpdateType(
         nextForm.currentValue,
         nextForm.newValue,

--- a/packages/app/src/features/simulator/use-simulator-form.ts
+++ b/packages/app/src/features/simulator/use-simulator-form.ts
@@ -1,5 +1,5 @@
 import { type Dispatch, type KeyboardEvent, type SetStateAction, useMemo, useState } from "react";
-import type * as EngineModule from "@renovate-config-visualizer/engine";
+import type * as EngineModule from "@renovate-config-debugger/engine";
 import { EMPTY_FORM, type FormState, UPDATE_TYPES } from "./form";
 
 export interface SimulatorForm {

--- a/packages/app/src/features/simulator/use-thread-nav.ts
+++ b/packages/app/src/features/simulator/use-thread-nav.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { SimulationResult } from "@renovate-config-visualizer/engine";
+import type { SimulationResult } from "@renovate-config-debugger/engine";
 import { flashTarget, motionScrollOptions } from "@/lib/motion";
 import { RULE_POP_SELECTOR } from "./rule-pop-dom";
 

--- a/packages/app/src/features/simulator/verdict-sentence.ts
+++ b/packages/app/src/features/simulator/verdict-sentence.ts
@@ -1,4 +1,4 @@
-import type { RuleAttribution, SimulationResult } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution, SimulationResult } from "@renovate-config-debugger/engine";
 
 /** A config value in a plain-language sentence: `[a, b]`, `"x"`, `42`. */
 function plainValue(value: unknown): string {

--- a/packages/app/src/features/simulator/verdict-threads.test.ts
+++ b/packages/app/src/features/simulator/verdict-threads.test.ts
@@ -14,7 +14,7 @@ import type {
   ProvenanceLayer,
   RuleEvaluation,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import { describe, expect, test } from "vitest";
 import type { MergeStop } from "./merge-stops";
 import { buildVerdictThreads } from "./verdict-threads";

--- a/packages/app/src/features/simulator/verdict-threads.ts
+++ b/packages/app/src/features/simulator/verdict-threads.ts
@@ -3,7 +3,7 @@ import type {
   MergedKey,
   ProvenanceLayer,
   SimulationResult,
-} from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
 import type { MergeStop } from "./merge-stops";
 
 /**

--- a/packages/app/src/hooks/option-docs-hooks.ts
+++ b/packages/app/src/hooks/option-docs-hooks.ts
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useRef } from "react";
-import type { OptionIndex } from "@renovate-config-visualizer/engine";
+import type { OptionIndex } from "@renovate-config-debugger/engine";
 
 /**
  * The option-docs context and the hooks that read it, plus the caret

--- a/packages/app/src/hooks/rule-provenance.ts
+++ b/packages/app/src/hooks/rule-provenance.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { RuleAttribution, TraceResult } from "@renovate-config-visualizer/engine";
+import type { RuleAttribution, TraceResult } from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 032: `computeRuleProvenance` replays the layer merge over every
@@ -15,7 +15,7 @@ const ruleProvenanceCache = new WeakMap<TraceResult, Promise<RuleAttribution[] |
 function ruleProvenanceFor(result: TraceResult): Promise<RuleAttribution[] | null> {
   let promise = ruleProvenanceCache.get(result);
   if (!promise) {
-    promise = import("@renovate-config-visualizer/engine").then(
+    promise = import("@renovate-config-debugger/engine").then(
       (engine) => engine.computeRuleProvenance(result) ?? null,
     );
     ruleProvenanceCache.set(result, promise);

--- a/packages/app/src/hooks/use-inherited-config-layer.ts
+++ b/packages/app/src/hooks/use-inherited-config-layer.ts
@@ -17,7 +17,7 @@
  * on but does not own comes in through {@link InheritedConfigLayerHost}.
  */
 import { useMemo, useState } from "react";
-import type { RepoPlatform } from "@renovate-config-visualizer/engine";
+import type { RepoPlatform } from "@renovate-config-debugger/engine";
 import {
   inheritFieldValues,
   type InheritLayerState,

--- a/packages/app/src/hooks/use-repo-load.ts
+++ b/packages/app/src/hooks/use-repo-load.ts
@@ -15,7 +15,7 @@
  * path itself — and hands it in through {@link RepoLoadHost}.
  */
 import { type RefObject, useRef, useState } from "react";
-import type { RepoPlatform, TraceResult } from "@renovate-config-visualizer/engine";
+import type { RepoPlatform, TraceResult } from "@renovate-config-debugger/engine";
 import { PLATFORM_ENDPOINTS } from "@/data/platform-endpoints";
 import { isValidRepoHost, isValidRepoRefPart } from "@/lib/input-schemas";
 import type { ShareFileName, UntrustedEndpointGuard } from "@/lib/share";

--- a/packages/app/src/hooks/use-run-summary.ts
+++ b/packages/app/src/hooks/use-run-summary.ts
@@ -11,7 +11,7 @@
  * counts from the digest would be splitting the two halves of that guarantee.
  */
 import { useMemo } from "react";
-import type { TraceEvent, TraceResult } from "@renovate-config-visualizer/engine";
+import type { TraceEvent, TraceResult } from "@renovate-config-debugger/engine";
 import type { EffectiveStats } from "@/components/EffectiveConfig";
 import { presetTreeSummary } from "@/components/preset-tree-stats";
 import type { ResultsTabDescriptor } from "@/components/ResultsPanel";

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -12,7 +12,7 @@
  * live here; their comments moved with the statements they annotate.
  */
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { TraceResult } from "@renovate-config-visualizer/engine";
+import type { TraceResult } from "@renovate-config-debugger/engine";
 import {
   completeCallback,
   type OAuthConfig,

--- a/packages/app/src/lib/input-schemas-zod.ts
+++ b/packages/app/src/lib/input-schemas-zod.ts
@@ -15,7 +15,7 @@
  * exists, so the zod and zod-free views of a rule can never disagree.
  */
 import * as z from "zod/mini";
-import type { StageId } from "@renovate-config-visualizer/engine";
+import type { StageId } from "@renovate-config-debugger/engine";
 import { RESULTS_TAB_IDS, type ResultsTabId } from "@/data/results-tabs";
 import {
   isHttpUrl,

--- a/packages/app/src/lib/input-schemas.ts
+++ b/packages/app/src/lib/input-schemas.ts
@@ -17,7 +17,7 @@
  * modules are the one place all of that gets checked; callers (share.ts,
  * App.tsx, oauth.ts, PresetTree.tsx) replace their ad hoc checks with these.
  */
-import type { STAGE_IDS as ENGINE_STAGE_IDS } from "@renovate-config-visualizer/engine";
+import type { STAGE_IDS as ENGINE_STAGE_IDS } from "@renovate-config-debugger/engine";
 
 // ---------------------------------------------------------------------------
 // Deep pollution guard

--- a/packages/app/src/lib/preset-hover.ts
+++ b/packages/app/src/lib/preset-hover.ts
@@ -1,4 +1,4 @@
-import type { PresetNode, PresetNodeState } from "@renovate-config-visualizer/engine";
+import type { PresetNode, PresetNodeState } from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 023: preset-string hovers in the config editor. Hovering a preset

--- a/packages/app/src/lib/share.ts
+++ b/packages/app/src/lib/share.ts
@@ -10,7 +10,7 @@
  * Tokens and manually-injected presets are NEVER encoded. The Renovate version
  * current at encode time rides along so the opener can warn on version drift.
  */
-import type { StageId } from "@renovate-config-visualizer/engine";
+import type { StageId } from "@renovate-config-debugger/engine";
 import type { ResultsTabId } from "@/data/results-tabs";
 import { isTrustedEndpoint, PLATFORM_ENDPOINTS } from "@/data/platform-endpoints";
 

--- a/packages/app/src/lib/stage-activity.ts
+++ b/packages/app/src/lib/stage-activity.ts
@@ -1,4 +1,4 @@
-import type { StageId, TraceEvent, TraceResult } from "@renovate-config-visualizer/engine";
+import type { StageId, TraceEvent, TraceResult } from "@renovate-config-debugger/engine";
 
 /**
  * Roadmap 024: what a stage chip's dot should say happened this run, on top

--- a/packages/app/src/platform/editor-schema.ts
+++ b/packages/app/src/platform/editor-schema.ts
@@ -16,8 +16,8 @@ import { type EditorView, type Extension, hoverTooltip, type Tooltip } from "@ui
 import { jsonLanguage } from "@codemirror/lang-json";
 import { jsonCompletion, jsonSchema, jsonSchemaHover } from "codemirror-json-schema";
 import type { RefObject } from "react";
-import { renovateSchema } from "@renovate-config-visualizer/engine/schema";
-import type { PresetNodeState } from "@renovate-config-visualizer/engine";
+import { renovateSchema } from "@renovate-config-debugger/engine/schema";
+import type { PresetNodeState } from "@renovate-config-debugger/engine";
 import type { PresetHoverContext, PresetHoverInfo } from "@/lib/preset-hover";
 
 const STRING_RE = /"(?:[^"\\]|\\.)*"/g;

--- a/packages/app/src/platform/run.ts
+++ b/packages/app/src/platform/run.ts
@@ -10,8 +10,8 @@ import type {
   TraceResult,
   TranslatedMessage,
   ValidationMessage,
-} from "@renovate-config-visualizer/engine";
-import type * as EngineModule from "@renovate-config-visualizer/engine";
+} from "@renovate-config-debugger/engine";
+import type * as EngineModule from "@renovate-config-debugger/engine";
 import { HOST_TOKENS } from "@/data/host-tokens";
 import { isValidToken } from "@/lib/input-schemas";
 import { getValidToken } from "./oauth";
@@ -89,7 +89,7 @@ function applyAuth(engine: Engine, oauthToken: string | null, opts?: RunOptions)
  */
 async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
   const [engine, oauthToken] = await Promise.all([
-    import("@renovate-config-visualizer/engine"),
+    import("@renovate-config-debugger/engine"),
     opts?.suppressTokens ? null : getValidToken(),
   ]);
   applyAuth(engine, oauthToken, opts);
@@ -104,7 +104,7 @@ async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
  * failure here is swallowed, the real import on Run will surface it.
  */
 export function preloadEngine(): void {
-  void import("@renovate-config-visualizer/engine").catch(() => {});
+  void import("@renovate-config-debugger/engine").catch(() => {});
 }
 
 /**
@@ -118,13 +118,13 @@ export async function run(input: PipelineInput, opts?: RunOptions): Promise<Trac
 
 /** Option metadata for hover docs; cheap once the engine chunk is loaded. */
 export async function loadOptionIndex(): Promise<OptionIndex> {
-  const engine = await import("@renovate-config-visualizer/engine");
+  const engine = await import("@renovate-config-debugger/engine");
   return engine.getOptionIndex();
 }
 
 /** The bundled Renovate version — for the shareable-link version-drift check. */
 export async function getRenovateVersion(): Promise<string> {
-  const engine = await import("@renovate-config-visualizer/engine");
+  const engine = await import("@renovate-config-debugger/engine");
   return engine.renovateVersion;
 }
 
@@ -145,7 +145,7 @@ export interface ErrorTranslationLib {
 }
 
 export async function loadErrorTranslationLib(): Promise<ErrorTranslationLib> {
-  const engine = await import("@renovate-config-visualizer/engine");
+  const engine = await import("@renovate-config-debugger/engine");
   return {
     translateMessage: engine.translateMessage,
     findMentionedOption: engine.findMentionedOption,

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite";
-import { renovateShims } from "@renovate-config-visualizer/engine/vite-plugin";
+import { renovateShims } from "@renovate-config-debugger/engine/vite-plugin";
 
 /**
  * Bundle review finding — cuts two dependencies out of the lazy schema chunk

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from "node:url";
-import { renovateShims } from "@renovate-config-visualizer/engine/vite-plugin";
+import { renovateShims } from "@renovate-config-debugger/engine/vite-plugin";
 import { defineConfig } from "vitest/config";
 
 const srcAlias = { "@": fileURLToPath(new URL("./src", import.meta.url)) };

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovate-config-visualizer/engine",
+  "name": "@renovate-config-debugger/engine",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/packages/engine/scripts/generate-registry-names.mjs
+++ b/packages/engine/scripts/generate-registry-names.mjs
@@ -15,7 +15,7 @@
  * static generated module keeps that subtree out of the browser graph
  * entirely while still surfacing Renovate's real registry names.
  *
- * Run: `pnpm --filter @renovate-config-visualizer/engine generate:registries`
+ * Run: `pnpm --filter @renovate-config-debugger/engine generate:registries`
  * after every Renovate version bump. `test/registries.node.test.ts` guards
  * against forgetting — it re-imports the real api.js maps (itself running in
  * Node, so this is safe there) and fails if the generated lists have drifted.
@@ -45,7 +45,7 @@ const contents = `/**
  *
  * Produced by \`scripts/generate-registry-names.mjs\` from renovate@${pkg.version}'s
  * own datasource/manager registries (\`renovate/dist/modules/{datasource,manager}/api.js\`).
- * Regenerate with \`pnpm --filter @renovate-config-visualizer/engine generate:registries\`
+ * Regenerate with \`pnpm --filter @renovate-config-debugger/engine generate:registries\`
  * after bumping the \`renovate\` dependency — see that script's header for why
  * this is a build-time snapshot rather than a runtime import.
  */

--- a/packages/engine/src/registry-names.generated.ts
+++ b/packages/engine/src/registry-names.generated.ts
@@ -3,7 +3,7 @@
  *
  * Produced by `scripts/generate-registry-names.mjs` from renovate@44.4.6's
  * own datasource/manager registries (`renovate/dist/modules/{datasource,manager}/api.js`).
- * Regenerate with `pnpm --filter @renovate-config-visualizer/engine generate:registries`
+ * Regenerate with `pnpm --filter @renovate-config-debugger/engine generate:registries`
  * after bumping the `renovate` dependency — see that script's header for why
  * this is a build-time snapshot rather than a runtime import.
  */

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -86,7 +86,7 @@ export function renovateShims(): Plugin {
             "semver-stable",
             "semver-utils",
             "yaml",
-          ].map((dep) => `@renovate-config-visualizer/engine > renovate > ${dep}`),
+          ].map((dep) => `@renovate-config-debugger/engine > renovate > ${dep}`),
         },
         resolve: {
           alias: [

--- a/packages/oauth-worker/README.md
+++ b/packages/oauth-worker/README.md
@@ -1,4 +1,4 @@
-# @renovate-config-visualizer/oauth-worker
+# @renovate-config-debugger/oauth-worker
 
 A static SPA cannot finish GitHub's OAuth flow on its own: GitHub requires the
 `client_secret` at the token exchange (even with PKCE) and serves no CORS on
@@ -122,8 +122,8 @@ before GitHub is contacted. Responses reflect the exact matched origin (never
 <summary>Development</summary>
 
 ```bash
-pnpm --filter @renovate-config-visualizer/oauth-worker test        # vitest, fetch stubbed
-pnpm --filter @renovate-config-visualizer/oauth-worker typecheck
+pnpm --filter @renovate-config-debugger/oauth-worker test        # vitest, fetch stubbed
+pnpm --filter @renovate-config-debugger/oauth-worker typecheck
 ```
 
 The request handler is the pure exported `handleRequest(req, env)` so the tests

--- a/packages/oauth-worker/README.md
+++ b/packages/oauth-worker/README.md
@@ -90,7 +90,7 @@ GITHUB_CLIENT_ID=... GITHUB_CLIENT_SECRET=... ALLOWED_ORIGINS=https://rcv.exampl
 `server.mjs` is a dependency-free `node:http` adapter around the same pure
 handler. It passes headers and body through verbatim, so the `Origin`
 allow-list stays the security boundary. It is what the
-`ghcr.io/secustor/renovate-config-visualizer-oauth-proxy` image runs (roadmap
+`ghcr.io/secustor/renovate-config-debugger-oauth-proxy` image runs (roadmap
 [043](../../roadmap/043-docker-self-host.md)); the provisioning above is
 identical either way.
 

--- a/packages/oauth-worker/package.json
+++ b/packages/oauth-worker/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@renovate-config-visualizer/oauth-worker",
+  "name": "@renovate-config-debugger/oauth-worker",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
       '@lezer/highlight':
         specifier: 1.2.3
         version: 1.2.3
-      '@renovate-config-visualizer/engine':
+      '@renovate-config-debugger/engine':
         specifier: workspace:*
         version: link:../engine
       '@uiw/react-codemirror':

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,8 @@
       "postUpgradeTasks": {
         "commands": [
           "pnpm install --frozen-lockfile",
-          "pnpm --filter @renovate-config-visualizer/engine generate:registries",
-          "pnpm --filter @renovate-config-visualizer/engine exec vitest run --project golden --update"
+          "pnpm --filter @renovate-config-debugger/engine generate:registries",
+          "pnpm --filter @renovate-config-debugger/engine exec vitest run --project golden --update"
         ],
         "executionMode": "update",
         "fileFilters": [

--- a/tools/agents/hooks/readme.md
+++ b/tools/agents/hooks/readme.md
@@ -41,7 +41,7 @@ blocks the stop if any fail, handing back the tail of the failing output.
   them.
 - **Never**: the Playwright e2e suite. It needs a production build first and
   takes minutes — running it stays a deliberate step
-  (`pnpm --filter @renovate-config-visualizer/app build` then `… test:e2e`).
+  (`pnpm --filter @renovate-config-debugger/app build` then `… test:e2e`).
 
 Markdown-only changes skip everything, since none of the checks read prose.
 

--- a/tools/agents/hooks/stop-check.ts
+++ b/tools/agents/hooks/stop-check.ts
@@ -25,7 +25,7 @@ const PACKAGES = ["engine", "app", "oauth-worker"] as const;
 type PackageName = (typeof PACKAGES)[number];
 
 function filter(pkg: PackageName, script: string): string[] {
-  return ["--filter", `@renovate-config-visualizer/${pkg}`, script];
+  return ["--filter", `@renovate-config-debugger/${pkg}`, script];
 }
 
 /** Repo-wide and cheap (~7s together) — run whenever anything at all changed. */


### PR DESCRIPTION
The repository was renamed to `secustor/renovate-config-debugger`; the images and the package scope still carried the old name.

**Docker images**
- `ghcr.io/secustor/renovate-config-visualizer` → `…/renovate-config-debugger`
- `…-visualizer-oauth-proxy` → `…-debugger-oauth-proxy`

**Workspace packages**
- `@renovate-config-visualizer/{app,engine,oauth-worker}` → `@renovate-config-debugger/*`
- root package `renovate-config-visualizer` → `renovate-config-debugger`

86 files, all mechanical. `pnpm-lock.yaml` moves by one line (the workspace importer key). The only non-mechanical bits: two import lists in `packages/app/src/features/simulator/` collapse to one line now that the specifier is shorter (oxfmt), and the `ProjectLinks.tsx` comment that noted the images/packages disagreed with the repo name is no longer true, so that clause is gone.

**Verified locally:** typecheck, lint, format:check, full test suite (engine golden 66 + shimmed 114, oauth-worker 11, app unit 297), `pnpm build`, all 67 Playwright e2e against the production build, and both Docker targets (`app`, `oauth-proxy`) building end-to-end.

**Deliberately untouched:** `patches/*.patch` ("PATCHED (renovate-config-visualizer)" is a project label, and editing it rewrites the patch hash), `roadmap/020` (historical doc quoting a base path that no longer exists), the `my-renovate-config-visualizer` sample GitHub App slug in `docker-compose.yml`, and a fixture URL in `handler.test.ts`. Say the word if you want any of those swept too.

Note: the first main build after merge misses the registry buildcache, since those tags move with the image name.