### PR TITLE
fix(app): never report zero effective options while provenance is loading

### DIFF
--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Replay-02 N3: the stats effect used to call `onStats` while provenance was
+ * still loading, reporting an honest-looking `{keys: 0}` that overwrote App's
+ * pending `null` — the Overview painted "✓ accepted … merged into 0 effective
+ * options" next to the tab badge's 0 on first paint, self-correcting only
+ * once provenance resolved. The contract this locks: silence until real
+ * numbers exist, and the first report already carries them.
+ */
+import { runPipeline } from "@renovate-config-debugger/engine";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { EffectiveConfig } from "./EffectiveConfig";
+
+afterEach(cleanup);
+
+it("reports stats only once provenance has resolved, never a loading-time zero", async () => {
+  // No `extends`, so the run resolves offline; several non-default options so
+  // the real report has something to count.
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      automerge: true,
+      labels: ["dependencies"],
+      rangeStrategy: "bump",
+    }),
+  });
+
+  const onStats = vi.fn();
+  render(<EffectiveConfig result={result} onStats={onStats} />);
+
+  // Mount-time effects run with provenance still loading — the old code
+  // reported {keys: 0} right here.
+  expect(onStats).not.toHaveBeenCalled();
+
+  await waitFor(() => expect(onStats).toHaveBeenCalled());
+  const first = onStats.mock.calls[0]?.[0] as { keys: number } | undefined;
+  expect(first?.keys).toBeGreaterThan(0);
+});

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -769,8 +769,16 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   }, [entries]);
 
   useEffect(() => {
+    // Replay-02 N3: while provenance is still loading (`undefined`), `entries`
+    // is empty and the tallies are an honest-looking zero — reporting them
+    // overwrote App's pending `null` and painted "0 effective options" next
+    // to a green verdict on first paint. Stay silent until real numbers
+    // exist; the digest keeps its "still being counted…" clause meanwhile.
+    if (provenance === undefined) {
+      return;
+    }
     onStats?.({ keys: tallies.shown, overridden: tallies.overridden });
-  }, [tallies, onStats]);
+  }, [tallies, onStats, provenance]);
 
   // Focus (and select) the filter box when the Overview's "Where did a setting
   // come from?" pill routed the user here — the tab is already visible by the


### PR DESCRIPTION
Replay-02 finding N3: EffectiveConfig's stats effect fired while
useProvenance was still undefined, reporting an honest-looking {keys: 0}
that overwrote App's pending null — the Overview painted '✓ accepted …
merged into 0 effective options' beside a 0 tab badge on first paint,
self-correcting only when provenance landed. The effect now stays silent
until provenance resolves, so the digest keeps its 'still being counted…'
clause and the badge stays absent instead of wrong. Render test locks
the contract: no call before provenance, first call carries real keys.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>