### PR TITLE
docs(roadmap): 056/057 — publish the engine, fork codemirror-json-schema

### DIFF
--- a/roadmap/056-publish-engine-package.md
+++ b/roadmap/056-publish-engine-package.md
@@ -70,7 +70,11 @@ rediscover which of Renovate's internals refuse to load off a server.
 
 - **Version scheme: `0.x`, minor = breaking, plus a compat table.** Until the
   export surface settles, `0.x` with breaking changes in the minor is the
-  honest signal. Every release row records `engine` → `renovate` →
+  honest signal — and with a Renovate bump able to force a release at any
+  time, iteration here is expected to be fast for the foreseeable future.
+  No `1.0.0` is scheduled; it is a decision to make once the exports have
+  stopped moving, not a milestone to aim at. `^0.x` ranges not crossing the
+  minor is the mechanism that keeps that safe for consumers. Every release row records `engine` → `renovate` →
   `renovate-schema` so a consumer can answer "which Renovate does this
   reproduce?" without unpacking the tarball. `renovateVersion` is already
   exported from `src/version.ts` and stays the runtime answer to the same

--- a/roadmap/056-publish-engine-package.md
+++ b/roadmap/056-publish-engine-package.md
@@ -1,0 +1,164 @@
+# 056 — Publish the engine as `@renovate-config-debugger/engine`
+
+Milestone: M15 · Status: proposed
+
+## Summary
+
+`packages/engine` is the only part of this repository that is not
+app-specific. It is the thing nobody else has: Renovate's own config
+pipeline — parse, migrate, massage, validate, resolve presets, merge,
+re-migrate (052), simulate `packageRules` — running **in a browser**, with a
+trace of every stage, because a Vite plugin swaps Renovate's Node-only choke
+points for browser-safe shims. Today it is `private: true`, its `exports`
+point straight at `.ts` files in `src/`, and the only consumer that can use it
+is the app sitting next to it in the workspace.
+
+This item publishes it to npm as `@renovate-config-debugger/engine` so that
+anything else — a docs site, an IDE extension, a CI check that diffs a
+config's resolved output, a bot that explains its own decisions — can reuse
+the pipeline instead of re-deriving the shim trick.
+
+## User story
+
+As someone building a tool that needs to know what Renovate will do with a
+config, I want to `pnpm add @renovate-config-debugger/engine` and get the
+traced pipeline, so that I don't have to deep-import a non-public API and
+rediscover which of Renovate's internals refuse to load off a server.
+
+## Scope
+
+- The engine's three entry points become a published, versioned contract:
+  `.` (pipeline + trace + simulator), `./schema` (the stripped Renovate JSON
+  schema), `./vite-plugin` (`renovateShims()`).
+- A build step: compiled ESM + `.d.ts`, replacing `exports` that currently
+  resolve to TypeScript sources.
+- Package metadata, license statement, README, and a compatibility table
+  pinning each engine release to the Renovate version it was built against.
+- A publish workflow with npm provenance, and packaging tests that fail CI
+  when the published shape would be broken.
+- Renaming the workspace scope from `@renovate-config-visualizer/*` to
+  `@renovate-config-debugger/*` (see below).
+
+## Decisions
+
+- **Scope rename, all packages at once.** The project has been
+  "Renovate Config Debugger" since 016, and GitHub already renamed the
+  repository (`ProjectLinks.tsx` documents the redirect). Publishing the
+  engine under the new name while `app` and `oauth-worker` keep the old scope
+  would leave the workspace speaking two names for one project. All four
+  manifests move to `@renovate-config-debugger/*` in the same change; only the
+  engine gets `private: false`. The Docker images (`ghcr.io/…-visualizer`)
+  are a separate, user-visible rename and stay out of this item.
+
+- **AGPL-3.0-only, stated on the tin.** The engine links Renovate's own code
+  (`renovate` is `AGPL-3.0-only`), which is why this repository is AGPL too.
+  Publishing does not change that, but it changes who has to know: a
+  consumer who `pnpm add`s a copyleft library into a closed-source product has
+  a licensing problem, and npm's package page is where they will look for it.
+  The `license` field, the README's first section and the package description
+  all say it. This is a property of running Renovate's real code — the
+  alternative is reimplementing the pipeline, which is exactly the thing this
+  project refuses to do.
+
+- **`renovate` stays an exact `dependency`, not a peer.** The engine reaches
+  into `renovate/dist/**` through one adapter module, against internals that
+  are explicitly not a public API; a peer range would let a consumer install a
+  version whose internals moved and hand us a broken pipeline at runtime. The
+  exact pin is the contract. Two consequences, both stated in the README:
+  a consumer's install pulls the whole `renovate` package (it is large), and
+  **a Renovate bump is a release of this package**, not a floating detail.
+
+- **Version scheme: `0.x`, minor = breaking, plus a compat table.** Until the
+  export surface settles, `0.x` with breaking changes in the minor is the
+  honest signal. Every release row records `engine` → `renovate` →
+  `renovate-schema` so a consumer can answer "which Renovate does this
+  reproduce?" without unpacking the tarball. `renovateVersion` is already
+  exported from `src/version.ts` and stays the runtime answer to the same
+  question.
+
+- **Emit files, do not bundle.** `renovateShims()` builds its shim map from
+  `path.join(shimDir, …)` where `shimDir` is derived from `import.meta.url`,
+  and returns those paths from `resolveId` for the consumer's bundler to load.
+  A bundled single-file plugin would have nothing to point at. The build
+  therefore emits a mirrored file tree (`dist/shims/*.js` beside
+  `dist/shims/vite-plugin-renovate-shims.js`), and the shims ship as compiled
+  JS rather than `.ts`, so a consumer's bundler is not required to transform
+  TypeScript that lives inside `node_modules`.
+
+- **`vite` is a `peerDependency` of the package, needed only by
+  `./vite-plugin`.** That entry imports `node:module`/`node:path`/`node:url`
+  and a `Plugin` type; it is Node-only build-time code and must not be pulled
+  into a browser graph. Mark the peer optional so a consumer using another
+  bundler (who then owns the shim wiring themselves) does not get a warning.
+
+- **Audit the export surface before freezing it.** `src/index.ts` re-exports
+  roughly a dozen modules, some of which are app copy rather than engine
+  capability — `error-translations.ts` and `error-fix-text.ts` produce
+  human-facing English strings and quick-fix text, and `option-docs.ts` builds
+  an index for editor tooltips. Each one is a keep-or-drop decision made once,
+  in this item, because after publishing it is a breaking change either way.
+  Recommendation: keep them (they are derived from Renovate's own option
+  metadata and are the expensive part to rebuild), but move anything whose
+  shape is dictated by the app's components behind an explicitly
+  "unstable" subpath.
+
+## What it takes
+
+1. **Build.** `tsc` declaration + JS emit (the package is already
+   `"type": "module"`, ESM only — no dual CJS build; a CJS consumer of a
+   package that deep-imports `renovate/dist` ESM is not a case worth
+   carrying). Verify the emitted `.d.ts` does not leak `renovate/dist/**`
+   type paths into the public surface; where it does, re-declare the type in
+   `src/types/` rather than re-export it.
+2. **Manifest.** `files`, `repository`/`homepage`/`bugs`, `license`,
+   `sideEffects: false`, `publishConfig.access: public`, `engines`.
+   `exports` gains `types` conditions per entry.
+3. **Packaging tests, run in CI.** `publint` and
+   `@arethetypeswrong/cli` over `pnpm pack`'s tarball, plus a smoke consumer:
+   a scratch Vite project outside the workspace that installs the tarball,
+   imports all three entries, runs one pipeline and asserts the trace — the
+   packed-artifact equivalent of `check:dev-graph`, and the only way an
+   `exports` typo gets caught before a user finds it.
+4. **Publish workflow.** Tag-triggered (`engine-v*`), OIDC/trusted publishing
+   with npm provenance rather than a long-lived `NPM_TOKEN` — the repository
+   already reports an OpenSSF Scorecard, and provenance is the cheapest win
+   on it. The workflow re-runs `checks` before publishing; it never publishes
+   from a branch.
+5. **Package README.** What it does, the AGPL statement, the Renovate-pin
+   statement, a minimal Vite example (plugin + `runPipeline`), the "this
+   consumes a non-public API" caveat, and the compat table.
+
+## Out of scope
+
+- Publishing `app` or `oauth-worker`. The app is a deployable, already
+  distributed as an image (043); the worker is deployment glue.
+- A non-Vite build path (webpack/rspack/esbuild plugin equivalents). The shim
+  mechanism is documented well enough for someone to port it, and a second
+  official integration is a maintenance commitment to make only when asked.
+- Running the engine under plain Node without a bundler. The golden test
+  project proves untouched Renovate works there, but the shimmed graph is a
+  bundler-resolution feature; a Node entry point would need a loader hook and
+  is its own item.
+- Renaming the published container images.
+
+## Dependencies
+
+- The `@renovate-config-debugger` npm organization must exist and be owned by
+  the project before either this item or 057 can publish. Same prerequisite
+  for both; whichever lands first creates it.
+- 001 (the engine and its trace model), 052 (the pipeline's current fidelity —
+  publishing freezes whatever fidelity ships).
+
+## Verification
+
+- `pnpm -r typecheck`, `pnpm lint`, `pnpm test` unchanged and green after the
+  scope rename (every intra-workspace import and the four `.oxlintrc.json`
+  restricted-import rules name packages by specifier).
+- The engine's golden and shimmed projects must still produce byte-identical
+  results **through the built artifact**, not only through `src/` — the
+  shimmed project is what proves the shims don't alter behavior, and the
+  build must not alter it either.
+- `publint` and `attw` clean on the tarball; the scratch-consumer smoke test
+  green.
+- A dry-run publish (`npm publish --dry-run`) whose file list is reviewed by
+  hand once, so nothing from `test/` or `scripts/` ships.

--- a/roadmap/056-publish-engine-package.md
+++ b/roadmap/056-publish-engine-package.md
@@ -36,19 +36,19 @@ rediscover which of Renovate's internals refuse to load off a server.
   pinning each engine release to the Renovate version it was built against.
 - A publish workflow with npm provenance, and packaging tests that fail CI
   when the published shape would be broken.
-- Renaming the workspace scope from `@renovate-config-visualizer/*` to
-  `@renovate-config-debugger/*` (see below).
+- Flipping the engine to `private: false`. The **name is already correct**:
+  #120 renamed every workspace package to `@renovate-config-debugger/*` (and
+  the Docker images to match), so this item no longer has to move it.
 
 ## Decisions
 
-- **Scope rename, all packages at once.** The project has been
-  "Renovate Config Debugger" since 016, and GitHub already renamed the
-  repository (`ProjectLinks.tsx` documents the redirect). Publishing the
-  engine under the new name while `app` and `oauth-worker` keep the old scope
-  would leave the workspace speaking two names for one project. All four
-  manifests move to `@renovate-config-debugger/*` in the same change; only the
-  engine gets `private: false`. The Docker images (`ghcr.io/…-visualizer`)
-  are a separate, user-visible rename and stay out of this item.
+- **The name is settled; only publication is left.** This item was drafted
+  expecting to rename the workspace scope as part of publishing. #120
+  (2026-08-04) did it first, for its own reasons — the repository has been
+  `renovate-config-debugger` on GitHub for a while and the packages had
+  drifted from it. The remaining delta between the engine's manifest and a
+  publishable one is therefore small and mechanical: `private`, `files`,
+  `exports` pointing at built output, and the metadata below.
 
 - **AGPL-3.0-only, stated on the tin.** The engine links Renovate's own code
   (`renovate` is `AGPL-3.0-only`), which is why this repository is AGPL too.
@@ -155,14 +155,15 @@ rediscover which of Renovate's internals refuse to load off a server.
 
 ## Verification
 
-- `pnpm -r typecheck`, `pnpm lint`, `pnpm test` unchanged and green after the
-  scope rename (every intra-workspace import and the four `.oxlintrc.json`
-  restricted-import rules name packages by specifier).
+- `pnpm -r typecheck`, `pnpm lint`, `pnpm test` green against the built
+  artifact rather than `src/` — the app resolves the engine through
+  `workspace:*`, so pointing `exports` at `dist/` changes what every consumer
+  in the repo actually loads.
 - The engine's golden and shimmed projects must still produce byte-identical
   results **through the built artifact**, not only through `src/` — the
   shimmed project is what proves the shims don't alter behavior, and the
   build must not alter it either.
 - `publint` and `attw` clean on the tarball; the scratch-consumer smoke test
   green.
-- A dry-run publish (`npm publish --dry-run`) whose file list is reviewed by
+- A dry-run publish (`pnpm publish --dry-run`) whose file list is reviewed by
   hand once, so nothing from `test/` or `scripts/` ships.

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -42,8 +42,10 @@ patch-refresh and a re-measurement.
 
 Together: 242.3 ms → 1.9 ms per completion (measured on the `{ "ran| }`
 fixture against the Renovate schema; verified end-to-end in the app at
-1.95 ms), and the two bundle cuts that keep 031's lazy schema chunk at
-~160 kB gz.
+1.95 ms), and a schema payload at editor mount of 82 kB gz instead of 172 —
+total JS 3,294 → 2,955 kB, with every other engine chunk md5-identical
+(measured in `525a96f`, 2026-07-27; 031's "~160 kB gz schema layer" is the
+figure from *before* these cuts).
 
 ## Scope
 
@@ -173,9 +175,10 @@ they do.
 - `packages/app/src/platform/editor-schema.ts` — the static import and the
   lazy `import("…/json5")`.
 - `.oxlintrc.json` — four `no-restricted-imports` rules name the package by
-  specifier to keep the ~160 kB gz schema stack behind
-  `platform/editor-schema.ts` (031). All four must name the new package, or
-  the guard silently stops guarding.
+  specifier to keep the schema stack behind `platform/editor-schema.ts`
+  (031). All four must name the new package, or the guard silently stops
+  guarding. Their message still quotes 031's pre-shim "~160 kB gz"; worth
+  refreshing to the current 82 while touching all four anyway.
 - Prose references to the package name (`keystroke-render.test.tsx`'s comment
   on why no hover mock is needed, `patches/README.md`, `AGENTS.md`). No test
   or script matches on the specifier, so nothing here can fail silently.
@@ -253,9 +256,9 @@ prove, and the reason to move the fix into source. In this repository, 032's
 keystroke test must match the patched baseline (~1.9 ms per completion), not
 merely beat the unpatched one.
 
-**1.0.0 (bundle).** The schema chunk must not grow past its post-shim size
-(031's ~160 kB gz), measured after the shim plugin is deleted — the fork now
-has to be doing what the plugin did. The e2e suite is what actually exercises
+**1.0.0 (bundle).** The schema payload at editor mount must still be 82 kB gz,
+not 172, once the shim plugin is deleted — the fork now has to be doing what
+the plugin did, and `525a96f`'s measurement is the baseline to reproduce. The e2e suite is what actually exercises
 hover, completion and validation in a real browser, and is where an
 over-aggressive markdown or parser change would surface.
 

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -32,20 +32,20 @@ patch-refresh and a re-measurement.
 
 ## What is carried locally today
 
-| Fix | Where it lives now | Why |
-| --- | --- | --- |
-| `Draft07` memoized on schema identity (completion) | `patches/…@0.8.1.patch` | `new Draft07(schema)` pre-processes 258 kB of Renovate schema (~123 ms) and upstream builds a fresh one at every call site, up to 6× per keystroke |
-| `this.originalSchema = schemaFromState` assignment | same patch | upstream compares the field but never assigns it, so the whole change-detection block (including `makeSchemaLax` over the full schema) ran on every call |
-| `Draft04` memoized (hover, validation) | same patch | ~69 ms rebuilt on every hover and every `doValidation` |
-| `utils/markdown.js` → markdown-it only | `packages/app/vite.config.ts` shim | upstream's module runs a top-level async IIFE building a shiki highlighter (~330 kB raw) purely to colour code fences in tooltips, statically imported by three features |
-| `parsers/yaml-parser.js` → throw | same shim | the parsers barrel statically imports the YAML parser, dragging `yaml` into the schema chunk for an app that never uses YAML mode |
+| Fix                                                | Where it lives now                 | Why                                                                                                                                                                      |
+| -------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Draft07` memoized on schema identity (completion) | `patches/…@0.8.1.patch`            | `new Draft07(schema)` pre-processes 258 kB of Renovate schema (~123 ms) and upstream builds a fresh one at every call site, up to 6× per keystroke                       |
+| `this.originalSchema = schemaFromState` assignment | same patch                         | upstream compares the field but never assigns it, so the whole change-detection block (including `makeSchemaLax` over the full schema) ran on every call                 |
+| `Draft04` memoized (hover, validation)             | same patch                         | ~69 ms rebuilt on every hover and every `doValidation`                                                                                                                   |
+| `utils/markdown.js` → markdown-it only             | `packages/app/vite.config.ts` shim | upstream's module runs a top-level async IIFE building a shiki highlighter (~330 kB raw) purely to colour code fences in tooltips, statically imported by three features |
+| `parsers/yaml-parser.js` → throw                   | same shim                          | the parsers barrel statically imports the YAML parser, dragging `yaml` into the schema chunk for an app that never uses YAML mode                                        |
 
 Together: 242.3 ms → 1.9 ms per completion (measured on the `{ "ran| }`
 fixture against the Renovate schema; verified end-to-end in the app at
 1.95 ms), and a schema payload at editor mount of 82 kB gz instead of 172 —
 total JS 3,294 → 2,955 kB, with every other engine chunk md5-identical
 (measured in `525a96f`, 2026-07-27; 031's "~160 kB gz schema layer" is the
-figure from *before* these cuts).
+figure from _before_ these cuts).
 
 ## Scope
 
@@ -61,11 +61,11 @@ figure from *before* these cuts).
 
 ## Release sequence
 
-| Release | Contents | What a consumer sees |
-| --- | --- | --- |
-| **0.8.1** | upstream `v0.8.1` verbatim, renamed | nothing — a specifier rename |
-| **0.9.0** | + the three `Draft0x` memoizations | 242.3 ms → 1.9 ms per completion; no API change, no visible change |
-| **0.10.0** | + markdown-it rendering, YAML parser off the default path | no API change; tooltip code fences lose syntax colours |
+| Release    | Contents                                                  | What a consumer sees                                               |
+| ---------- | --------------------------------------------------------- | ------------------------------------------------------------------ |
+| **0.8.1**  | upstream `v0.8.1` verbatim, renamed                       | nothing — a specifier rename                                       |
+| **0.9.0**  | + the three `Draft0x` memoizations                        | 242.3 ms → 1.9 ms per completion; no API change, no visible change |
+| **0.10.0** | + markdown-it rendering, YAML parser off the default path | no API change; tooltip code fences lose syntax colours             |
 
 There is no `1.0.0` on this roadmap. The fork stays in `0.x` for as long as
 it exists — see the versioning decision below.
@@ -135,7 +135,7 @@ would make the "no-op" switch quietly not one.
   the one place where the fork must be more careful than the shim it
   replaces. `getDefaultParser` is a runtime `switch` over all three parsers,
   statically importing each — which is why importing the main entry drags
-  `yaml` in even though the mode is fixed by *which entry you imported*. The
+  `yaml` in even though the mode is fixed by _which entry you imported_. The
   app's shim can make `yaml-parser.js` throw because the app never uses YAML
   mode; a library cannot, because `codemirror-json-schema/yaml` must keep
   working. The fork's fix is for each entry to supply its own parser instead

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -1,0 +1,169 @@
+# 057 — Fork `codemirror-json-schema` as `@renovate-config-debugger/codemirror-json-schema`
+
+Milestone: M15 · Status: proposed
+
+## Summary
+
+The editor's schema intelligence — completion, hover docs (003), validation —
+comes from `codemirror-json-schema@0.8.1`. The app does not use it as shipped.
+It carries a **pnpm patch against the published `dist`/`cjs` output** for three
+performance defects, and a **Vite `resolveId` plugin** that swaps two of the
+library's modules out of the bundle. Both are local stand-ins for changes that
+belong upstream, and upstream (`acao/codemirror-json-schema`) has merged
+nothing since 2025-04-21 with several PRs open.
+
+That arrangement has a floor on how good it can get: a patch against build
+output re-breaks on every bump, is invisible to TypeScript, cannot be tested,
+and cannot be shared. This item forks the library, applies the same five
+changes **at the source**, and publishes the result as
+`@renovate-config-debugger/codemirror-json-schema` — deleting the patch, the
+shim plugin and the two shim modules from this repository.
+
+## User story
+
+As a maintainer, I want the library the editor depends on to already contain
+the fixes it needs, so that a version bump is a version bump instead of a
+patch-refresh and a re-measurement.
+
+## What is carried locally today
+
+| Fix | Where it lives now | Why |
+| --- | --- | --- |
+| `Draft07` memoized on schema identity (completion) | `patches/…@0.8.1.patch` | `new Draft07(schema)` pre-processes 258 kB of Renovate schema (~123 ms) and upstream builds a fresh one at every call site, up to 6× per keystroke |
+| `this.originalSchema = schemaFromState` assignment | same patch | upstream compares the field but never assigns it, so the whole change-detection block (including `makeSchemaLax` over the full schema) ran on every call |
+| `Draft04` memoized (hover, validation) | same patch | ~69 ms rebuilt on every hover and every `doValidation` |
+| `utils/markdown.js` → markdown-it only | `packages/app/vite.config.ts` shim | upstream's module runs a top-level async IIFE building a shiki highlighter (~330 kB raw) purely to colour code fences in tooltips, statically imported by three features |
+| `parsers/yaml-parser.js` → throw | same shim | the parsers barrel statically imports the YAML parser, dragging `yaml` into the schema chunk for an app that never uses YAML mode |
+
+Together: 242.3 ms → 1.9 ms per completion (measured on the `{ "ran| }`
+fixture against the Renovate schema; verified end-to-end in the app at
+1.95 ms), and the two bundle cuts that keep 031's lazy schema chunk at
+~160 kB gz.
+
+## Scope
+
+- A GitHub fork of `acao/codemirror-json-schema` at the 0.8.1 tag, with the
+  five changes applied to `src/features/*.ts` and `src/utils/`, upstream's
+  test suite kept green.
+- Published under the project's npm scope with provenance, same pipeline
+  shape as 056.
+- This repository migrates onto it: the patch, `patchedDependencies`,
+  `codemirrorJsonSchemaShims()` and `src/platform/shims/*` all disappear.
+- An upstream-tracking arrangement so the fork can die when upstream revives.
+
+## Decisions
+
+- **A real GitHub fork, not a vendored package in this workspace.** The point
+  of this fork is to be temporary: every change in it is meant to be filed
+  upstream, and `git diff upstream/main` is the artifact that says how far
+  we've drifted and what still needs filing. Copying the sources into
+  `packages/` throws that away and quietly converts a rebase into a rewrite.
+  It also keeps an MIT-licensed library out of an AGPL-3.0 repository, where
+  contributing changes back would raise a licensing question that does not
+  need to exist.
+
+- **Fix at source, publish source-built artifacts.** The current patch edits
+  four generated files (`dist/` and `cjs/` copies of the same three modules)
+  because that is all a published tarball exposes. In the fork the same fix is
+  three edits in TypeScript, type-checked, and covered by upstream's own
+  tests.
+
+- **The two bundle shims become library behavior, not consumer workarounds.**
+  Both are defects for every consumer, not just this app: no one wants an
+  unconditional shiki highlighter in a tooltip path, and a parsers barrel that
+  statically imports YAML defeats the library's own `/yaml` entry point. In
+  the fork, markdown rendering drops to `markdown-it` with syntax highlighting
+  made opt-in (a consumer that wants shiki passes it in), and the YAML parser
+  moves behind the `/yaml` entry so the barrel stops reaching it. That deletes
+  ~330 kB from every consumer's graph and removes the app's shim plugin
+  entirely.
+
+- **`filter: false` is still left alone.** Upstream re-invokes the completion
+  source on every keystroke instead of filtering a cached list. At ~2 ms per
+  query that is cheap, and `validFor` is incompatible with the library's own
+  manual filtering — the same call made in `patches/README.md`, carried
+  forward unchanged.
+
+- **Independent versioning from `1.0.0`, with a fork-point table.** Mirroring
+  upstream's version numbers invites a collision the first time upstream
+  releases `0.8.2`, and a `-rcd.N` prerelease suffix sorts *below* the version
+  it is built on. The package versions itself, and the README states the
+  upstream commit it was forked from and every upstream release merged since —
+  the same compat-table pattern as 056.
+
+- **Every change is filed upstream, and the fork's README says so.** If a PR
+  merges and a release ships, the exit is: drop the dependency, go back to
+  `codemirror-json-schema`, delete the fork. To notice that moment, the fork
+  keeps upstream pinned as a devDependency so this project's own Renovate bot
+  opens a PR on every upstream release — the rebase signal arrives by the same
+  mechanism as every other dependency here.
+
+- **MIT stays MIT.** Upstream's license, copyright and attribution are kept
+  verbatim; a NOTICE records what diverged. The published package is MIT even
+  though the app consuming it is AGPL.
+
+## Migration in this repository
+
+- `packages/app/package.json` — swap the dependency.
+- `pnpm-workspace.yaml` — drop the `patchedDependencies` entry;
+  `patches/codemirror-json-schema@0.8.1.patch` and its `patches/README.md`
+  section go with it.
+- `packages/app/vite.config.ts` — delete `codemirrorJsonSchemaShims()` and its
+  ~40 lines of rationale comment; `src/platform/shims/codemirror-json-schema-*.ts`
+  are deleted.
+- `packages/app/src/platform/editor-schema.ts` — update the import specifiers
+  (including the lazy `import("codemirror-json-schema/json5")`) and the
+  comments that reason about upstream's `bundled.js` layout, which the fork
+  now owns.
+- `.oxlintrc.json` — four `no-restricted-imports` rules name the package by
+  specifier to keep the ~160 kB gz schema stack behind
+  `platform/editor-schema.ts` (031). All four must name the new package, or
+  the guard silently stops guarding.
+- Root `README.md` / `docs/Architecture.md` — the shim-system section
+  currently cites the codemirror-json-schema plugin as the app's copy of the
+  engine's mechanism; that sentence loses its example.
+
+## Risks
+
+- **A fork is a maintenance commitment.** Security fixes and
+  `json-schema-library` drift become ours to track for as long as it lives.
+  Mitigated by keeping the diff small, upstream-shaped and filed — and by the
+  fork being the thing that lets us stop patching `dist` blind.
+- **The bundle changes alter behavior**, not just size: tooltip code fences
+  lose syntax colours (already the accepted delta today), and a consumer
+  importing the parsers barrel expecting YAML gets an error instead. Both are
+  breaking for hypothetical other consumers, which is why the fork starts at
+  its own `1.0.0` with the deltas listed at the top of its README.
+
+## Out of scope
+
+- Rewriting the library's completion architecture, or moving it off
+  `json-schema-library` v9.
+- Taking over maintenance of upstream (adopting the package, publishing under
+  its original name, or asking for commit rights). If that conversation
+  happens it replaces this item rather than extending it.
+- The `codemirror-json5` dependency, which is unpatched and unforked.
+
+## Dependencies
+
+- The `@renovate-config-debugger` npm organization (shared prerequisite with
+  056 — whichever lands first creates it) and the publish workflow shape
+  established there.
+- 031 (the chunk budget the bundle fixes exist to protect) and 032 (the
+  keystroke-render regression test that measured the patch in the first
+  place).
+
+## Verification
+
+- Upstream's own suite green on the fork (0.8.1's baseline is 50/50 completion
+  tests and a clean `tsc`; the 7 `lang-yaml` failures on that checkout are
+  pre-existing drift and stay documented as such), plus new tests for each of
+  the five changes — the memoization ones assert a single `Draft0x`
+  construction across repeated calls, which is what the patch has never been
+  able to prove.
+- In this repository, after migration: the `render` project's keystroke test
+  (032) must show no regression against the patched baseline, and the schema
+  chunk must not grow — the two numbers this whole arrangement exists to hold.
+- `pnpm lint` (the restricted-import rules resolve against the new
+  specifier), `pnpm typecheck`, `test:unit`, and the e2e suite, which is what
+  actually exercises hover, completion and validation in a real browser.

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -65,10 +65,20 @@ figure from *before* these cuts).
 | --- | --- | --- |
 | **0.8.1** | upstream `v0.8.1` verbatim, renamed | nothing — a specifier rename |
 | **0.9.0** | + the three `Draft0x` memoizations | 242.3 ms → 1.9 ms per completion; no API change, no visible change |
-| **0.10.0** | + markdown-it rendering, YAML behind `/yaml` | **breaking**: tooltip code fences lose syntax colours, the parsers barrel no longer pulls YAML |
+| **0.10.0** | + markdown-it rendering, YAML parser off the default path | no API change; tooltip code fences lose syntax colours |
 
 There is no `1.0.0` on this roadmap. The fork stays in `0.x` for as long as
 it exists — see the versioning decision below.
+
+**None of the three releases breaks the public API**, which is worth stating
+because the app's local versions of these changes would. The library's main
+entry exports the three extensions, `jsonSchema`, the JSON parser, the
+pointer utils and the state module — `getDefaultParser` is **not** among
+them (features import it internally from `../parsers`), and
+`parseYAMLDocumentState` is exported from the `/yaml` entry, not from `.`.
+`renderMarkdown` is likewise internal to `utils/`. So both bundle changes are
+internal rewiring plus one cosmetic delta; `0.10.0` gets its own minor
+because the tooltip change is visible, not because anything is removed.
 
 ### What "identical" means for 0.8.1, and how it's proven
 
@@ -121,6 +131,18 @@ would make the "no-op" switch quietly not one.
   ~330 kB from every consumer's graph and removes the app's shim plugin
   entirely.
 
+- **The YAML change routes around the parser; it does not stub it.** This is
+  the one place where the fork must be more careful than the shim it
+  replaces. `getDefaultParser` is a runtime `switch` over all three parsers,
+  statically importing each — which is why importing the main entry drags
+  `yaml` in even though the mode is fixed by *which entry you imported*. The
+  app's shim can make `yaml-parser.js` throw because the app never uses YAML
+  mode; a library cannot, because `codemirror-json-schema/yaml` must keep
+  working. The fork's fix is for each entry to supply its own parser instead
+  of asking a barrel to pick one — same exported symbols, same behavior per
+  entry, and the static edge from `.` to `yaml` simply doesn't exist. It is
+  also the version of the change that upstream could actually merge.
+
 - **`filter: false` is still left alone.** Upstream re-invokes the completion
   source on every keystroke instead of filtering a cached list. At ~2 ms per
   query that is cheap, and `validFor` is incompatible with the library's own
@@ -142,18 +164,19 @@ would make the "no-op" switch quietly not one.
 - **Stay in `0.x`; there is no `1.0.0`.** The fork is expected to iterate
   fast and to be short-lived — a `1.0.0` would promise a stability we have no
   intention of offering while upstream's own shape is still moving underneath
-  us, and it would make every subsequent breaking change a major bump we'd
-  have to justify. In `0.x` the minor is the breaking slot (the same scheme
-  056 uses for the engine), which also makes npm's own defaults do the right
-  thing: `^0.9.0` does **not** match `0.10.0`, so a consumer never picks up
-  the bundle changes without deciding to. If the fork ever outlives its
-  purpose enough to deserve a stable major, that is a decision made then, on
-  evidence, not scheduled here.
+  us, and it would make every later change of consequence a major bump we'd
+  have to justify. In `0.x` the minor carries anything notable, breaking or
+  not (the same scheme 056 uses for the engine), and npm's defaults back that
+  up: `^0.9.0` does not match `0.10.0`, so nothing arrives without a
+  deliberate bump — useful here not because `0.10.0` breaks anything, but
+  because it is the release with a visible change in it. If the fork ever
+  outlives its purpose enough to deserve a stable major, that is a decision
+  made then, on evidence, not scheduled here.
 
 - **One release per class of change.** The memoizations (`0.9.0`) are
-  behavior-preserving and measurable; the bundle changes (`0.10.0`) are
-  breaking and visible. Bundling them into one release would force a consumer
-  to accept unhighlighted tooltips in order to get the 240 ms back, and would
+  invisible and measurable; the bundle changes (`0.10.0`) are visible and
+  measurable in a different unit. Bundling them would force a consumer to
+  accept unhighlighted tooltips in order to get the 240 ms back, and would
   leave us unable to tell which change moved a number when one of them
   regresses.
 
@@ -221,13 +244,13 @@ size, which must not grow.
   `json-schema-library` drift become ours to track for as long as it lives.
   Mitigated by keeping the diff small, upstream-shaped and filed — and by the
   fork being the thing that lets us stop patching `dist` blind.
-- **The bundle changes alter behavior**, not just size: tooltip code fences
-  lose syntax colours (already the accepted delta today), and a consumer
-  importing the parsers barrel expecting YAML gets an error instead. Both are
-  breaking for hypothetical other consumers, which is why they land alone in
-  `0.10.0` with the deltas listed at the top of its README, rather than riding
-  along with the perf fixes. Under `0.x` a caret range does not cross the
-  minor, so nobody gets them by accident.
+- **One bundle change is visible.** Tooltip code fences lose syntax colours —
+  already the accepted delta in this app, but a change a different consumer
+  might care about, which is why it lands alone in `0.10.0` with the delta at
+  the top of the README rather than riding along with the perf fixes. The
+  YAML rerouting is invisible if done right; if it can't be done without
+  changing an exported symbol, that is the signal to stop and rethink the
+  approach, not to relabel the release.
 - **A mirror release can be misread as an endorsement to switch.** `0.8.1`
   under our name is upstream's code, published by us, and someone finding it
   may assume it's maintained beyond the five changes we care about. The

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -19,6 +19,11 @@ changes **at the source**, and publishes the result as
 `@renovate-config-debugger/codemirror-json-schema` — deleting the patch, the
 shim plugin and the two shim modules from this repository.
 
+It ships in three releases, and the **first one changes nothing**: upstream
+0.8.1 under a new name, so switching to the fork is a specifier rename with no
+behavior to evaluate and nothing to trust yet. The fixes arrive after that, one
+release per class of change, each independently adoptable and revertible.
+
 ## User story
 
 As a maintainer, I want the library the editor depends on to already contain
@@ -46,10 +51,43 @@ fixture against the Renovate schema; verified end-to-end in the app at
   five changes applied to `src/features/*.ts` and `src/utils/`, upstream's
   test suite kept green.
 - Published under the project's npm scope with provenance, same pipeline
-  shape as 056.
-- This repository migrates onto it: the patch, `patchedDependencies`,
-  `codemirrorJsonSchemaShims()` and `src/platform/shims/*` all disappear.
+  shape as 056 — in three releases (below), starting with a verbatim mirror.
+- This repository migrates onto it in three matching steps: the patch,
+  `patchedDependencies`, `codemirrorJsonSchemaShims()` and
+  `src/platform/shims/*` all disappear, but not all at once.
 - An upstream-tracking arrangement so the fork can die when upstream revives.
+
+## Release sequence
+
+| Release | Contents | What a consumer sees |
+| --- | --- | --- |
+| **0.8.1** | upstream `v0.8.1` verbatim, renamed | nothing — a specifier rename |
+| **0.9.0** | + the three `Draft0x` memoizations | 242.3 ms → 1.9 ms per completion; no API change, no visible change |
+| **1.0.0** | + markdown-it rendering, YAML behind `/yaml` | **breaking**: tooltip code fences lose syntax colours, the parsers barrel no longer pulls YAML |
+
+### What "identical" means for 0.8.1, and how it's proven
+
+The mirror is only worth publishing if the claim is checkable. The release job
+builds the fork at the upstream tag, then diffs its tarball against
+`codemirror-json-schema@0.8.1`'s published tarball file by file. The only
+permitted differences are the package's identity: `name`, `repository`,
+`homepage`, `bugs`, and the added `publishConfig`/provenance metadata.
+Everything else — `version`, `exports` and every subpath (`/json5`, `/yaml`,
+`…`), `peerDependencies` ranges, `dependencies`, and each emitted file under
+`dist/` and `cjs/` — must match byte for byte.
+
+If upstream's published artifact turns out not to be reproducible from its own
+tag (build-tool version drift, embedded paths), the honest options are to
+republish upstream's tarball contents with only the identity fields rewritten,
+or to build from source and record the exact diff in the release notes. What
+is not acceptable is shipping "basically the same" under a version number that
+promises otherwise. Establishing which case we're in is the first task of this
+item, because it decides how the mirror is built.
+
+Keeping the peer ranges identical also matters mechanically: the app already
+depends on `@codemirror/language`, `@codemirror/view` and friends directly, and
+a widened or narrowed peer range would change how pnpm dedupes them — which
+would make the "no-op" switch quietly not one.
 
 ## Decisions
 
@@ -84,12 +122,24 @@ fixture against the Renovate schema; verified end-to-end in the app at
   manual filtering — the same call made in `patches/README.md`, carried
   forward unchanged.
 
-- **Independent versioning from `1.0.0`, with a fork-point table.** Mirroring
-  upstream's version numbers invites a collision the first time upstream
-  releases `0.8.2`, and a `-rcd.N` prerelease suffix sorts *below* the version
-  it is built on. The package versions itself, and the README states the
-  upstream commit it was forked from and every upstream release merged since —
-  the same compat-table pattern as 056.
+- **Mirror first at upstream's own version number, then diverge.** The first
+  release is `0.8.1` — the same version string as the upstream release it
+  copies, because that is the one number that says exactly what it is. It buys
+  something a diverged first release cannot: adopting the fork and adopting
+  the changes become two separate decisions, for us and for anyone else. If
+  the editor misbehaves after the switch, the fork is not a suspect.
+  Divergence starts at `0.9.0`, which leaves upstream's `0.8.x` line free —
+  a future upstream `0.8.2` then can't be confused for one of ours. From
+  `0.9.0` on the package versions itself, and its README carries the
+  fork-point commit plus every upstream release merged since (the same
+  compat-table pattern as 056).
+
+- **One release per class of change.** The memoizations (`0.9.0`) are
+  behavior-preserving and measurable; the bundle changes (`1.0.0`) are
+  breaking and visible. Bundling them into one release would force a consumer
+  to accept unhighlighted tooltips in order to get the 240 ms back, and would
+  leave us unable to tell which change moved a number when one of them
+  regresses.
 
 - **Every change is filed upstream, and the fork's README says so.** If a PR
   merges and a release ships, the exit is: drop the dependency, go back to
@@ -104,24 +154,49 @@ fixture against the Renovate schema; verified end-to-end in the app at
 
 ## Migration in this repository
 
-- `packages/app/package.json` — swap the dependency.
-- `pnpm-workspace.yaml` — drop the `patchedDependencies` entry;
-  `patches/codemirror-json-schema@0.8.1.patch` and its `patches/README.md`
-  section go with it.
-- `packages/app/vite.config.ts` — delete `codemirrorJsonSchemaShims()` and its
-  ~40 lines of rationale comment; `src/platform/shims/codemirror-json-schema-*.ts`
-  are deleted.
-- `packages/app/src/platform/editor-schema.ts` — update the import specifiers
-  (including the lazy `import("codemirror-json-schema/json5")`) and the
-  comments that reason about upstream's `bundled.js` layout, which the fork
-  now owns.
+Three steps, one per release, each landing on its own and each revertible by
+reverting one commit.
+
+**Step 1 — the no-op switch (onto `0.8.1`).** Nothing but names change; the
+patch and both shims stay exactly where they are and keep doing exactly what
+they do.
+
+- `packages/app/package.json` — swap the specifier.
+- `pnpm-workspace.yaml` — the `patchedDependencies` key becomes
+  `@renovate-config-debugger/codemirror-json-schema@0.8.1`, and the patch file
+  is renamed to match pnpm's convention. Its **contents don't change** — it
+  patches the same `dist`/`cjs` bytes, which is a second, incidental proof
+  that the mirror is identical: a patch that no longer applies cleanly means
+  it isn't.
+- `packages/app/vite.config.ts` — the shim plugin's `require.resolve` and its
+  two path suffixes carry the package name; both must move.
+- `packages/app/src/platform/editor-schema.ts` — the static import and the
+  lazy `import("…/json5")`.
 - `.oxlintrc.json` — four `no-restricted-imports` rules name the package by
   specifier to keep the ~160 kB gz schema stack behind
   `platform/editor-schema.ts` (031). All four must name the new package, or
   the guard silently stops guarding.
-- Root `README.md` / `docs/Architecture.md` — the shim-system section
-  currently cites the codemirror-json-schema plugin as the app's copy of the
-  engine's mechanism; that sentence loses its example.
+- Prose references to the package name (`keystroke-render.test.tsx`'s comment
+  on why no hover mock is needed, `patches/README.md`, `AGENTS.md`). No test
+  or script matches on the specifier, so nothing here can fail silently.
+
+The step is correct exactly when the full suite — unit, render, e2e — passes
+with no other edits and no numbers moving. That is the whole point of it.
+
+**Step 2 — drop the patch (onto `0.9.0`).** Delete
+`patches/…codemirror-json-schema@0.8.1.patch`, its `patchedDependencies`
+entry and its `patches/README.md` section. Guarded by 032's keystroke-render
+test: the per-completion number must match the patched baseline, because the
+fix is the same fix.
+
+**Step 3 — drop the shims (onto `1.0.0`).** Delete
+`codemirrorJsonSchemaShims()` from `vite.config.ts` along with its ~40 lines
+of rationale comment, and `src/platform/shims/codemirror-json-schema-*.ts`.
+Update `editor-schema.ts`'s comments that reason about upstream's `bundled.js`
+layout, which the fork now owns, and the sentence in `AGENTS.md` /
+`docs/Architecture.md` that cites this plugin as the app's copy of the
+engine's shim mechanism — it loses its example. Guarded by the schema chunk's
+size, which must not grow.
 
 ## Risks
 
@@ -132,8 +207,14 @@ fixture against the Renovate schema; verified end-to-end in the app at
 - **The bundle changes alter behavior**, not just size: tooltip code fences
   lose syntax colours (already the accepted delta today), and a consumer
   importing the parsers barrel expecting YAML gets an error instead. Both are
-  breaking for hypothetical other consumers, which is why the fork starts at
-  its own `1.0.0` with the deltas listed at the top of its README.
+  breaking for hypothetical other consumers, which is why they land alone in
+  `1.0.0` with the deltas listed at the top of its README, rather than riding
+  along with the perf fixes.
+- **A mirror release can be misread as an endorsement to switch.** `0.8.1`
+  under our name is upstream's code, published by us, and someone finding it
+  may assume it's maintained beyond the five changes we care about. The
+  package README's first paragraph says what it is, what it will diverge into,
+  and that the intent is for it to become unnecessary.
 
 ## Out of scope
 
@@ -155,15 +236,29 @@ fixture against the Renovate schema; verified end-to-end in the app at
 
 ## Verification
 
-- Upstream's own suite green on the fork (0.8.1's baseline is 50/50 completion
-  tests and a clean `tsc`; the 7 `lang-yaml` failures on that checkout are
-  pre-existing drift and stay documented as such), plus new tests for each of
-  the five changes — the memoization ones assert a single `Draft0x`
-  construction across repeated calls, which is what the patch has never been
-  able to prove.
-- In this repository, after migration: the `render` project's keystroke test
-  (032) must show no regression against the patched baseline, and the schema
-  chunk must not grow — the two numbers this whole arrangement exists to hold.
-- `pnpm lint` (the restricted-import rules resolve against the new
-  specifier), `pnpm typecheck`, `test:unit`, and the e2e suite, which is what
-  actually exercises hover, completion and validation in a real browser.
+Per release, since each is adopted on its own:
+
+**0.8.1 (mirror).** The tarball diff against upstream's published artifact,
+described above — identity fields only. Upstream's own suite green on the
+fork as published (0.8.1's baseline is 50/50 completion tests and a clean
+`tsc`; the 7 `lang-yaml` failures on that checkout are pre-existing drift and
+stay documented as such). In this repository, step 1's rename must leave the
+existing patch applying cleanly and every suite — `test:unit`, the `render`
+project, e2e — passing with **no other change**; a number that moves here
+means the mirror isn't one.
+
+**0.9.0 (perf).** New tests in the fork asserting a single `Draft0x`
+construction across repeated calls — what the patch has never been able to
+prove, and the reason to move the fix into source. In this repository, 032's
+keystroke test must match the patched baseline (~1.9 ms per completion), not
+merely beat the unpatched one.
+
+**1.0.0 (bundle).** The schema chunk must not grow past its post-shim size
+(031's ~160 kB gz), measured after the shim plugin is deleted — the fork now
+has to be doing what the plugin did. The e2e suite is what actually exercises
+hover, completion and validation in a real browser, and is where an
+over-aggressive markdown or parser change would surface.
+
+Throughout: `pnpm lint` (the restricted-import rules must resolve against the
+new specifier — a rule naming a package that is no longer installed enforces
+nothing), `pnpm typecheck`, `pnpm format:check`.

--- a/roadmap/057-fork-codemirror-json-schema.md
+++ b/roadmap/057-fork-codemirror-json-schema.md
@@ -65,7 +65,10 @@ figure from *before* these cuts).
 | --- | --- | --- |
 | **0.8.1** | upstream `v0.8.1` verbatim, renamed | nothing — a specifier rename |
 | **0.9.0** | + the three `Draft0x` memoizations | 242.3 ms → 1.9 ms per completion; no API change, no visible change |
-| **1.0.0** | + markdown-it rendering, YAML behind `/yaml` | **breaking**: tooltip code fences lose syntax colours, the parsers barrel no longer pulls YAML |
+| **0.10.0** | + markdown-it rendering, YAML behind `/yaml` | **breaking**: tooltip code fences lose syntax colours, the parsers barrel no longer pulls YAML |
+
+There is no `1.0.0` on this roadmap. The fork stays in `0.x` for as long as
+it exists — see the versioning decision below.
 
 ### What "identical" means for 0.8.1, and how it's proven
 
@@ -136,8 +139,19 @@ would make the "no-op" switch quietly not one.
   fork-point commit plus every upstream release merged since (the same
   compat-table pattern as 056).
 
+- **Stay in `0.x`; there is no `1.0.0`.** The fork is expected to iterate
+  fast and to be short-lived — a `1.0.0` would promise a stability we have no
+  intention of offering while upstream's own shape is still moving underneath
+  us, and it would make every subsequent breaking change a major bump we'd
+  have to justify. In `0.x` the minor is the breaking slot (the same scheme
+  056 uses for the engine), which also makes npm's own defaults do the right
+  thing: `^0.9.0` does **not** match `0.10.0`, so a consumer never picks up
+  the bundle changes without deciding to. If the fork ever outlives its
+  purpose enough to deserve a stable major, that is a decision made then, on
+  evidence, not scheduled here.
+
 - **One release per class of change.** The memoizations (`0.9.0`) are
-  behavior-preserving and measurable; the bundle changes (`1.0.0`) are
+  behavior-preserving and measurable; the bundle changes (`0.10.0`) are
   breaking and visible. Bundling them into one release would force a consumer
   to accept unhighlighted tooltips in order to get the 240 ms back, and would
   leave us unable to tell which change moved a number when one of them
@@ -192,7 +206,7 @@ entry and its `patches/README.md` section. Guarded by 032's keystroke-render
 test: the per-completion number must match the patched baseline, because the
 fix is the same fix.
 
-**Step 3 — drop the shims (onto `1.0.0`).** Delete
+**Step 3 — drop the shims (onto `0.10.0`).** Delete
 `codemirrorJsonSchemaShims()` from `vite.config.ts` along with its ~40 lines
 of rationale comment, and `src/platform/shims/codemirror-json-schema-*.ts`.
 Update `editor-schema.ts`'s comments that reason about upstream's `bundled.js`
@@ -211,8 +225,9 @@ size, which must not grow.
   lose syntax colours (already the accepted delta today), and a consumer
   importing the parsers barrel expecting YAML gets an error instead. Both are
   breaking for hypothetical other consumers, which is why they land alone in
-  `1.0.0` with the deltas listed at the top of its README, rather than riding
-  along with the perf fixes.
+  `0.10.0` with the deltas listed at the top of its README, rather than riding
+  along with the perf fixes. Under `0.x` a caret range does not cross the
+  minor, so nobody gets them by accident.
 - **A mirror release can be misread as an endorsement to switch.** `0.8.1`
   under our name is upstream's code, published by us, and someone finding it
   may assume it's maintained beyond the five changes we care about. The
@@ -256,7 +271,7 @@ prove, and the reason to move the fix into source. In this repository, 032's
 keystroke test must match the patched baseline (~1.9 ms per completion), not
 merely beat the unpatched one.
 
-**1.0.0 (bundle).** The schema payload at editor mount must still be 82 kB gz,
+**0.10.0 (bundle).** The schema payload at editor mount must still be 82 kB gz,
 not 172, once the shim plugin is deleted — the fork now has to be doing what
 the plugin did, and `525a96f`'s measurement is the baseline to reproduce. The e2e suite is what actually exercises
 hover, completion and validation in a real browser, and is where an

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -162,5 +162,8 @@ workspace can use it — its `exports` point at `.ts` sources and it is
 pnpm patch against `codemirror-json-schema`'s build output and a Vite
 shim plugin that cuts two of its modules — with a source-level fork
 published under the same scope, upstream having merged nothing since
-2025-04-21. Both need the npm organization to exist first; whichever
-lands first creates it.
+2025-04-21. It ships in three releases, the first of which is upstream
+0.8.1 verbatim under the new name: adopting the fork and adopting its
+changes are separate decisions, and the no-op switch is what proves the
+mirror honest. Both items need the package registry organization to
+exist first; whichever lands first creates it.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -59,6 +59,8 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity) | M14                  | done   |
 | [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost | M14                  | done   |
 | [055](055-header-project-links.md)                      | Header links to the source and the issue tracker           | M14                  | done   |
+| [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`   | M15                  | proposed |
+| [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                    | M15                  | proposed |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -150,3 +152,15 @@ approved
 [mockups/051/effective-config-output.html](mockups/051/effective-config-output.html)
 (variant B; the originally proposed filter-bar checkbox was rejected as
 a mode masquerading as a filter).
+
+M15 — **Packages** — is the second distribution milestone (after M11's
+images), aimed at npm rather than at self-hosters. 056 publishes the
+engine as `@renovate-config-debugger/engine`: it is the only part of the
+repository that isn't app-specific, and today nothing outside the
+workspace can use it — its `exports` point at `.ts` sources and it is
+`private`. 057 replaces the two local workarounds under the editor — a
+pnpm patch against `codemirror-json-schema`'s build output and a Vite
+shim plugin that cuts two of its modules — with a source-level fork
+published under the same scope, upstream having merged nothing since
+2025-04-21. Both need the npm organization to exist first; whichever
+lands first creates it.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,62 +3,62 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 
-| #                                                       | Feature                                                    | Milestone            | Status |
-| ------------------------------------------------------- | ---------------------------------------------------------- | -------------------- | ------ |
-| [001](001-engine-and-config-input.md)                   | Trace engine + config input                                | M0/M1                | done   |
-| [002](002-preset-resolution-tree.md)                    | Preset resolution tree                                     | M1 (MVP centerpiece) | done   |
-| [003](003-inline-option-docs.md)                        | Inline option documentation                                | M1                   | done   |
-| [004](004-migration-step-through.md)                    | Migration step-through                                     | M2                   | done   |
-| [005](005-merge-provenance-view.md)                     | Merge provenance view                                      | M2                   | done   |
-| [006](006-package-rules-simulator.md)                   | packageRules simulator                                     | M3                   | done   |
-| [007](007-shareable-links-and-repo-fetch.md)            | Shareable links + fetch config from repo                   | M4                   | done   |
-| [008](008-global-and-inherited-config.md)               | Global + inherited config layers                           | M3                   | done   |
-| [009](009-github-oauth-sign-in.md)                      | "Sign in with GitHub" (replace PAT field)                  | M4                   | done   |
-| [010](010-preset-hosting-coverage.md)                   | Preset hosting coverage + `local>`                         | M2                   | done   |
-| [011](011-preset-tree-legibility-at-scale.md)           | Preset tree legibility at scale                            | M2                   | done   |
-| [012](012-simulator-verdict-first-results.md)           | Simulator: verdict-first results + update-type flattening  | M5                   | done   |
-| [013](013-rule-identity-and-provenance.md)              | Rule identity: numbering, provenance, cross-links          | M5                   | done   |
-| [014](014-validation-translations-and-quick-fixes.md)   | Validation error translations + suggested fixes            | M5                   | done   |
-| [015](015-simulator-input-ergonomics.md)                | Simulator input ergonomics                                 | M5                   | done   |
-| [016](016-scale-framing-and-page-ergonomics.md)         | Scale framing, badge glossary, page & editor ergonomics    | M5                   | done   |
-| [017](017-share-links-in-a-running-app.md)              | Share links opened in a running app (hashchange)           | M5                   | done   |
-| [018](018-evidence-export-and-expert-precision.md)      | Evidence export + expert-grade precision                   | M6                   | done   |
-| [019](019-persona-replay-skill.md)                      | Persona usability-test replay skill                        | M6                   | done   |
-| [020](020-browser-e2e-tests.md)                         | Browser end-to-end test suite                              | M6                   | done   |
-| [021](021-simulator-input-hardening.md)                 | Simulator input hardening + A/B comparison integrity       | M7                   | done   |
-| [022](022-verdict-copy-precision.md)                    | Verdict & translation copy precision                       | M7                   | done   |
-| [023](023-post-action-focus-and-guidance.md)            | Post-action focus, honest error states, rule filters       | M7                   | done   |
-| [024](024-stage-chips-signal-outcomes.md)               | Stage chips signal what each stage did                     | M7                   | done   |
-| [025](025-hover-card-overflow.md)                       | Hover card text overflows its box                          | M7                   | done   |
-| [026](026-schema-first-class-option.md)                 | Treat `$schema` as a first-class option                    | M7                   | done   |
-| [027](027-share-link-failure-diagnostics.md)            | Share-link failure diagnostics                             | M7                   | done   |
-| [028](028-tabbed-results-shell.md)                      | Tabbed results shell (post-run progressive disclosure)     | M8                   | done   |
-| [029](029-run-digest.md)                                | Run digest (plain-English overview)                        | M8                   | done   |
-| [030](030-input-validation-zod.md)                      | Input validation at every boundary (zod/mini)              | M8                   | done   |
-| [031](031-critical-path-loading.md)                     | Critical-path loading performance                          | M9                   | done   |
-| [032](032-keystroke-render-performance.md)              | Keystroke render performance                               | M9                   | done   |
-| [033](033-app-decomposition-and-boundaries.md)          | App decomposition + single-source boundaries               | M9                   | done   |
-| [034](034-lint-hardening.md)                            | Lint hardening (oxlint)                                    | M9                   | done   |
-| [035](035-layout-polish.md)                             | Layout polish + regression tests                           | M10                  | done   |
-| [036](036-unified-chrome.md)                            | Unified chrome: filled badges, copy button, diff toolbar   | M10                  | done   |
-| [037](037-theme-switcher.md)                            | Light / dark theme switcher                                | M10                  | done   |
-| [038](038-lint-audit-follow-up.md)                      | Lint audit follow-up: quick wins + 034 corrections         | M10                  | done   |
-| [039](039-editor-column-polish.md)                      | Editor column polish: theme, one Button, repo-load         | M10                  | done   |
-| [040](040-jsx-depth-decomposition.md)                   | JSX-depth ratchet: decompose the monoliths to depth 4      | M10                  | done   |
-| [041](041-warn-tier-to-error.md)                        | Promote the warn tier to error                             | M10                  | done   |
-| [042](042-rewrites-inset-and-pipeline-arrows.md)        | Rewrites inset + Pipeline order arrows                     | M10                  | done   |
-| [043](043-docker-self-host.md)                          | Docker self-host distribution                              | M11                  | done   |
-| [044](044-simulator-merge-step-through.md)              | Simulator: step through rule merges one at a time          | M12                  | done   |
-| [045](045-auto-load-inherited-config.md)                | Auto-load the inherited config for a loaded repository     | M12                  | done   |
-| [046](046-simulator-verdict-card-and-merge-timeline.md) | Simulator: verdict card + merge timeline                   | M12                  | done   |
-| [047](047-simulator-progressive-disclosure.md)          | Simulator: progressive disclosure                          | M12                  | done   |
-| [048](048-app-decomposition-and-depth-ratchet.md)       | App decomposition + depth ratchet to 3                     | M13                  | done   |
-| [049](049-feature-layer-expansion.md)                   | Feature-layer expansion: editor, presets                   | M13                  | done   |
-| [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement       | M13                  | done   |
-| [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document   | M14                  | done   |
-| [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity) | M14                  | done   |
-| [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost | M14                  | done   |
-| [055](055-header-project-links.md)                      | Header links to the source and the issue tracker           | M14                  | done   |
+| #                                                       | Feature                                                    | Milestone            | Status   |
+| ------------------------------------------------------- | ---------------------------------------------------------- | -------------------- | -------- |
+| [001](001-engine-and-config-input.md)                   | Trace engine + config input                                | M0/M1                | done     |
+| [002](002-preset-resolution-tree.md)                    | Preset resolution tree                                     | M1 (MVP centerpiece) | done     |
+| [003](003-inline-option-docs.md)                        | Inline option documentation                                | M1                   | done     |
+| [004](004-migration-step-through.md)                    | Migration step-through                                     | M2                   | done     |
+| [005](005-merge-provenance-view.md)                     | Merge provenance view                                      | M2                   | done     |
+| [006](006-package-rules-simulator.md)                   | packageRules simulator                                     | M3                   | done     |
+| [007](007-shareable-links-and-repo-fetch.md)            | Shareable links + fetch config from repo                   | M4                   | done     |
+| [008](008-global-and-inherited-config.md)               | Global + inherited config layers                           | M3                   | done     |
+| [009](009-github-oauth-sign-in.md)                      | "Sign in with GitHub" (replace PAT field)                  | M4                   | done     |
+| [010](010-preset-hosting-coverage.md)                   | Preset hosting coverage + `local>`                         | M2                   | done     |
+| [011](011-preset-tree-legibility-at-scale.md)           | Preset tree legibility at scale                            | M2                   | done     |
+| [012](012-simulator-verdict-first-results.md)           | Simulator: verdict-first results + update-type flattening  | M5                   | done     |
+| [013](013-rule-identity-and-provenance.md)              | Rule identity: numbering, provenance, cross-links          | M5                   | done     |
+| [014](014-validation-translations-and-quick-fixes.md)   | Validation error translations + suggested fixes            | M5                   | done     |
+| [015](015-simulator-input-ergonomics.md)                | Simulator input ergonomics                                 | M5                   | done     |
+| [016](016-scale-framing-and-page-ergonomics.md)         | Scale framing, badge glossary, page & editor ergonomics    | M5                   | done     |
+| [017](017-share-links-in-a-running-app.md)              | Share links opened in a running app (hashchange)           | M5                   | done     |
+| [018](018-evidence-export-and-expert-precision.md)      | Evidence export + expert-grade precision                   | M6                   | done     |
+| [019](019-persona-replay-skill.md)                      | Persona usability-test replay skill                        | M6                   | done     |
+| [020](020-browser-e2e-tests.md)                         | Browser end-to-end test suite                              | M6                   | done     |
+| [021](021-simulator-input-hardening.md)                 | Simulator input hardening + A/B comparison integrity       | M7                   | done     |
+| [022](022-verdict-copy-precision.md)                    | Verdict & translation copy precision                       | M7                   | done     |
+| [023](023-post-action-focus-and-guidance.md)            | Post-action focus, honest error states, rule filters       | M7                   | done     |
+| [024](024-stage-chips-signal-outcomes.md)               | Stage chips signal what each stage did                     | M7                   | done     |
+| [025](025-hover-card-overflow.md)                       | Hover card text overflows its box                          | M7                   | done     |
+| [026](026-schema-first-class-option.md)                 | Treat `$schema` as a first-class option                    | M7                   | done     |
+| [027](027-share-link-failure-diagnostics.md)            | Share-link failure diagnostics                             | M7                   | done     |
+| [028](028-tabbed-results-shell.md)                      | Tabbed results shell (post-run progressive disclosure)     | M8                   | done     |
+| [029](029-run-digest.md)                                | Run digest (plain-English overview)                        | M8                   | done     |
+| [030](030-input-validation-zod.md)                      | Input validation at every boundary (zod/mini)              | M8                   | done     |
+| [031](031-critical-path-loading.md)                     | Critical-path loading performance                          | M9                   | done     |
+| [032](032-keystroke-render-performance.md)              | Keystroke render performance                               | M9                   | done     |
+| [033](033-app-decomposition-and-boundaries.md)          | App decomposition + single-source boundaries               | M9                   | done     |
+| [034](034-lint-hardening.md)                            | Lint hardening (oxlint)                                    | M9                   | done     |
+| [035](035-layout-polish.md)                             | Layout polish + regression tests                           | M10                  | done     |
+| [036](036-unified-chrome.md)                            | Unified chrome: filled badges, copy button, diff toolbar   | M10                  | done     |
+| [037](037-theme-switcher.md)                            | Light / dark theme switcher                                | M10                  | done     |
+| [038](038-lint-audit-follow-up.md)                      | Lint audit follow-up: quick wins + 034 corrections         | M10                  | done     |
+| [039](039-editor-column-polish.md)                      | Editor column polish: theme, one Button, repo-load         | M10                  | done     |
+| [040](040-jsx-depth-decomposition.md)                   | JSX-depth ratchet: decompose the monoliths to depth 4      | M10                  | done     |
+| [041](041-warn-tier-to-error.md)                        | Promote the warn tier to error                             | M10                  | done     |
+| [042](042-rewrites-inset-and-pipeline-arrows.md)        | Rewrites inset + Pipeline order arrows                     | M10                  | done     |
+| [043](043-docker-self-host.md)                          | Docker self-host distribution                              | M11                  | done     |
+| [044](044-simulator-merge-step-through.md)              | Simulator: step through rule merges one at a time          | M12                  | done     |
+| [045](045-auto-load-inherited-config.md)                | Auto-load the inherited config for a loaded repository     | M12                  | done     |
+| [046](046-simulator-verdict-card-and-merge-timeline.md) | Simulator: verdict card + merge timeline                   | M12                  | done     |
+| [047](047-simulator-progressive-disclosure.md)          | Simulator: progressive disclosure                          | M12                  | done     |
+| [048](048-app-decomposition-and-depth-ratchet.md)       | App decomposition + depth ratchet to 3                     | M13                  | done     |
+| [049](049-feature-layer-expansion.md)                   | Feature-layer expansion: editor, presets                   | M13                  | done     |
+| [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement       | M13                  | done     |
+| [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document   | M14                  | done     |
+| [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity) | M14                  | done     |
+| [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost | M14                  | done     |
+| [055](055-header-project-links.md)                      | Header links to the source and the issue tracker           | M14                  | done     |
 | [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`   | M15                  | proposed |
 | [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                    | M15                  | proposed |
 


### PR DESCRIPTION
Two proposed roadmap items for a new **M15 — Packages** milestone, plus their index rows. Docs only; no code changes.

### 056 — Publish the engine as `@renovate-config-debugger/engine`

The engine is the only part of the repo that isn't app-specific, and nothing outside the workspace can use it today: its `exports` resolve to `.ts` sources and it is `private`.

Decisions worth reviewing before this is built:

- **AGPL-3.0-only, stated on the tin.** The engine links Renovate's own code, so the published package is copyleft. That belongs on the package page, not just in the repo.
- **`renovate` stays an exact `dependency`, not a peer** — the engine deep-imports non-public dist internals, so the pin is the contract. Consequence: a Renovate bump is a release, and consumers install the whole `renovate` package.
- **Emit files, don't bundle.** `renovateShims()` returns filesystem paths derived from `import.meta.url`, so the shim tree has to ship as real sibling files.
- **`0.x`, minor = breaking, no `1.0.0` scheduled.**
- The export surface needs an audit before it's frozen — `error-translations`, `error-fix-text` and `option-docs` are arguably app copy rather than engine capability.

### 057 — Fork `codemirror-json-schema`

Replaces the two local workarounds under the editor (a pnpm patch against the published `dist`, and the Vite shim plugin) with a source-level fork, upstream having merged nothing since 2025-04-21.

Three releases, and the first one changes nothing:

| Release | Contents | What a consumer sees |
| --- | --- | --- |
| `0.8.1` | upstream v0.8.1 verbatim, renamed | nothing — a specifier rename |
| `0.9.0` | the three `Draft0x` memoizations | 242.3 ms → 1.9 ms per completion |
| `0.10.0` | markdown-it rendering, YAML off the default path | no API change; tooltip code fences lose syntax colours |

- The mirror release makes "adopt the fork" and "adopt its changes" two separate decisions. The in-repo migration is three matching steps, each one revertible commit; step 1 keeps the pnpm patch in place with only its key renamed, which is itself corroboration that the mirror is identical.
- **Nothing here breaks the public API.** `getDefaultParser` and `renderMarkdown` are internal; `parseYAMLDocumentState` is exported only from the `/yaml` entry.
- The fork must **reroute** around the YAML parser rather than stub it — the app's shim can make `yaml-parser.js` throw because it never uses YAML mode, but `codemirror-json-schema/yaml` has to keep working. That's also the version upstream could merge.

### Notes

- Rebased onto #120, which already renamed the workspace packages — 056 was drafted expecting to do that itself, and no longer claims it.
- Both items need the registry organization to exist; whichever lands first creates it.
- One correction to existing docs is flagged inline, not made here: the four `.oxlintrc.json` restricted-import messages still quote 031's pre-shim "~160 kB gz" schema stack, which has been 82 kB gz since 525a96f.
