### PR TITLE
fix(app): distinguish fail-closed no-input from real mismatches, fix verdict copy

### DIFF
--- a/packages/app/e2e/06-error-states-and-filters.spec.ts
+++ b/packages/app/e2e/06-error-states-and-filters.spec.ts
@@ -35,11 +35,13 @@ test("a validation error adds a hypothetical-run banner to post-Validate results
 });
 
 /**
- * Roadmap 023 — the "my rules only" filter. The most common wish across the
- * persona sessions: find your own rule fast. One click filters the simulator
- * results to the repo config's own packageRules, with clause evidence expanded.
+ * Roadmap 023 — the rules drawer's provenance filter, the successor to the
+ * "my rules only" toggle. The most common wish across the persona sessions:
+ * find your own rule fast. Narrowing the facet to `repo config` filters the
+ * simulator results to the repo config's own packageRules, with clause
+ * evidence expanded.
  */
-test("the simulator 'my rules only' filter shows repo rules with clause evidence expanded", async ({
+test("the simulator's repo-config filter shows repo rules with clause evidence expanded", async ({
   page,
 }) => {
   const fragment = await encodeShareFragment({ config: PACKAGE_RULES_CONFIG });
@@ -57,9 +59,9 @@ test("the simulator 'my rules only' filter shows repo rules with clause evidence
   // drawer now — the filter is one disclosure away, not gone.
   await simulator.getByText("Matched rules").click();
 
-  const myRules = simulator.getByRole("button", { name: "my rules only" });
-  await expect(myRules).toBeVisible();
-  await myRules.click();
+  const presetFilter = simulator.getByLabel("Filter rules by preset");
+  await expect(presetFilter).toBeVisible();
+  await presetFilter.selectOption("repo");
 
   // The repo rule row is shown, pre-expanded, with its clause evidence visible.
   const expandedRow = simulator.locator(".sim-rule.expanded").first();

--- a/packages/app/src/components/rule-framing.tsx
+++ b/packages/app/src/components/rule-framing.tsx
@@ -127,6 +127,11 @@ export function RuleFramingText({
   return (
     <>
       {bare} — <FramingBreakdown framing={framing} />
+      {/* Replay-02 R6: the one visible anchor tying the 1-based count to the
+          0-based `packageRules[N]` citations everywhere else on the page. */}
+      {total > 1 ? (
+        <> (indexed packageRules[0]–packageRules[{nf.format(total - 1)}], as Renovate cites them)</>
+      ) : null}
     </>
   );
 }

--- a/packages/app/src/data/glossary-data.ts
+++ b/packages/app/src/data/glossary-data.ts
@@ -122,6 +122,18 @@ export const GLOSSARY = {
       "the sourceUrl field.",
     url: "https://docs.renovatebot.com/configuration-options/#matchrepositories",
   },
+  // Replay-02 R3/R4: the rule row's own verdict chip. A rule that lost to an
+  // empty simulator field is a different fact from one that mismatched real
+  // data, and "no input" is short enough to sit in the row — the card is where
+  // the distinction is spelled out.
+  noInput: {
+    name: "no input",
+    plain:
+      "This rule did not match, but nothing about your dependency contradicted it: a field the " +
+      "rule reads is simply not set in this simulation. Renovate treats a missing value as a " +
+      "non-match, so the rule would be skipped for a real dependency missing that field too. " +
+      "Fill the field in the form above and re-run to see what the rule does with it.",
+  },
   dependencyDashboard: {
     name: "Dependency Dashboard",
     plain:

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -6,7 +6,7 @@ import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";
 import { ClauseGrid } from "./ClauseGrid";
 import { RULE_POP_CLASS, RULE_POP_SELECTOR } from "./rule-pop-dom";
-import { ruleAppliedMarkdown, VERDICT_LABEL, writeMark } from "./rule-format";
+import { ruleAppliedMarkdown, ruleVerdictLabel, writeMark } from "./rule-format";
 import type { RuleEvidence, RuleWrite } from "./rule-evidence";
 import { WriteRow } from "./WriteRow";
 
@@ -70,14 +70,20 @@ function RuleEvidenceHead({
   evidence: RuleEvidence;
   onSelectPreset?: (nodeId: string) => void;
 }) {
-  const verdict = evidence.verdict ? ` — ${VERDICT_LABEL[evidence.verdict]}` : "";
+  const verdictLabel = evidence.verdict
+    ? ruleVerdictLabel({ verdict: evidence.verdict, clauses: evidence.clauses })
+    : undefined;
+  const verdict = verdictLabel ? ` — ${verdictLabel}` : "";
   return (
     <p className="sim-rule-pop-head">
-      <code className="sim-rule-pop-id">packageRules[{evidence.ruleIndex}]</code>
-      {evidence.verdict ? (
-        <span className={`badge sim-verdict verdict-${evidence.verdict}`}>
-          {VERDICT_LABEL[evidence.verdict]}
-        </span>
+      <code
+        className="sim-rule-pop-id"
+        title="0-based index — the same numbering Renovate's own validator messages use; the last of N rules is packageRules[N−1]"
+      >
+        packageRules[{evidence.ruleIndex}]
+      </code>
+      {verdictLabel && evidence.verdict ? (
+        <span className={`badge sim-verdict verdict-${evidence.verdict}`}>{verdictLabel}</span>
       ) : null}
       {evidence.layer ? (
         <ProvenanceChip layer={evidence.layer} onSelectPreset={onSelectPreset} />

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -3,7 +3,7 @@ import type { MergedKey, ProvenanceLayer, RuleEvaluation } from "@renovate-confi
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { ClauseGrid } from "./ClauseGrid";
-import { ruleAppliedMarkdown, ruleLabel, VERDICT_LABEL, writeMark } from "./rule-format";
+import { ruleAppliedMarkdown, ruleLabel, ruleVerdictLabel, writeMark } from "./rule-format";
 import { WriteRow } from "./WriteRow";
 
 /** Roadmap 018/040/054: what a matching rule applied to the dependency config,
@@ -15,7 +15,7 @@ function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: Merg
         Applied to the dependency config
         <CopyMarkdownButton
           className="inline"
-          header={`\`packageRules[${rule.index}]\` ${ruleLabel(rule)} — ${VERDICT_LABEL[rule.verdict]}`}
+          header={`\`packageRules[${rule.index}]\` ${ruleLabel(rule)} — ${ruleVerdictLabel(rule)}`}
           code={ruleAppliedMarkdown(merged)}
         />
       </div>
@@ -60,11 +60,17 @@ export function RuleRow({
         <span className="caret">{expanded ? "▾" : "▸"}</span>
         {/* Roadmap 013: canonical form — the SAME text a validator message and
             the editor cross-link use, so this row is unmistakably the same
-            rule as "packageRules[N]" elsewhere on the page. */}
-        <span className="sim-rule-index">packageRules[{rule.index}]</span>
+            rule as "packageRules[N]" elsewhere on the page. Replay-02 R6: the
+            title says WHY it's 0-based next to the page's 1-based counts. */}
+        <span
+          className="sim-rule-index"
+          title="0-based index — the same numbering Renovate's own validator messages use; the last of N rules is packageRules[N−1]"
+        >
+          packageRules[{rule.index}]
+        </span>
         <span className="sim-rule-label">{ruleLabel(rule)}</span>
         <span className={`badge sim-verdict verdict-${rule.verdict}`}>
-          {VERDICT_LABEL[rule.verdict]}
+          {ruleVerdictLabel(rule)}
         </span>
         {layer ? (
           <span className="sim-rule-provenance">

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from "react";
 import type { MergedKey, ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
+import { Explained } from "@/components/glossary";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
+import { GLOSSARY } from "@/data/glossary-data";
 import { ClauseGrid } from "./ClauseGrid";
-import { ruleAppliedMarkdown, ruleLabel, ruleVerdictLabel, writeMark } from "./rule-format";
+import {
+  isNoInputNoMatch,
+  ruleAppliedMarkdown,
+  ruleLabel,
+  ruleVerdictLabel,
+  writeMark,
+} from "./rule-format";
 import { WriteRow } from "./WriteRow";
 
 /** Roadmap 018/040/054: what a matching rule applied to the dependency config,
@@ -31,6 +39,31 @@ function SimMergedApplied({ rule, merged }: { rule: RuleEvaluation; merged: Merg
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Replay-02 R3/R4: the row's verdict. A no-match decided solely by an unset
+ * simulator field wears its own short chip — "no input", in the warn hue its
+ * clause glyph already uses — with the distinction spelled out in the hover
+ * card beside it, exactly as the provenance chip explains its layer. The full
+ * sentence stays in `ruleVerdictLabel`, which is what the markdown export and
+ * the evidence card render.
+ */
+function RuleVerdictBadge({ rule }: { rule: RuleEvaluation }) {
+  if (isNoInputNoMatch(rule)) {
+    return (
+      <Explained entry={GLOSSARY.noInput}>
+        {(handlers) => (
+          <span className="badge sim-verdict verdict-no-input explained" tabIndex={0} {...handlers}>
+            no input
+          </span>
+        )}
+      </Explained>
+    );
+  }
+  return (
+    <span className={`badge sim-verdict verdict-${rule.verdict}`}>{ruleVerdictLabel(rule)}</span>
   );
 }
 
@@ -69,9 +102,7 @@ export function RuleRow({
           packageRules[{rule.index}]
         </span>
         <span className="sim-rule-label">{ruleLabel(rule)}</span>
-        <span className={`badge sim-verdict verdict-${rule.verdict}`}>
-          {ruleVerdictLabel(rule)}
-        </span>
+        <RuleVerdictBadge rule={rule} />
         {layer ? (
           <span className="sim-rule-provenance">
             <ProvenanceChip layer={layer} onSelectPreset={onSelectPreset} />

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -107,10 +107,8 @@ export const RuleSimulator = memo(function RuleSimulator({
     running,
     error,
     emptyGuardTriggered,
-    showAll,
-    setShowAll,
-    myRulesOnly,
-    setMyRulesOnly,
+    ruleFilters,
+    setRuleFilters,
     focusHint,
     setFocusHint,
     simulate,
@@ -141,25 +139,28 @@ export const RuleSimulator = memo(function RuleSimulator({
     jumpToRules,
     jumpToStep,
   } = useSimulatorDrawers({ mergeStepIndex, onMergeStepChange });
-  // Roadmap 023: the user's own repo-config rules (013 provenance) — the merged
-  // indices that came from the repo layer, for the "my rules only" filter.
-  const repoRuleIndices = useMemo(
-    () =>
-      new Set((ruleAttribution ?? []).filter((a) => a.layer.kind === "repo").map((a) => a.index)),
-    [ruleAttribution],
-  );
+  // Roadmap 013: which config level contributed each merged rule — the rule
+  // rows' provenance chips, the drawer's badge row, and the provenance filter
+  // facet (the successor to "my rules only") all read it. Declared here rather
+  // than beside the other derived state because `useRuleFocus` needs it to
+  // answer "is the row this link names currently filtered out?".
+  const layerByIndex = useMemo(() => {
+    const map = new Map<number, ProvenanceLayer>();
+    for (const attr of ruleAttribution ?? []) {
+      map.set(attr.index, attr.layer);
+    }
+    return map;
+  }, [ruleAttribution]);
   const { cardRef, focusRule } = useRuleFocus({
     focusRuleIndex,
     onRuleFocused,
     sim,
-    showAll,
-    setShowAll,
-    myRulesOnly,
-    setMyRulesOnly,
+    ruleFilters,
+    setRuleFilters,
+    layerByIndex,
     rulesOpen,
     setRulesOpen,
     setFocusHint,
-    repoRuleIndices,
   });
   const { pinned, pin, unpin, comparison, currentDescriptor } = useAbComparison({
     engineModule,
@@ -175,14 +176,6 @@ export const RuleSimulator = memo(function RuleSimulator({
     () => (Array.isArray(finalConfig?.packageRules) ? finalConfig.packageRules : []),
     [finalConfig],
   );
-  const layerByIndex = useMemo(() => {
-    const map = new Map<number, ProvenanceLayer>();
-    for (const attr of ruleAttribution ?? []) {
-      map.set(attr.index, attr.layer);
-    }
-    return map;
-  }, [ruleAttribution]);
-
   // Keys the rules changed vs. the pre-rules effective config, for the verdict
   // ledger and the final section's summary. Roadmap 046: the base is flattened
   // the same way the engine flattens `finalDependencyConfig` — the update-type
@@ -486,11 +479,8 @@ export const RuleSimulator = memo(function RuleSimulator({
             <SimRulesDrawer
               rules={sim.rules}
               matchedCount={matchedCount}
-              repoRuleIndices={repoRuleIndices}
-              myRulesOnly={myRulesOnly}
-              onMyRulesOnlyChange={setMyRulesOnly}
-              showAll={showAll}
-              onShowAllChange={setShowAll}
+              filters={ruleFilters}
+              onFiltersChange={setRuleFilters}
               layerByIndex={layerByIndex}
               onSelectPreset={onSelectPreset}
               open={rulesOpen}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -26,7 +26,7 @@ import { useSimulationRun } from "./use-simulation-run";
 import { useSimulatorDrawers } from "./use-simulator-drawers";
 import { useSimulatorForm } from "./use-simulator-form";
 import { useThreadNav } from "./use-thread-nav";
-import { buildVerdictSegments } from "./verdict-sentence";
+import { buildNoInputCaveat, buildVerdictSegments } from "./verdict-sentence";
 import { buildVerdictThreads } from "./verdict-threads";
 
 /**
@@ -232,6 +232,12 @@ export const RuleSimulator = memo(function RuleSimulator({
       sim ? buildVerdictSegments(sim, sim.flattened.updateType, changedKeys, ruleAttribution) : [],
     [sim, changedKeys, ruleAttribution],
   );
+  // Replay-02 R3: "your rule lost to an empty form field, not to your data" —
+  // stated on the card itself, since the card is what gets screenshotted.
+  const verdictCaveat = useMemo(
+    () => (sim ? buildNoInputCaveat(sim, ruleAttribution) : undefined),
+    [sim, ruleAttribution],
+  );
   // Roadmap 047: the authored update-type blocks flattening consumed without
   // applying — the only thing that still earns the verdict card's aside.
   const consumedBlocks = useMemo(
@@ -408,6 +414,7 @@ export const RuleSimulator = memo(function RuleSimulator({
               matchedCount={matchedCount}
               totalRules={sim.rules.length}
               segments={verdictSegments}
+              caveat={verdictCaveat}
               threads={verdictThreads}
               threadNav={{
                 open: threadNav.openThreads,

--- a/packages/app/src/features/simulator/SimRulesBody.tsx
+++ b/packages/app/src/features/simulator/SimRulesBody.tsx
@@ -1,65 +1,160 @@
 import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
+import {
+  ALL_PRESETS,
+  DEFAULT_RULE_FILTERS,
+  type FilterOption,
+  isDefaultView,
+  type PresetFilter,
+  REPO_RULES,
+  type RuleFilters,
+  type VerdictFilter,
+  presetFilterOptions,
+  verdictFilterOptions,
+} from "./rule-filters";
 import { RuleRow } from "./RuleRow";
 
+function optionLabel(option: FilterOption): string {
+  return `${option.label} (${option.count})`;
+}
+
 /**
- * Roadmap 023/047: the body of the "Matched rules" drawer — the shown/filter
- * controls the persona study leaned on, then the rule rows themselves. The
- * "N of M rules shown" line stays inside the body: the drawer's own summary
- * row already carries the headline count, and this one tracks what the
- * filters are currently doing to the list below it.
+ * Roadmap 023/047: the rules drawer's filter row — the Effective Config tab's
+ * `.prov-filters` chrome, one `<select>` per facet. The controls sit on the
+ * right edge because the drawer's own summary row already carries the headline
+ * count on the left, and the shown-count is stated only while the filters are
+ * actually narrowing the list: unfiltered it would repeat "N of M matched"
+ * from the row above it.
+ *
+ * Its own component for the depth ratchet (`react/jsx-max-depth` is 3) —
+ * the same reason `ProvFilters` is separate from the panel it filters.
+ */
+function SimRulesFilters({
+  filters,
+  onFiltersChange,
+  verdictOptions,
+  presetOptions,
+  shownCount,
+  totalCount,
+}: {
+  filters: RuleFilters;
+  onFiltersChange: (filters: RuleFilters) => void;
+  verdictOptions: FilterOption[];
+  presetOptions: FilterOption[];
+  shownCount: number;
+  totalCount: number;
+}) {
+  const plural = totalCount === 1 ? "" : "s";
+  // Stated only where it says something the rest of the drawer does not: the
+  // default view's count is the summary row's own "N of M matched", and a
+  // facet that hides nothing ("All verdicts") has nothing to report.
+  const stateCount = shownCount < totalCount && !isDefaultView(filters);
+  return (
+    <div className="prov-filters sim-filters">
+      {stateCount ? (
+        <span className="sim-filter-count">
+          {shownCount} of {totalCount} rule{plural} shown
+        </span>
+      ) : null}
+      <select
+        aria-label="Filter rules by verdict"
+        value={filters.verdict}
+        onChange={(e) => onFiltersChange({ ...filters, verdict: e.target.value as VerdictFilter })}
+      >
+        {verdictOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {optionLabel(option)}
+          </option>
+        ))}
+      </select>
+      <select
+        aria-label="Filter rules by preset"
+        value={filters.preset}
+        onChange={(e) => onFiltersChange({ ...filters, preset: e.target.value as PresetFilter })}
+      >
+        <option value={ALL_PRESETS}>All presets</option>
+        {presetOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            only from {optionLabel(option)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+/** What an empty list means depends on why it is empty: at the default view
+ *  it is the run's own answer ("nothing matched"), under a narrowed facet it
+ *  is the filters' doing — and each states the way out of itself. */
+function SimRulesEmpty({
+  filters,
+  onFiltersChange,
+  hiddenCount,
+  totalRules,
+}: {
+  filters: RuleFilters;
+  onFiltersChange: (filters: RuleFilters) => void;
+  hiddenCount: number;
+  totalRules: number;
+}) {
+  if (!isDefaultView(filters)) {
+    return (
+      <p className="empty-note">
+        No rule matches these filters.{" "}
+        <button
+          type="button"
+          className="sim-toggle inline"
+          onClick={() => onFiltersChange(DEFAULT_RULE_FILTERS)}
+        >
+          Clear them.
+        </button>
+      </p>
+    );
+  }
+  return (
+    <p className="empty-note">
+      No rule matched this dependency.{" "}
+      {hiddenCount > 0 ? (
+        <button
+          type="button"
+          className="sim-toggle inline"
+          onClick={() => onFiltersChange({ ...filters, verdict: "all" })}
+        >
+          Show all {totalRules} anyway.
+        </button>
+      ) : null}
+    </p>
+  );
+}
+
+/**
+ * Roadmap 023/047: the body of the "Matched rules" drawer — the filter row the
+ * persona study leaned on, then the rule rows themselves.
  */
 export function SimRulesBody({
   rules,
   shownRules,
-  notableCount,
-  hiddenCount,
-  repoRuleCount,
-  myRulesOnly,
-  onMyRulesOnlyChange,
-  showAll,
-  onShowAllChange,
+  filters,
+  onFiltersChange,
   layerByIndex,
   onSelectPreset,
 }: {
   rules: RuleEvaluation[];
   shownRules: RuleEvaluation[];
-  notableCount: number;
-  hiddenCount: number;
-  repoRuleCount: number;
-  myRulesOnly: boolean;
-  onMyRulesOnlyChange: (value: boolean) => void;
-  showAll: boolean;
-  onShowAllChange: (value: boolean) => void;
+  filters: RuleFilters;
+  onFiltersChange: (filters: RuleFilters) => void;
   layerByIndex: Map<number, ProvenanceLayer>;
   onSelectPreset?: (nodeId: string) => void;
 }) {
-  const plural = rules.length === 1 ? "" : "s";
   return (
     <>
-      <div className="sim-rules-head">
-        <span className="sim-summary">
-          {myRulesOnly
-            ? `your ${repoRuleCount} config rule${repoRuleCount === 1 ? "" : "s"}`
-            : showAll
-              ? `all ${rules.length} rule${plural}`
-              : `${notableCount} of ${rules.length} rule${plural} shown`}
-        </span>
-        {repoRuleCount > 0 ? (
-          <button
-            type="button"
-            className={`sim-toggle${myRulesOnly ? " active" : ""}`}
-            onClick={() => onMyRulesOnlyChange(!myRulesOnly)}
-            title="Show only the packageRules from your own repo config, with their clause evidence expanded"
-          >
-            {myRulesOnly ? "show all rules" : "my rules only"}
-          </button>
-        ) : null}
-        {hiddenCount > 0 && !myRulesOnly ? (
-          <button type="button" className="sim-toggle" onClick={() => onShowAllChange(!showAll)}>
-            {showAll ? "show matched only" : `show all ${rules.length}`}
-          </button>
-        ) : null}
-      </div>
+      <SimRulesFilters
+        filters={filters}
+        onFiltersChange={onFiltersChange}
+        verdictOptions={verdictFilterOptions(rules)}
+        presetOptions={presetFilterOptions(rules, layerByIndex, filters.preset)}
+        shownCount={shownRules.length}
+        totalCount={rules.length}
+      />
       {shownRules.length > 0 ? (
         <div className="sim-rules">
           {shownRules.map((rule) => (
@@ -68,27 +163,20 @@ export function SimRulesBody({
               rule={rule}
               layer={layerByIndex.get(rule.index)}
               onSelectPreset={onSelectPreset}
-              defaultExpanded={myRulesOnly}
+              // Roadmap 023: narrowing to the user's OWN rules is the "where is
+              // my rule?" move — those few rows open with their clause evidence
+              // already showing, as the "my rules only" toggle used to.
+              defaultExpanded={filters.preset === REPO_RULES}
             />
           ))}
         </div>
-      ) : myRulesOnly ? (
-        <p className="empty-note">
-          None of your repo config&apos;s rules are in the merged set for this run.
-        </p>
       ) : (
-        <p className="empty-note">
-          No rule matched this dependency.{" "}
-          {hiddenCount > 0 ? (
-            <button
-              type="button"
-              className="sim-toggle inline"
-              onClick={() => onShowAllChange(true)}
-            >
-              Show all {rules.length} anyway.
-            </button>
-          ) : null}
-        </p>
+        <SimRulesEmpty
+          filters={filters}
+          onFiltersChange={onFiltersChange}
+          hiddenCount={rules.length - shownRules.length}
+          totalRules={rules.length}
+        />
       )}
     </>
   );

--- a/packages/app/src/features/simulator/SimRulesDrawer.tsx
+++ b/packages/app/src/features/simulator/SimRulesDrawer.tsx
@@ -4,6 +4,7 @@ import { layerId } from "@/components/provenance-layer";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { SummaryDrawer } from "./SummaryDrawer";
 import { type LayerMatchCount, matchedLayerCounts } from "./layer-counts";
+import { filterRules, type RuleFilters } from "./rule-filters";
 import { SimRulesBody } from "./SimRulesBody";
 
 /** How many distinct provenance layers the rules drawer names before it
@@ -49,8 +50,8 @@ function RulesSummary({ matchedCount, totalRules }: { matchedCount: number; tota
 /**
  * Roadmap 047: the "Matched rules" evidence layer. The list defaults to the
  * rules that actually did something (matched or unresolved), hiding the sea of
- * "no match" rows behind a toggle; "my rules only" narrows it to the user's
- * own repo-config rules.
+ * "no match" rows; the two filter facets (verdict, provenance) are what open
+ * it up again — including to the user's own repo-config rules.
  *
  * Roadmap 032: memoized — it filters the whole rule list (hundreds of entries
  * for a preset-heavy config) and every prop it takes comes from the last RUN,
@@ -59,11 +60,8 @@ function RulesSummary({ matchedCount, totalRules }: { matchedCount: number; tota
 export const SimRulesDrawer = memo(function SimRulesDrawer({
   rules,
   matchedCount,
-  repoRuleIndices,
-  myRulesOnly,
-  onMyRulesOnlyChange,
-  showAll,
-  onShowAllChange,
+  filters,
+  onFiltersChange,
   layerByIndex,
   onSelectPreset,
   open,
@@ -72,24 +70,15 @@ export const SimRulesDrawer = memo(function SimRulesDrawer({
 }: {
   rules: RuleEvaluation[];
   matchedCount: number;
-  repoRuleIndices: Set<number>;
-  myRulesOnly: boolean;
-  onMyRulesOnlyChange: (value: boolean) => void;
-  showAll: boolean;
-  onShowAllChange: (value: boolean) => void;
+  filters: RuleFilters;
+  onFiltersChange: (filters: RuleFilters) => void;
   layerByIndex: Map<number, ProvenanceLayer>;
   onSelectPreset?: (nodeId: string) => void;
   open: boolean;
   onToggle: (open: boolean) => void;
   detailsRef?: RefObject<HTMLDetailsElement | null>;
 }) {
-  const notableRules = rules.filter((r) => r.verdict !== "no-match");
-  const hiddenCount = rules.length - notableRules.length;
-  const shownRules = myRulesOnly
-    ? rules.filter((r) => repoRuleIndices.has(r.index))
-    : showAll
-      ? rules
-      : notableRules;
+  const shownRules = filterRules(rules, filters, layerByIndex);
   const layerCounts = matchedLayerCounts(rules, layerByIndex);
   return (
     <SummaryDrawer
@@ -108,13 +97,8 @@ export const SimRulesDrawer = memo(function SimRulesDrawer({
       <SimRulesBody
         rules={rules}
         shownRules={shownRules}
-        notableCount={notableRules.length}
-        hiddenCount={hiddenCount}
-        repoRuleCount={repoRuleIndices.size}
-        myRulesOnly={myRulesOnly}
-        onMyRulesOnlyChange={onMyRulesOnlyChange}
-        showAll={showAll}
-        onShowAllChange={onShowAllChange}
+        filters={filters}
+        onFiltersChange={onFiltersChange}
         layerByIndex={layerByIndex}
         onSelectPreset={onSelectPreset}
       />

--- a/packages/app/src/features/simulator/SimVerdictBlock.tsx
+++ b/packages/app/src/features/simulator/SimVerdictBlock.tsx
@@ -57,6 +57,7 @@ export function SimVerdictBlock({
   matchedCount,
   totalRules,
   segments,
+  caveat,
   threads,
   threadNav,
   flattened,
@@ -78,6 +79,10 @@ export function SimVerdictBlock({
   matchedCount: number;
   totalRules: number;
   segments: VerdictSegment[];
+  /** Replay-02 R3: "N of your rules failed only because a field was left
+   *  unset" — rendered right under the sentence, because the sentence is what
+   *  gets screenshotted. Absent when every no-match lost on real data. */
+  caveat?: string;
   /** Roadmap 054: one thread per setting the rules changed. */
   threads: ThreadModel[];
   /** Roadmap 054 layer 4: which threads are expanded, and where a jump out of
@@ -137,6 +142,7 @@ export function SimVerdictBlock({
             ),
           )}
         </p>
+        {caveat ? <p className="sim-verdict-caveat">⚠ {caveat}</p> : null}
       </div>
       <div className="sim-verdict-body">
         {threads.length === 0 ? (

--- a/packages/app/src/features/simulator/rule-filters.test.ts
+++ b/packages/app/src/features/simulator/rule-filters.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The rules drawer's two filter facets. The verdict facet has to split a
+ * fail-closed "no match — input not set" from a genuine mismatch exactly the
+ * way the badge does (Replay-02 R3/R4 — one predicate, `isNoInputNoMatch`),
+ * and `ruleVisible` has to be the SAME predicate the cross-link focus uses to
+ * decide whether a row is hidden. Both are locked here.
+ */
+import type {
+  ClauseEvaluation,
+  ProvenanceLayer,
+  RuleEvaluation,
+} from "@renovate-config-debugger/engine";
+import { describe, expect, test } from "vitest";
+import {
+  ALL_PRESETS,
+  DEFAULT_RULE_FILTERS,
+  filterRules,
+  presetFilterOptions,
+  REPO_RULES,
+  ruleVisible,
+  verdictFilterOptions,
+} from "./rule-filters";
+
+function clause(state: ClauseEvaluation["state"]): ClauseEvaluation {
+  return {
+    key: "matchSourceUrls",
+    value: ["x"],
+    state,
+    inputValues: {},
+    readFields: ["sourceUrl"],
+  };
+}
+
+function rule(
+  index: number,
+  verdict: RuleEvaluation["verdict"],
+  clauses: ClauseEvaluation[] = [],
+): RuleEvaluation {
+  return { index, verdict, clauses, notes: [] };
+}
+
+const REPO_LAYER: ProvenanceLayer = { kind: "repo" };
+const PRESET_LAYER: ProvenanceLayer = { kind: "preset", name: "config:recommended", nodeId: "n1" };
+
+// 0 matched (repo) · 1 no-input (preset) · 2 no-match (preset) · 3 not-simulated (preset)
+const RULES = [
+  rule(0, "matched", [clause("matched")]),
+  rule(1, "no-match", [clause("no-input")]),
+  rule(2, "no-match", [clause("no-match")]),
+  rule(3, "not-simulated"),
+];
+const LAYERS = new Map<number, ProvenanceLayer>([
+  [0, REPO_LAYER],
+  [1, PRESET_LAYER],
+  [2, PRESET_LAYER],
+  [3, PRESET_LAYER],
+]);
+
+const indices = (rules: RuleEvaluation[]) => rules.map((r) => r.index);
+
+describe("the verdict facet", () => {
+  test("the default view keeps everything that is not a plain no-match", () => {
+    expect(indices(filterRules(RULES, DEFAULT_RULE_FILTERS, LAYERS))).toEqual([0, 3]);
+  });
+
+  test("no-input and no-match are separate facets, split like the badge", () => {
+    const at = (verdict: "all" | "matched" | "no-input" | "no-match") =>
+      indices(filterRules(RULES, { verdict, preset: ALL_PRESETS }, LAYERS));
+    expect(at("all")).toEqual([0, 1, 2, 3]);
+    expect(at("matched")).toEqual([0]);
+    expect(at("no-input")).toEqual([1]);
+    expect(at("no-match")).toEqual([2]);
+  });
+});
+
+describe("the provenance facet", () => {
+  test("narrowing to the repo layer is the old 'my rules only'", () => {
+    // Note the verdict facet stays at its default: the two facets compose.
+    expect(indices(filterRules(RULES, { verdict: "all", preset: REPO_RULES }, LAYERS))).toEqual([
+      0,
+    ]);
+  });
+
+  test("a rule with no attribution is hidden by any narrowed preset facet", () => {
+    const orphan = rule(9, "matched");
+    expect(ruleVisible(orphan, { verdict: "all", preset: REPO_RULES }, LAYERS)).toBe(false);
+    expect(ruleVisible(orphan, { verdict: "all", preset: ALL_PRESETS }, LAYERS)).toBe(true);
+  });
+
+  test("options carry their counts, most-contributing first", () => {
+    expect(presetFilterOptions(RULES, LAYERS, ALL_PRESETS)).toEqual([
+      { value: "preset:config:recommended", label: "config:recommended", count: 3 },
+      { value: "repo", label: "repo config", count: 1 },
+    ]);
+  });
+
+  test("a selected layer the run no longer has stays listed, at zero", () => {
+    const options = presetFilterOptions(RULES, LAYERS, "preset:group:monorepos");
+    expect(options).toContainEqual({
+      value: "preset:group:monorepos",
+      label: "group:monorepos",
+      count: 0,
+    });
+  });
+});
+
+test("the verdict options state what each would leave", () => {
+  expect(verdictFilterOptions(RULES).map((o) => [o.value, o.count])).toEqual([
+    ["notable", 2],
+    ["all", 4],
+    ["matched", 1],
+    ["no-input", 1],
+    ["no-match", 1],
+  ]);
+});

--- a/packages/app/src/features/simulator/rule-filters.ts
+++ b/packages/app/src/features/simulator/rule-filters.ts
@@ -1,0 +1,162 @@
+import type { ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
+import { type LayerId, layerId, layerLabel } from "@/components/provenance-layer";
+import { isNoInputNoMatch } from "./rule-format";
+
+/**
+ * The rules drawer's two filter facets — verdict and provenance — as one
+ * value, with the pure filtering they drive.
+ *
+ * They replace the three link toggles the drawer used to carry ("all N rules"
+ * / "my rules only" / "show all N"): a link that both states the current view
+ * and changes it reads as a caption, and the persona sessions had people
+ * clicking "show all 715" to find out what it did. Two labelled `<select>`s in
+ * the Effective Config tab's `.prov-filters` chrome say what they filter
+ * before they are touched, and "my rules only" survives as what it always
+ * was — the provenance facet narrowed to `repo config`.
+ *
+ * Pure functions in their own module (not inside the components) because
+ * `useRuleFocus` must answer "is this rule currently visible?" with the exact
+ * predicate the list renders with — a cross-link that scrolls to a row the
+ * filters are hiding is the bug this shape prevents.
+ */
+
+/** The verdict facet. `notable` is the default view (matched + unresolved,
+ *  i.e. everything except a plain no-match) — roadmap 012/047's finding that a
+ *  first screen of 700 "no match" rows buries the handful that did something.
+ *  The other three are the verdicts a rule row can wear, split the way the
+ *  badge splits them (see {@link isNoInputNoMatch}). */
+export type VerdictFilter = "notable" | "all" | "matched" | "no-input" | "no-match";
+
+/** The provenance facet: a layer id present in the run, or {@link ALL_PRESETS}.
+ *  A plain {@link LayerId} rather than a `"all" | LayerId` union — that union
+ *  collapses to `string` anyway (see `no-redundant-type-constituents`), and
+ *  `layerId()` only ever produces the four level kinds or a `preset:`-prefixed
+ *  name, so the sentinel can never collide with a real layer. */
+export type PresetFilter = LayerId;
+
+export const ALL_PRESETS: PresetFilter = "all";
+
+/** The repo layer's own id — "my rules only", as a filter value. */
+export const REPO_RULES: PresetFilter = "repo";
+
+export interface RuleFilters {
+  verdict: VerdictFilter;
+  preset: PresetFilter;
+}
+
+export const DEFAULT_RULE_FILTERS: RuleFilters = { verdict: "notable", preset: ALL_PRESETS };
+
+/** Whether the drawer is showing its default view — the state whose count the
+ *  drawer's own summary row already states. */
+export function isDefaultView(filters: RuleFilters): boolean {
+  return (
+    filters.verdict === DEFAULT_RULE_FILTERS.verdict &&
+    filters.preset === DEFAULT_RULE_FILTERS.preset
+  );
+}
+
+export function matchesVerdictFilter(rule: RuleEvaluation, filter: VerdictFilter): boolean {
+  if (filter === "all") {
+    return true;
+  }
+  if (filter === "notable") {
+    return rule.verdict !== "no-match";
+  }
+  if (filter === "matched") {
+    return rule.verdict === "matched";
+  }
+  if (filter === "no-input") {
+    return isNoInputNoMatch(rule);
+  }
+  return rule.verdict === "no-match" && !isNoInputNoMatch(rule);
+}
+
+function matchesPresetFilter(
+  rule: RuleEvaluation,
+  filter: PresetFilter,
+  layerByIndex: Map<number, ProvenanceLayer>,
+): boolean {
+  if (filter === ALL_PRESETS) {
+    return true;
+  }
+  const layer = layerByIndex.get(rule.index);
+  return layer !== undefined && layerId(layer) === filter;
+}
+
+export function ruleVisible(
+  rule: RuleEvaluation,
+  filters: RuleFilters,
+  layerByIndex: Map<number, ProvenanceLayer>,
+): boolean {
+  return (
+    matchesVerdictFilter(rule, filters.verdict) &&
+    matchesPresetFilter(rule, filters.preset, layerByIndex)
+  );
+}
+
+export function filterRules(
+  rules: RuleEvaluation[],
+  filters: RuleFilters,
+  layerByIndex: Map<number, ProvenanceLayer>,
+): RuleEvaluation[] {
+  return rules.filter((rule) => ruleVisible(rule, filters, layerByIndex));
+}
+
+export interface FilterOption {
+  value: string;
+  label: string;
+  count: number;
+}
+
+/**
+ * The verdict `<select>`'s options, each carrying how many rules it would
+ * leave — the count is what makes the facet answerable before it is chosen
+ * ("is it worth filtering?"), and a 0 says the run has none of that kind
+ * rather than leaving the user to discover it by picking.
+ */
+export function verdictFilterOptions(rules: RuleEvaluation[]): FilterOption[] {
+  const count = (filter: VerdictFilter) =>
+    rules.filter((rule) => matchesVerdictFilter(rule, filter)).length;
+  return [
+    { value: "notable", label: "Matched & unresolved", count: count("notable") },
+    { value: "all", label: "All verdicts", count: rules.length },
+    { value: "matched", label: "only matched", count: count("matched") },
+    { value: "no-input", label: "only no input", count: count("no-input") },
+    { value: "no-match", label: "only no match", count: count("no-match") },
+  ];
+}
+
+/**
+ * The provenance `<select>`'s options — one per layer that contributed a rule
+ * to this run, most-contributing first (the same ordering the drawer's badge
+ * row uses). `selected` is kept in the list even when the current run has no
+ * rule from it: a re-simulation against a config that dropped a preset must
+ * not silently show "all presets" while the state still filters by the gone
+ * one.
+ */
+export function presetFilterOptions(
+  rules: RuleEvaluation[],
+  layerByIndex: Map<number, ProvenanceLayer>,
+  selected: PresetFilter,
+): FilterOption[] {
+  const byLayer = new Map<LayerId, FilterOption>();
+  for (const rule of rules) {
+    const layer = layerByIndex.get(rule.index);
+    if (!layer) {
+      continue;
+    }
+    const id = layerId(layer);
+    const entry = byLayer.get(id);
+    if (entry) {
+      entry.count += 1;
+    } else {
+      byLayer.set(id, { value: id, label: layerLabel(layer), count: 1 });
+    }
+  }
+  if (selected !== ALL_PRESETS && !byLayer.has(selected)) {
+    byLayer.set(selected, { value: selected, label: selected.replace(/^preset:/, ""), count: 0 });
+  }
+  return [...byLayer.values()].toSorted(
+    (a, b) => b.count - a.count || a.label.localeCompare(b.label),
+  );
+}

--- a/packages/app/src/features/simulator/rule-format.test.ts
+++ b/packages/app/src/features/simulator/rule-format.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Replay-02 R3/R4: the collapsed rule label and the verdict badge are what
+ * survive a screenshot, and both used to render a fail-closed missing-input
+ * rule identically to a genuine data mismatch. Locks the three distinctions —
+ * label suffix, badge text, clause glyph — with two different fields, so the
+ * fix stays field-agnostic rather than sourceUrl-specific.
+ */
+import type { ClauseEvaluation, RuleEvaluation } from "@renovate-config-debugger/engine";
+import { describe, expect, test } from "vitest";
+import { clauseIcon, ruleLabel, ruleVerdictLabel } from "./rule-format";
+
+function clause(
+  key: string,
+  state: ClauseEvaluation["state"],
+  readFields: string[],
+): ClauseEvaluation {
+  return { key, value: ["x"], state, inputValues: {}, readFields };
+}
+
+function rule(clauses: ClauseEvaluation[], verdict: RuleEvaluation["verdict"]): RuleEvaluation {
+  return { index: 0, verdict, clauses, notes: [] };
+}
+
+describe("ruleLabel", () => {
+  test("a fail-closed deciding clause names the unset field, whatever it is", () => {
+    expect(
+      ruleLabel(rule([clause("matchSourceUrls", "no-input", ["sourceUrl"])], "no-match")),
+    ).toBe("matchSourceUrls — failed on matchSourceUrls (sourceUrl not set in this simulation)");
+    // A matcher reading several fields names them all.
+    expect(
+      ruleLabel(rule([clause("matchDepTypes", "no-input", ["depType", "depTypes"])], "no-match")),
+    ).toBe("matchDepTypes — failed on matchDepTypes (depType/depTypes not set in this simulation)");
+  });
+
+  test("a genuine mismatch keeps the plain failed-on suffix", () => {
+    expect(
+      ruleLabel(rule([clause("matchPackageNames", "no-match", ["packageName"])], "no-match")),
+    ).toBe("matchPackageNames — failed on matchPackageNames");
+  });
+
+  test("an all-matched rule is just the joined clause list", () => {
+    expect(
+      ruleLabel(rule([clause("matchDatasources", "matched", ["datasource"])], "matched")),
+    ).toBe("matchDatasources");
+  });
+});
+
+describe("ruleVerdictLabel", () => {
+  test("no-match decided solely by missing input says so", () => {
+    expect(
+      ruleVerdictLabel(rule([clause("matchCategories", "no-input", ["categories"])], "no-match")),
+    ).toBe("no match — input not set");
+  });
+
+  test("a real mismatch anywhere keeps the plain badge", () => {
+    expect(
+      ruleVerdictLabel(
+        rule(
+          [
+            clause("matchSourceUrls", "no-input", ["sourceUrl"]),
+            clause("matchPackageNames", "no-match", ["packageName"]),
+          ],
+          "no-match",
+        ),
+      ),
+    ).toBe("no match");
+    expect(ruleVerdictLabel(rule([], "matched"))).toBe("matched");
+  });
+});
+
+describe("clauseIcon", () => {
+  test("fail-closed, mismatch, and never-evaluated all render distinctly", () => {
+    expect(clauseIcon("no-input")).toBe("⚠");
+    expect(clauseIcon("not-applicable")).toBe("∅");
+    expect(clauseIcon("not-simulated")).toBe("∅");
+    expect(clauseIcon("no-match")).toBe("✗");
+    expect(clauseIcon("matched")).toBe("✓");
+    expect(clauseIcon("no-match")).not.toBe(clauseIcon("no-input"));
+    expect(clauseIcon("no-input")).not.toBe(clauseIcon("not-applicable"));
+  });
+});

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -48,9 +48,15 @@ export function clauseIcon(state: ClauseEvaluation["state"]): string {
   }
   // no-input — evaluated to a real fail-closed `false` (see clauseExplanation),
   // but flagged rather than a plain ✗ since the cause is a missing input, not
-  // a genuine mismatch against a value. not-applicable / not-simulated — the
-  // matcher never produced a true-or-false verdict at all.
-  return "⚠";
+  // a genuine mismatch against a value.
+  if (state === "no-input") {
+    return "⚠";
+  }
+  // not-applicable / not-simulated — the matcher never produced a true-or-false
+  // verdict at all. Replay-02 R4: a distinct glyph from no-input, because the
+  // icon is what survives a screenshot and "fail-closed false" vs "never
+  // evaluated" are different facts about the run.
+  return "∅";
 }
 
 /**
@@ -122,6 +128,32 @@ export const VERDICT_LABEL: Record<RuleEvaluation["verdict"], string> = {
   "not-simulated": "not simulated",
 };
 
+/** The clause states that fail a rule (as opposed to the neutral
+ *  not-applicable / not-simulated, which decide nothing). */
+function failingClauses(clauses: ClauseEvaluation[]): ClauseEvaluation[] {
+  return clauses.filter(
+    (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
+  );
+}
+
+/**
+ * Replay-02 R3/R4: the badge text for a rule's verdict. A no-match decided
+ * SOLELY by fail-closed no-input clauses says so — "no match — input not set"
+ * — because the badge is what survives a screenshot, and a rule that lost to
+ * an empty simulator field is a different fact from one that mismatched real
+ * data. Field-agnostic: driven by the clause state, not by which field the
+ * matcher reads.
+ */
+export function ruleVerdictLabel(rule: Pick<RuleEvaluation, "verdict" | "clauses">): string {
+  if (rule.verdict === "no-match") {
+    const failing = failingClauses(rule.clauses);
+    if (failing.length > 0 && failing.every((c) => c.state === "no-input")) {
+      return "no match — input not set";
+    }
+  }
+  return VERDICT_LABEL[rule.verdict];
+}
+
 /**
  * Roadmap 013: label lists EVERY `match*` / `exclude*` clause the rule
  * carries, and names the one that decided a no-match verdict — e.g.
@@ -139,5 +171,15 @@ export function ruleLabel(rule: RuleEvaluation): string {
   const failing = rule.clauses.find(
     (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
   );
-  return failing ? `${joined} — failed on ${failing.key}` : joined;
+  if (!failing) {
+    return joined;
+  }
+  // Replay-02 R3: a fail-closed deciding clause names the unset field right in
+  // the collapsed label — "failed on matchSourceUrls" alone reads identically
+  // to a genuine mismatch, and the difference is the whole diagnosis. Works
+  // for whatever field(s) the matcher reads (`readFields`), not just sourceUrl.
+  if (failing.state === "no-input" && failing.readFields.length > 0) {
+    return `${joined} — failed on ${failing.key} (${failing.readFields.join("/")} not set in this simulation)`;
+  }
+  return `${joined} — failed on ${failing.key}`;
 }

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -137,6 +137,22 @@ function failingClauses(clauses: ClauseEvaluation[]): ClauseEvaluation[] {
 }
 
 /**
+ * Replay-02 R3/R4: a no-match decided SOLELY by fail-closed no-input clauses —
+ * the rule lost to an empty simulator field, not to real data that mismatched.
+ * Exported because the rules drawer's verdict filter separates the two into
+ * their own facets, and one predicate must decide the badge text and the
+ * filter alike (a row filtered as "no input" that then says "no match" is the
+ * exact confusion R3/R4 was about).
+ */
+export function isNoInputNoMatch(rule: Pick<RuleEvaluation, "verdict" | "clauses">): boolean {
+  if (rule.verdict !== "no-match") {
+    return false;
+  }
+  const failing = failingClauses(rule.clauses);
+  return failing.length > 0 && failing.every((c) => c.state === "no-input");
+}
+
+/**
  * Replay-02 R3/R4: the badge text for a rule's verdict. A no-match decided
  * SOLELY by fail-closed no-input clauses says so — "no match — input not set"
  * — because the badge is what survives a screenshot, and a rule that lost to
@@ -145,11 +161,8 @@ function failingClauses(clauses: ClauseEvaluation[]): ClauseEvaluation[] {
  * matcher reads.
  */
 export function ruleVerdictLabel(rule: Pick<RuleEvaluation, "verdict" | "clauses">): string {
-  if (rule.verdict === "no-match") {
-    const failing = failingClauses(rule.clauses);
-    if (failing.length > 0 && failing.every((c) => c.state === "no-input")) {
-      return "no match — input not set";
-    }
+  if (isNoInputNoMatch(rule)) {
+    return "no match — input not set";
   }
   return VERDICT_LABEL[rule.verdict];
 }

--- a/packages/app/src/features/simulator/use-rule-focus.ts
+++ b/packages/app/src/features/simulator/use-rule-focus.ts
@@ -6,8 +6,9 @@ import {
   useRef,
   useState,
 } from "react";
-import type { SimulationResult } from "@renovate-config-debugger/engine";
+import type { ProvenanceLayer, SimulationResult } from "@renovate-config-debugger/engine";
 import { flashTarget, motionScrollOptions } from "@/lib/motion";
+import { type RuleFilters, ruleVisible } from "./rule-filters";
 
 export interface RuleFocus {
   /** The simulator card itself — where a cross-link lands when no simulation
@@ -21,33 +22,29 @@ export interface RuleFocus {
  * Roadmap 013/023/047: scroll to and flash the rule row a cross-link named —
  * either the external `focusRuleIndex` prop or a click on this component's own
  * `packageRules[N]`-in-message links. Anything hiding the row (a closed rules
- * drawer, the matched-only filter, the my-rules filter) is cleared first and
- * the effect re-runs once the row is actually in the DOM.
+ * drawer, either filter facet) is cleared first and the effect re-runs once
+ * the row is actually in the DOM.
  */
 export function useRuleFocus({
   focusRuleIndex,
   onRuleFocused,
   sim,
-  showAll,
-  setShowAll,
-  myRulesOnly,
-  setMyRulesOnly,
+  ruleFilters,
+  setRuleFilters,
+  layerByIndex,
   rulesOpen,
   setRulesOpen,
   setFocusHint,
-  repoRuleIndices,
 }: {
   focusRuleIndex?: number | null;
   onRuleFocused?: () => void;
   sim: SimulationResult | null;
-  showAll: boolean;
-  setShowAll: Dispatch<SetStateAction<boolean>>;
-  myRulesOnly: boolean;
-  setMyRulesOnly: Dispatch<SetStateAction<boolean>>;
+  ruleFilters: RuleFilters;
+  setRuleFilters: Dispatch<SetStateAction<RuleFilters>>;
+  layerByIndex: Map<number, ProvenanceLayer>;
   rulesOpen: boolean;
   setRulesOpen: Dispatch<SetStateAction<boolean>>;
   setFocusHint: Dispatch<SetStateAction<number | null>>;
-  repoRuleIndices: Set<number>;
 }): RuleFocus {
   const cardRef = useRef<HTMLDivElement>(null);
   // Roadmap 013: the merged index awaiting a scroll+flash.
@@ -60,9 +57,9 @@ export function useRuleFocus({
   }, [focusRuleIndex]);
 
   // Performs the actual scroll+flash once the target row is guaranteed to be
-  // in the DOM: if it is currently hidden behind the matched-only filter,
-  // reveal it first and let the effect re-run on the next render (checked
-  // against `sim` directly rather than the derived `notableRules`).
+  // in the DOM: if a filter facet is currently hiding it, reveal it first and
+  // let the effect re-run on the next render (checked against `sim` and the
+  // list's own `ruleVisible` predicate, never a copy of its filtering).
   useEffect(() => {
     if (scrollTarget == null) {
       return;
@@ -90,14 +87,12 @@ export function useRuleFocus({
       setRulesOpen(true);
       return;
     }
-    // Reveal the target row if a filter is hiding it, then let the effect re-run.
-    if (myRulesOnly && !repoRuleIndices.has(rule.index)) {
-      setMyRulesOnly(false);
-      return;
-    }
-    const visible = myRulesOnly || showAll || rule.verdict !== "no-match";
-    if (!visible) {
-      setShowAll(true);
+    // Reveal the target row if either facet is hiding it, then let the effect
+    // re-run. Both are dropped at once (rather than relaxed one at a time):
+    // the link's promise is "here is that rule", and a second re-run to get
+    // past the other facet would scroll the page twice to keep it.
+    if (!ruleVisible(rule, ruleFilters, layerByIndex)) {
+      setRuleFilters({ verdict: "all", preset: "all" });
       return;
     }
     const el = document.getElementById(`sim-rule-${scrollTarget}`);
@@ -110,13 +105,11 @@ export function useRuleFocus({
   }, [
     scrollTarget,
     sim,
-    showAll,
-    myRulesOnly,
+    ruleFilters,
+    layerByIndex,
     rulesOpen,
-    repoRuleIndices,
     onRuleFocused,
-    setShowAll,
-    setMyRulesOnly,
+    setRuleFilters,
     setRulesOpen,
     setFocusHint,
   ]);

--- a/packages/app/src/features/simulator/use-simulation-run.ts
+++ b/packages/app/src/features/simulator/use-simulation-run.ts
@@ -9,6 +9,7 @@ import {
 } from "react";
 import type { SimulationResult, TraceResult } from "@renovate-config-debugger/engine";
 import { type FormState, hasMeaningfulInput, toDescriptor } from "./form";
+import { DEFAULT_RULE_FILTERS, type RuleFilters } from "./rule-filters";
 
 export type Simulate = (nextForm: FormState, touched: boolean, keepStep?: boolean) => Promise<void>;
 
@@ -25,10 +26,9 @@ export interface SimulationRun {
   running: boolean;
   error: string | null;
   emptyGuardTriggered: boolean;
-  showAll: boolean;
-  setShowAll: Dispatch<SetStateAction<boolean>>;
-  myRulesOnly: boolean;
-  setMyRulesOnly: Dispatch<SetStateAction<boolean>>;
+  /** Roadmap 023/047: the rules drawer's two filter facets (verdict, provenance). */
+  ruleFilters: RuleFilters;
+  setRuleFilters: Dispatch<SetStateAction<RuleFilters>>;
   focusHint: number | null;
   setFocusHint: Dispatch<SetStateAction<number | null>>;
   simulate: Simulate;
@@ -56,10 +56,11 @@ export function useSimulationRun({
   const [ranKey, setRanKey] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [showAll, setShowAll] = useState(false);
-  // Roadmap 023: a one-click filter to the user's OWN repo-config rules (their
-  // most common "where's my rule?" wish), with clause evidence pre-expanded.
-  const [myRulesOnly, setMyRulesOnly] = useState(false);
+  // Roadmap 023/047: the rules drawer's filters — the verdict facet defaults to
+  // the matched-and-unresolved view, the provenance facet to every layer. The
+  // user's OWN repo-config rules (their most common "where's my rule?" wish)
+  // are `preset: "repo"`, which also pre-expands those rows' clause evidence.
+  const [ruleFilters, setRuleFilters] = useState<RuleFilters>(DEFAULT_RULE_FILTERS);
   // Roadmap 023: the merged index a cross-link asked to see before any
   // simulation exists to render its row — kept to show a "run a simulation"
   // hint rather than the click doing nothing (the "looks broken" finding).
@@ -68,7 +69,7 @@ export function useSimulationRun({
   // input; cleared reactively the moment the form has ANY meaningful field.
   const [emptyGuardTriggered, setEmptyGuardTriggered] = useState(false);
   // Roadmap 016: re-simulating (e.g. after editing the form and clicking
-  // Simulate again) resets `showAll` to the matched-only default, which can
+  // Simulate again) resets the verdict facet to its default, which can
   // unmount rows the user was scrolled past — the browser's scroll-anchoring
   // then repicks a higher anchor and the page visibly jumps. Capture the
   // scroll position right before the state update that causes the unmount,
@@ -90,23 +91,22 @@ export function useSimulationRun({
     setSimEffectiveUpdateType("");
     setRanKey(null);
     setError(null);
-    setShowAll(false);
-    setMyRulesOnly(false);
+    setRuleFilters(DEFAULT_RULE_FILTERS);
     setFocusHint(null);
     setEmptyGuardTriggered(false);
   }, [result]);
 
   // Roadmap 016: restore the scroll position captured in `simulate` right
-  // before the DOM the browser is about to repaint — after `sim`/`showAll`
-  // change together, so this runs once against the settled layout rather than
-  // an intermediate one.
+  // before the DOM the browser is about to repaint — after `sim` and the
+  // verdict facet change together, so this runs once against the settled
+  // layout rather than an intermediate one.
   useLayoutEffect(() => {
     const y = scrollYBeforeSimulate.current;
     if (y !== null) {
       scrollYBeforeSimulate.current = null;
       window.scrollTo({ top: y, behavior: "auto" });
     }
-  }, [sim, showAll]);
+  }, [sim, ruleFilters.verdict]);
 
   /**
    * @param touched Roadmap 015: whether the CALLER's updateType is a manual
@@ -152,7 +152,10 @@ export function useSimulationRun({
       setSimForm(nextForm);
       setSimEffectiveUpdateType(effectiveType);
       setRanKey(JSON.stringify(nextForm));
-      setShowAll(false);
+      // The verdict facet goes back to the default view for the new run; the
+      // provenance one is left alone — a user filtered to their own rules
+      // stays there across a re-run, as the "my rules only" toggle did.
+      setRuleFilters((prev) => ({ ...prev, verdict: DEFAULT_RULE_FILTERS.verdict }));
       setFocusHint(null);
       // Roadmap 044: a new simulation is a new merge sequence — start at its
       // first step (the controlled index lives in App, so the reset does too,
@@ -180,10 +183,8 @@ export function useSimulationRun({
     running,
     error,
     emptyGuardTriggered,
-    showAll,
-    setShowAll,
-    myRulesOnly,
-    setMyRulesOnly,
+    ruleFilters,
+    setRuleFilters,
     focusHint,
     setFocusHint,
     simulate,

--- a/packages/app/src/features/simulator/verdict-sentence.test.ts
+++ b/packages/app/src/features/simulator/verdict-sentence.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Replay-02 N4/R3: the verdict sentence is the simulator's most-screenshotted
+ * string and shipped with no test at all — grammar and scoping defects lived
+ * in the one artifact built to be quoted verbatim. Locks the assembled prose
+ * (the shared "would" distributing over every positive, the config-scoped
+ * automerge parenthetical) and the fail-closed no-input caveat, on
+ * hand-written fixtures in the engine's real shapes (same discipline as
+ * verdict-threads.test.ts).
+ */
+import type {
+  ClauseEvaluation,
+  RuleAttribution,
+  RuleEvaluation,
+  SimulationResult,
+} from "@renovate-config-debugger/engine";
+import { describe, expect, test } from "vitest";
+import { buildNoInputCaveat, buildVerdictSegments, type VerdictSegment } from "./verdict-sentence";
+
+function simFixture(
+  finalDependencyConfig: Record<string, unknown>,
+  overrides: Partial<SimulationResult> = {},
+): SimulationResult {
+  return {
+    rules: [],
+    rawFinalConfig: finalDependencyConfig,
+    finalDependencyConfig,
+    flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    mergeSteps: [],
+    errors: [],
+    warnings: [],
+    notes: [],
+    ...overrides,
+  };
+}
+
+/** The plain sentence, with the modal badges upper-cased the way the card
+ *  renders them — the exact text a screenshot carries. */
+function joined(segments: VerdictSegment[]): string {
+  return segments.map((s) => (typeof s === "string" ? s : s.modal.toUpperCase())).join("");
+}
+
+function noInputClause(key: string, readFields: string[]): ClauseEvaluation {
+  return { key, value: ["x"], state: "no-input", inputValues: {}, readFields };
+}
+
+function noMatchClause(key: string): ClauseEvaluation {
+  return {
+    key,
+    value: ["react"],
+    state: "no-match",
+    inputValues: { packageName: "lodash" },
+    readFields: ["packageName"],
+  };
+}
+
+function noMatchRule(index: number, clauses: ClauseEvaluation[]): RuleEvaluation {
+  return { index, verdict: "no-match", clauses, notes: [] };
+}
+
+const REPO_ATTRIBUTION = (indices: number[]): RuleAttribution[] =>
+  indices.map((index) => ({ index, sourceIndex: index, layer: { kind: "repo" } }));
+
+describe("buildVerdictSegments", () => {
+  test("the shared WOULD distributes over every positive, auto-approval included", () => {
+    // The replay's broken ordering: automerge + labels + autoApprove read as
+    // "would automerge, get labels […], and auto-approval" — a bare noun under
+    // a verb-phrase modal.
+    const sim = simFixture({ automerge: true, labels: ["deploy_pr"], autoApprove: true });
+    expect(joined(buildVerdictSegments(sim, "minor", [], null))).toBe(
+      "This minor update WOULD automerge, get labels [deploy_pr], and get auto-approval.",
+    );
+  });
+
+  test("scoped automerge is attributed to the config, with its source preset", () => {
+    const sim = simFixture(
+      { labels: ["deploy_pr"], autoApprove: true },
+      {
+        flattened: {
+          merged: [],
+          blocks: { minor: { automerge: true }, patch: { automerge: true } },
+          authoredBlocks: [],
+        },
+        rules: [
+          {
+            index: 5,
+            verdict: "matched",
+            clauses: [],
+            notes: [],
+            merged: [
+              { key: "minor", after: { automerge: true } },
+              { key: "patch", after: { automerge: true } },
+            ],
+          },
+        ],
+      },
+    );
+    const attribution: RuleAttribution[] = [
+      {
+        index: 5,
+        sourceIndex: 0,
+        layer: { kind: "preset", nodeId: "n1", name: ":automergeMinor" },
+      },
+    ];
+    expect(joined(buildVerdictSegments(sim, "major", [], attribution))).toBe(
+      "This major update WOULD get labels [deploy_pr] and get auto-approval, " +
+        "but WOULD NOT automerge (your config enables automerge only for minor/patch updates — from `:automergeMinor`).",
+    );
+  });
+
+  test("scoped automerge without a traceable source stays uncredited", () => {
+    const sim = simFixture(
+      {},
+      {
+        flattened: { merged: [], blocks: { minor: { automerge: true } }, authoredBlocks: [] },
+      },
+    );
+    expect(joined(buildVerdictSegments(sim, "major", [], null))).toBe(
+      "This major update WOULD NOT automerge (your config enables automerge only for minor updates).",
+    );
+  });
+
+  test("nothing special renders the defaults sentence", () => {
+    expect(joined(buildVerdictSegments(simFixture({}), "patch", [], null))).toBe(
+      "This patch update gets no special handling from your matched rules — the defaults apply.",
+    );
+  });
+});
+
+describe("buildNoInputCaveat", () => {
+  test("names every unset field behind a repo rule's fail-closed no-match", () => {
+    // Two different fields on purpose: the caveat is field-agnostic, and must
+    // not regress into sourceUrl-only handling.
+    const sim = simFixture(
+      {},
+      {
+        rules: [
+          noMatchRule(0, [noInputClause("matchSourceUrls", ["sourceUrl"])]),
+          noMatchRule(1, [noInputClause("matchCategories", ["categories"])]),
+          noMatchRule(2, [noMatchClause("matchPackageNames")]),
+        ],
+      },
+    );
+    expect(buildNoInputCaveat(sim, REPO_ATTRIBUTION([0, 1, 2]))).toBe(
+      "2 of your rules failed only because a field was left unset in this simulation " +
+        "(sourceUrl, categories) — this result may not reflect a real Renovate run.",
+    );
+  });
+
+  test("a rule that also mismatched real data earns no caveat", () => {
+    const sim = simFixture(
+      {},
+      {
+        rules: [
+          noMatchRule(0, [
+            noInputClause("matchSourceUrls", ["sourceUrl"]),
+            noMatchClause("matchPackageNames"),
+          ]),
+        ],
+      },
+    );
+    expect(buildNoInputCaveat(sim, REPO_ATTRIBUTION([0]))).toBeUndefined();
+  });
+
+  test("preset rules failing on unset side-channel fields are not a signal", () => {
+    const sim = simFixture(
+      {},
+      { rules: [noMatchRule(0, [noInputClause("matchSourceUrls", ["sourceUrl"])])] },
+    );
+    const presetAttribution: RuleAttribution[] = [
+      {
+        index: 0,
+        sourceIndex: 0,
+        layer: { kind: "preset", nodeId: "n1", name: "config:recommended" },
+      },
+    ];
+    expect(buildNoInputCaveat(sim, presetAttribution)).toBeUndefined();
+    expect(buildNoInputCaveat(sim, null)).toBeUndefined();
+  });
+});

--- a/packages/app/src/features/simulator/verdict-sentence.ts
+++ b/packages/app/src/features/simulator/verdict-sentence.ts
@@ -67,11 +67,15 @@ function automergeScopeSource(
  * options — enabled/skipReason, automerge (with update-type scoping and,
  * when known, its source preset), labels, grouping, schedule — splitting
  * them into what the update WOULD and would NOT get, e.g. "This major update
- * WOULD get labels [deploy_pr] and auto-approval, but would NOT automerge
- * (automerge is scoped to minor/patch — from `:automergeMinor`)". Roadmap
- * 022: no-op clauses (an empty label list, the default unrestricted
- * schedule) are left out entirely rather than quoted as if they meant
- * something, so the sentence stays quotable verbatim.
+ * WOULD get labels [deploy_pr] and get auto-approval, but would NOT automerge
+ * (your config enables automerge only for minor/patch updates — from
+ * `:automergeMinor`)". Roadmap 022: no-op clauses (an empty label list, the
+ * default unrestricted schedule) are left out entirely rather than quoted as
+ * if they meant something, so the sentence stays quotable verbatim. Replay-02
+ * N4: every positive is a verb phrase so the shared "would" distributes over
+ * any ordering, and the automerge parenthetical attributes the scoping to
+ * THIS config — `automerge` is a perfectly valid top-level option, and "is
+ * scoped to" taught a false general rule when quoted.
  *
  * Roadmap 046: returned as SEGMENTS rather than one string, so the verdict
  * card can set the modal verbs — the single most information-bearing words the
@@ -114,7 +118,7 @@ export function buildVerdictSegments(
       ? sources[0]
       : undefined;
     negatives.push(
-      `automerge (automerge is scoped to ${scopedAutomerge.join("/")}${source ? ` — from \`${source}\`` : ""})`,
+      `automerge (your config enables automerge only for ${scopedAutomerge.join("/")} updates${source ? ` — from \`${source}\`` : ""})`,
     );
   } else if (c.automerge === false && changed.has("automerge")) {
     negatives.push("automerge");
@@ -127,7 +131,7 @@ export function buildVerdictSegments(
     positives.push(`add labels ${plainValue(c.addLabels)}`);
   }
   if (c.autoApprove === true) {
-    positives.push("auto-approval");
+    positives.push("get auto-approval");
   }
   if (typeof c.groupName === "string" && c.groupName.length > 0) {
     positives.push(`be grouped as "${c.groupName}"`);
@@ -151,4 +155,50 @@ export function buildVerdictSegments(
   }
   segments.push(".");
   return segments;
+}
+
+/**
+ * Replay-02 R3: the verdict card's honesty caveat. A rule from the user's own
+ * config that reached "no match" SOLELY through fail-closed `no-input` clauses
+ * lost to an empty simulator field, not to the user's data — without saying
+ * so, the card manufactures a confident-looking "no match" that may not
+ * reflect a real Renovate run. Field-agnostic by construction: it names
+ * whatever `readFields` the deciding clauses consulted. Scoped to repo-config
+ * rules (via `ruleAttribution`) because preset rules failing on unset
+ * side-channel fields is the norm on every run, not a signal.
+ */
+export function buildNoInputCaveat(
+  sim: SimulationResult,
+  ruleAttribution: RuleAttribution[] | null | undefined,
+): string | undefined {
+  if (!ruleAttribution) {
+    return undefined;
+  }
+  const repoRules = new Set(
+    ruleAttribution.filter((a) => a.layer.kind === "repo").map((a) => a.index),
+  );
+  const fields = new Set<string>();
+  let count = 0;
+  for (const rule of sim.rules) {
+    if (rule.verdict !== "no-match" || !repoRules.has(rule.index)) {
+      continue;
+    }
+    const failing = rule.clauses.filter(
+      (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
+    );
+    if (failing.length === 0 || !failing.every((c) => c.state === "no-input")) {
+      continue;
+    }
+    count++;
+    for (const clause of failing) {
+      for (const field of clause.readFields) {
+        fields.add(field);
+      }
+    }
+  }
+  if (count === 0) {
+    return undefined;
+  }
+  const named = [...fields].join(", ");
+  return `${count} of your rule${count === 1 ? "" : "s"} failed only because a field was left unset in this simulation (${named}) — this result may not reflect a real Renovate run.`;
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2413,10 +2413,23 @@ pre.config-view.prov-before {
   color: var(--error);
 }
 
-.sim-clause-row.state-no-input .sim-clause-mark,
+.sim-clause-row.state-no-input .sim-clause-mark {
+  color: var(--warn);
+}
+
+/* Replay-02 R4: neutral states get a neutral hue — a warn-colored glyph on a
+   clause that was never evaluated reads like a problem with the run. */
 .sim-clause-row.state-not-applicable .sim-clause-mark,
 .sim-clause-row.state-not-simulated .sim-clause-mark {
+  color: var(--muted);
+}
+
+/* Replay-02 R3: the verdict card's fail-closed caveat — visually part of the
+   answer band so a screenshot of the sentence carries its own disclaimer. */
+.sim-verdict-caveat {
   color: var(--warn);
+  font-size: 0.82rem;
+  margin: 0.35rem 0 0;
 }
 
 .sim-merged {

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2319,12 +2319,6 @@ pre.config-view.prov-before {
   margin: 0.25rem 0;
 }
 
-.sim-summary {
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin: 0.25rem 0 0.5rem;
-}
-
 .sim-rules {
   border: 1px solid var(--border);
   border-radius: 8px;
@@ -2387,6 +2381,13 @@ pre.config-view.prov-before {
 
 .badge.sim-verdict.verdict-no-match {
   color: var(--muted);
+}
+
+/* Replay-02 R3/R4: the fail-closed no-match wears the warn hue its clause
+   glyph already uses — the row says "no input" and the hover card says why,
+   rather than a muted chip carrying a sentence too long for the row. */
+.badge.sim-verdict.verdict-no-input {
+  color: var(--warn);
 }
 
 .badge.sim-verdict.verdict-not-simulated {
@@ -2693,8 +2694,15 @@ pre.config-view.prov-before {
    this update actually is. Rows are subgrid so both value columns line up
    straight down the grid; the comparison IS the evidence, and the prose form
    this replaced (layer 7 retired it) hid the comparison in a sentence. */
+/* Both text columns are `fr`, not `1fr auto`: an `auto` last track takes its
+   max-content width first, and a clause that did NOT match carries a whole
+   sentence there ("evaluated false — the simulated dependency has no depType
+   …"). That left the checks column ~1ch wide, breaking its value one character
+   per line. Sharing the slack keeps every state on the same tracks; the
+   explanation gets the larger share because it is prose, while the value it
+   sits beside is a `previewValue`, capped at 60 characters. */
 .sim-clause-grid {
-  --kv-cols: max-content max-content minmax(0, 1fr) auto;
+  --kv-cols: max-content max-content minmax(0, 1fr) minmax(0, 1.6fr);
   --kv-row-gap: 0.2rem;
 
   margin: 0.3rem 0;
@@ -3064,13 +3072,24 @@ pre.config-view.prov-before {
   margin-top: 0.3rem;
 }
 
-.sim-rules-head {
-  align-items: baseline;
-  display: flex;
-  gap: 0.75rem;
-  justify-content: space-between;
-  margin: 0.25rem 0 0.5rem;
+/* The rules drawer's filter row: the SAME chrome as the Effective Config tab's
+   `.prov-filters` (one `<select>` per facet), but the controls sit on the right
+   edge — the drawer's own summary row already carries the headline count on the
+   left, so the row reads header-left / controls-right. */
+.sim-filters {
+  justify-content: flex-end;
+  margin-bottom: 0.5rem;
   scroll-margin-top: 0.5rem;
+}
+
+/* Stated ONLY while the filters are narrowing the list (the component renders
+   nothing otherwise): unfiltered it would repeat "N of M matched" from the
+   summary row above it. */
+.sim-filter-count {
+  color: var(--muted);
+  font-size: 0.85rem;
+  margin-right: auto;
+  white-space: nowrap;
 }
 
 .sim-toggle {
@@ -3587,13 +3606,6 @@ pre.config-view.prov-before {
   position: fixed;
   transform: translateX(-50%);
   z-index: var(--z-toast);
-}
-
-/* The active state of the simulator "my rules only" filter toggle. */
-.sim-toggle.active {
-  background: var(--accent-fill);
-  border-color: var(--accent-fill);
-  color: var(--on-accent);
 }
 
 /* Hint shown when a "packageRules[N]" cross-link is clicked before any


### PR DESCRIPTION
Replay-02 findings R3/R4/N4/R6, all in the simulator's formatting layer:

- ruleLabel names the unset field when the deciding clause fail-closed
  ('failed on matchSourceUrls (sourceUrl not set in this simulation)') —
  field-agnostic via the clause's readFields, not sourceUrl-specific
- new ruleVerdictLabel renders 'no match — input not set' when a rule
  lost solely to fail-closed clauses; used by both badge sites
- verdict card gains a caveat line when the user's own rules failed only
  on unset simulator fields ('this result may not reflect a real
  Renovate run'), scoped to repo-config rules via ruleAttribution
- clauseIcon splits never-evaluated (∅, muted) from fail-closed (⚠, warn)
- verdict sentence: every positive is a verb phrase so the shared WOULD
  distributes ('get auto-approval'), and the automerge parenthetical
  attributes scoping to this config instead of teaching a false general
  rule ('your config enables automerge only for minor/patch updates')
- 0-based packageRules[N] citations carry a title explaining the
  numbering, and the full rule-framing line anchors it visibly

New unit suites lock the sentence prose, the caveat, and the label/badge
branches with two different fields each.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>