### PR TITLE
fix(app): make failing clause rows legible and stale results self-labelling

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -301,6 +301,27 @@ test("the consumed-blocks aside names an authored block that didn't apply, and s
 });
 
 /**
+ * Replay-02 R1: the stale veil alone is invisible in a cropped screenshot —
+ * a stale and a fresh card are structurally identical. The card must carry
+ * the stale class (which paints the veil + stamp), and the banner must name
+ * the RUN's inputs, not the form's, so any capture is self-labelling.
+ */
+test("stale results are veiled and the banner names the run they belong to", async ({ page }) => {
+  await page.goto(await encodeShareFragment({ config: PACKAGE_RULES_CONFIG }));
+  await openTab(page, "simulator");
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+
+  // Change an input WITHOUT re-running: the run below is now stale.
+  await simulator.getByLabel("packageName", { exact: true }).fill("react");
+
+  await expect(page.locator(".sim-results-body")).toHaveClass(/stale/);
+  // The banner quotes the run (lodash, from the quick-fill), not the form (react).
+  await expect(page.locator(".sim-stale-banner")).toContainText("lodash");
+});
+
+/**
  * Replay-02 regression (findings-validity N2): the flatten cross-link used to
  * scroll in the same tick it opened the drawer, so the scroll ran against the
  * closed-drawer document height — from the bottom of the page it clamped into

--- a/packages/app/e2e/12-layout-regressions.spec.ts
+++ b/packages/app/e2e/12-layout-regressions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { PACKAGE_RULES_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
+import { INVALID_RULES_CONFIG, PACKAGE_RULES_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
 import { must, openTab, runAndAwaitResult, setEditorContent } from "./helpers";
 
 /**
@@ -286,4 +286,34 @@ test("the preset detail panel is readable, unclipped and scrollable to its last 
   const panelBox = must(panelBoxRaw, "the preset detail panel's bounding box");
   expect(lastBox.y).toBeGreaterThanOrEqual(panelBox.y - 1);
   expect(lastBox.y + lastBox.height).toBeLessThanOrEqual(panelBox.y + panelBox.height + 1);
+});
+
+/**
+ * Replay-02 R1: the hypothetical banner disappearing after an applied fix
+ * used to move the Simulate button mid-flow — clicks landed on whatever
+ * shifted under the pointer. Once shown, the banner's box stays reserved for
+ * the session, so the button must not move when validation clears.
+ */
+test("the simulate button holds its position when the validation banner clears", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+  await setEditorContent(page, INVALID_RULES_CONFIG);
+  await runAndAwaitResult(page);
+
+  await openTab(page, "simulator");
+  const panel = page.locator("#panel-simulator");
+  await expect(panel.locator(".hypothetical-banner")).toBeVisible();
+  const simulate = panel.getByRole("button", { name: "Simulate", exact: true });
+  const before = must(await simulate.boundingBox(), "the simulate button's bounding box");
+
+  await setEditorContent(page, PACKAGE_RULES_CONFIG);
+  await runAndAwaitResult(page);
+  await openTab(page, "simulator");
+  // The banner is gone from view but its box is reserved (visibility, not unmount)…
+  await expect(panel.locator(".hypothetical-banner")).toBeHidden();
+  // …so the button sits exactly where the pointer left it.
+  const after = must(await simulate.boundingBox(), "the simulate button's bounding box");
+  expect(Math.abs(after.y - before.y)).toBeLessThan(1);
 });

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -211,6 +211,24 @@ export const FIXED_AUTOMERGE_CONFIG = `{
 }
 `;
 
+/** `PACKAGE_RULES_CONFIG` plus the same validate-stage type error the automerge
+ *  pair carries, so fixing it lands exactly on `PACKAGE_RULES_CONFIG`. The
+ *  rules matter: the simulator renders its "hypothetical" banner and Simulate
+ *  button only once there is something to simulate, so the banner's layout
+ *  behaviour (Replay-02 R1) cannot be exercised by a rule-less config. */
+export const INVALID_RULES_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": "yes",
+  "packageRules": [
+    {
+      "matchPackageNames": ["lodash"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}
+`;
+
 /** A config whose only issue is a deprecated option: `semanticCommits` used
  *  to be a boolean and is now the enum `"enabled"`/`"disabled"` — migrateConfig
  *  rewrites it. No `extends`, so it runs offline. Used by journey 024 (the

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import type { ClauseEvaluation } from "@renovate-config-debugger/engine";
-import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
+import { clauseEvaluated, clauseIcon, fullValue, previewValue } from "./rule-format";
 
 /**
  * Roadmap 054 (variant A): a rule's clause evidence as ALIGNED columns —
@@ -15,13 +16,33 @@ import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
  * matcher/value edges still line up across the whole grid.
  */
 function ClauseGridRow({ clause }: { clause: ClauseEvaluation }) {
+  // Replay-02 N6: `previewValue` slices the JSON before it reaches the DOM, so
+  // the complete clause value — the citable artifact for a long
+  // matchSourceUrls array — never existed on the page. A truncated value
+  // renders as click-to-expand, with the full value also in its title.
+  const [valueExpanded, setValueExpanded] = useState(false);
   const evaluated = clauseEvaluated(clause);
+  const preview = previewValue(clause.value, 60);
+  const full = fullValue(clause.value);
   return (
     <div className={`kv-row sim-clause-row state-${clause.state}`}>
       <span className="sim-clause-mark">{clauseIcon(clause.state)}</span>
       <code className="sim-clause-key">{clause.key}</code>
       <span className="sim-clause-checks">
-        checks <span className="sim-clause-value">{previewValue(clause.value, 60)}</span>
+        checks{" "}
+        {preview === full ? (
+          <span className="sim-clause-value">{preview}</span>
+        ) : (
+          <button
+            type="button"
+            className="sim-clause-value sim-clause-expand"
+            title={valueExpanded ? "Collapse" : full}
+            aria-expanded={valueExpanded}
+            onClick={() => setValueExpanded(!valueExpanded)}
+          >
+            {valueExpanded ? full : preview}
+          </button>
+        )}
       </span>
       <span className="sim-clause-evaluated">
         {`· ${evaluated.text}`}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ProvenanceLayer, TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
@@ -42,6 +42,25 @@ import { buildVerdictThreads } from "./verdict-threads";
 // Roadmap 032: memoized — the simulator renders the full merged rule list and
 // reads nothing from the editor; its callback props are identity-stable in
 // App (useCallback / the latest-ref idiom), so typing never re-renders it.
+/** Replay-02 R1: the stale banner names the run it describes, so a cropped
+ *  screenshot of a stale card is self-labelling instead of actively wrong. */
+function SimStaleBanner({ ranLabel }: { ranLabel: string }) {
+  if (!ranLabel) {
+    return (
+      <p className="sim-stale-banner">
+        Inputs changed since this run — these results may no longer reflect the form above. Simulate
+        again to refresh.
+      </p>
+    );
+  }
+  return (
+    <p className="sim-stale-banner">
+      These results are for <code>{ranLabel}</code> — inputs changed since this run. Simulate again
+      to refresh.
+    </p>
+  );
+}
+
 export const RuleSimulator = memo(function RuleSimulator({
   result,
   onSelectPreset,
@@ -231,6 +250,15 @@ export const RuleSimulator = memo(function RuleSimulator({
     () => (sim ? buildNoInputCaveat(sim, ruleAttribution) : undefined),
     [sim, ruleAttribution],
   );
+  // Replay-02 R1: once the hypothetical banner has been shown, its box stays
+  // reserved (visibility, not unmount) — the banner vanishing after an
+  // applied fix used to move the Simulate button out from under the pointer.
+  const [invalidSeen, setInvalidSeen] = useState(false);
+  useEffect(() => {
+    if (configInvalid) {
+      setInvalidSeen(true);
+    }
+  }, [configInvalid]);
   // Roadmap 047: the authored update-type blocks flattening consumed without
   // applying — the only thing that still earns the verdict card's aside.
   const consumedBlocks = useMemo(
@@ -323,6 +351,17 @@ export const RuleSimulator = memo(function RuleSimulator({
   }
 
   const stale = sim !== null && ranKey !== JSON.stringify(form);
+  // Replay-02 R1: what the LAST RUN simulated (not the live form) — the stale
+  // banner quotes it so a stale capture names the inputs it belongs to.
+  const ranLabel = simForm
+    ? [
+        simForm.packageName || simForm.depName,
+        simForm.currentValue,
+        simForm.newValue ? `→ ${simForm.newValue}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ")
+    : "";
   // Roadmap 015: reactive, not sticky — the moment the form gains ANY
   // meaningful field, the guard clears itself even without clicking Simulate.
   const showEmptyGuard = emptyGuardTriggered && !hasMeaningfulInput(form);
@@ -342,7 +381,11 @@ export const RuleSimulator = memo(function RuleSimulator({
           <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
         </span>
       </div>
-      {configInvalid ? <HypotheticalBanner /> : null}
+      {configInvalid || invalidSeen ? (
+        <div className={`sim-banner-slot${configInvalid ? "" : " ghost"}`}>
+          <HypotheticalBanner />
+        </div>
+      ) : null}
       {focusHint !== null && !sim ? (
         <p className="sim-focus-hint">
           <code>packageRules[{focusHint}]</code> is evaluated here once you run a simulation —
@@ -392,12 +435,7 @@ export const RuleSimulator = memo(function RuleSimulator({
           found easy to skim past) with a banner explaining why. */}
       {sim ? (
         <div className="sim-results">
-          {stale ? (
-            <p className="sim-stale-banner">
-              Inputs changed since this run — these results may no longer reflect the form above.
-              Simulate again to refresh.
-            </p>
-          ) : null}
+          {stale ? <SimStaleBanner ranLabel={ranLabel} /> : null}
           {/* The banner above stays full-strength; everything below it (the
               actual results) is what gets visibly veiled while stale. */}
           <div className={`sim-results-body${stale ? " stale" : ""}`}>

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -5,8 +5,10 @@ export function previewValue(value: unknown, max = 60): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-/** Untruncated JSON rendering for copy-as-markdown export. */
-function fullValue(value: unknown): string {
+/** Untruncated JSON rendering — the copy-as-markdown export and (replay-02
+ *  N6) the clause grid's click-to-expand both need the complete value; a
+ *  60-char preview of a matchSourceUrls list is not a citable artifact. */
+export function fullValue(value: unknown): string {
   return JSON.stringify(value) ?? "undefined";
 }
 

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2694,13 +2694,15 @@ pre.config-view.prov-before {
    this update actually is. Rows are subgrid so both value columns line up
    straight down the grid; the comparison IS the evidence, and the prose form
    this replaced (layer 7 retired it) hid the comparison in a sentence. */
-/* Both text columns are `fr`, not `1fr auto`: an `auto` last track takes its
-   max-content width first, and a clause that did NOT match carries a whole
-   sentence there ("evaluated false — the simulated dependency has no depType
-   …"). That left the checks column ~1ch wide, breaking its value one character
-   per line. Sharing the slack keeps every state on the same tracks; the
-   explanation gets the larger share because it is prose, while the value it
-   sits beside is a `previewValue`, capped at 60 characters. */
+/* Replay-02 N6: both text columns are `fr`, not `1fr auto`. An `auto` track
+   grows toward its max-content BEFORE any fr track gets space, and a clause
+   that did NOT match carries a whole sentence there ("evaluated false — the
+   simulated dependency has no depType …"). That starved the checks column to
+   ~1ch, breaking its value one glyph per line — and because subgrid sizes
+   tracks across ALL rows, a single failing clause collapsed the whole grid.
+   Two minmax(0, fr) tracks can't starve each other; the explanation gets the
+   larger share because it is prose, while the value it sits beside is a
+   `previewValue`, capped at 60 characters. */
 .sim-clause-grid {
   --kv-cols: max-content max-content minmax(0, 1fr) minmax(0, 1.6fr);
   --kv-row-gap: 0.2rem;
@@ -2732,6 +2734,19 @@ pre.config-view.prov-before {
   color: var(--ink);
   font-family: var(--font-mono);
   font-size: 0.78rem;
+}
+
+/* Replay-02 N6: a truncated clause value is a button — click for the full
+   value (also in its title). Inherits the value styling above; the dotted
+   underline is the only affordance chrome. */
+.sim-clause-expand {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
 }
 
 /* 054 layer 3: the rule-evidence popover. The plane is the app's existing
@@ -3456,9 +3471,36 @@ pre.config-view.prov-before {
   padding: 0.5rem 0.65rem;
 }
 
+/* Replay-02 R1: once the hypothetical banner has been shown, its box stays
+   reserved for the session — the banner vanishing after an applied fix used
+   to move the Simulate button out from under the pointer. */
+.sim-banner-slot.ghost {
+  visibility: hidden;
+}
+
 .sim-results-body.stale {
   filter: grayscale(65%);
-  opacity: 0.5;
+  opacity: 0.4;
+  position: relative;
+}
+
+/* Replay-02 R1: the dim alone is invisible in a cropped screenshot — a stale
+   and a fresh card are structurally identical. The stamp makes any capture
+   self-labelling (it dims with the card, but stays legible). */
+.sim-results-body.stale::after {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 6px;
+  color: var(--warn);
+  content: "Stale — inputs changed, simulate again";
+  font-size: 0.9rem;
+  font-weight: 600;
+  left: 50%;
+  padding: 0.4rem 0.8rem;
+  position: absolute;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  white-space: nowrap;
 }
 
 /* The veil FADES in only for readers who did not ask for less motion; the


### PR DESCRIPTION
Replay-02 findings N6/R1:

- clause grid: the evaluated track was 'auto', which grows toward its
  max-content before any fr track gets space — a long fail explanation
  starved the checks column to one glyph per line, and subgrid spread the
  collapse across every row. Two minmax(0, fr) tracks can't starve each
  other.
- truncated clause values (previewValue slices at 60 chars before the
  DOM) are now click-to-expand buttons carrying the full JSON in their
  title — the complete matchSourceUrls list is the citable artifact
- stale results: the veil gains an on-card 'Stale — inputs changed'
  stamp and the banner quotes the run's own inputs, so a cropped
  screenshot can no longer pass as a fresh result
- the hypothetical banner's box stays reserved once shown (visibility,
  not unmount) — it vanishing after an applied fix moved the Simulate
  button out from under the pointer

New e2e: stale class + run-labelled banner (04), Simulate button position
stability across the validation banner clearing (12).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>