### PR TITLE
docs(roadmap): 058/059/060 — rcv CLI, published package, MCP + discovery

### DIFF
--- a/roadmap/058-rcv-debugger-cli.md
+++ b/roadmap/058-rcv-debugger-cli.md
@@ -1,0 +1,83 @@
+# 058 — `rcv`: the debugger CLI on the shimmed engine
+
+Milestone: M16 · Status: proposed
+
+Derived from the
+[2026-08 agent debug interface research](2026-08-agent-debug-interface-research.md),
+whose feasibility spike this item turns into a package.
+
+## Summary
+
+Agents (Claude Code sessions, CI bots, the 019 persona skill) that need to
+debug config resolution today either drive the web app in a browser — full
+information, read through pixels — or import the engine in plain Node, which
+is silently lossy: the preset tree and provenance are reconstructed from
+Renovate's log stream by the logger shim, so they only exist in the shimmed
+module graph. This item adds `packages/cli`: an `rcv` bin that hosts the
+**browser module graph under Node** via Vite's SSR module runner with the
+existing `renovateShims()` plugin, giving the terminal the same information
+the web app renders — preset tree with per-node bodies, per-key provenance,
+resolved-config document, simulator, A/B compare, translated validation
+errors — as structured data.
+
+## User story
+
+As an agent (or a human in a terminal) debugging a Renovate config, I want
+one command that resolves the config exactly as the visualizer does and
+answers "what did `extends` expand into", "who set this key", and "would
+this PR match", so that I don't have to drive a browser or trust a lossy
+plain-Node import.
+
+## Scope
+
+- `packages/cli` workspace package, bin `rcv`, built on the spike's runner
+  (Vite `createServer` + `ssrLoadModule`, `renovateShims()` active,
+  `ssr.noExternal: [/renovate/, /fast-json-patch/]`, HMR off).
+- Subcommands, one per question — `run`, `validate`, `digest`, `tree`,
+  `provenance`, `resolved`, `simulate`, `compare`, `docs` — mapping 1:1 onto
+  existing engine/app modules; no new resolution logic.
+- `--format <pretty|json>` on every subcommand, defaulting to `pretty`;
+  `--format json` emits the typed `TraceResult`/`SimulationResult` slices.
+- Inputs: file path, stdin, or `--repo owner/repo` (via `fetchRepoConfig`);
+  `--global-config`, `--inherited`, `--platform`/`--endpoint`/
+  `--platform-override`, `--inject` for unreachable presets.
+- Tokens from env only (`RCV_*_TOKEN`, falling back to `GITHUB_TOKEN`/
+  `GH_TOKEN`/`GITLAB_TOKEN`), mapped onto `setPresetAuth`; endpoint guard as
+  below.
+- Exit codes: `0` clean, `2` Renovate would refuse the config, `1`
+  infrastructure error.
+- CLAUDE.md wires `rcv` in as the sanctioned way to debug resolution;
+  hoist the effective-config tally derivation out of `EffectiveConfig.tsx`
+  into `lib/` so digest/tally parity is import-level, not re-implemented.
+- Tests: golden↔shimmed parity already proves the engine; the CLI adds
+  its own thin tests for arg parsing, output shapes, and exit codes.
+
+## Decisions
+
+- **The shimmed graph, not plain Node.** Parity is the entire point: the
+  preset tree and provenance only exist when the logger shim is the module
+  graph's logger. The spike measured ~0.7 s engine import + ~0.8 s
+  `runPipeline` for `config:recommended` (1,080 tree nodes) — acceptable for
+  a debugger.
+- **Subcommand per question, `--help` as the discovery surface.** Agents
+  discover CLIs by reading help text; separate verbs with distinct output
+  shapes beat one command with many flags.
+- **`pretty` is the default format.** A human at a terminal gets the digest
+  narrative; agents and pipelines opt into `--format json`.
+- **Exit `2` = config refused, deliberately.** Claude Code hooks treat exit
+  2 as the blocking "feed stderr back to the model and fix it" signal, so
+  `rcv validate` drops straight into a Stop/PreToolUse hook with no wrapper.
+  `1` stays infrastructure error.
+- **Read-only.** No `fix`/`migrate-file` verbs: agents edit configs with
+  their own tools and use `validate`/`compare` as the oracle; the engine's
+  `applyFixToText` stays available through `validate` output rather than as
+  a mutation command.
+- **Endpoint guard carried over from the app.** Fetchers send the host token
+  to whatever endpoint the platform context resolves to, so tokens are only
+  attached to endpoints from explicit flags/env — never from the config file
+  under inspection — unless `--trust-endpoints` is passed (the CLI's
+  `suppressTokens`).
+- **Relation to `renovate-config-validator`:** upstream is the linter —
+  pass/fail on the file as written, no preset resolution. `rcv` is the
+  debugger; both run the same pinned `renovate` code, so they cannot
+  disagree about semantics.

--- a/roadmap/059-publish-cli-package.md
+++ b/roadmap/059-publish-cli-package.md
@@ -1,0 +1,51 @@
+# 059 — Publish the CLI as `@renovate-config-debugger/cli`
+
+Milestone: M16 · Status: proposed
+
+## Summary
+
+058's `rcv` runs in-repo on Vite's dev-time SSR runner. That is the right
+core, but agents outside this repository can't use it, and every invocation
+pays the transform pipeline. This item packages the same module graph as a
+prebuilt SSR bundle (`vite build`, shim plugin active, Node target) and
+publishes it as `@renovate-config-debugger/cli`, so any agent anywhere can
+run `pnpm dlx @renovate-config-debugger/cli validate renovate.json` —
+sub-second startup, no checkout, no install step.
+
+## User story
+
+As an agent answering a Renovate config question in a repository that has
+nothing to do with this project, I want `pnpm dlx @renovate-config-debugger/cli`
+to resolve and explain the config, so that the debugger reaches the places
+where configs actually live.
+
+## Scope
+
+- A `vite build` SSR configuration in `packages/cli` producing a plain Node
+  ESM bundle with the engine (and its inlined `renovate` graph) baked in;
+  the published bin dispatches to it instead of the dev runner.
+- Package metadata mirroring 056: AGPL-3.0-only stated on the tin, exact
+  `renovate` pin surfaced, compat table row per release
+  (`cli` → `engine` → `renovate`).
+- Publish workflow with npm provenance, sharing 056's registry organization
+  (whichever lands first creates it).
+- CI proof: the engine's shimmed snapshot suite re-run **against the
+  bundle**, so "the bundle is the same graph" is tested, not assumed.
+- README with the agent-facing one-liners (`pnpm dlx …`, and 060's
+  `claude mcp add …` once it exists).
+
+## Decisions
+
+- **Bundle the engine; don't depend on the published engine package.** 056
+  publishes `@renovate-config-debugger/engine` for programmatic consumers,
+  but the CLI inlines its graph at build time instead of importing the
+  package: the parity proof (shimmed snapshots vs. the bundle) must pin one
+  exact artifact, and a resolvable dependency range would reintroduce the
+  drift the pin exists to prevent. The compat table states which engine
+  build each CLI release embeds.
+- **Version scheme follows 056**: `0.x`, breaking changes in the minor, and
+  a Renovate bump is a release — the CLI's answers change when Renovate's
+  code does, and the version must say so.
+- **The dev runner stays.** In-repo, `pnpm rcv …` keeps using the SSR
+  runner against `src/` — same code paths the app and tests use, no build
+  step during development; the bundle is a packaging concern only.

--- a/roadmap/060-mcp-server-and-agent-discovery.md
+++ b/roadmap/060-mcp-server-and-agent-discovery.md
@@ -1,0 +1,61 @@
+# 060 — `rcv mcp` + pointing agents at the headless interface
+
+Milestone: M16 · Status: proposed
+
+## Summary
+
+Two closing moves from the
+[2026-08 research](2026-08-agent-debug-interface-research.md): an MCP server
+so interactive agent sessions get a warm engine and typed tools, and the
+discovery surface that tells agents the headless interface exists at all.
+The MCP server is `rcv mcp` — one stdio subcommand over 058's core, no new
+functionality, purely better interaction economics. Discovery is
+deliberately boring: the mechanisms that were researched and rejected
+(hidden in-page hints, `.well-known` manifests, llms.txt-as-signal) are
+documented in the research doc; what ships is visible documentation plus the
+one shipped in-band protocol, Claude Code's plugin hint marker.
+
+## User story
+
+As an agent iterating on a config in an MCP-capable client, I want
+`run_config` once and cheap drill-down calls afterwards, so that an
+edit-run-compare loop doesn't pay a boot and a full round of preset fetches
+per question — and as an agent that only knows the web app, I want to find
+out that this exists.
+
+## Scope
+
+- `rcv mcp`: stdio MCP server registered via
+  `claude mcp add rcv -- pnpm dlx @renovate-config-debugger/cli mcp`.
+- Tool surface mirroring the subcommands: `run_config` returning
+  `{runId, digest, stageStatus, errors, warnings, treeSummary}`, then
+  `get_final_config` / `get_preset_tree` / `get_preset_node` /
+  `get_provenance` / `get_resolved_config` / `simulate` /
+  `compare_simulations` / `explain_message` / `get_option_docs` against a
+  small LRU of held runs.
+- Tool descriptions carry the domain hints agents otherwise learn the hard
+  way ("preset-node bodies are large — query one node at a time").
+- Discovery surface: a visible "for agents/scripts" note in the app
+  (semantic HTML, in-flow — never hidden text), a README/docs section with
+  the exact one-liners, the `claude-code-hint` stderr marker emitted by the
+  CLI when `CLAUDECODE=1` (from `--help`, unknown-subcommand errors, first
+  run), and an optional `public/llms.txt`.
+
+## Decisions
+
+- **Handles over payloads.** A full trace for `config:recommended` is 1,080
+  nodes × four bodies; `runId` + drill-down is the web app's progressive
+  disclosure as tool calls. It also buys run consistency: two CLI
+  invocations can describe different worlds if a remote preset changed
+  between them; two `{runId}` lookups cannot.
+- **A subcommand, not a second package.** The CLI stays the universal
+  least-common-denominator (shell, CI, `jq`); the server is strictly better
+  only for sessions, and one entry point is one thing to install, document
+  and hint at.
+- **No hidden agent messaging, ever.** Off-screen instructions to agents are
+  the canonical indirect-prompt-injection pattern; this project's discovery
+  is all visible text a human can read too.
+- **Plugin hint emitted from day one, expectations set accordingly.** Claude
+  Code only prompts for plugins in the official Anthropic marketplace; until
+  a listing exists the marker is inert but forward-compatible, and
+  README/AGENTS.md remain the working channel.

--- a/roadmap/061-claude-plugin-marketplace.md
+++ b/roadmap/061-claude-plugin-marketplace.md
@@ -8,12 +8,14 @@ Milestone: M16 · Status: proposed
 it": the `claude-code-hint` marker is inert until an official-marketplace
 listing exists, and a raw `claude mcp add` one-liner registers the server
 but carries none of the know-how. Claude Code's plugin system closes both —
-a **marketplace** is nothing more than a `.claude-plugin/marketplace.json`
-in a git repository, and a **plugin** bundles the MCP server registration
-together with a skill that teaches the debugging workflow. This item ships
-both from this repository: `/plugin marketplace add
-secustor/renovate-config-debugger`, then one install, and every later
-session has the tools _and_ knows how to use them.
+a **marketplace** is a `.claude-plugin/marketplace.json` in a git
+repository, and a **plugin** bundles the MCP server registration together
+with a skill that teaches the debugging workflow. This item splits the two
+across the right repos: a thin **`secustor/claude-plugins`** catalog
+repository holding only the marketplace manifest, whose entry points back
+at the plugin directory maintained _here_, next to the CLI it describes.
+`/plugin marketplace add secustor/claude-plugins`, one install, and every
+later session has the tools _and_ knows how to use them.
 
 ## User story
 
@@ -24,11 +26,14 @@ starts with the tools and the workflow already in place.
 
 ## Scope
 
-- `.claude-plugin/marketplace.json` at the repository root — marketplace
-  name `renovate-config-debugger`, plugin sources as relative paths, so the
-  catalog versions with the repo and an update is a push (users refresh via
-  `/plugin marketplace update`).
-- One plugin, `plugins/renovate-config-debugger/`:
+- New repository `secustor/claude-plugins` containing only
+  `.claude-plugin/marketplace.json` (marketplace name `claude-plugins`) and
+  a README — the plugin entry uses the `git-subdir` source type
+  (`{url, path, ref?}`, sparse clone, built for monorepos) pointing at
+  `plugins/renovate-config-debugger` in this repository, so consumers
+  fetch a kilobyte catalog, never this monorepo, and the catalog changes
+  only when a plugin is added or repointed.
+- One plugin, maintained here at `plugins/renovate-config-debugger/`:
   - `.claude-plugin/plugin.json` (name, description, version — the name
     matches 060's hint value, `renovate-config-debugger`).
   - MCP server config launching the published CLI:
@@ -48,12 +53,17 @@ starts with the tools and the workflow already in place.
 
 ## Decisions
 
-- **The marketplace lives in this repo, not a separate one.** A dedicated
-  marketplace repository is infrastructure with no second tenant in sight;
-  in-repo, the plugin and the CLI it launches are versioned and reviewed
-  together, and `/plugin marketplace add secustor/renovate-config-debugger`
-  is the whole hosting story. If more plugins ever accumulate, extraction
-  is mechanical (marketplace entries can point at other repos).
+- **Thin catalog repo, plugin content stays here.** `/plugin marketplace
+add` clones the marketplace repository and re-fetches it on update; an
+  in-repo marketplace would make every plugin consumer clone this entire
+  monorepo to read one JSON file. The split takes the best of both:
+  consumers get a kilobyte catalog that is one `marketplace add` for
+  _every_ future secustor plugin, while the plugin's skill and MCP config
+  stay versioned and reviewed in this repo, next to the CLI whose
+  interface they describe — so the drift risk that normally argues against
+  a second repo doesn't apply (the catalog names the plugin, it doesn't
+  restate its content). The `git-subdir` source's optional `ref` pin is
+  the escape hatch if a plugin release ever needs to lag the repo's HEAD.
 - **The plugin wraps the published CLI, never bundles it.** The plugin's
   MCP config shells out to `pnpm dlx @renovate-config-debugger/cli`; the
   plugin version can therefore lag the CLI's without breaking, and a

--- a/roadmap/061-claude-plugin-marketplace.md
+++ b/roadmap/061-claude-plugin-marketplace.md
@@ -1,0 +1,74 @@
+# 061 — Claude plugin marketplace for the debugger
+
+Milestone: M16 · Status: proposed
+
+## Summary
+
+060 leaves a gap between "the MCP server exists" and "an agent session has
+it": the `claude-code-hint` marker is inert until an official-marketplace
+listing exists, and a raw `claude mcp add` one-liner registers the server
+but carries none of the know-how. Claude Code's plugin system closes both —
+a **marketplace** is nothing more than a `.claude-plugin/marketplace.json`
+in a git repository, and a **plugin** bundles the MCP server registration
+together with a skill that teaches the debugging workflow. This item ships
+both from this repository: `/plugin marketplace add
+secustor/renovate-config-debugger`, then one install, and every later
+session has the tools _and_ knows how to use them.
+
+## User story
+
+As a Claude Code user who wants my agent to debug Renovate configs, I want
+to install one plugin instead of registering an MCP server by hand and
+hoping the agent discovers the right call sequence, so that the session
+starts with the tools and the workflow already in place.
+
+## Scope
+
+- `.claude-plugin/marketplace.json` at the repository root — marketplace
+  name `renovate-config-debugger`, plugin sources as relative paths, so the
+  catalog versions with the repo and an update is a push (users refresh via
+  `/plugin marketplace update`).
+- One plugin, `plugins/renovate-config-debugger/`:
+  - `.claude-plugin/plugin.json` (name, description, version — the name
+    matches 060's hint value, `renovate-config-debugger`).
+  - MCP server config launching the published CLI:
+    `pnpm dlx @renovate-config-debugger/cli mcp` (or `npx -y`), so the
+    plugin itself contains no engine code and updates ride 059's releases.
+  - A `skills/debug-renovate-config` skill encoding the workflow the
+    research settled: `validate` first (exit codes as signal), `digest` for
+    orientation, then drill down (`tree` / `provenance`), `simulate` +
+    `compare` as the edit oracle — including the "preset-node bodies are
+    large, query one node at a time" guidance, and falling back to the CLI
+    (`--format json`) when the MCP server isn't available.
+- README/docs: the marketplace add + install one-liners join the
+  agent-facing section defined in 060; AGENTS.md points repo-internal
+  agents at the same skill.
+- Docs for the install-scope nuance: plugins install per user/project
+  scope; the project-scope recommendation goes in the README.
+
+## Decisions
+
+- **The marketplace lives in this repo, not a separate one.** A dedicated
+  marketplace repository is infrastructure with no second tenant in sight;
+  in-repo, the plugin and the CLI it launches are versioned and reviewed
+  together, and `/plugin marketplace add secustor/renovate-config-debugger`
+  is the whole hosting story. If more plugins ever accumulate, extraction
+  is mechanical (marketplace entries can point at other repos).
+- **The plugin wraps the published CLI, never bundles it.** The plugin's
+  MCP config shells out to `pnpm dlx @renovate-config-debugger/cli`; the
+  plugin version can therefore lag the CLI's without breaking, and a
+  Renovate bump (= CLI release, per 059) needs no marketplace change.
+  Hard dependency: 059 must be published first.
+- **A skill ships alongside the server, deliberately.** Tool schemas say
+  what each tool takes, not when to call it; the skill carries the
+  sequencing knowledge (validate → digest → drill down → compare) that the
+  research doc otherwise leaves in prose no agent session reads. This is
+  the "skills and plugins" half of discovery that 060's visible-docs
+  surface can only link to, not inject.
+- **The hint protocol stays as 060 states it.** Self-hosted marketplaces
+  are invisible to `claude-code-hint` (official-marketplace-only), so the
+  marker keeps pointing at a future `claude-plugins-official` listing; this
+  marketplace is the working channel until then, and remains the channel
+  for users who prefer explicit installs. Internal dev skills (019's
+  persona replay) stay in-repo and out of the marketplace — they drive this
+  project's own dev loop, not a consumer's.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -61,6 +61,9 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [055](055-header-project-links.md)                      | Header links to the source and the issue tracker           | M14                  | done     |
 | [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`   | M15                  | proposed |
 | [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                    | M15                  | proposed |
+| [058](058-rcv-debugger-cli.md)                          | `rcv`: the debugger CLI on the shimmed engine              | M16                  | proposed |
+| [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli`         | M16                  | proposed |
+| [060](060-mcp-server-and-agent-discovery.md)            | `rcv mcp` + pointing agents at the headless interface      | M16                  | proposed |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -167,3 +170,17 @@ published under the same scope, upstream having merged nothing since
 changes are separate decisions, and the no-op switch is what proves the
 mirror honest. Both items need the package registry organization to
 exist first; whichever lands first creates it.
+
+M16 — **Agent debug interface** — grows out of the
+[2026-08 research](2026-08-agent-debug-interface-research.md): agents
+debugging config resolution either drive the web app in a browser or
+import the engine in plain Node, where the preset tree and provenance
+silently vanish (they only exist in the shimmed module graph). 058 ships
+`rcv`, a CLI hosting the browser module graph under Node via Vite's SSR
+runner — web-app parity by construction, one subcommand per question,
+hook-grade exit codes. 059 packages the same graph as a prebuilt bundle
+published as `@renovate-config-debugger/cli` (bundle proven identical by
+re-running the shimmed snapshots against it). 060 adds `rcv mcp` — warm
+engine, `runId` handles instead of firehose payloads — and the discovery
+surface: visible docs plus Claude Code's plugin-hint marker, with hidden
+agent messaging explicitly ruled out.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -185,7 +185,9 @@ re-running the shimmed snapshots against it). 060 adds `rcv mcp` — warm
 engine, `runId` handles instead of firehose payloads — and the discovery
 surface: visible docs plus Claude Code's plugin-hint marker, with hidden
 agent messaging explicitly ruled out. 061 closes the loop with a Claude
-plugin marketplace hosted in this repository: one plugin bundling the MCP
-server registration with a skill that carries the debugging workflow
-itself, so an installed session starts with the tools and the sequencing
-knowledge together.
+plugin marketplace: a thin `secustor/claude-plugins` catalog repo whose
+entry points back at a plugin maintained here (git-subdir source), the
+plugin bundling the MCP server registration with a skill that carries the
+debugging workflow itself — so an installed session starts with the tools
+and the sequencing knowledge together, and consumers never clone the
+monorepo for a kilobyte of catalog.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -64,6 +64,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [058](058-rcv-debugger-cli.md)                          | `rcv`: the debugger CLI on the shimmed engine              | M16                  | proposed |
 | [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli`         | M16                  | proposed |
 | [060](060-mcp-server-and-agent-discovery.md)            | `rcv mcp` + pointing agents at the headless interface      | M16                  | proposed |
+| [061](061-claude-plugin-marketplace.md)                 | Claude plugin marketplace for the debugger                 | M16                  | proposed |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -183,4 +184,8 @@ published as `@renovate-config-debugger/cli` (bundle proven identical by
 re-running the shimmed snapshots against it). 060 adds `rcv mcp` — warm
 engine, `runId` handles instead of firehose payloads — and the discovery
 surface: visible docs plus Claude Code's plugin-hint marker, with hidden
-agent messaging explicitly ruled out.
+agent messaging explicitly ruled out. 061 closes the loop with a Claude
+plugin marketplace hosted in this repository: one plugin bundling the MCP
+server registration with a skill that carries the debugging workflow
+itself, so an installed session starts with the tools and the sequencing
+knowledge together.


### PR DESCRIPTION
## Summary

Turns the [2026-08 agent debug interface research](../blob/docs/agent-debug-interface-research/roadmap/2026-08-agent-debug-interface-research.md) into four M16 roadmap items:

- **058** — `rcv`: the debugger CLI hosting the shimmed (browser) engine graph under Node via Vite's SSR runner. One subcommand per question (`run`/`validate`/`digest`/`tree`/`provenance`/`resolved`/`simulate`/`compare`/`docs`), `--format pretty|json`, exit `2` = config refused (Claude Code blocking-hook signal), env-only tokens with the app's endpoint guard, read-only by design.
- **059** — publish it as `@renovate-config-debugger/cli`: prebuilt SSR bundle for `pnpm dlx`, engine inlined (not depended on) so the shimmed-snapshot parity proof pins one artifact; versioning follows 056 (0.x, Renovate bump = release; shares the registry org).
- **060** — `rcv mcp` stdio server (warm engine, `runId` handles over firehose payloads) + the discovery surface: visible in-app note, README one-liners, `claude-code-hint` marker; hidden agent messaging explicitly ruled out.
- **061** — Claude plugin marketplace, split across the right repos: a thin `secustor/claude-plugins` catalog holding only `marketplace.json`, its entry pointing via `git-subdir` (sparse clone) at `plugins/renovate-config-debugger/` maintained in this repo — the plugin bundles the MCP server registration (wrapping the published CLI via `pnpm dlx`) with a `debug-renovate-config` skill carrying the workflow sequencing. Consumers fetch a kilobyte catalog, never the monorepo; skill stays reviewed next to the CLI it describes.

Also adds the index rows and the M16 narrative paragraph to `roadmap/README.md`.

**Stack:** #122 (056/057) ← #121 (research doc) ← this.