### PR TITLE
fix(engine,app): flag inherited defaults in the A/B config delta

### DIFF
--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Replay-02 N3: the stats effect used to call `onStats` while provenance was
+ * still loading, reporting an honest-looking `{keys: 0}` that overwrote App's
+ * pending `null` — the Overview painted "✓ accepted … merged into 0 effective
+ * options" next to the tab badge's 0 on first paint, self-correcting only
+ * once provenance resolved. The contract this locks: silence until real
+ * numbers exist, and the first report already carries them.
+ */
+import { runPipeline } from "@renovate-config-debugger/engine";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { EffectiveConfig } from "./EffectiveConfig";
+
+afterEach(cleanup);
+
+it("reports stats only once provenance has resolved, never a loading-time zero", async () => {
+  // No `extends`, so the run resolves offline; several non-default options so
+  // the real report has something to count.
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      automerge: true,
+      labels: ["dependencies"],
+      rangeStrategy: "bump",
+    }),
+  });
+
+  const onStats = vi.fn();
+  render(<EffectiveConfig result={result} onStats={onStats} />);
+
+  // Mount-time effects run with provenance still loading — the old code
+  // reported {keys: 0} right here.
+  expect(onStats).not.toHaveBeenCalled();
+
+  await waitFor(() => expect(onStats).toHaveBeenCalled());
+  const first = onStats.mock.calls[0]?.[0] as { keys: number } | undefined;
+  expect(first?.keys).toBeGreaterThan(0);
+});

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -769,8 +769,16 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   }, [entries]);
 
   useEffect(() => {
+    // Replay-02 N3: while provenance is still loading (`undefined`), `entries`
+    // is empty and the tallies are an honest-looking zero — reporting them
+    // overwrote App's pending `null` and painted "0 effective options" next
+    // to a green verdict on first paint. Stay silent until real numbers
+    // exist; the digest keeps its "still being counted…" clause meanwhile.
+    if (provenance === undefined) {
+      return;
+    }
     onStats?.({ keys: tallies.shown, overridden: tallies.overridden });
-  }, [tallies, onStats]);
+  }, [tallies, onStats, provenance]);
 
   // Focus (and select) the filter box when the Overview's "Where did a setting
   // come from?" pill routed the user here — the tab is already visible by the

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -7,7 +7,7 @@ import type {
 import { toDescriptor } from "./form";
 import { previewValue, writeMark } from "./rule-format";
 import type { PinnedRun } from "./use-ab-comparison";
-import { WriteRow } from "./WriteRow";
+import { WriteRow, type WriteValue } from "./WriteRow";
 
 /**
  * Roadmap 021: the fields two descriptors disagree on, sorted for a stable
@@ -94,6 +94,27 @@ function RuleDeltaList({
  *  the shared write row (054 layer 7); a key that exists on only one side keeps
  *  this panel's own sentinels, since `(unset)` and `(removed)` are words, not
  *  values the config carries. */
+/** Replay-02 N8: one side of a delta row. An inherited value — present in the
+ *  run's final config but written by NO merge step — is a Renovate default,
+ *  not something the config set; rendering it as a bare value asserted an
+ *  explicit `automerge: false` that A's own field list (correctly) never
+ *  showed. Words, not JSON, so it can't be read as a value the config carries. */
+function deltaSide(
+  value: unknown,
+  present: boolean,
+  inherited: boolean | undefined,
+  absent: string,
+  run: "A" | "B",
+): WriteValue {
+  if (!present) {
+    return { text: absent };
+  }
+  if (inherited) {
+    return { text: `${previewValue(value, 60)} (default — not set in ${run})` };
+  }
+  return { json: value };
+}
+
 function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) {
   return (
     <div className="sim-compare-config">
@@ -105,8 +126,8 @@ function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) 
               key={d.key}
               name={d.key}
               mark={writeMark(d.inA, d.inB)}
-              before={d.inA ? { json: d.before } : { text: "(unset)" }}
-              after={d.inB ? { json: d.after } : { text: "(removed)" }}
+              before={deltaSide(d.before, d.inA, d.beforeInherited, "(unset)", "A")}
+              after={deltaSide(d.after, d.inB, d.afterInherited, "(removed)", "B")}
             />
           ))}
         </div>

--- a/packages/engine/src/simulate-compare.ts
+++ b/packages/engine/src/simulate-compare.ts
@@ -34,6 +34,15 @@ export interface ConfigKeyDelta {
   after?: unknown;
   inA: boolean;
   inB: boolean;
+  /**
+   * Replay-02 N8: true when A carries the key but NO merge step in A wrote it
+   * — the value is an inherited Renovate default, not something the config
+   * set. Without this the delta asserted an explicit `automerge: false` that
+   * A's own field list (correctly) never showed. Present only when true.
+   */
+  beforeInherited?: boolean;
+  /** Same, for B's side of the delta. */
+  afterInherited?: boolean;
 }
 
 export interface SimulationComparison {
@@ -69,6 +78,13 @@ function matchedRules(result: SimulationResult): RuleEvaluation[] {
 
 function jsonEqual(a: unknown, b: unknown): boolean {
   return a === b || JSON.stringify(a) === JSON.stringify(b);
+}
+
+/** Replay-02 N8: a key nothing in the run wrote (no rule step, no flatten
+ *  step) reached the final config by inheritance — Renovate's own default or
+ *  the pre-rules base — not through the user's rules. */
+function inheritedIn(result: SimulationResult, key: string): boolean {
+  return !result.mergeSteps.some((step) => step.merged.some((m) => m.key === key));
 }
 
 /**
@@ -111,6 +127,8 @@ export function compareSimulations(a: SimulationResult, b: SimulationResult): Si
       ...(inB ? { after: configB[key] } : {}),
       inA,
       inB,
+      ...(inA && inheritedIn(a, key) ? { beforeInherited: true } : {}),
+      ...(inB && inheritedIn(b, key) ? { afterInherited: true } : {}),
     });
   }
 

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -89,11 +89,46 @@ describe("compareSimulations", () => {
     });
     const cmp = compareSimulations(a, b);
     expect(cmp.noChange).toBe(false);
-    // sorted by key: automerge (changed), groupName (added in B), labels (removed from A)
+    // sorted by key: automerge (changed), groupName (added in B), labels
+    // (removed from A). These fixtures have no merge steps, so every present
+    // value is honestly flagged as inherited (replay-02 N8).
     expect(cmp.configDelta).toEqual([
-      { key: "automerge", before: false, after: true, inA: true, inB: true },
-      { key: "groupName", after: "grp", inA: false, inB: true },
-      { key: "labels", before: ["old"], inA: true, inB: false },
+      {
+        key: "automerge",
+        before: false,
+        after: true,
+        inA: true,
+        inB: true,
+        beforeInherited: true,
+        afterInherited: true,
+      },
+      { key: "groupName", after: "grp", inA: false, inB: true, afterInherited: true },
+      { key: "labels", before: ["old"], inA: true, inB: false, beforeInherited: true },
+    ]);
+  });
+
+  it("distinguishes an inherited default from a value a merge step wrote (replay-02 N8)", () => {
+    // A: automerge=false reached the final config with NO step writing it —
+    // Renovate's default surviving a major run. B: a step (the flatten step of
+    // a minor run) wrote automerge=true. The delta must not present A's
+    // default as an explicit value: that asserts an `automerge: false` the
+    // config never contains.
+    const a = sim([matched(0, [["matchPackageNames", ["x"]]])], { automerge: false });
+    const b = {
+      ...sim([matched(0, [["matchPackageNames", ["x"]]])], { automerge: true }),
+      mergeSteps: [
+        {
+          kind: "flatten" as const,
+          updateType: "minor",
+          before: { automerge: false },
+          after: { automerge: true },
+          merged: [{ key: "automerge", before: false, after: true }],
+        },
+      ],
+    };
+    const cmp = compareSimulations(a, b);
+    expect(cmp.configDelta).toEqual([
+      { key: "automerge", before: false, after: true, inA: true, inB: true, beforeInherited: true },
     ]);
   });
 


### PR DESCRIPTION
Replay-02 finding N8: compareSimulations diffed raw finalDependencyConfigs
with no provenance, so an inherited Renovate default (automerge: false
surviving a major run) rendered as '~ automerge false → true' — asserting
an explicit value A's own field list correctly never showed. The delta
now carries beforeInherited/afterInherited (a key no merge step wrote is
inheritance, not authorship), and the panel renders such sides as
'false (default — not set in A)' — words, not JSON, so it can't be read
as a value the config carries. The engine test that pinned the
provenance-free shape now pins the distinction instead.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>