### PR TITLE
docs(roadmap): 062–064 — custom-manager extraction simulation

### DIFF
--- a/roadmap/062-results-tab-taxonomy.md
+++ b/roadmap/062-results-tab-taxonomy.md
@@ -1,0 +1,64 @@
+# 062 — Results tabs: `Simulator` becomes `packageRules`, `Extraction` joins it
+
+Milestone: M17 · Status: proposed — deferred until the current simulator work
+(054's remaining variants) has stabilized
+
+Renumbered from 056 (2026-08-05): main took 056–061 for the packages and
+agent-debug-interface milestones.
+
+## Summary
+
+`Simulator` is named after the mechanism, not the thing it simulates. That was
+unambiguous while there was one simulator; 063 adds a second, and then both
+tabs simulate and the name distinguishes nothing. Rename the existing tab to
+**`packageRules`** — the config key it actually reproduces — and reserve
+**`Extraction`** beside it for 063.
+
+This item is the rename and the empty slot only. It carries no new behavior,
+which is the point: it lands cheaply and independently, so 063 arrives into a
+taxonomy that is already correct instead of renaming a tab a user just learned.
+
+## User story
+
+As someone who has just learned what the Simulator tab does, I want each tab
+named after the Renovate phase it reproduces, so that a second simulator does
+not make the first one's name meaningless.
+
+## Scope
+
+- `results-tabs.ts`: label `Simulator` → `packageRules`; add the `Extraction`
+  id and label, ordered **before** `packageRules`.
+- `use-run-summary.ts`: tab descriptor list follows the same order.
+- Call sites that name the tab: `App.tsx` (`jumpToTab`), `OverviewTab.tsx`
+  (`onOpen`), and the `openTab(page, …)` calls across the e2e suite (~15).
+- Until 063 lands, `Extraction` either stays out of `RESULTS_TAB_IDS` entirely
+  or renders an explicit "not built yet" panel — never an empty tab that reads
+  as a broken one.
+
+## Decisions
+
+- **Name tabs after the Renovate phase, not the mechanism.** `packageRules` is
+  spelled as the config key, matching how the app already borrows upstream
+  vocabulary; `Extraction` is upstream's own word for the `extractPackageFile`
+  phase, and unlike `Managers` or `Regex` it privileges neither custom manager
+  type.
+- **Order mirrors Renovate's execution order**: extraction produces the
+  dependencies, `packageRules` are applied to them afterwards. The Pipeline tab
+  already teaches by ordering; the tab strip should not contradict it.
+- **The tab id is share-link wire format — keep `simulator` as the id.**
+  `view.tab` is encoded into links and validated against `RESULTS_TAB_IDS`
+  (`input-schemas-zod.ts`). Decode already tolerates an unknown tab (the link
+  opens without selecting one), so a renamed id would degrade quietly rather
+  than break — but silently losing the sender's selection is precisely what 017
+  and 027 exist to prevent. Changing the label while leaving the id alone costs
+  nothing and risks nothing. If the id is ever renamed for tidiness, it needs a
+  legacy mapping in the same shape as `legacyTabForView`.
+- **Its own commit, landed before 063.** The change is mechanical but spans the
+  e2e specs; bundling it into the feature would make that diff unreviewable.
+
+## Verification
+
+- `11-tabbed-shell.spec.ts` covers the strip: both tabs present, in pipeline
+  order, selected by accessible name.
+- A share-link test asserts a link carrying `tab: "simulator"` still opens on
+  the renamed tab — the compatibility claim above, made executable.

--- a/roadmap/063-custom-manager-extraction.md
+++ b/roadmap/063-custom-manager-extraction.md
@@ -1,0 +1,92 @@
+# 063 — Custom-manager extraction: simulate what a `matchStrings` regex finds
+
+Milestone: M17 · Status: proposed — deferred until the current feature set has
+stabilized. Renumbered from 057 (2026-08-05); main took 056–061.
+Feasibility proven:
+[2026-08-custom-manager-simulation-feasibility.md](2026-08-custom-manager-simulation-feasibility.md)
+
+## Summary
+
+A `# renovate: …` comment with one character wrong extracts nothing, silently,
+and the author finds out weeks later — the complaint behind
+[renovatebot/renovate#45071](https://github.com/renovatebot/renovate/discussions/45071),
+which asks upstream for a `warnOnMismatch` option. This app can answer the
+question without waiting for that: paste the config **and** a sample file, and
+see which spans matched, what each match extracted, and which near-misses were
+discarded and why.
+
+Every stage the app traces today stops at a resolved config. This is the first
+that takes a **package file** as input, which is the whole of the new surface —
+the extraction itself is upstream's own code, unmodified.
+
+## User story
+
+As someone who just wrote a custom manager, I want to paste a file and see what
+Renovate would extract from it, so that I learn my regex is wrong now rather
+than from a dependency that never updates.
+
+## Scope
+
+- **Engine** — `simulate-custom-managers.ts` beside `simulate-package-rules.ts`,
+  in two deliberately separate steps (see Decisions):
+  1. path-only matching via upstream `getMatchingFiles` (`managerFilePatterns`,
+     `includePaths`, `ignorePaths`) — touches no file content;
+  2. per-file `extractPackageFile` for `custom.regex` and `custom.jsonata`.
+- Three new re-exports in `renovate-adapter.ts` (the two extractors and
+  `getMatchingFiles`) — the boundary rule holds, nothing else deep-imports.
+- Discard reasons come from the logger shim: `checkIsValidDependency` already
+  emits a `logger.trace` carrying the partial dependency, so "matched but
+  thrown away, and here is what was missing" needs no new instrumentation.
+- Matched spans are located by `indexOf(replaceString)` — upstream's own
+  auto-replace anchor — so nothing re-runs the regexes and drifts from them.
+- **Input** — `ConfigColumn` grows a set of `{ path, content }` pairs.
+- **Results** — the `Extraction` tab from 062.
+
+## Decisions
+
+- **The files are input, so they live in `ConfigColumn`** — the input half of
+  the split, alongside the config editor and its toolbar. Not a results tab,
+  not a modal.
+- **The path is a first-class, editable field**, not a caption.
+  `managerFilePatterns` matches against it, so `Dockerfile` and
+  `docker/Dockerfile.ci` give different answers; a fixed or implied filename
+  would quietly answer a different question than the one asked.
+- **More than one file must be representable.** "Which of my files does this
+  manager miss?" is the question; a single-file input answers a strictly weaker
+  one.
+- **`ConfigColumn` takes the file set as one grouped prop** (or an
+  already-constructed element, the pattern `advancedZone` uses). It is
+  presentational with ~30 flat props already; adding an n-file list flat would
+  make it unmanageable. The list is its own component under `features/editor/`
+  — `jsx-max-depth: 3` forces that decomposition up front.
+- **Extraction runs on demand, per file — never as a batch over the set.** Cost
+  scales with `files × managers × matchStrings`, each sweep carrying upstream's
+  10 000-iteration cap plus handlebars compilation per matched dependency, and
+  it would land on the typing path that the `render` vitest project exists to
+  protect. Results are memoized per `(content, manager config)`; anything shown
+  across all files at once (e.g. "3 files matched no dependencies") is derived
+  from the cheap path-only step, with content extraction still deferred until a
+  file is opened.
+- **Only what upstream computes is shown.** No re-implementation of the
+  matching, no invented "why didn't this match?" narration beyond what the
+  trace actually contains — 064 adds the honest version of that.
+
+## Not in scope
+
+- RE2 fidelity warnings and unmatched-comment detection → **064**.
+- Populating the file set from a repository (007's fetch path, at repo scale).
+  The two-step split above is what keeps that tractable later; this item must
+  not foreclose it.
+- Non-custom managers. Simulating `npm` or `gradle` extraction means the whole
+  manager registry and a very different bundle conversation.
+
+## Verification
+
+- Engine: a golden/shimmed pair on RE2-safe fixtures, holding the byte-identity
+  invariant. Fixtures include the discussion's own failure — a correct
+  `# renovate:` comment and a typo'd one in the same file, asserting one
+  extraction and one silence.
+- App: a `render`-project test that typing in the config editor does **not**
+  trigger extraction, which is the performance decision made executable.
+- e2e: paste a Dockerfile, open `Extraction`, see the dependency and the
+  matched span.

--- a/roadmap/064-extraction-fidelity-and-mismatch.md
+++ b/roadmap/064-extraction-fidelity-and-mismatch.md
@@ -1,0 +1,92 @@
+# 064 — Extraction fidelity: the RE2 gap, and comments that matched nothing
+
+Milestone: M17 · Status: proposed — deferred; depends on **063**.
+Renumbered from 058 (2026-08-05); main took 056–061. Evidence:
+[2026-08-custom-manager-simulation-feasibility.md](2026-08-custom-manager-simulation-feasibility.md) §3
+
+## Summary
+
+063 shows what Renovate would extract. This item makes that claim honest, and
+then answers the question #45071 actually asked.
+
+Two things stand between "the app extracted this" and "Renovate will extract
+this". First, production Renovate compiles `matchStrings` with **RE2**; the
+browser falls back to native `RegExp`, and the two languages differ in both
+directions — including two constructs that diverge **silently**, with no error
+from either engine. Second, a manager that extracts nothing from a file is
+reported as "no dependencies", which is exactly what a working manager on an
+unrelated file also reports; the user cannot tell "nothing to find" from "your
+regex is wrong", which is the whole complaint.
+
+## User story
+
+As someone whose custom manager found nothing, I want to be told whether my
+pattern is even valid in real Renovate and which of my `# renovate:` comments
+were ignored, so that a clean result means "correct" rather than "silent".
+
+## Scope
+
+### Fidelity — RE2 as an oracle
+
+- Add `re2js` (pure-JS RE2 port, no WASM, ~60 KB gzipped), **lazily imported**
+  so it stays off the critical path (031) and loads only when a config actually
+  declares custom managers.
+- Compile every `matchString` with it **beside** native `RegExp`, and report
+  the disagreement:
+  - RE2 rejects, JS accepts (lookahead, lookbehind, backrefs) → "Renovate would
+    fail validation on this pattern" — the dangerous direction, where the app
+    would otherwise show a confident, wrong preview;
+  - RE2 accepts, JS rejects (`(?i)`-style global inline flags) → "valid in
+    Renovate, cannot be previewed in a browser" — an honest limitation, not the
+    bogus syntax error the app would otherwise show;
+  - both accept but the **match spans differ** (`[[:alpha:]]`, `\p{…}` without
+    `u`) → warn from the observed difference.
+- Surface it as a per-pattern state in the `Extraction` tab, not a global
+  banner: one bad `matchString` among four should mark that one.
+
+### Mismatch — the `warnOnMismatch` question
+
+- A probe pattern (default `#\s*renovate:`, editable) is matched against each
+  file; any hit falling **outside** every extracted span is flagged as a comment
+  that looks intended for a manager and was ignored.
+- Distinguish the two silent outcomes already available from 063's trace: never
+  matched at all, versus matched and then **discarded** by
+  `checkIsValidDependency` (missing `datasource`, or no `currentValue` /
+  `currentDigest`) — the second names the missing field.
+
+## Decisions
+
+- **`re2js` is an oracle, not the engine.** Extraction keeps running upstream's
+  own code path so results stay attributable to Renovate's functions. Swapping
+  `re2js` in via the `expose.ts` `re2()` slot would be higher fidelity but
+  materially more work — it is not RegExp-API-compatible, so the shim would owe
+  `exec` with `lastIndex` advancement, `test`, and the well-known symbols
+  (`Symbol.replace`/`Symbol.match`) that Renovate uses through
+  `String.replace(regEx(…), …)`, each unimplemented one a silent break. Revisit
+  only if the oracle proves insufficient in practice.
+- **Not a static lint.** Two of the divergences compile cleanly in both engines
+  and merely match different things; no pattern inspection can see that. Running
+  both engines over the real sample file can, and it costs nothing extra once
+  `re2js` is loaded.
+- **Native `RegExp` cannot be configured into RE2 mode.** V8 does ship an
+  RE2-style linear-time engine behind an `l` flag that rejects exactly the
+  non-regular constructs, but it requires `--enable-experimental-regexp-engine`
+  at V8 startup, is not exposed to web content, and has no Firefox or Safari
+  equivalent — and it would still only cover one of the two directions.
+  Measured, not assumed; see the feasibility note.
+- **The gap is an edge case, and the framing should say so.** All 60
+  `matchStrings` in Renovate's own bundled `custom-managers` presets use named
+  groups and nothing else. Warnings must not imply the common case is unsafe.
+  Precedent for a named, documented gap: `conda` versioning.
+- **The probe pattern is editable, and its default is a guess.** `#\s*renovate:`
+  fits comment-style managers and misses others; presenting it as authoritative
+  would trade one silent failure for another.
+
+## Verification
+
+- Pure unit tests for the oracle's verdicts, one per row of the divergence
+  table in the feasibility note (§3.1) — including the two silent cases, which
+  assert on differing match spans rather than on compilation.
+- A test that the whole `re2js` import is absent from the entry chunk.
+- Mismatch detection tested on the #45071 fixture from 063: the typo'd comment
+  is flagged, the correct one is not.

--- a/roadmap/2026-08-custom-manager-simulation-feasibility.md
+++ b/roadmap/2026-08-custom-manager-simulation-feasibility.md
@@ -1,0 +1,141 @@
+# Custom-manager (regex/JSONata) simulation — feasibility spike (2026-08-05)
+
+Prompted by [renovatebot/renovate#45071](https://github.com/renovatebot/renovate/discussions/45071)
+("Detect mistakes in regex manager syntax"): a user writes a `# renovate: …`
+comment, gets one character wrong, and Renovate silently extracts nothing.
+Upstream is asked for a `warnOnMismatch` option. **This app can answer the same
+question today, without an upstream change** — paste the config _and_ a sample
+file, see which spans matched, what each match extracted, and which
+almost-matches were discarded and why.
+
+This note records what a spike proved about feasibility, and what it would cost.
+
+## 1. What already exists here
+
+The pipeline stops at a resolved config. Nothing in the app has ever taken a
+_package file_ as input — that is the whole gap. Everything else is closer than
+expected:
+
+| Needed                                   | Status                                                                                               |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `custom.regex` extraction                | upstream `modules/manager/custom/regex/index.js`, browser-safe                                       |
+| `custom.jsonata` extraction              | upstream `modules/manager/custom/jsonata/index.js`, browser-safe                                     |
+| `managerFilePatterns` matching           | upstream `workers/repository/extract/file-match.js` (`getMatchingFiles`), browser-safe               |
+| handlebars (`*Template` fields)          | **already in the bundle** — `config/validation.js` imports `util/template`                           |
+| jsonata, minimatch                       | **already in the bundle** — same import chain (`util/jsonata`, `util/string-match`)                  |
+| "dep discarded, failed validation" trace | **free** — `checkIsValidDependency` calls `logger.trace`, and `shims/logger.ts` forwards every level |
+
+The only genuinely new runtime dependency is `toml-eslint-parser` (~100 KB
+unpacked), and only for JSONata managers with `fileFormat: "toml"`.
+
+## 2. Spike result
+
+A throwaway test in the engine's `shimmed` project (the exact browser module
+graph) imported the three upstream entry points above and ran them. All six
+assertions passed on the first run, unmodified:
+
+- regex manager extracted `jqlang/jq @ 1.7.1` from a Dockerfile sample, and
+  correctly extracted **nothing** from the deliberately typo'd
+  `# renovate: datasoure=…` comment below it — the exact failure #45071 is about;
+- `depNameTemplate: "prefix/{{{depName}}}"` compiled through handlebars;
+- JSONata manager parsed YAML and evaluated `deps.{ "depName": name, … }`;
+- `getMatchingFiles` resolved `**/[Dd]ockerfile*` against a file list.
+
+**No new shims were required.** The extraction path never touches `fs`, `git`,
+`exec`, or the datasource layer.
+
+Reproduce: see the appendix at the end of this file.
+
+## 3. The one real fidelity gap: RE2
+
+Production Renovate compiles `matchStrings` with **RE2**, via
+`expose.js → util/regex.js`. The browser's `expose.ts` shim throws for `re2()`,
+so `regEx()` falls back to native `RegExp` (`regexEngineStatus: "unavailable"`,
+confirmed in the spike). RE2 does not support lookahead, lookbehind, or
+backreferences; native `RegExp` does. So a pattern using `(?= …)` **works here
+and fails in production Renovate** — the worst possible direction for a tool
+whose value is trust.
+
+Two things make this awkward beyond the usual shim caveats:
+
+- The golden/shimmed byte-identity regime does **not** catch it. In this
+  checkout `re2`'s native binary is unbuilt (`Cannot find module
+'./build/Release/re2.node'` on Node 26), so the golden project _also_ falls
+  back to native and the invariant passes vacuously. Verified, not assumed.
+- Named capture groups — `(?<depName>…)`, the thing every custom manager uses —
+  _are_ RE2-supported. A lint must not false-positive on them.
+
+Mitigation options, cheapest first:
+
+1. **Static pattern lint** (~50 lines, pure, no upstream dep): flag `(?=`,
+   `(?!`, `(?<=`, `(?<!`, `\1`, `\k<…>` and surface "RE2 rejects this; real
+   Renovate would fail validation". Deliberately narrow and honest about being
+   a heuristic. Recommended.
+2. Bundle a WASM RE2 build and use it as the engine. Highest fidelity, but a
+   new large dependency and a second engine to keep in step — worth pricing
+   separately, not in a first version. (I have not verified any specific WASM
+   RE2 package works in this bundle.)
+
+Precedent for shipping a known, named gap exists: `conda` versioning is
+excluded and reports an honest error (CLAUDE.md).
+
+## 4. Effort
+
+Roughly **one week** for a version worth shipping; **1–2 days** for a
+demonstrable proof of concept. Split:
+
+**Engine — ~0.5–1 day.** A `simulate-custom-managers.ts` (~250 lines) beside
+`simulate-package-rules.ts`: 3 new re-exports in `renovate-adapter.ts`, input =
+`{ files: {path, content}[], config }`, run `getMatchingFiles` per custom
+manager, run `extractPackageFile`, collect the logger trace, return per-file
+results. Match spans come from `indexOf(replaceString)` — upstream's own
+auto-replace anchor, so no second regex pass to drift from. Plus the RE2 lint.
+Tests: a golden/shimmed pair on RE2-safe fixtures.
+
+**App — ~2–3 days, the bulk.** A file-input surface (path + content, ideally
+n files) and a results view. New results tab, wired into `results-tabs.ts`.
+The reusable parts of the existing simulator (drawers, evidence cards, thread
+nav) do not transfer directly — this is a different shape of answer.
+`jsx-max-depth: 3` means decomposition up front, not after.
+
+**Polish — ~2 days.** Share-link encoding for file contents (needs a size cap;
+the fragment is deflated but not free), e2e coverage, docs, roadmap entry.
+
+**The `warnOnMismatch` idea itself is the cheap part** (~50 lines): given the
+matched spans, flag any line matching a probe pattern (default `#\s*renovate:`)
+that falls outside all of them. Pure, testable, no upstream dependency — and it
+lets this app demonstrate the feature while #45071 is still an open idea.
+
+Biggest unknown is not technical: **how many files at once**. One file keeps
+the UI trivial; a repo's worth is what actually reproduces "which of my 200
+Dockerfiles has the typo", and pulls in the repo-fetch path (007) and
+`ignorePaths`/`includePaths`.
+
+## Appendix — reproducing the spike
+
+Add to `packages/engine/vitest.config.ts` under the `shimmed` project's
+`include`, then run
+`pnpm --filter @renovate-config-debugger/engine exec vitest run --project shimmed`:
+
+```ts
+import { extractPackageFile as regexExtract } from "renovate/dist/modules/manager/custom/regex/index.js";
+import { extractPackageFile as jsonataExtract } from "renovate/dist/modules/manager/custom/jsonata/index.js";
+import { getMatchingFiles } from "renovate/dist/workers/repository/extract/file-match.js";
+import { regexEngineStatus } from "renovate/dist/util/regex.js";
+
+const dockerfile = `FROM alpine:3.20
+
+# renovate: datasource=github-releases depName=jqlang/jq
+ARG JQ_VERSION=1.7.1
+
+# renovate: datasoure=github-releases depName=typo/typo
+ARG TYPO_VERSION=1.0.0
+`;
+
+const matchStrings = [
+  "# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)\\s(?:ENV|ARG)\\s+[A-Za-z0-9_]+?_VERSION[ =\"']?(?<currentValue>.+?)[\"']?\\s",
+];
+
+const res = regexExtract(dockerfile, "Dockerfile", { matchStrings } as never);
+// → 1 dep (jqlang/jq @ 1.7.1); the `datasoure=` typo yields nothing
+```

--- a/roadmap/2026-08-custom-manager-simulation-feasibility.md
+++ b/roadmap/2026-08-custom-manager-simulation-feasibility.md
@@ -180,6 +180,41 @@ This also keeps the door open to the repo-fetch path (007) later: a repo's worth
 of files can be listed and pattern-matched cheaply, with content fetched and
 extracted only for the file the user actually opens.
 
+### 4.3 Tab taxonomy: `Simulator` becomes `packageRules`, `Extraction` joins it
+
+Today's single `Simulator` tab is named after the _mechanism_. Once a second
+simulator exists that answer stops working — both tabs simulate. Name them
+after the **Renovate phase each one reproduces**:
+
+- `Simulator` → **`packageRules`**, spelled as the config key it simulates,
+  consistent with how the app already names things after upstream vocabulary.
+- new **`Extraction`** tab — upstream's own term for this phase
+  (`extractPackageFile`, the extract worker), and it covers both custom manager
+  types without privileging regex.
+
+**Order them in Renovate's execution order: `Extraction` before `packageRules`.**
+Extraction produces the dependencies; `packageRules` are applied to those
+dependencies afterwards. Tab order that mirrors the real pipeline is the same
+teaching device the Pipeline tab already relies on.
+
+**The rename is not free — the tab id is share-link wire format.** `view.tab`
+is encoded into links and validated against `RESULTS_TAB_IDS`
+(`input-schemas-zod.ts`). Decoding already _tolerates_ an unknown tab (the link
+opens, just without selecting a tab), so old links would degrade quietly rather
+than break — but quietly losing the sender's selection is exactly the failure
+017 and 027 exist to prevent. So:
+
+- Change the **label** freely; treat the **id** as a compatibility concern.
+- Either keep the id `simulator` behind the new label (cheapest, zero risk), or
+  rename it and map the legacy value on decode — the same shape as
+  `legacyTabForView`, which already exists for pre-028 links.
+
+Touch points for the rename beyond the label: `results-tabs.ts` (ids + labels),
+`use-run-summary.ts` (tab descriptor list), `App.tsx` (`jumpToTab("simulator")`),
+`OverviewTab.tsx` (`onOpen("simulator")`), and ~15 `openTab(page, "simulator")`
+call sites across the e2e suite. Mechanical, but it spans the e2e specs, so the
+rename wants to be its own commit rather than riding along with the feature.
+
 ## 5. Effort
 
 Roughly **one week** for a version worth shipping; **1–2 days** for a
@@ -196,10 +231,15 @@ imported so its 60 KB stays off the critical path (031). Tests: a golden/shimmed
 pair on RE2-safe fixtures, and a pure unit test for the oracle's verdicts.
 
 **App — ~2–3 days, the bulk.** The `ConfigColumn` file-set input of §4.1 and a
-results view for what came out. New results tab, wired into `results-tabs.ts`.
-The reusable parts of the existing simulator (drawers, evidence cards, thread
-nav) do not transfer directly — this is a different shape of answer.
+results view for what came out, in the new `Extraction` tab (§4.3). The
+reusable parts of the existing simulator (drawers, evidence cards, thread nav)
+do not transfer directly — this is a different shape of answer.
 `jsx-max-depth: 3` means decomposition up front, not after.
+
+**Tab rename — ~0.5 day, separate commit.** `Simulator` → `packageRules` per
+§4.3, including the id-compatibility decision and the e2e call sites. Worth
+landing before the feature so the new tab arrives into an already-correct
+taxonomy.
 
 **Polish — ~2 days.** Share-link encoding for file contents (needs a size cap;
 the fragment is deflated but not free), e2e coverage, docs, roadmap entry.

--- a/roadmap/2026-08-custom-manager-simulation-feasibility.md
+++ b/roadmap/2026-08-custom-manager-simulation-feasibility.md
@@ -63,37 +63,140 @@ Two things make this awkward beyond the usual shim caveats:
 './build/Release/re2.node'` on Node 26), so the golden project _also_ falls
   back to native and the invariant passes vacuously. Verified, not assumed.
 - Named capture groups — `(?<depName>…)`, the thing every custom manager uses —
-  _are_ RE2-supported. A lint must not false-positive on them.
+  _are_ RE2-supported, so whatever checks patterns must not flag them.
 
-Mitigation options, cheapest first:
+### 3.1 Can native `RegExp` be configured to behave like RE2?
 
-1. **Static pattern lint** (~50 lines, pure, no upstream dep): flag `(?=`,
-   `(?!`, `(?<=`, `(?<!`, `\1`, `\k<…>` and surface "RE2 rejects this; real
-   Renovate would fail validation". Deliberately narrow and honest about being
-   a heuristic. Recommended.
-2. Bundle a WASM RE2 build and use it as the engine. Highest fidelity, but a
-   new large dependency and a second engine to keep in step — worth pricing
-   separately, not in a first version. (I have not verified any specific WASM
-   RE2 package works in this bundle.)
+**No.** There is no flag, option, or constructor argument in any shipping
+browser that restricts `RegExp` to the RE2 language. Two near-misses, both
+measured:
 
-Precedent for shipping a known, named gap exists: `conda` versioning is
-excluded and reports an honest error (CLAUDE.md).
+- **V8's linear-time engine is real but not web-reachable.** V8 ships a
+  non-backtracking engine behind an `l` flag that rejects precisely the
+  non-regular constructs: `new RegExp("a(?=b)", "l")` fails with _"Cannot be
+  executed in linear time"_. But it requires `--enable-experimental-regexp-engine`
+  at V8 startup — verified: without it, even `new RegExp("a", "l")` is a
+  `SyntaxError`. It is not exposed to web content, and Firefox and Safari have
+  no equivalent at all.
+- **It would only fix one direction anyway.** `l` covers "JS accepts what RE2
+  rejects". It does nothing for "RE2 accepts what JS rejects" — verified below.
 
-## 4. Effort
+The divergence is genuinely two-way, and one class of it is silent:
+
+| Construct                 | RE2     | native `RegExp`       | Direction                                |
+| ------------------------- | ------- | --------------------- | ---------------------------------------- |
+| `(?<name>…)` named group  | accepts | accepts               | — (what real configs use)                |
+| lookahead `(?=`, `(?!`    | rejects | accepts               | works here, fails in prod                |
+| lookbehind `(?<=`, `(?<!` | rejects | accepts               | works here, fails in prod                |
+| backref `\1`, `\k<n>`     | rejects | accepts               | works here, fails in prod                |
+| inline flags `(?i)`       | accepts | **`SyntaxError`**     | fails here, works in prod                |
+| POSIX `[[:alpha:]]`       | letters | **matches `[:alph]`** | **silent** — no error, different matches |
+| `\p{L}` without `u`       | letters | **literal `p{L}`**    | **silent** — no error, different matches |
+
+The last two are the reason a static lint is not sufficient: both engines
+compile the pattern without complaint and simply match different things.
+
+### 3.2 Recommended: `re2js` as an oracle, not as the engine
+
+[`re2js`](https://www.npmjs.com/package/re2js) is a pure-JS port of RE2 (no
+WASM, no native binding), actively maintained, **60 KB gzipped** (246 KB raw).
+Probed against every row above: it reproduces RE2's accept/reject decisions
+exactly, and matches `[[:alpha:]]+` against `"abc"` where native `RegExp`
+returns `null`.
+
+Use it **beside** native `RegExp`, not instead of it:
+
+- **Extraction keeps using upstream's own code path** (native `RegExp` via
+  `regEx()`), so what the app shows is produced by Renovate's real functions.
+- **`re2js` compiles each `matchString` as a validator**, giving exact,
+  non-heuristic verdicts in _both_ directions: "RE2 rejects this — Renovate
+  would fail validation", and "this is valid RE2 that cannot be previewed in a
+  browser" instead of a bogus syntax error.
+- **Running both engines over the sample file catches the silent cases**: if the
+  match spans differ, warn. That is an empirical check no static lint can make.
+
+Swapping `re2js` in as the engine (via the existing `expose.ts` `re2()` slot)
+is the higher-fidelity option but materially more work: `re2js` is not
+RegExp-API-compatible, so the shim would have to implement `exec` with
+`lastIndex` advancement, `test`, and the well-known symbols
+(`Symbol.replace`/`Symbol.match`) that Renovate relies on via
+`String.replace(regEx(…), …)` — and each unimplemented symbol is a silent
+break. Not for a first version.
+
+**Reassurance on priority:** all 60 `matchStrings` in Renovate's own bundled
+`custom-managers` presets use named groups and nothing else — zero RE2-only or
+JS-only constructs. The common subset is where real configs live, so this is an
+edge-case guard, not a blocker. Precedent for shipping a known, named gap
+exists: `conda` versioning is excluded and reports an honest error (CLAUDE.md).
+
+## 4. Decided design
+
+Two decisions are settled and should not be re-litigated during build.
+
+### 4.1 The preprocess input lives in `ConfigColumn`
+
+The files being matched are **input**, not results — they belong on the input
+half of the split, in `ConfigColumn.tsx`, alongside the config editor, its
+toolbar and the Advanced zone. Not in a results tab, and not in a modal.
+
+This means `ConfigColumn` has to grow a representation it does not have today:
+**a set of `{ path, content }` pairs**, not a single text buffer. Concretely:
+
+- The path is a first-class field, not decoration — `managerFilePatterns`
+  matches against it, so `Dockerfile` vs `docker/Dockerfile.ci` changes the
+  answer. Every content buffer needs an editable path next to it.
+- More than one file must be representable, because "which of my files does
+  this manager miss?" is the question being asked; a single-file input answers
+  a strictly weaker one.
+- `ConfigColumn` already threads its state through props (it is a presentational
+  component — ~30 props, no local state). Adding an n-file list this way would
+  make the prop list unmanageable, so the file set should arrive as one grouped
+  prop (or a small already-constructed element, the pattern `advancedZone`
+  already uses) rather than as a dozen new flat props.
+- `jsx-max-depth: 3` applies: the file list is its own component under
+  `features/editor/`, not nesting inside the existing editor card.
+
+### 4.2 Extraction runs on demand, never across all files
+
+Do **not** extract from every file on every keystroke, or even on every run.
+Each file × each custom manager is a full regex sweep with a 10 000-iteration
+ceiling per `matchString` (upstream's `regexMatchAll` cap), plus handlebars
+compilation per matched dependency — the cost scales with
+`files × managers × matchStrings` and lands directly on the typing path the
+`render` vitest project exists to protect.
+
+Instead:
+
+- Extraction is triggered per file, on explicit demand — opening/selecting that
+  file's result, or an explicit action — not as a batch pass over the set.
+- Results are memoized per `(file content, manager config)` pair so a re-render,
+  or reselecting a file, costs nothing.
+- Anything that must be shown for all files at once (e.g. a "3 files matched no
+  dependencies" summary) should be derived from the cheap step only —
+  `getMatchingFiles` on paths, which touches no file content — with the
+  expensive extraction still deferred until that file is opened.
+
+This also keeps the door open to the repo-fetch path (007) later: a repo's worth
+of files can be listed and pattern-matched cheaply, with content fetched and
+extracted only for the file the user actually opens.
+
+## 5. Effort
 
 Roughly **one week** for a version worth shipping; **1–2 days** for a
 demonstrable proof of concept. Split:
 
-**Engine — ~0.5–1 day.** A `simulate-custom-managers.ts` (~250 lines) beside
+**Engine — ~1 day.** A `simulate-custom-managers.ts` (~250 lines) beside
 `simulate-package-rules.ts`: 3 new re-exports in `renovate-adapter.ts`, input =
-`{ files: {path, content}[], config }`, run `getMatchingFiles` per custom
-manager, run `extractPackageFile`, collect the logger trace, return per-file
-results. Match spans come from `indexOf(replaceString)` — upstream's own
-auto-replace anchor, so no second regex pass to drift from. Plus the RE2 lint.
-Tests: a golden/shimmed pair on RE2-safe fixtures.
+`{ files: {path, content}[], config }`, split into the cheap path-only step
+(`getMatchingFiles`) and the per-file extraction step 4.2 defers, run
+`extractPackageFile`, collect the logger trace, return per-file results. Match
+spans come from `indexOf(replaceString)` — upstream's own auto-replace anchor,
+so no second regex pass to drift from. Plus the `re2js` oracle (§3.2), lazily
+imported so its 60 KB stays off the critical path (031). Tests: a golden/shimmed
+pair on RE2-safe fixtures, and a pure unit test for the oracle's verdicts.
 
-**App — ~2–3 days, the bulk.** A file-input surface (path + content, ideally
-n files) and a results view. New results tab, wired into `results-tabs.ts`.
+**App — ~2–3 days, the bulk.** The `ConfigColumn` file-set input of §4.1 and a
+results view for what came out. New results tab, wired into `results-tabs.ts`.
 The reusable parts of the existing simulator (drawers, evidence cards, thread
 nav) do not transfer directly — this is a different shape of answer.
 `jsx-max-depth: 3` means decomposition up front, not after.
@@ -106,10 +209,11 @@ matched spans, flag any line matching a probe pattern (default `#\s*renovate:`)
 that falls outside all of them. Pure, testable, no upstream dependency — and it
 lets this app demonstrate the feature while #45071 is still an open idea.
 
-Biggest unknown is not technical: **how many files at once**. One file keeps
-the UI trivial; a repo's worth is what actually reproduces "which of my 200
-Dockerfiles has the typo", and pulls in the repo-fetch path (007) and
-`ignorePaths`/`includePaths`.
+Remaining open question: how the file set is **populated** — hand-authored
+entries only, or fed from the repo-fetch path (007), which also brings
+`ignorePaths`/`includePaths` into scope. §4.2's split (cheap path matching now,
+content extraction on demand) is what makes the repo-scale version tractable
+later, so the first version should not foreclose it.
 
 ## Appendix — reproducing the spike
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -66,6 +66,9 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli` (experimental) | M16                  | proposed |
 | [060](060-mcp-server-and-agent-discovery.md)            | `rcv mcp` + pointing agents at the headless interface             | M16                  | proposed |
 | [061](061-claude-plugin-marketplace.md)                 | Claude plugin marketplace for the debugger                        | M16                  | proposed |
+| [062](062-results-tab-taxonomy.md)                      | Results tabs: `Simulator` → `packageRules`, + `Extraction`        | M17                  | proposed |
+| [063](063-custom-manager-extraction.md)                 | Custom-manager extraction simulator                               | M17                  | proposed |
+| [064](064-extraction-fidelity-and-mismatch.md)          | Extraction fidelity: RE2 gap + unmatched comments                 | M17                  | proposed |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -192,3 +195,18 @@ plugin bundling the MCP server registration with a skill that carries the
 debugging workflow itself — so an installed session starts with the tools
 and the sequencing knowledge together, and consumers never clone the
 monorepo for a kilobyte of catalog.
+
+M17 — **Extraction** — is deferred until the current feature set (054's
+remaining variants in particular) has stabilized. It originates in
+[renovatebot/renovate#45071](https://github.com/renovatebot/renovate/discussions/45071)
+— custom-manager comments that silently match nothing — and is scoped by
+the spike in
+[2026-08-custom-manager-simulation-feasibility.md](2026-08-custom-manager-simulation-feasibility.md),
+which proved Renovate's own extraction code runs unmodified in the browser
+module graph, no new shims required. Build the three in order: 062 fixes
+the tab taxonomy before a second simulator makes `Simulator` a name that
+distinguishes nothing, 063 is the feature (the first input the app has
+ever taken that is not a config), and 064 makes its claims honest — real
+Renovate compiles `matchStrings` with RE2, the browser falls back to
+native `RegExp`, and the two diverge in both directions — while answering
+the discussion's actual question.


### PR DESCRIPTION
Scopes a custom-manager (regex / JSONata) extraction simulator, prompted by
[renovatebot/renovate#45071](https://github.com/renovatebot/renovate/discussions/45071)
— a `# renovate:` comment with one character wrong extracts nothing, silently,
and the author finds out weeks later. Upstream is asked for a `warnOnMismatch`
option; this app can answer the same question without waiting for it.

Docs only. No source changes, no new runtime dependencies.

## What's here

- **[2026-08-custom-manager-simulation-feasibility.md](roadmap/2026-08-custom-manager-simulation-feasibility.md)** —
  the spike and its findings.
- **062** — results tab taxonomy: `Simulator` → `packageRules`, `Extraction` joins it.
- **063** — the extraction simulator itself.
- **064** — extraction fidelity: the RE2 gap, and comments that matched nothing.

All three are `proposed`, M17, explicitly deferred until the current feature set
(054's remaining variants) has stabilized.

## Feasibility is proven, not estimated

A throwaway test in the engine's `shimmed` project — the exact browser module
graph — imported Renovate's real `custom/regex`, `custom/jsonata` and
`getMatchingFiles` and ran them. Six assertions passed on the first run,
unmodified, **with no new shims**: the regex manager extracted `jqlang/jq @ 1.7.1`
from a Dockerfile and correctly extracted nothing from a deliberately typo'd
`datasoure=` comment below it — the exact failure #45071 is about. The extraction
path never touches `fs`, `git`, `exec`, or the datasource layer.

Most of the dependency graph is already shipped: handlebars, jsonata and minimatch
all arrive via `config/validation.js` today, and the "dep discarded, failed
validation" diagnostic is free — `checkIsValidDependency` calls `logger.trace`,
which the logger shim already forwards into the trace collector.

Estimated cost: ~1 week, the bulk of it app-side, because the file set is the
first input this app has ever taken that is not a config.

## The one real gap: RE2

Production Renovate compiles `matchStrings` with RE2; the browser falls back to
native `RegExp`. Native `RegExp` **cannot** be configured into RE2 mode — V8 does
ship an RE2-style linear engine behind an `l` flag that rejects exactly the
non-regular constructs, but it needs `--enable-experimental-regexp-engine` at V8
startup, is not exposed to web content, and has no Firefox or Safari equivalent.

The divergence runs both ways, and two cases are silent — both engines compile
the pattern and simply match different things, so no static lint can see them:

| Construct | RE2 | native `RegExp` |
| --- | --- | --- |
| lookahead / lookbehind / backrefs | rejects | accepts |
| inline flags `(?i)` | accepts | `SyntaxError` |
| POSIX `[[:alpha:]]` | letters | matches `[:alph]` — **silent** |
| `\p{L}` without `u` | letters | literal `p{L}` — **silent** |

064 therefore proposes `re2js` (pure-JS RE2 port, ~60 KB gzipped, lazily loaded)
as an **oracle beside** native `RegExp` rather than as a replacement engine —
extraction keeps running upstream's own code path, while the oracle gives exact
verdicts in both directions and cross-checking the two engines on the sample file
catches the silent cases empirically.

For scale: all 60 `matchStrings` in Renovate's own bundled `custom-managers`
presets use named groups and nothing else. This is an edge-case guard, not a
blocker.

## Note on numbering

Originally written as 056–058; renumbered to **062–064** after rebasing, since
#125 took 056–061 for the packages and agent-debug-interface milestones. Each doc
records the renumber, following 054's precedent.
