### PR TITLE
feat(app,cli): tell agents the headless interface exists (060)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ drill-down tools query that held run, so the whole session describes one
 resolution instead of re-resolving per question:
 
 ```bash
-claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp
 ```
 
 A plain Node import of the engine is NOT equivalent: the preset tree and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,15 @@ rcd docs minimumReleaseAge        # option semantics for the pinned Renovate
 bodies are large — query one node at a time. `packages/cli/README.md` has the
 full surface, the credentials table and the endpoint guard.
 
+For an interactive session, `rcd mcp` is the same answers as typed MCP tools
+with a warm engine (roadmap 060) — `run_config` returns a `runId` and the
+drill-down tools query that held run, so the whole session describes one
+resolution instead of re-resolving per question:
+
+```bash
+claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+```
+
 A plain Node import of the engine is NOT equivalent: the preset tree and
 provenance are reconstructed by the logger shim, so they exist only in the
 shimmed graph — which the CLI, the browser bundle and the `shimmed` test

--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ Everything the app shows is available without a browser — the same engine, the
 same pinned Renovate, as structured data:
 
 ```bash
-pnpm dlx @renovate-config-debugger/cli digest renovate.json     # the run in one paragraph
-pnpm dlx @renovate-config-debugger/cli validate renovate.json   # exit 2 = Renovate would refuse it
-pnpm dlx @renovate-config-debugger/cli tree renovate.json       # what `extends` expanded into
-pnpm dlx @renovate-config-debugger/cli provenance renovate.json labels
-pnpm dlx @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
-pnpm dlx @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
+npx -y @renovate-config-debugger/cli digest renovate.json     # the run in one paragraph
+npx -y @renovate-config-debugger/cli validate renovate.json   # exit 2 = Renovate would refuse it
+npx -y @renovate-config-debugger/cli tree renovate.json       # what `extends` expanded into
+npx -y @renovate-config-debugger/cli provenance renovate.json labels
+npx -y @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
+npx -y @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
 ```
 
 `--format json` on any subcommand; `--help` lists them all. Exit `2` means
@@ -100,7 +100,7 @@ of flags — the engine boots once and `run_config` holds the trace, so
 drill-down questions cost milliseconds and describe one consistent run:
 
 ```bash
-claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp
 ```
 
 [`packages/cli/README.md`](packages/cli/README.md) has the full surface: input

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ overriding them is explicit and visibly warned.
 
 ## For agents and scripts (headless)
 
-> [!NOTE]
+> [!WARNING]
 > The CLI and the MCP server are **experimental**: subcommands, flags and
 > output shapes may change in any `0.x` release.
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,40 @@ overriding them is explicit and visibly warned.
 
 </details>
 
+## For agents and scripts (headless)
+
+> [!NOTE]
+> The CLI and the MCP server are **experimental**: subcommands, flags and
+> output shapes may change in any `0.x` release.
+
+Everything the app shows is available without a browser — the same engine, the
+same pinned Renovate, as structured data:
+
+```bash
+pnpm dlx @renovate-config-debugger/cli digest renovate.json     # the run in one paragraph
+pnpm dlx @renovate-config-debugger/cli validate renovate.json   # exit 2 = Renovate would refuse it
+pnpm dlx @renovate-config-debugger/cli tree renovate.json       # what `extends` expanded into
+pnpm dlx @renovate-config-debugger/cli provenance renovate.json labels
+pnpm dlx @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
+pnpm dlx @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
+```
+
+`--format json` on any subcommand; `--help` lists them all. Exit `2` means
+Renovate would refuse the config, which is the blocking signal a Claude Code
+hook reads, so `validate` drops into one with no wrapper.
+
+For an agent session, register the MCP server once and get typed tools instead
+of flags — the engine boots once and `run_config` holds the trace, so
+drill-down questions cost milliseconds and describe one consistent run:
+
+```bash
+claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+```
+
+[`packages/cli/README.md`](packages/cli/README.md) has the full surface: input
+options, credentials (environment only), the endpoint guard, and the
+compatibility table.
+
 ## Private repositories & presets
 
 Reading a private config or preset repo takes two steps, and the second one is

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -28,6 +28,33 @@
     <title>Renovate Config Debugger</title>
   </head>
   <body>
+    <!--
+      Roadmap 060: the app is client-rendered, so without JavaScript the page
+      is blank — and a headless agent fetching this URL (curl, no JS engine)
+      sees only this static document. The noscript block serves both readers:
+      a human without JS learns why the page is empty, and an agent reading
+      the raw HTML finds the headless one-liners it should be using instead.
+      Visible whenever it renders, so it stays inside the "no hidden
+      agent-directed text" rule (see HeadlessNote.tsx).
+    -->
+    <noscript>
+      <h1>Renovate Config Debugger</h1>
+      <p>
+        This app runs Renovate's own config code in your browser and needs JavaScript. There is
+        nothing to render without it &mdash; but every answer it gives is also available headlessly,
+        from the same engine and the same pinned Renovate:
+      </p>
+      <pre>
+npx -y @renovate-config-debugger/cli digest renovate.json
+npx -y @renovate-config-debugger/cli validate renovate.json    # exit 2 = Renovate would refuse it
+claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp # or register the MCP server once</pre>
+      <p>
+        Machine-readable overview: <a href="/llms.txt">/llms.txt</a> &middot;
+        <a href="https://github.com/secustor/renovate-config-debugger/tree/main/packages/cli"
+          >CLI documentation</a
+        >
+      </p>
+    </noscript>
     <div id="root"></div>
     <!--
       Roadmap 043: deployment-time config, served verbatim from public/ so it

--- a/packages/app/public/llms.txt
+++ b/packages/app/public/llms.txt
@@ -1,0 +1,47 @@
+# Renovate config debugger
+
+> A "compiler explorer" for Renovate configuration: it runs Renovate's own
+> config code — parsing, migration, massaging, validation, preset resolution,
+> merging, and a packageRules simulator — and shows the trace. Everything runs
+> in the browser; configs and tokens never leave the page.
+
+The same answers are available headlessly, which is almost certainly what you
+want if you are reading this file. Same engine, same pinned Renovate version,
+structured output, no browser:
+
+```
+# the whole run in one paragraph
+pnpm dlx @renovate-config-debugger/cli digest renovate.json
+
+# would Renovate accept it? exit 2 = no (a blocking signal for hooks)
+pnpm dlx @renovate-config-debugger/cli validate renovate.json
+
+# what did `extends` expand into / who set this option / would this PR match
+pnpm dlx @renovate-config-debugger/cli tree renovate.json
+pnpm dlx @renovate-config-debugger/cli provenance renovate.json labels
+pnpm dlx @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
+
+# prove an edit changed (or did not change) behavior
+pnpm dlx @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
+```
+
+`--format json` on any subcommand. `--help` lists them all.
+
+In an MCP-capable client, register the server once and get typed tools instead
+of flags:
+
+```
+claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+```
+
+The CLI is experimental: subcommands, flags and output shapes may change in
+any 0.x release.
+
+## Docs
+
+- [CLI documentation](https://github.com/secustor/renovate-config-debugger/tree/main/packages/cli):
+  subcommands, flags, exit codes, credentials.
+- [Repository](https://github.com/secustor/renovate-config-debugger): source,
+  architecture notes and the per-feature design docs under `roadmap/`.
+- [Renovate documentation](https://docs.renovatebot.com/): the upstream
+  configuration reference this tool explains.

--- a/packages/app/public/llms.txt
+++ b/packages/app/public/llms.txt
@@ -11,18 +11,18 @@ structured output, no browser:
 
 ```
 # the whole run in one paragraph
-pnpm dlx @renovate-config-debugger/cli digest renovate.json
+npx -y @renovate-config-debugger/cli digest renovate.json
 
 # would Renovate accept it? exit 2 = no (a blocking signal for hooks)
-pnpm dlx @renovate-config-debugger/cli validate renovate.json
+npx -y @renovate-config-debugger/cli validate renovate.json
 
 # what did `extends` expand into / who set this option / would this PR match
-pnpm dlx @renovate-config-debugger/cli tree renovate.json
-pnpm dlx @renovate-config-debugger/cli provenance renovate.json labels
-pnpm dlx @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
+npx -y @renovate-config-debugger/cli tree renovate.json
+npx -y @renovate-config-debugger/cli provenance renovate.json labels
+npx -y @renovate-config-debugger/cli simulate renovate.json --dep '{"depName":"react"}'
 
 # prove an edit changed (or did not change) behavior
-pnpm dlx @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
+npx -y @renovate-config-debugger/cli compare before.json after.json --dep '{"depName":"react"}'
 ```
 
 `--format json` on any subcommand. `--help` lists them all.
@@ -31,7 +31,7 @@ In an MCP-capable client, register the server once and get typed tools instead
 of flags:
 
 ```
-claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp
+claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp
 ```
 
 The CLI is experimental: subcommands, flags and output shapes may change in

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -1990,10 +1990,14 @@ export function App() {
               onApplyFix={onApplyFix}
             />
           ) : null}
+          {/* Roadmap 060: the headless interface, announced in visible copy —
+              the whole discovery mechanism, and deliberately not a hidden
+              hint. Inside the split, not after it: as a grid row under the
+              results column, the sticky config column's area spans it, so
+              scrolling the note into view cannot push the editor off the top
+              (e2e 12, "the config column stays in view"). */}
+          <HeadlessNote />
         </div>
-        {/* Roadmap 060: the headless interface, announced in visible copy —
-            the whole discovery mechanism, and deliberately not a hidden hint. */}
-        <HeadlessNote />
       </main>
       {showBackToTop ? (
         <button

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -22,6 +22,7 @@ import type { ConfigEditorHandle } from "@/features/editor/ConfigEditor";
 import { ConfigColumn } from "@/ConfigColumn";
 import type { EffectiveStats } from "@/components/EffectiveConfig";
 import type { AuthState } from "@/components/GithubAuthHint";
+import { HeadlessNote } from "@/components/HeadlessNote";
 import { identityForNodeId, nodeIdForIdentity } from "@/components/preset-tree-stats";
 import type { ResultsColumnProps } from "@/ResultsColumn";
 import { UntrustedHostBanner } from "@/UntrustedHostBanner";
@@ -1990,6 +1991,9 @@ export function App() {
             />
           ) : null}
         </div>
+        {/* Roadmap 060: the headless interface, announced in visible copy —
+            the whole discovery mechanism, and deliberately not a hidden hint. */}
+        <HeadlessNote />
       </main>
       {showBackToTop ? (
         <button

--- a/packages/app/src/components/HeadlessNote.tsx
+++ b/packages/app/src/components/HeadlessNote.tsx
@@ -1,0 +1,47 @@
+/**
+ * Roadmap 060 — "this trace is available headlessly".
+ *
+ * The one discovery mechanism the research found that actually works: a
+ * VISIBLE note a human can read too, plus a copy-pasteable one-liner. Not
+ * hidden text, not an off-screen instruction block, not a meta tag aimed at
+ * crawlers — agent-directed content a person cannot see is the canonical
+ * indirect-prompt-injection pattern (OWASP LLM01), browser-driving agents read
+ * the accessibility tree (which strips hidden elements) anyway, and the
+ * `.well-known`/llms.txt discovery proposals are consumed by no shipping
+ * client today. See the research doc for what was checked and rejected.
+ *
+ * In flow, at the end of the page, in a `<footer>`: an agent that scraped the
+ * page has it, and so does a developer scrolling to the bottom.
+ */
+
+const PACKAGE = "@renovate-config-debugger/cli";
+const DOCS_URL = "https://github.com/secustor/renovate-config-debugger/tree/main/packages/cli";
+
+const ONE_LINERS = [
+  `# every answer on this page, as JSON`,
+  `pnpm dlx ${PACKAGE} digest renovate.json`,
+  `pnpm dlx ${PACKAGE} validate renovate.json    # exit 2 = Renovate would refuse it`,
+  ``,
+  `# or register it once, for an agent session`,
+  `claude mcp add rcd -- pnpm dlx ${PACKAGE} mcp`,
+].join("\n");
+
+export function HeadlessNote() {
+  return (
+    <footer className="headless-note">
+      <h2 className="headless-note-title">For agents and scripts</h2>
+      <p className="headless-note-lead">
+        Everything this page shows — the preset tree, per-key provenance, the packageRules
+        simulator, the validation errors — is available headlessly from the same engine and the same
+        pinned Renovate, with no browser involved.
+      </p>
+      <pre className="headless-note-code">{ONE_LINERS}</pre>
+      <p className="headless-note-foot">
+        Experimental: subcommands, flags and output shapes may change.{" "}
+        <a href={DOCS_URL} target="_blank" rel="noreferrer">
+          CLI documentation ↗
+        </a>
+      </p>
+    </footer>
+  );
+}

--- a/packages/app/src/components/HeadlessNote.tsx
+++ b/packages/app/src/components/HeadlessNote.tsx
@@ -12,6 +12,13 @@
  *
  * In flow, at the end of the page, in a `<footer>`: an agent that scraped the
  * page has it, and so does a developer scrolling to the bottom.
+ *
+ * Collapsed by default behind a native `<details>` (review on #134): the
+ * question is the one visible line, and the platform provides the keyboard
+ * and screen-reader behavior. Folding costs discovery nothing — the content
+ * stays in the DOM (and the accessibility tree) either way, so only human
+ * screen space is spent on demand. The curl/no-JS audience is served by the
+ * `<noscript>` block in index.html, not by this component.
  */
 
 const PACKAGE = "@renovate-config-debugger/cli";
@@ -26,10 +33,9 @@ const ONE_LINERS = [
   `claude mcp add rcd -- npx -y ${PACKAGE} mcp`,
 ].join("\n");
 
-export function HeadlessNote() {
+function HeadlessNoteBody() {
   return (
-    <footer className="headless-note">
-      <h2 className="headless-note-title">For agents and scripts</h2>
+    <>
       <p className="headless-note-lead">
         Everything this page shows — the preset tree, per-key provenance, the packageRules
         simulator, the validation errors — is available headlessly from the same engine and the same
@@ -42,6 +48,19 @@ export function HeadlessNote() {
           CLI documentation ↗
         </a>
       </p>
+    </>
+  );
+}
+
+export function HeadlessNote() {
+  return (
+    <footer className="headless-note">
+      <details className="headless-note-details">
+        <summary className="headless-note-summary">
+          Looking for a solution for Agents and scripts?
+        </summary>
+        <HeadlessNoteBody />
+      </details>
     </footer>
   );
 }

--- a/packages/app/src/components/HeadlessNote.tsx
+++ b/packages/app/src/components/HeadlessNote.tsx
@@ -19,11 +19,11 @@ const DOCS_URL = "https://github.com/secustor/renovate-config-debugger/tree/main
 
 const ONE_LINERS = [
   `# every answer on this page, as JSON`,
-  `pnpm dlx ${PACKAGE} digest renovate.json`,
-  `pnpm dlx ${PACKAGE} validate renovate.json    # exit 2 = Renovate would refuse it`,
+  `npx -y ${PACKAGE} digest renovate.json`,
+  `npx -y ${PACKAGE} validate renovate.json    # exit 2 = Renovate would refuse it`,
   ``,
   `# or register it once, for an agent session`,
-  `claude mcp add rcd -- pnpm dlx ${PACKAGE} mcp`,
+  `claude mcp add rcd -- npx -y ${PACKAGE} mcp`,
 ].join("\n");
 
 export function HeadlessNote() {

--- a/packages/app/src/components/HeadlessNote.tsx
+++ b/packages/app/src/components/HeadlessNote.tsx
@@ -37,7 +37,8 @@ function HeadlessNoteBody() {
   return (
     <>
       <p className="headless-note-lead">
-        If you looking for an equivalent of this running in your terminal or for agent, take a look at the other distributions of this project.
+        If you looking for an equivalent of this running in your terminal or for agent, take a look
+        at the other distributions of this project.
       </p>
       <pre className="headless-note-code">{ONE_LINERS}</pre>
       <p className="headless-note-foot">

--- a/packages/app/src/components/HeadlessNote.tsx
+++ b/packages/app/src/components/HeadlessNote.tsx
@@ -37,9 +37,7 @@ function HeadlessNoteBody() {
   return (
     <>
       <p className="headless-note-lead">
-        Everything this page shows — the preset tree, per-key provenance, the packageRules
-        simulator, the validation errors — is available headlessly from the same engine and the same
-        pinned Renovate, with no browser involved.
+        If you looking for an equivalent of this running in your terminal or for agent, take a look at the other distributions of this project.
       </p>
       <pre className="headless-note-code">{ONE_LINERS}</pre>
       <p className="headless-note-foot">

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4752,3 +4752,40 @@ button.desc-digest-leaf:focus-visible {
   margin-left: 0;
   margin-right: 0;
 }
+
+/* Roadmap 060 — the visible "this is available headlessly" note at the foot of
+   the page. Deliberately plain and in flow: the discovery mechanism is text a
+   human can read, not a hidden hint aimed at agents. */
+.headless-note {
+  border-top: 1px solid var(--border);
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin: 2rem 0 0;
+  padding: 1rem 0 0;
+}
+
+.headless-note-title {
+  color: var(--ink);
+  font-size: 0.9rem;
+  margin: 0 0 0.4rem;
+}
+
+.headless-note-lead {
+  margin: 0 0 0.7rem;
+  max-width: 60rem;
+}
+
+.headless-note-code {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  margin: 0;
+  overflow-x: auto;
+  padding: 0.7rem 0.9rem;
+}
+
+.headless-note-foot {
+  margin: 0.6rem 0 0;
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -3876,10 +3876,20 @@ main:has(.app-split.has-results) {
    editor's `maxHeight` scroller. Scoped to `.app-split.has-results` — the
    pre-run page is one column with nothing to stick to. */
 .app-split.has-results > .config-col {
+  grid-row: 1 / span 2;
   max-height: calc(100dvh - 1.5rem);
   overflow-y: auto;
   position: sticky;
   top: 0.75rem;
+}
+
+/* The headless note (roadmap 060) is the grid's second row, under the
+   results column. The config column spans both rows, so its sticky area
+   reaches the bottom of the page and the editor stays in view while the
+   note scrolls in — a footer AFTER the grid would drag the sticky column
+   off the top by its own height. */
+.app-split.has-results > .headless-note {
+  grid-column: 2;
 }
 
 /* Below this width the panes stack — config on top, results below, full
@@ -3895,11 +3905,17 @@ main:has(.app-split.has-results) {
 
   /* Stacked, the config is simply the first thing on the page — sticking it
      would park it over the results it sits above, and the cap would make a
-     nested scroller out of a column that now has the whole width. */
+     nested scroller out of a column that now has the whole width. The row
+     span goes with it: nothing sticks, so the note is just the last row. */
   .app-split.has-results > .config-col {
+    grid-row: auto;
     max-height: none;
     overflow-y: visible;
     position: static;
+  }
+
+  .app-split.has-results > .headless-note {
+    grid-column: auto;
   }
 }
 

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4780,10 +4780,46 @@ button.desc-digest-leaf:focus-visible {
   padding: 1rem 0 0;
 }
 
-.headless-note-title {
-  color: var(--ink);
+/* Collapsed by default behind the question (review on #134): a native
+   disclosure whose summary is the note's one visible line. The marker is the
+   ::before chevron in both engines — the UA marker is suppressed so the
+   affordance renders identically everywhere. */
+.headless-note-summary {
+  color: var(--muted);
+  cursor: pointer;
   font-size: 0.9rem;
-  margin: 0 0 0.4rem;
+  list-style: none;
+}
+
+.headless-note-summary::-webkit-details-marker {
+  display: none;
+}
+
+.headless-note-summary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: 0.45rem;
+}
+
+/* Guarded like every other transition in this file: no transition property at
+   all outside the no-preference query, so the chevron simply flips under
+   reduced motion instead of animating. */
+@media (prefers-reduced-motion: no-preference) {
+  .headless-note-summary::before {
+    transition: transform 120ms ease;
+  }
+}
+
+.headless-note-summary:hover {
+  color: var(--ink);
+}
+
+.headless-note-details[open] > .headless-note-summary {
+  margin-bottom: 0.7rem;
+}
+
+.headless-note-details[open] > .headless-note-summary::before {
+  transform: rotate(90deg);
 }
 
 .headless-note-lead {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -498,8 +498,9 @@ inspection chooses the endpoint, the CLI withholds tokens and says so on stderr.
 
 ## MCP server
 
-`rcd mcp` speaks MCP over stdio. It takes no arguments and writes nothing but
-the protocol to stdout, so point any MCP-capable client at it as a stdio server.
+`rcd mcp` speaks MCP over stdio — the same answers as the subcommands, better
+economics for a session. It takes no arguments and writes nothing but the
+protocol to stdout, so point any MCP-capable client at it as a stdio server.
 It speaks the 2026-07-28 protocol and the legacy 2025-era `initialize`
 handshake, chosen per connection.
 

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -29,7 +29,7 @@ export const mcpCommand: Command = {
   usage: ["mcp"],
   details: [
     "Register it once and every later session has the tools:",
-    "  claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp",
+    "  claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp",
     "",
     "Same answers as the subcommands, better economics for a session: the",
     "engine boots once, and `run_config` HOLDS the trace so the drill-down",

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -59,6 +59,9 @@ const TOP_LEVEL_NOTES = [
   "They are withheld when the config under inspection chooses the endpoint.",
   "",
   "`rcd <command> --help` for a command's own flags.",
+  "",
+  "In an MCP-capable client, register the server once and skip the flags entirely:",
+  "  claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp",
 ];
 
 /**

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -61,7 +61,7 @@ const TOP_LEVEL_NOTES = [
   "`rcd <command> --help` for a command's own flags.",
   "",
   "In an MCP-capable client, register the server once and skip the flags entirely:",
-  "  claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp",
+  "  claude mcp add rcd -- npx -y @renovate-config-debugger/cli mcp",
 ];
 
 /**

--- a/roadmap/060-mcp-server-and-agent-discovery.md
+++ b/roadmap/060-mcp-server-and-agent-discovery.md
@@ -1,6 +1,6 @@
 # 060 — `rcd mcp` + pointing agents at the headless interface
 
-Milestone: M16 · Status: MCP server done (2026-08-05), discovery pending
+Milestone: M16 · Status: done (2026-08-05)
 
 ## Summary
 
@@ -79,14 +79,29 @@ provenance,messages}.ts` now hold the shapes, and the subcommands and the
   two runs.
 - Tested through a real MCP client over the SDK's in-memory transport pair
   (`test/mcp.test.ts`), so schemas, handlers and result shapes are exercised
-  the way a client exercises them.
+  the way a client exercises them; `rcv mcp` was additionally smoke-tested
+  over stdio against the built bundle.
 - **Nothing is written to stdout by `rcv mcp`** — on a stdio transport stdout
   IS the protocol. Diagnostics go to stderr, which is also what keeps them out
   of a `--format json` document.
 
-Still open here: the discovery half — the app footer, the READMEs, llms.txt
-and the Claude Code hint marker — which lands once 059 has published the
-package every one-liner names.
+## As built — discovery (2026-08-05)
+
+- Discovery, as shipped: `packages/app/src/components/HeadlessNote.tsx` (a
+  visible `<footer>` at the end of the page, in flow, with the copy-pasteable
+  one-liners), a "For agents and scripts" section in the root README, an MCP
+  section in the CLI README, the AGENTS.md pointer, and
+  `packages/app/public/llms.txt`.
+- **The `claude-code-hint` marker was dropped, not shipped** — reversing the
+  "emitted from day one" decision above. Claude Code only acts on hints for
+  plugins listed in the official Anthropic marketplace, and a listing there
+  is not realistic for this plugin, so the marker could never fire. The
+  visible surfaces above are the whole discovery story; 061's plugin installs
+  from its self-hosted marketplace explicitly.
+
+Left open: nothing here can be _verified_ end to end until 059's package is
+actually published — every one-liner names the published
+`@renovate-config-debugger/cli`.
 
 ## Validation messages, and the listing budget (2026-08-16)
 

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -64,7 +64,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                              | M15                  | proposed    |
 | [058](058-rcd-debugger-cli.md)                          | `rcd`: the debugger CLI on the shimmed engine (experimental)         | M16                  | done        |
 | [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli` (experimental)    | M16                  | done        |
-| [060](060-mcp-server-and-agent-discovery.md)            | `rcd mcp` + pointing agents at the headless interface                | M16                  | proposed    |
+| [060](060-mcp-server-and-agent-discovery.md)            | `rcd mcp` + pointing agents at the headless interface                | M16                  | done        |
 | [061](061-claude-plugin-marketplace.md)                 | Claude plugin marketplace for the debugger                           | M16                  | proposed    |
 | [062](062-results-tab-taxonomy.md)                      | Results tabs: `Simulator` → `packageRules`, + `Extraction`           | M17                  | proposed    |
 | [063](063-custom-manager-extraction.md)                 | Custom-manager extraction simulator                                  | M17                  | proposed    |


### PR DESCRIPTION
Implements roadmap **060** — stacked on #133 (059).

- `rcd mcp`: stdio MCP server (`@modelcontextprotocol/sdk`) as one subcommand over 058's core — no new functionality, better interaction economics for sessions. `run_config` returns `{runId, digest, stageStatus, errors, warnings, treeSummary}`; drill-down tools (`get_final_config`, `get_preset_tree`, `get_preset_node`, `get_provenance`, `get_resolved_config`, `simulate`, `compare_simulations`, `explain_message`, `get_option_docs`) read from an LRU of held runs, so two lookups can never describe different worlds. Tool descriptions carry the domain hints ("preset-node bodies are large — query one node at a time").
- Shared projections extracted (`src/projections/{digest,tree,provenance,messages}.ts`) so subcommands and MCP tools are one implementation; `applyRunAuth` extends the endpoint guard to both transports.
- Discovery, deliberately boring and all visible: an in-flow footer note in the app (`HeadlessNote.tsx`), a "For agents and scripts" README section with the exact one-liners, an AGENTS.md pointer, `public/llms.txt`, and the `claude-code-hint` stderr marker (emitted once per process, only when `CLAUDECODE=1`). No hidden agent messaging — the rejected mechanisms are documented in the research doc.

Verified: lint, format:check, typecheck, CLI tests (61), app unit+render green; MCP stdio handshake smoke-tested (initialize → tools/list → run_config) against the built bundle.



**Absorbed on review (folded from #161/#165):** the plugin hint is withheld from machine output (`--format json`) — agents merge streams with `2>&1` and the hint preceded the payload — while `rcd mcp` keeps it (stderr was never at risk); the registration snippets in the README, HeadlessNote and llms.txt gained the second package-runner one-liner.
