### PR TITLE
feat(engine): publish the engine as @renovate-config-debugger/engine (056)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
         run: pnpm --filter @renovate-config-debugger/engine test:golden
       - name: Shimmed tests (browser module graph)
         run: pnpm --filter @renovate-config-debugger/engine test:shimmed
+      # Roadmap 056: packs the engine, unpacks the tarball and type-checks a
+      # scratch consumer against it — a broken `exports`, a missing file or a
+      # renovate/dist type path leaking into the public surface fails here
+      # instead of on someone's `pnpm add`.
+      - name: Packaging tests (the engine's published shape)
+        run: pnpm --filter @renovate-config-debugger/engine test:packaging
       - name: OAuth worker tests
         run: pnpm --filter @renovate-config-debugger/oauth-worker test
       - name: App unit tests (pure modules — the run digest, …)

--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -1,0 +1,97 @@
+name: Publish engine
+
+# Roadmap 056 — publishes @renovate-config-debugger/engine to npm.
+#
+# Tag-triggered only (`engine-v0.1.0`), never from a branch: a publish is an
+# irreversible act tied to one commit, and the tag is what says which one. The
+# tag must match the version in packages/engine/package.json — the first job
+# refuses to go on otherwise, so a forgotten version bump fails before anything
+# is uploaded.
+#
+# The whole check suite re-runs here rather than trusting main's green run:
+# the engine deep-imports renovate/dist internals, so "the tests passed on the
+# commit this tag points at" is the only statement worth publishing on.
+on:
+  push:
+    tags: ["engine-v*"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: publish-engine-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+
+      - id: version
+        name: The tag and the manifest must agree
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          manifest="$(node -p "require('./packages/engine/package.json').version")"
+          tagged="${TAG#engine-v}"
+          if [ "$manifest" != "$tagged" ]; then
+            echo "::error::tag $TAG says $tagged, packages/engine/package.json says $manifest"
+            exit 1
+          fi
+          echo "version=$manifest" >> "$GITHUB_OUTPUT"
+
+      - run: pnpm lint
+      - run: pnpm format:check
+      - run: pnpm typecheck
+
+      - name: Golden tests (real renovate modules)
+        run: pnpm --filter @renovate-config-debugger/engine test:golden
+      - name: Shimmed tests (browser module graph)
+        run: pnpm --filter @renovate-config-debugger/engine test:shimmed
+      # Packs the tarball and type-checks a scratch consumer against it — the
+      # published shape, checked before it is published rather than after.
+      - name: Packaging tests (the published shape)
+        run: pnpm --filter @renovate-config-debugger/engine test:packaging
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      # npm provenance: the attestation is signed with a workflow-scoped OIDC
+      # token, which is what lets npm show "Built and signed on GitHub Actions"
+      # next to the package.
+      id-token: write
+    # An environment gate is where a human approval (or a scoped secret) hangs;
+    # create it in the repo settings before the first tag.
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/@renovate-config-debugger/engine
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ./.github/actions/setup
+
+      # `prepack` builds, `publishConfig` rewrites exports/main/types onto
+      # dist/, `files` decides what travels — all asserted by the packaging
+      # tests the verify job just ran.
+      #
+      # --no-git-checks: pnpm otherwise refuses to publish from a detached HEAD,
+      # which is exactly what a tag checkout is.
+      - name: Publish to npm with provenance
+        working-directory: packages/engine
+        env:
+          # Granular access token with publish rights on the
+          # @renovate-config-debugger scope. npm's trusted publishing (OIDC,
+          # no stored token) is the better answer as soon as pnpm supports the
+          # exchange — the id-token permission above is already in place for it.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+        run: |
+          echo "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" > ~/.npmrc
+          pnpm publish --access public --provenance --no-git-checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Targeted tests:
 ```bash
 pnpm --filter @renovate-config-debugger/engine test:golden    # real renovate modules, reference snapshots
 pnpm --filter @renovate-config-debugger/engine test:shimmed   # browser module graph, must match golden
+pnpm --filter @renovate-config-debugger/engine test:packaging # packs the tarball, type-checks a scratch consumer against it (056)
 pnpm --filter @renovate-config-debugger/app test:unit         # pure-module unit tests (vitest "unit" project)
 pnpm --filter @renovate-config-debugger/app test:e2e          # playwright; requires `pnpm --filter …/app build` first
 pnpm --filter @renovate-config-debugger/app exec vitest run --project unit src/lib/share.test.ts   # single file

--- a/packages/engine/LICENSE
+++ b/packages/engine/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -1,0 +1,121 @@
+# @renovate-config-debugger/engine
+
+Renovate's own config pipeline — parse, migrate, massage, validate, resolve
+presets, merge, re-migrate, and simulate `packageRules` — running **in a
+browser**, with a trace of every stage. It is the engine behind
+[renovate-config-debugger](https://github.com/secustor/renovate-config-debugger),
+extracted so anything else can reuse it.
+
+## License: AGPL-3.0-only
+
+**Read this before you install it.** This package runs Renovate's real code
+(the [`renovate`](https://github.com/renovatebot/renovate) package is
+`AGPL-3.0-only`) and is therefore `AGPL-3.0-only` itself. Linking it into a
+network-accessible product puts that product under the AGPL's source-offer
+obligation. That is a property of running the real pipeline; the alternative is
+reimplementing Renovate's config semantics, which is exactly what this project
+refuses to do. The full text is in [LICENSE](./LICENSE).
+
+## What you get
+
+Three entry points, and nothing else is public API:
+
+| Entry point                                    | What it is                                                                                                                                                  |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@renovate-config-debugger/engine`             | `runPipeline()` and the trace model, the `packageRules` simulator, provenance and resolved-config derivations, preset auth, error translations, option docs |
+| `@renovate-config-debugger/engine/schema`      | Renovate's own JSON schema, stripped of the `%`-prefixed keys that break JSON-pointer tooling                                                               |
+| `@renovate-config-debugger/engine/vite-plugin` | `renovateShims()` — the Vite plugin that makes the two above work off a server                                                                              |
+
+## Install
+
+```sh
+pnpm add @renovate-config-debugger/engine
+```
+
+The `renovate` package comes with it as an **exact** dependency (see the pin
+below). It is large — this is not a small install.
+
+`vite` is an optional peer dependency, needed only by the `./vite-plugin`
+entry: that module is build-time Node code (`node:module`, `node:path`,
+`node:url`) and must never reach a browser graph.
+
+## Use
+
+`renovateShims()` swaps Renovate's Node-only choke points (OpenTelemetry,
+bunyan, `re2`, datasource lookups, preset HTTP clients) for browser-safe
+modules, and the logger shim doubles as the trace collector — **without the
+plugin there is no trace, and most of the pipeline will not even load.**
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { renovateShims } from "@renovate-config-debugger/engine/vite-plugin";
+
+export default defineConfig({ plugins: [renovateShims()] });
+```
+
+```ts
+// anywhere in the browser bundle
+import { runPipeline } from "@renovate-config-debugger/engine";
+
+const trace = await runPipeline({
+  fileName: "renovate.json",
+  content: '{ "extends": ["config:recommended"] }',
+});
+
+console.log(trace.stageStatus); // per-stage ok/error/skipped
+console.log(trace.finalConfig); // what Renovate would run with
+console.log(trace.presetTree); // the `extends` tree, from Renovate's own logs
+```
+
+Preset fetching is plain `fetch()` against the CORS-enabled host APIs
+(GitHub, GitLab, Gitea/Forgejo, npm, plain HTTP). A host that does not send
+CORS headers cannot be resolved from a browser — that is the network's answer,
+not this package's.
+
+## This consumes a non-public API
+
+Renovate's config modules (`renovate/dist/config/**`) are internals, not an
+exported interface. A Renovate release can move a file and break the pipeline
+with no semver signal at all. Two consequences:
+
+- **The `renovate` dependency is pinned exactly, never ranged.** A range would
+  let an install hand this package internals it was never tested against.
+- **A Renovate bump is a release of this package**, not an implementation
+  detail. Every bump runs the full test suite: a golden project against
+  untouched Renovate modules, and a shimmed project over the exact browser
+  module graph, which must produce byte-identical results.
+
+`renovateVersion` is exported for the same question at runtime.
+
+## Versions
+
+`0.x`, and a **minor bump may be breaking** until the export surface settles —
+range against `^0.1` (i.e. not across the minor), not `^0`. No `1.0.0` is
+scheduled; it is a decision to make once the exports stop moving.
+
+Every release records the Renovate it reproduces:
+
+| engine | renovate | renovate schema |
+| ------ | -------- | --------------- |
+| 0.1.0  | 44.4.6   | 44.4.6          |
+
+The schema column is the `renovate-schema.json` shipped by that same
+`renovate` version — the `./schema` entry is a filtered copy of it, never a
+hand-maintained one.
+
+## Not in scope
+
+- **Non-Vite bundlers.** The shim mechanism is a `resolveId` redirect and can
+  be ported (the plugin is ~100 readable lines), but only Vite is shipped and
+  supported here.
+- **Plain Node without a bundler.** The emitted ESM is bundler-targeted; a
+  Node entry point would need a loader hook and is its own piece of work.
+- **`matchCurrentVersion` for `conda`.** Its ~3 MB WASM parser is excluded
+  from the browser build on purpose; such clauses report an honest error
+  instead of silently mis-evaluating.
+
+## Contributing
+
+Issues and PRs go to
+[secustor/renovate-config-debugger](https://github.com/secustor/renovate-config-debugger).

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,18 +1,62 @@
 {
   "name": "@renovate-config-debugger/engine",
-  "version": "0.0.0",
-  "private": true,
+  "version": "0.1.0",
+  "description": "AGPL-3.0-only. Renovate's own config pipeline — parse, migrate, massage, validate, resolve presets, merge, simulate packageRules — running in a browser, with a trace of every stage.",
+  "keywords": [
+    "browser",
+    "config",
+    "packageRules",
+    "presets",
+    "renovate",
+    "renovate-config",
+    "renovatebot",
+    "vite-plugin"
+  ],
+  "homepage": "https://github.com/secustor/renovate-config-debugger/tree/main/packages/engine#readme",
+  "bugs": "https://github.com/secustor/renovate-config-debugger/issues",
+  "license": "AGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/secustor/renovate-config-debugger.git",
+    "directory": "packages/engine"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
     "./schema": "./src/schema.ts",
     "./vite-plugin": "./src/shims/vite-plugin-renovate-shims.ts"
   },
+  "publishConfig": {
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./schema": {
+        "types": "./dist/schema.d.ts",
+        "default": "./dist/schema.js"
+      },
+      "./vite-plugin": {
+        "types": "./dist/shims/vite-plugin-renovate-shims.d.ts",
+        "default": "./dist/shims/vite-plugin-renovate-shims.js"
+      }
+    },
+    "access": "public"
+  },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "pnpm build",
     "typecheck": "tsc --noEmit",
-    "test": "pnpm test:golden && pnpm test:shimmed",
+    "test": "pnpm test:golden && pnpm test:shimmed && pnpm test:packaging",
     "test:golden": "vitest run --project golden",
     "test:shimmed": "vitest run --project shimmed",
+    "test:packaging": "vitest run --project packaging",
     "generate:registries": "node scripts/generate-registry-names.mjs"
   },
   "dependencies": {
@@ -25,5 +69,16 @@
     "typescript": "7.0.2",
     "vite": "8.2.1",
     "vitest": "4.1.10"
+  },
+  "peerDependencies": {
+    "vite": ">=6.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }

--- a/packages/engine/src/config-merge.ts
+++ b/packages/engine/src/config-merge.ts
@@ -1,0 +1,22 @@
+/**
+ * The published `mergeChildConfig` — Renovate's own child-over-parent config
+ * merge (overwrite scalars, concatenate arrays, recurse into objects), the
+ * operation every layer of the pipeline is built out of and the one a consumer
+ * needs to replay a merge of its own.
+ *
+ * It is re-exported through this module rather than straight off
+ * `renovate-adapter.ts` (roadmap 056): the adapter also re-exports a dozen
+ * `renovate/dist` modules that ship no `.d.ts` — this package declares those
+ * ambiently in `src/types/`, which works inside the workspace but is not
+ * something a published entry point may drag into a consumer's type graph.
+ * Declaring the signature here keeps `dist/index.d.ts` free of unresolvable
+ * `renovate/dist/**` type paths. The implementation is upstream's, untouched.
+ */
+import { mergeChildConfig as upstreamMergeChildConfig } from "./renovate-adapter";
+
+export function mergeChildConfig<
+  Parent extends Record<string, unknown>,
+  Child extends Record<string, unknown> | undefined,
+>(parent: Parent, child: Child): Parent & Child {
+  return upstreamMergeChildConfig(parent, child);
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -22,7 +22,12 @@ export {
 } from "./simulate-compare";
 export { getPresetAuth, setPresetAuth, type PresetAuth } from "./auth";
 export { deriveUpdateType, renovateVersion } from "./version";
-export { getOptions, mergeChildConfig } from "./renovate-adapter";
+// Roadmap 056 froze this surface for publication. `getOptions()` — Renovate's
+// raw option metadata — is deliberately NOT part of it: `getOptionIndex()`
+// below is this package's own curated view of the same data, and anyone who
+// wants the raw list can call Renovate's `getOptions()` directly (the engine
+// pins the exact version it was built against, so both agree by construction).
+export { mergeChildConfig } from "./config-merge";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";
 export { listDatasourceNames, listManagerNames } from "./registries";
 export {

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -19,29 +19,38 @@ export function renovateShims(): Plugin {
   const renovateRoot = path.dirname(require.resolve("renovate/package.json"));
   const renovateDist = path.join(renovateRoot, "dist");
   const shimDir = fileURLToPath(new URL(".", import.meta.url));
+  // The shims sit next to this file in both trees this plugin ever runs from:
+  // as `.ts` inside the workspace (app build, vitest "shimmed" project) and as
+  // compiled `.js` inside the published package (roadmap 056). This module's
+  // own extension is which of the two it is, so the map below stays
+  // extensionless and the emitted build needs no path rewriting.
+  const shimExt = path.extname(fileURLToPath(import.meta.url));
 
   const shimMap = new Map<string, string>(
     Object.entries({
-      "_virtual/_rolldown/runtime.js": "rolldown-runtime.ts",
-      "instrumentation/index.js": "instrumentation.ts",
-      "logger/index.js": "logger.ts",
-      "config/migration.js": "migration.ts",
-      "expose.js": "expose.ts",
-      "config/presets/github/index.js": "presets/github.ts",
-      "config/presets/npm/index.js": "presets/npm.ts",
-      "config/presets/gitlab/index.js": "presets/gitlab.ts",
-      "config/presets/http/index.js": "presets/http.ts",
-      "config/presets/local/index.js": "presets/local.ts",
-      "config/presets/gitea/index.js": "presets/gitea.ts",
-      "config/presets/forgejo/index.js": "presets/forgejo.ts",
-      "modules/datasource/index.js": "datasource-index.ts",
-      "util/cache/package/index.js": "package-cache.ts",
-      "util/hash.js": "hash.ts",
-      "util/merge-confidence/index.js": "merge-confidence.ts",
+      "_virtual/_rolldown/runtime.js": "rolldown-runtime",
+      "instrumentation/index.js": "instrumentation",
+      "logger/index.js": "logger",
+      "config/migration.js": "migration",
+      "expose.js": "expose",
+      "config/presets/github/index.js": "presets/github",
+      "config/presets/npm/index.js": "presets/npm",
+      "config/presets/gitlab/index.js": "presets/gitlab",
+      "config/presets/http/index.js": "presets/http",
+      "config/presets/local/index.js": "presets/local",
+      "config/presets/gitea/index.js": "presets/gitea",
+      "config/presets/forgejo/index.js": "presets/forgejo",
+      "modules/datasource/index.js": "datasource-index",
+      "util/cache/package/index.js": "package-cache",
+      "util/hash.js": "hash",
+      "util/merge-confidence/index.js": "merge-confidence",
       // conda's version parser is a ~3.9 MB inlined WASM blob (rattler) —
       // over half the bundle for one niche scheme; see shims/versioning-conda.ts
-      "modules/versioning/conda/index.js": "versioning-conda.ts",
-    }).map(([dist, shim]) => [path.join(renovateDist, dist), path.join(shimDir, shim)]),
+      "modules/versioning/conda/index.js": "versioning-conda",
+    }).map(([dist, shim]) => [
+      path.join(renovateDist, dist),
+      path.join(shimDir, `${shim}${shimExt}`),
+    ]),
   );
 
   function lookup(resolved: string): string | undefined {

--- a/packages/engine/test/packaging.pack.test.ts
+++ b/packages/engine/test/packaging.pack.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Roadmap 056 — the published shape, asserted against a real tarball.
+ *
+ * `pnpm pack` (which runs `prepack` → the tsc build, and applies the
+ * `publishConfig` rewrite of `exports`) is unpacked into a scratch directory
+ * outside the workspace, linked up like a consumer's `node_modules`, and then:
+ *
+ * 1. the packed manifest is checked (nothing private, AGPL stated, exports
+ *    pointing at `dist/`, the Renovate pin exact);
+ * 2. the tarball's file list is checked (dist + README + LICENSE, no sources,
+ *    no tests, no scripts);
+ * 3. a scratch consumer that imports all three entry points is TYPE-CHECKED
+ *    against the tarball — the only thing that catches an `exports` typo, a
+ *    missing `types` condition, or a `renovate/dist/**` type path leaking into
+ *    the public surface (those modules ship no `.d.ts`; this package declares
+ *    them ambiently, which does not travel);
+ * 4. the packed Vite plugin is loaded and every shim it redirects to is
+ *    required to exist inside the tarball — the compiled tree still has to
+ *    line up with `renovateShims()`'s own path arithmetic.
+ *
+ * Deliberately NOT executed: the emitted ESM is bundler-targeted (extensionless
+ * relative specifiers, JSON imports of `renovate/package.json`), which is the
+ * documented consumption model — running the engine under plain Node is its own
+ * roadmap item.
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const pkgRoot = fileURLToPath(new URL("..", import.meta.url));
+const PACKAGE_NAME = "@renovate-config-debugger/engine";
+
+/** The scratch consumer: touches every entry point, values and types alike. */
+const CONSUMER_SOURCE = `
+import {
+  mergeChildConfig,
+  renovateVersion,
+  runPipeline,
+  simulatePackageRules,
+  STAGE_IDS,
+  type PipelineInput,
+  type TraceResult,
+} from "${PACKAGE_NAME}";
+import { renovateSchema } from "${PACKAGE_NAME}/schema";
+import { renovateShims } from "${PACKAGE_NAME}/vite-plugin";
+
+export const stages: readonly string[] = STAGE_IDS;
+export const version: string = renovateVersion;
+export const schemaKeys: string[] = Object.keys(renovateSchema);
+export const plugin = renovateShims();
+export const merged = mergeChildConfig({ a: 1 }, { b: 2 });
+export const simulate = simulatePackageRules;
+
+export function run(input: PipelineInput): Promise<TraceResult> {
+  return runPipeline(input);
+}
+`;
+
+const CONSUMER_TSCONFIG = {
+  compilerOptions: {
+    target: "ES2023",
+    module: "ESNext",
+    moduleResolution: "bundler",
+    lib: ["ES2023", "DOM"],
+    strict: true,
+    noEmit: true,
+    skipLibCheck: false,
+    types: [],
+  },
+  files: ["consumer.ts"],
+};
+
+interface PackedManifest {
+  private?: boolean;
+  version: string;
+  license: string;
+  description: string;
+  files: string[];
+  keywords: string[];
+  homepage: string;
+  repository: { url: string; directory: string };
+  exports: Record<string, { types: string; default: string }>;
+  types: string;
+  dependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  publishConfig?: Record<string, unknown>;
+  scripts?: Record<string, string>;
+}
+
+/** The one hook shape this plugin uses — a plain function, not an object hook. */
+interface ShimPlugin {
+  resolveId: (source: string, importer?: string) => string | null;
+}
+
+let scratch = "";
+/** The unpacked tarball: `<scratch>/package`. */
+let packed = "";
+let manifest: PackedManifest;
+let tarballFiles: string[] = [];
+
+function run(command: string, args: string[], cwd: string): string {
+  return execFileSync(command, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/** Failure output rather than a thrown Error, so a tsc diagnostic is readable. */
+function runForDiagnostics(command: string, args: string[], cwd: string): string {
+  try {
+    run(command, args, cwd);
+    return "";
+  } catch (error) {
+    const { stdout, stderr } = error as { stdout?: string; stderr?: string };
+    return `${stdout ?? ""}${stderr ?? ""}`.trim() || String(error);
+  }
+}
+
+beforeAll(() => {
+  scratch = fs.mkdtempSync(path.join(os.tmpdir(), "rcd-engine-pack-"));
+
+  // `pnpm pack` runs prepack (the build) and rewrites exports/types from
+  // publishConfig — i.e. exactly what `pnpm publish` would upload.
+  run("pnpm", ["pack", "--pack-destination", scratch], pkgRoot);
+  const tarball = fs.readdirSync(scratch).find((entry) => entry.endsWith(".tgz"));
+  expect(tarball, "pnpm pack produced no tarball").toBeDefined();
+
+  tarballFiles = run("tar", ["-tzf", String(tarball)], scratch)
+    .split("\n")
+    .filter(Boolean)
+    // every entry is prefixed `package/`; compare against the paths a consumer
+    // would see instead.
+    .map((entry) => entry.replace(/^package\//, ""))
+    .filter((entry) => !entry.endsWith("/"));
+  run("tar", ["-xzf", String(tarball)], scratch);
+  packed = path.join(scratch, "package");
+  manifest = JSON.parse(fs.readFileSync(path.join(packed, "package.json"), "utf8"));
+
+  // A consumer's node_modules: the tarball under its own name, plus everything
+  // the published manifest says an install brings with it (its declared
+  // dependencies, and `vite` for the optional peer the plugin entry needs).
+  // Symlinked to the real store paths so their own dependencies keep resolving
+  // — which also makes a dependency this package forgot to declare fail here.
+  const nodeModules = path.join(scratch, "node_modules");
+  fs.mkdirSync(path.join(nodeModules, "@renovate-config-debugger"), { recursive: true });
+  fs.symlinkSync(packed, path.join(nodeModules, PACKAGE_NAME), "dir");
+  for (const dep of [...Object.keys(manifest.dependencies), "vite"]) {
+    fs.symlinkSync(
+      fs.realpathSync(path.join(pkgRoot, "node_modules", dep)),
+      path.join(nodeModules, dep),
+      "dir",
+    );
+  }
+
+  fs.writeFileSync(path.join(scratch, "consumer.ts"), CONSUMER_SOURCE);
+  fs.writeFileSync(path.join(scratch, "tsconfig.json"), JSON.stringify(CONSUMER_TSCONFIG, null, 2));
+}, 300_000);
+
+describe("the packed manifest", () => {
+  it("is publishable and says AGPL on the tin", () => {
+    expect(manifest.private).toBeUndefined();
+    expect(manifest.license).toBe("AGPL-3.0-only");
+    // The engine links Renovate's own AGPL code; npm's package page is where a
+    // consumer looks for that, so the description states it too (roadmap 056).
+    expect(manifest.description).toMatch(/AGPL-3\.0-only/);
+    expect(manifest.version).toMatch(/^0\.\d+\.\d+$/);
+    expect(manifest.keywords).toContain("renovate");
+    expect(manifest.homepage).toContain("github.com/secustor/renovate-config-debugger");
+    expect(manifest.repository.directory).toBe("packages/engine");
+  });
+
+  it("pins renovate exactly rather than ranging over it", () => {
+    // The engine reaches into renovate/dist internals that are not a public
+    // API: the exact pin IS the contract (roadmap 056).
+    expect(manifest.dependencies.renovate).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(manifest.peerDependencies.vite).toBeDefined();
+  });
+
+  it("exports the three entry points from built output, types first", () => {
+    expect(Object.keys(manifest.exports)).toEqual([".", "./schema", "./vite-plugin"]);
+    for (const [subpath, conditions] of Object.entries(manifest.exports)) {
+      // `types` must precede `default`: conditions are matched in order.
+      expect(Object.keys(conditions), subpath).toEqual(["types", "default"]);
+      for (const target of Object.values(conditions)) {
+        expect(target, subpath).toMatch(/^\.\/dist\//);
+        expect(fs.existsSync(path.join(packed, target)), `${subpath} → ${target}`).toBe(true);
+      }
+    }
+    expect(manifest.types).toBe("./dist/index.d.ts");
+  });
+});
+
+describe("the tarball contents", () => {
+  it("ships the build, the README and the license — and nothing else", () => {
+    expect(tarballFiles).toContain("README.md");
+    expect(tarballFiles).toContain("LICENSE");
+    expect(tarballFiles).toContain("package.json");
+    const unexpected = tarballFiles.filter(
+      (entry) =>
+        !entry.startsWith("dist/") && !["README.md", "LICENSE", "package.json"].includes(entry),
+    );
+    expect(unexpected).toEqual([]);
+  });
+
+  it("ships no TypeScript sources beyond the declarations", () => {
+    const sources = tarballFiles.filter(
+      (entry) => entry.endsWith(".ts") && !entry.endsWith(".d.ts"),
+    );
+    expect(sources).toEqual([]);
+  });
+
+  it("keeps the workspace-facing exports on the sources", () => {
+    // The app and the engine's own vitest projects consume `src/*.ts` through
+    // the workspace; only the PUBLISHED manifest points at dist/ (publishConfig).
+    const workspace = JSON.parse(fs.readFileSync(path.join(pkgRoot, "package.json"), "utf8")) as {
+      exports: Record<string, string>;
+    };
+    expect(workspace.exports).toEqual({
+      ".": "./src/index.ts",
+      "./schema": "./src/schema.ts",
+      "./vite-plugin": "./src/shims/vite-plugin-renovate-shims.ts",
+    });
+  });
+});
+
+describe("a consumer of the tarball", () => {
+  it("type-checks against all three entry points", () => {
+    // Runs the engine's own tsc over a scratch project whose only dependency
+    // is the packed tarball: resolution goes through the published `exports`,
+    // so a missing `types` condition or an unresolvable `renovate/dist` type
+    // path in the emitted declarations fails here.
+    const tsc = path.join(pkgRoot, "node_modules", ".bin", "tsc");
+    expect(runForDiagnostics(tsc, ["-p", "tsconfig.json"], scratch)).toBe("");
+  }, 300_000);
+
+  it("gets a Vite plugin whose shims all exist in the tarball", async () => {
+    const pluginModule = (await import(
+      pathToFileURL(path.join(packed, "dist/shims/vite-plugin-renovate-shims.js")).href
+    )) as { renovateShims: () => ShimPlugin };
+    const plugin = pluginModule.renovateShims();
+
+    // The redirect table lives in the source; reading the keys back out of it
+    // keeps this test from drifting when a choke point is added or removed.
+    const source = fs.readFileSync(
+      path.join(pkgRoot, "src/shims/vite-plugin-renovate-shims.ts"),
+      "utf8",
+    );
+    const chokePoints = [...source.matchAll(/^\s+"([\w./-]+\.js)":/gm)].map((match) => match[1]);
+    expect(chokePoints.length).toBeGreaterThan(10);
+
+    for (const chokePoint of chokePoints) {
+      const resolved = plugin.resolveId(`renovate/dist/${chokePoint}`);
+      expect(resolved, chokePoint).toBeTruthy();
+      expect(String(resolved).startsWith(packed), `${chokePoint} → ${resolved}`).toBe(true);
+      expect(fs.existsSync(String(resolved)), `${chokePoint} → ${resolved}`).toBe(true);
+    }
+  });
+});

--- a/packages/engine/tsconfig.build.json
+++ b/packages/engine/tsconfig.build.json
@@ -1,0 +1,21 @@
+{
+  // The published build (roadmap 056). `tsconfig.json` stays the editor/
+  // typecheck view (src + test, noEmit); this one emits `src/` only.
+  //
+  // Emit, not bundle: `renovateShims()` hands the consumer's bundler absolute
+  // paths under its own directory, so the shims have to exist as separate
+  // files next to the plugin — a single-file bundle would have nothing to
+  // point at. tsc's mirrored tree gives exactly that.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    // Emitted with the `.d.ts` next to it and no source maps: `files` ships
+    // dist/ only, so a map would point at sources that are not in the tarball.
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["src"]
+}

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -2,12 +2,16 @@ import { defineConfig } from "vitest/config";
 import { renovateShims } from "./src/shims/vite-plugin-renovate-shims";
 
 /**
- * Two projects sharing the same fixtures and file snapshots:
+ * Three projects. The first two share the same fixtures and file snapshots:
  * - "golden": real renovate modules, no shims — produces the reference
  *   snapshots straight from Renovate's own code.
  * - "shimmed": the exact module graph the browser bundle uses (shim plugin +
  *   renovate inlined through the Vite pipeline) — must match the golden
  *   snapshots, proving the shims don't alter behavior.
+ * - "packaging": neither graph, but the tarball `pnpm publish` would upload
+ *   (roadmap 056) — packs, unpacks and type-checks a scratch consumer against
+ *   it. Split out because it runs a build and a second tsc, which the other
+ *   two must not pay for.
  */
 export default defineConfig({
   test: {
@@ -45,6 +49,17 @@ export default defineConfig({
               inline: [/renovate/],
             },
           },
+        },
+      },
+      {
+        test: {
+          name: "packaging",
+          include: ["test/*.pack.test.ts"],
+          environment: "node",
+          // one `pnpm pack` (tsc build + tarball) and one tsc over the scratch
+          // consumer, both cold on a CI runner
+          testTimeout: 300_000,
+          hookTimeout: 300_000,
         },
       },
     ],

--- a/roadmap/056-publish-engine-package.md
+++ b/roadmap/056-publish-engine-package.md
@@ -1,6 +1,6 @@
 # 056 — Publish the engine as `@renovate-config-debugger/engine`
 
-Milestone: M15 · Status: proposed
+Milestone: M15 · Status: done (2026-08-05)
 
 ## Summary
 
@@ -167,3 +167,50 @@ rediscover which of Renovate's internals refuse to load off a server.
   green.
 - A dry-run publish (`pnpm publish --dry-run`) whose file list is reviewed by
   hand once, so nothing from `test/` or `scripts/` ships.
+
+## As implemented (2026-08-05)
+
+- **`publishConfig`, not a second manifest.** `exports` on disk still points at
+  `src/*.ts`, so the app, the golden/shimmed projects and `vite dev` load
+  exactly what they loaded before; pnpm rewrites `exports`/`types` onto
+  `dist/` when it packs. Verification therefore reads: the repo's suites prove
+  the sources, and the packaging suite proves the tarball. Pointing the
+  workspace at `dist/` instead would have made every dev edit require a build
+  for no gain the packed artifact doesn't already give.
+- **Packaging tests are one vitest project, `packaging`**, wired into CI's
+  test job and re-run by the publish workflow before it uploads anything.
+  It packs, unpacks into a scratch consumer's `node_modules`
+  (tarball + the manifest's own dependencies, symlinked), asserts the packed
+  manifest and file list, **type-checks a consumer that imports all three
+  entry points** against the tarball, and loads the packed Vite plugin to
+  require every shim it redirects to inside `dist/`.
+- **`publint`/`attw` were not adopted.** The scratch consumer above is the
+  same check with a sharper edge (it caught two real defects while being
+  written: the shim map's hard-coded `.ts` suffixes, and `fast-json-patch`
+  reaching the public declarations), and it needs no new dependency. `attw`
+  specifically would report node16 resolution errors that no supported
+  consumer hits: the emitted ESM is deliberately bundler-targeted
+  (extensionless relative specifiers; `renovate/package.json` and
+  `renovate/renovate-schema.json` imported as JSON), which is the same reason
+  "plain Node without a bundler" is out of scope above.
+- **Export-surface audit outcome:** `getOptions` was dropped from `.`, and
+  `mergeChildConfig` moved to `src/config-merge.ts` where its signature is
+  declared locally. Both for the same reason: `renovate-adapter.ts` re-exports
+  a dozen `renovate/dist` modules that ship no `.d.ts` (this repo declares them
+  ambiently in `src/types/`, which does not travel in a tarball), so a public
+  entry point must not route through it. `getOptionIndex()` remains the
+  engine's own view of the option metadata. `error-translations`,
+  `error-fix-text` and `option-docs` were kept as recommended, with no
+  "unstable" subpath: nothing in their shapes is dictated by an app component.
+- **`sideEffects: false` was not set.** The shim modules are pulled into a
+  consumer's graph by a `resolveId` redirect from inside `renovate/dist`, not
+  by an import from this package's own entry points; a blanket
+  side-effect-free claim over that tree is not one this package can honestly
+  make, and it would silently change the app's own bundle (same manifest,
+  workspace resolution) with only the e2e suite as a guard.
+- **Left for the publish-time human:** create the `@renovate-config-debugger`
+  npm organization; add the `NPM_TOKEN` secret and the `npm-publish`
+  environment to the repository; then push the first `engine-v0.1.0` tag. The
+  workflow refuses to publish if the tag and `packages/engine/package.json`
+  disagree, and re-runs lint/format/typecheck/golden/shimmed/packaging before
+  it uploads.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -60,7 +60,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost        | M14                  | done     |
 | [054](054-simulator-results-readability.md)             | Simulator: results readability — the ledger is the trace          | M14                  | done     |
 | [055](055-header-project-links.md)                      | Header links to the source and the issue tracker                  | M14                  | done     |
-| [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`          | M15                  | proposed |
+| [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`          | M15                  | done     |
 | [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                           | M15                  | proposed |
 | [058](058-rcd-debugger-cli.md)                          | `rcd`: the debugger CLI on the shimmed engine (experimental)      | M16                  | done     |
 | [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli` (experimental) | M16                  | done     |


### PR DESCRIPTION
Implements roadmap **056** — Stack A of the M15/M16 work, stacked on #125 (roadmap docs).

- `tsconfig.build.json` emits ESM + `.d.ts` into `dist/`; workspace resolution stays on `src/*.ts`, and `publishConfig` rewrites `exports`/`types` onto `dist/` at pack time, so app/dev/test flows are unchanged.
- Manifest made publishable: `private` removed, `0.1.0`, AGPL-3.0-only license + metadata, `files`, optional `vite` peer; package README leads with the AGPL statement and carries the compat table (0.1.0 → renovate 44.4.6) + `LICENSE` copy.
- New `packaging` vitest project: packs a real tarball, unpacks it, type-checks a scratch consumer against all three entries (`.`, `./schema`, `./vite-plugin`) and loads the packed Vite plugin — wired into CI. It caught two real defects while being written (shim map's hard-coded `.ts` suffixes; `fast-json-patch` leaking into public declarations).
- `.github/workflows/publish-engine.yml`: publish on `engine-v*` tags with npm provenance, refusing on tag/manifest version mismatch, full check suite first.
- 056 doc flipped to done with an "As implemented" section recording the deviations (publishConfig instead of repointed exports; scratch-consumer check instead of publint/attw; export-surface corrections; no `sideEffects: false`).

Verified: lint, format:check, typecheck, all workspace tests (incl. new packaging suite), full build, check:dev-graph, and the 67-test e2e suite.

**Left for publish time (nothing was published):** create the `@renovate-config-debugger` npm org, add `NPM_TOKEN` + the `npm-publish` environment, push the first `engine-v0.1.0` tag.

Item **057** (codemirror-json-schema fork) is deliberately not part of this stack: it requires the external fork repository and its npm releases to exist before any in-repo migration can keep CI green.
