### PR TITLE
docs(roadmap): restore the missing 054 row in the index

### DIFF
--- a/roadmap/054-simulator-results-readability.md
+++ b/roadmap/054-simulator-results-readability.md
@@ -1,6 +1,6 @@
 # 054 — Simulator: results readability
 
-Milestone: — · Status: **variant A implemented** (2026-08-02), shipped as the
+Milestone: M14 · Status: **variant A implemented** (2026-08-02), shipped as the
 five-layer stack below; variants B and C remain proposed
 
 Renumbered from 053 (2026-08-03): main took that number for the analytics

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -58,6 +58,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document   | M14                  | done     |
 | [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity) | M14                  | done     |
 | [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost | M14                  | done     |
+| [054](054-simulator-results-readability.md)             | Simulator: results readability — the ledger is the trace   | M14                  | done     |
 | [055](055-header-project-links.md)                      | Header links to the source and the issue tracker           | M14                  | done     |
 | [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`   | M15                  | proposed |
 | [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                    | M15                  | proposed |


### PR DESCRIPTION
## What

`roadmap/README.md` has no row for [054](../blob/main/roadmap/054-simulator-results-readability.md) — the table jumps 053 → 055.

## Why

The 2026-08-03 renumber (`210f227`, simulator-results-readability 053 → 054) renamed the file but never re-added its table row. The hole reads as a free number: it is what prompted the mis-numbering of the persistent-sign-in work in #73 (now renumbered to 062).

## Also

The doc's header said `Milestone: —`; every other doc in the 045–061 range names one. Set to M14, matching its neighbours 051–055.