### PR TITLE
test(persona-test): add scenario validity preconditions and a11y-tree discovery rule

### DIFF
--- a/.claude/skills/persona-test/SKILL.md
+++ b/.claude/skills/persona-test/SKILL.md
@@ -69,9 +69,23 @@ paper over a real startup failure.
 
 ## 3. Generate share links
 
-For each `(scenario, persona)` pair you're running, generate the share URL
-with the bundled generator (no dependencies, already verified to round-trip
-its own tokens):
+**First, verify every scenario you're about to run is still valid** on the
+pinned Renovate version (replay-02 finding S1 — a routine Renovate bump once
+silently fixed the bug a scenario tested, and three sessions chased a fixed
+bug):
+
+```sh
+node .claude/skills/persona-test/generate-links.mjs --verify
+```
+
+If any scenario reports `STALE`, **abort the run for that scenario and say so
+loudly** — do not spawn personas against it, and do not "fix" the run by
+rewording the framing. A stale scenario needs its ground truth re-derived or
+a replacement scenario (see `scenarios/README.md`).
+
+Then, for each `(scenario, persona)` pair you're running, generate the share
+URL with the bundled generator (no dependencies, already verified to
+round-trip its own tokens):
 
 ```sh
 node .claude/skills/persona-test/generate-links.mjs \
@@ -196,6 +210,17 @@ Stop the `vite preview` process you started.
   screenshot, remember the image you're looking at is scaled down from the
   actual viewport; don't feed screenshot pixel coordinates directly to a
   click without accounting for the scale factor.
+- **Interact only with VISIBLE elements — hidden DOM is not UI.** The app's
+  tab shell keeps inactive panels mounted under the HTML `hidden` attribute
+  (`display: none`): those subtrees have no accessibility-tree presence and
+  no geometry, and no real user can reach them. Raw-DOM element discovery
+  reports their controls as clickable anyway, and a coordinate click on a
+  zero-size element dispatches nowhere — replay-02's "Apply fix is dead
+  outside the Problems tab" finding was exactly this tooling artifact, not an
+  app bug. Discover elements via the accessibility tree or visibility-filtered
+  queries, treat anything inside a `[hidden]` ancestor as non-existent, and
+  treat "present in the DOM but silently un-clickable" observations as
+  suspect until reproduced on a visible control.
 - **MCP-injected JavaScript runs in an isolated world** — it cannot see or
   touch the page's own JS state/closures directly; interact through the DOM
   and real events, not by reaching into React internals or module state.

--- a/.claude/skills/persona-test/generate-links.mjs
+++ b/.claude/skills/persona-test/generate-links.mjs
@@ -46,6 +46,8 @@
  *   node generate-links.mjs -c /tmp/my-config.json -p 4173 --renovate 43.275.0
  */
 
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { readFile, readdir } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
@@ -79,10 +81,17 @@ Options:
   --unique <id>         Fixed value for the ?s= cache-busting param
                          (default: random per invocation).
   --list                List scenario files under ./scenarios and exit.
+  --verify              Check scenario validity preconditions against the
+                         PINNED renovate dist (the \`\`\`js verify block under
+                         "## Validity precondition"). With -c, one scenario;
+                         without, every scenario under ./scenarios. Exits
+                         non-zero on any stale scenario — run this before
+                         generating links or bumping the renovate pin.
   --help, -h            Show this help and exit.
 
 Examples:
   node generate-links.mjs --list
+  node generate-links.mjs --verify
   node generate-links.mjs -c scenarios/44529-group-preset-nesting.md -p 4173
   node generate-links.mjs -c /tmp/my-config.json -p 4173 --renovate 43.275.0
 `;
@@ -98,6 +107,9 @@ function parseArgs(argv) {
         break;
       case "--list":
         args.list = true;
+        break;
+      case "--verify":
+        args.verify = true;
         break;
       case "--config":
       case "-c":
@@ -226,6 +238,73 @@ function randomId() {
   return Math.random().toString(36).slice(2, 8);
 }
 
+/**
+ * Replay-02 S1 — scenario validity preconditions. A scenario's ground truth
+ * is written against ONE upstream state (a preset body, a validator message,
+ * a monorepo group); a routine Renovate bump can silently fix the very bug a
+ * scenario tests, after which the rubric grades correct persona observations
+ * as wrong. Each scenario therefore carries a machine-checkable
+ * `## Validity precondition` — a ```js verify fenced block run here with:
+ *   renovateDir  absolute path of the pinned renovate package
+ *   read(rel)    file text, relative to renovateDir
+ *   assert       node:assert/strict
+ * A throw marks the scenario stale. Content-based checks (read + includes)
+ * are deliberate: requiring renovate's dist modules from here is fragile.
+ */
+async function verifyScenario(scenarioPath, renovateDir) {
+  const raw = await readFile(scenarioPath, "utf8");
+  const block = raw.match(/## Validity precondition[\s\S]*?```js[^\n]*\n([\s\S]*?)\n```/);
+  if (!block) {
+    return {
+      ok: false,
+      message:
+        "no `## Validity precondition` ```js verify block — add one (see scenarios/README.md)",
+    };
+  }
+  const read = (rel) => readFileSync(path.join(renovateDir, rel), "utf8");
+  const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+  try {
+    const fn = new AsyncFunction("renovateDir", "read", "assert", block[1]);
+    await fn(renovateDir, read, assert);
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
+}
+
+async function verifyMain(args) {
+  let renovateDir;
+  try {
+    renovateDir = path.dirname(createRequire(ENGINE_PKG_JSON).resolve("renovate/package.json"));
+  } catch {
+    process.stderr.write(
+      "error: renovate is not installed (run pnpm install) — preconditions check the pinned dist\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const targets = args.config ? [path.resolve(process.cwd(), args.config)] : await listScenarios();
+  let failed = 0;
+  for (const target of targets) {
+    const name = path.relative(process.cwd(), target);
+    const res = await verifyScenario(target, renovateDir);
+    if (res.ok) {
+      process.stderr.write(`ok: ${name}\n`);
+    } else {
+      failed++;
+      process.stderr.write(`STALE: ${name} — ${res.message}\n`);
+    }
+  }
+  if (failed > 0) {
+    process.stderr.write(
+      `${failed} scenario(s) failed their validity precondition — do NOT run personas against them\n`,
+    );
+    process.exitCode = 1;
+  } else {
+    process.stderr.write("all scenario preconditions hold on the pinned renovate\n");
+  }
+}
+
 /** Builds the share token for a payload — same shape encodeShare() in share.ts produces. */
 async function encodeToken(payload) {
   const json = JSON.stringify(payload);
@@ -253,6 +332,11 @@ async function main() {
     for (const f of files) {
       process.stdout.write(`${path.relative(process.cwd(), f)}\n`);
     }
+    return;
+  }
+
+  if (args.verify) {
+    await verifyMain(args);
     return;
   }
 

--- a/.claude/skills/persona-test/personas.md
+++ b/.claude/skills/persona-test/personas.md
@@ -126,6 +126,13 @@ who answers questions on the discussion board rather than asks them.
   tools, do not search the web for the scenario's origin. Everything you use
   to reach a conclusion must come from what the app shows you in this
   session.
+- **Only visible elements are UI.** The app keeps inactive tab panels mounted
+  but `hidden` (`display: none`) — a real user cannot see or click anything
+  in them. If your tooling surfaces an element that is not visible on screen,
+  treat it as non-existent: do not click it, and do not report it as a
+  finding. A control that seems present but silently does nothing is,
+  first hypothesis, a hidden-subtree artifact of DOM-level discovery — verify
+  against what is actually visible before writing it up.
 - **Action budget ~30.** An "action" is one browser interaction (click, type,
   scroll, screenshot, key-press). Track your count loosely; wrap up your
   report when you're near budget even if unresolved — "ran out of budget,

--- a/.claude/skills/persona-test/scenarios/43936-star-exclusion.md
+++ b/.claude/skills/persona-test/scenarios/43936-star-exclusion.md
@@ -19,6 +19,18 @@
 }
 ```
 
+## Validity precondition
+
+```js verify
+// Run by `generate-links.mjs --verify` against the pinned renovate.
+// In scope: renovateDir, read(rel) → file text, assert (node:assert/strict).
+const src = read("dist/config/validation-helpers/regex-glob-matchers.js");
+assert.ok(
+  src.includes("along with other patterns"),
+  "the validator no longer emits the star-mixing error this scenario is built on",
+);
+```
+
 ## Symptom framing
 
 ### Entry

--- a/.claude/skills/persona-test/scenarios/44006-automerge-nesting.md
+++ b/.claude/skills/persona-test/scenarios/44006-automerge-nesting.md
@@ -20,6 +20,28 @@
 }
 ```
 
+## Validity precondition
+
+```js verify
+// Run by `generate-links.mjs --verify` against the pinned renovate.
+// The whole scenario rests on :automergeMinor nesting automerge ONLY under
+// update-type keys — a top-level automerge in the preset would void it.
+const src = read("dist/config/presets/internal/default.preset.js");
+const start = src.indexOf("automergeMinor:");
+assert.ok(start >= 0, ":automergeMinor no longer exists in the bundled presets");
+const block = src.slice(start, src.indexOf("\n\t},", start));
+for (const key of ["minor", "patch", "pin", "lockFileMaintenance"]) {
+  assert.ok(
+    block.includes(`${key}: { automerge: true }`),
+    `:automergeMinor no longer nests automerge under ${key}`,
+  );
+}
+assert.ok(
+  !/\n\t\tautomerge:/.test(block),
+  ":automergeMinor now sets a top-level automerge — the update-type scoping story is gone",
+);
+```
+
 ## Symptom framing
 
 ### Entry

--- a/.claude/skills/persona-test/scenarios/44529-group-preset-nesting.md
+++ b/.claude/skills/persona-test/scenarios/44529-group-preset-nesting.md
@@ -19,6 +19,22 @@
 }
 ```
 
+## Validity precondition
+
+```js verify
+// Run by `generate-links.mjs --verify` against the pinned renovate.
+// group:jacksonMonorepo is generated from the jackson monorepo group, and the
+// diagnosis hinges on the `you should not extend` validator guard existing.
+assert.ok(
+  read("dist/data/monorepo.js").includes('"jackson": ['),
+  "the jackson monorepo group is gone — rebase this scenario on another group: preset",
+);
+assert.ok(
+  read("dist/config/validation.js").includes("you should not extend"),
+  "the group:-preset extend guard message is gone from the validator",
+);
+```
+
 ## Symptom framing
 
 ### Entry

--- a/.claude/skills/persona-test/scenarios/README.md
+++ b/.claude/skills/persona-test/scenarios/README.md
@@ -10,12 +10,29 @@ the source discussion number, or any short stable id for a hand-built
 scenario). No registration step elsewhere is needed — `SKILL.md`'s scenario
 filter matches against the filename and the `## Discussion` heading.
 
+Every scenario also carries a **machine-checkable validity precondition**
+(replay-02 finding S1): a scenario's ground truth is written against ONE
+upstream state — a preset body, a validator message, a monorepo group — and a
+routine Renovate bump can silently fix the very bug the scenario tests. When
+that happened to scenario 44772 (the `monorepo:react` source-URL move was
+fixed upstream), three persona sessions chased a fixed bug and the rubric
+would have graded their correct observations as wrong. `generate-links.mjs
+--verify` runs every scenario's precondition against the pinned renovate dist
+and exits non-zero on staleness; `SKILL.md` runs it before any persona is
+spawned, and it should also run on any PR bumping the engine's renovate pin.
+
 ## Template
 
 Copy this into a new file. The `## Config` block is machine-read by
 `generate-links.mjs` (it takes the **first** ` ```json ` fenced block in the
 file), so keep exactly one fenced JSON config block per scenario, and put it
-under a `## Config` heading.
+under a `## Config` heading. The `## Validity precondition` block is run by
+`generate-links.mjs --verify` as an async function body with `renovateDir`
+(the pinned renovate package's absolute path), `read(rel)` (file text under
+it) and `assert` (`node:assert/strict`) in scope — prefer content checks
+(`read(...).includes(...)`) over `require`ing renovate's dist modules, which
+is fragile. Throwing marks the scenario stale; a missing block fails
+verification outright.
 
 ````markdown
 # <id> — <short title>
@@ -31,6 +48,17 @@ under a `## Config` heading.
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"]
 }
+```
+
+## Validity precondition
+
+```js verify
+// Assert the upstream facts the ground truth depends on, against the pinned
+// renovate dist. Throw (via assert) = scenario is stale, personas must not run.
+assert.ok(
+  read("dist/data/monorepo.js").includes('"<the anchor this scenario rests on>"'),
+  "explain what changed upstream and what to do about it",
+);
 ```
 
 ## Symptom framing

--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -353,6 +353,27 @@ test("the consumed-blocks aside names an authored block that didn't apply, and s
 });
 
 /**
+ * Replay-02 R1: the stale veil alone is invisible in a cropped screenshot —
+ * a stale and a fresh card are structurally identical. The card must carry
+ * the stale class (which paints the veil + stamp), and the banner must name
+ * the RUN's inputs, not the form's, so any capture is self-labelling.
+ */
+test("stale results are veiled and the banner names the run they belong to", async ({ page }) => {
+  await page.goto(await encodeShareFragment({ config: PACKAGE_RULES_CONFIG }));
+  await openTab(page, "simulator");
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+
+  // Change an input WITHOUT re-running: the run below is now stale.
+  await simulator.getByLabel("packageName", { exact: true }).fill("react");
+
+  await expect(page.locator(".sim-results-body")).toHaveClass(/stale/);
+  // The banner quotes the run (lodash, from the quick-fill), not the form (react).
+  await expect(page.locator(".sim-stale-banner")).toContainText("lodash");
+});
+
+/**
  * Replay-02 regression (findings-validity N2): the flatten cross-link used to
  * scroll in the same tick it opened the drawer, so the scroll ran against the
  * closed-drawer document height — from the bottom of the page it clamped into

--- a/packages/app/e2e/12-layout-regressions.spec.ts
+++ b/packages/app/e2e/12-layout-regressions.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
-import { PACKAGE_RULES_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
+import { INVALID_RULES_CONFIG, PACKAGE_RULES_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
 import { must, openTab, runAndAwaitResult, setEditorContent } from "./helpers";
 
 /**
@@ -286,4 +286,34 @@ test("the preset detail panel is readable, unclipped and scrollable to its last 
   const panelBox = must(panelBoxRaw, "the preset detail panel's bounding box");
   expect(lastBox.y).toBeGreaterThanOrEqual(panelBox.y - 1);
   expect(lastBox.y + lastBox.height).toBeLessThanOrEqual(panelBox.y + panelBox.height + 1);
+});
+
+/**
+ * Replay-02 R1: the hypothetical banner disappearing after an applied fix
+ * used to move the Simulate button mid-flow — clicks landed on whatever
+ * shifted under the pointer. Once shown, the banner's box stays reserved for
+ * the session, so the button must not move when validation clears.
+ */
+test("the simulate button holds its position when the validation banner clears", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+  await setEditorContent(page, INVALID_RULES_CONFIG);
+  await runAndAwaitResult(page);
+
+  await openTab(page, "simulator");
+  const panel = page.locator("#panel-simulator");
+  await expect(panel.locator(".hypothetical-banner")).toBeVisible();
+  const simulate = panel.getByRole("button", { name: "Simulate", exact: true });
+  const before = must(await simulate.boundingBox(), "the simulate button's bounding box");
+
+  await setEditorContent(page, PACKAGE_RULES_CONFIG);
+  await runAndAwaitResult(page);
+  await openTab(page, "simulator");
+  // The banner is gone from view but its box is reserved (visibility, not unmount)…
+  await expect(panel.locator(".hypothetical-banner")).toBeHidden();
+  // …so the button sits exactly where the pointer left it.
+  const after = must(await simulate.boundingBox(), "the simulate button's bounding box");
+  expect(Math.abs(after.y - before.y)).toBeLessThan(1);
 });

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -211,6 +211,24 @@ export const FIXED_AUTOMERGE_CONFIG = `{
 }
 `;
 
+/** `PACKAGE_RULES_CONFIG` plus the same validate-stage type error the automerge
+ *  pair carries, so fixing it lands exactly on `PACKAGE_RULES_CONFIG`. The
+ *  rules matter: the simulator renders its "hypothetical" banner and Simulate
+ *  button only once there is something to simulate, so the banner's layout
+ *  behaviour (Replay-02 R1) cannot be exercised by a rule-less config. */
+export const INVALID_RULES_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": "yes",
+  "packageRules": [
+    {
+      "matchPackageNames": ["lodash"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
+}
+`;
+
 /** A config whose only issue is a deprecated option: `semanticCommits` used
  *  to be a boolean and is now the enum `"enabled"`/`"disabled"` — migrateConfig
  *  rewrites it. No `extends`, so it runs offline. Used by journey 024 (the

--- a/packages/app/src/features/simulator/ClauseGrid.tsx
+++ b/packages/app/src/features/simulator/ClauseGrid.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import type { ClauseEvaluation } from "@renovate-config-debugger/engine";
-import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
+import { clauseEvaluated, clauseIcon, fullValue, previewValue } from "./rule-format";
 
 /**
  * Roadmap 054 (variant A): a rule's clause evidence as ALIGNED columns —
@@ -15,13 +16,33 @@ import { clauseEvaluated, clauseIcon, previewValue } from "./rule-format";
  * matcher/value edges still line up across the whole grid.
  */
 function ClauseGridRow({ clause }: { clause: ClauseEvaluation }) {
+  // Replay-02 N6: `previewValue` slices the JSON before it reaches the DOM, so
+  // the complete clause value — the citable artifact for a long
+  // matchSourceUrls array — never existed on the page. A truncated value
+  // renders as click-to-expand, with the full value also in its title.
+  const [valueExpanded, setValueExpanded] = useState(false);
   const evaluated = clauseEvaluated(clause);
+  const preview = previewValue(clause.value, 60);
+  const full = fullValue(clause.value);
   return (
     <div className={`kv-row sim-clause-row state-${clause.state}`}>
       <span className="sim-clause-mark">{clauseIcon(clause.state)}</span>
       <code className="sim-clause-key">{clause.key}</code>
       <span className="sim-clause-checks">
-        checks <span className="sim-clause-value">{previewValue(clause.value, 60)}</span>
+        checks{" "}
+        {preview === full ? (
+          <span className="sim-clause-value">{preview}</span>
+        ) : (
+          <button
+            type="button"
+            className="sim-clause-value sim-clause-expand"
+            title={valueExpanded ? "Collapse" : full}
+            aria-expanded={valueExpanded}
+            onClick={() => setValueExpanded(!valueExpanded)}
+          >
+            {valueExpanded ? full : preview}
+          </button>
+        )}
       </span>
       <span className="sim-clause-evaluated">
         {`· ${evaluated.text}`}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import type { ProvenanceLayer, TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
@@ -42,6 +42,25 @@ import { buildVerdictThreads } from "./verdict-threads";
 // Roadmap 032: memoized — the simulator renders the full merged rule list and
 // reads nothing from the editor; its callback props are identity-stable in
 // App (useCallback / the latest-ref idiom), so typing never re-renders it.
+/** Replay-02 R1: the stale banner names the run it describes, so a cropped
+ *  screenshot of a stale card is self-labelling instead of actively wrong. */
+function SimStaleBanner({ ranLabel }: { ranLabel: string }) {
+  if (!ranLabel) {
+    return (
+      <p className="sim-stale-banner">
+        Inputs changed since this run — these results may no longer reflect the form above. Simulate
+        again to refresh.
+      </p>
+    );
+  }
+  return (
+    <p className="sim-stale-banner">
+      These results are for <code>{ranLabel}</code> — inputs changed since this run. Simulate again
+      to refresh.
+    </p>
+  );
+}
+
 export const RuleSimulator = memo(function RuleSimulator({
   result,
   onSelectPreset,
@@ -231,6 +250,15 @@ export const RuleSimulator = memo(function RuleSimulator({
     () => (sim ? buildNoInputCaveat(sim, ruleAttribution) : undefined),
     [sim, ruleAttribution],
   );
+  // Replay-02 R1: once the hypothetical banner has been shown, its box stays
+  // reserved (visibility, not unmount) — the banner vanishing after an
+  // applied fix used to move the Simulate button out from under the pointer.
+  const [invalidSeen, setInvalidSeen] = useState(false);
+  useEffect(() => {
+    if (configInvalid) {
+      setInvalidSeen(true);
+    }
+  }, [configInvalid]);
   // Roadmap 047: the authored update-type blocks flattening consumed without
   // applying — the only thing that still earns the verdict card's aside.
   const consumedBlocks = useMemo(
@@ -323,6 +351,17 @@ export const RuleSimulator = memo(function RuleSimulator({
   }
 
   const stale = sim !== null && ranKey !== JSON.stringify(form);
+  // Replay-02 R1: what the LAST RUN simulated (not the live form) — the stale
+  // banner quotes it so a stale capture names the inputs it belongs to.
+  const ranLabel = simForm
+    ? [
+        simForm.packageName || simForm.depName,
+        simForm.currentValue,
+        simForm.newValue ? `→ ${simForm.newValue}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ")
+    : "";
   // Roadmap 015: reactive, not sticky — the moment the form gains ANY
   // meaningful field, the guard clears itself even without clicking Simulate.
   const showEmptyGuard = emptyGuardTriggered && !hasMeaningfulInput(form);
@@ -342,7 +381,11 @@ export const RuleSimulator = memo(function RuleSimulator({
           <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
         </span>
       </div>
-      {configInvalid ? <HypotheticalBanner /> : null}
+      {configInvalid || invalidSeen ? (
+        <div className={`sim-banner-slot${configInvalid ? "" : " ghost"}`}>
+          <HypotheticalBanner />
+        </div>
+      ) : null}
       {focusHint !== null && !sim ? (
         <p className="sim-focus-hint">
           <code>packageRules[{focusHint}]</code> is evaluated here once you run a simulation —
@@ -392,12 +435,7 @@ export const RuleSimulator = memo(function RuleSimulator({
           found easy to skim past) with a banner explaining why. */}
       {sim ? (
         <div className="sim-results">
-          {stale ? (
-            <p className="sim-stale-banner">
-              Inputs changed since this run — these results may no longer reflect the form above.
-              Simulate again to refresh.
-            </p>
-          ) : null}
+          {stale ? <SimStaleBanner ranLabel={ranLabel} /> : null}
           {/* The banner above stays full-strength; everything below it (the
               actual results) is what gets visibly veiled while stale. */}
           <div className={`sim-results-body${stale ? " stale" : ""}`}>

--- a/packages/app/src/features/simulator/rule-format.ts
+++ b/packages/app/src/features/simulator/rule-format.ts
@@ -5,8 +5,10 @@ export function previewValue(value: unknown, max = 60): string {
   return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
-/** Untruncated JSON rendering for copy-as-markdown export. */
-function fullValue(value: unknown): string {
+/** Untruncated JSON rendering — the copy-as-markdown export and (replay-02
+ *  N6) the clause grid's click-to-expand both need the complete value; a
+ *  60-char preview of a matchSourceUrls list is not a citable artifact. */
+export function fullValue(value: unknown): string {
   return JSON.stringify(value) ?? "undefined";
 }
 

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2694,13 +2694,15 @@ pre.config-view.prov-before {
    this update actually is. Rows are subgrid so both value columns line up
    straight down the grid; the comparison IS the evidence, and the prose form
    this replaced (layer 7 retired it) hid the comparison in a sentence. */
-/* Both text columns are `fr`, not `1fr auto`: an `auto` last track takes its
-   max-content width first, and a clause that did NOT match carries a whole
-   sentence there ("evaluated false — the simulated dependency has no depType
-   …"). That left the checks column ~1ch wide, breaking its value one character
-   per line. Sharing the slack keeps every state on the same tracks; the
-   explanation gets the larger share because it is prose, while the value it
-   sits beside is a `previewValue`, capped at 60 characters. */
+/* Replay-02 N6: both text columns are `fr`, not `1fr auto`. An `auto` track
+   grows toward its max-content BEFORE any fr track gets space, and a clause
+   that did NOT match carries a whole sentence there ("evaluated false — the
+   simulated dependency has no depType …"). That starved the checks column to
+   ~1ch, breaking its value one glyph per line — and because subgrid sizes
+   tracks across ALL rows, a single failing clause collapsed the whole grid.
+   Two minmax(0, fr) tracks can't starve each other; the explanation gets the
+   larger share because it is prose, while the value it sits beside is a
+   `previewValue`, capped at 60 characters. */
 .sim-clause-grid {
   --kv-cols: max-content max-content minmax(0, 1fr) minmax(0, 1.6fr);
   --kv-row-gap: 0.2rem;
@@ -2732,6 +2734,19 @@ pre.config-view.prov-before {
   color: var(--ink);
   font-family: var(--font-mono);
   font-size: 0.78rem;
+}
+
+/* Replay-02 N6: a truncated clause value is a button — click for the full
+   value (also in its title). Inherits the value styling above; the dotted
+   underline is the only affordance chrome. */
+.sim-clause-expand {
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline dotted;
+  text-underline-offset: 2px;
 }
 
 /* 054 layer 3: the rule-evidence popover. The plane is the app's existing
@@ -3467,9 +3482,36 @@ pre.config-view.prov-before {
   padding: 0.5rem 0.65rem;
 }
 
+/* Replay-02 R1: once the hypothetical banner has been shown, its box stays
+   reserved for the session — the banner vanishing after an applied fix used
+   to move the Simulate button out from under the pointer. */
+.sim-banner-slot.ghost {
+  visibility: hidden;
+}
+
 .sim-results-body.stale {
   filter: grayscale(65%);
-  opacity: 0.5;
+  opacity: 0.4;
+  position: relative;
+}
+
+/* Replay-02 R1: the dim alone is invisible in a cropped screenshot — a stale
+   and a fresh card are structurally identical. The stamp makes any capture
+   self-labelling (it dims with the card, but stays legible). */
+.sim-results-body.stale::after {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 6px;
+  color: var(--warn);
+  content: "Stale — inputs changed, simulate again";
+  font-size: 0.9rem;
+  font-weight: 600;
+  left: 50%;
+  padding: 0.4rem 0.8rem;
+  position: absolute;
+  top: 1.5rem;
+  transform: translateX(-50%);
+  white-space: nowrap;
 }
 
 /* The veil FADES in only for readers who did not ask for less motion; the


### PR DESCRIPTION
Replay-02 findings S1/N1, both in the study harness rather than the app:

- scenarios now carry a machine-checkable '## Validity precondition' —
  a js block generate-links.mjs --verify runs against the pinned
  renovate dist (read/assert in scope), exiting non-zero on staleness.
  Guards against the 44772 failure mode: a routine Renovate bump fixed
  the bug the scenario tested, and a full replay graded correct persona
  observations as wrong. SKILL.md step 3 now verifies before any persona
  spawns; run it on renovate-pin bump PRs too. All three current
  scenarios get anchored preconditions (validator message, preset body,
  monorepo group + extend guard).
- N1 was a study-tooling artifact, not an app bug: raw-DOM discovery
  surfaced a control inside a hidden tab panel (display:none — no a11y
  node, no geometry) and its no-op click became a false finding. The
  skill and the shared persona mechanics now require visibility-filtered
  element discovery and treat hidden subtrees as non-existent.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>