### PR TITLE
feat(oauth-worker): refresh-token cookie mode (roadmap 065)

### DIFF
--- a/packages/oauth-worker/README.md
+++ b/packages/oauth-worker/README.md
@@ -80,6 +80,45 @@ Until these are set, the app builds cleanly with the feature off: there is no
 sign-in UI, and the personal-access-token fallback (advanced settings) stays
 the only GitHub auth.
 
+## Persistent sign-in (`REFRESH_COOKIE`)
+
+Off by default. With `REFRESH_COOKIE=true` the Worker stops returning the
+`refresh_token` in the JSON body and returns it as an `HttpOnly` cookie
+instead, so closing the tab no longer ends the session while the long-lived
+token stays unreadable to JavaScript (roadmap
+[065](../../roadmap/065-persistent-sign-in.md)). The Worker stays stateless —
+the cookie _is_ the storage.
+
+The response body then carries `refresh_token_cookie: true` (how the app knows
+which mode it is talking to) and keeps `refresh_token_expires_in`; the cookie
+is `__Secure-rcv-refresh=<token>; HttpOnly; Secure; SameSite=Strict;
+Path=<mount>; Max-Age=<refresh_token_expires_in>`. GitHub rotates refresh
+tokens, so every successful `/refresh` re-sets it; a rejected grant and
+`POST /logout` clear it.
+
+> **Same-site only.** A cross-site cookie is dropped outright by Safari and by
+> every browser with third-party-cookie blocking on. A Worker reached from a
+> different site than the app — the `*.workers.dev` URL, a separate host —
+> must leave `REFRESH_COOKIE` unset and keep the 009 body protocol; the app
+> falls back to the in-memory session it has always had.
+
+Production satisfies that by mounting the Worker on the app's own hostname
+with a Cloudflare Workers route, `renovate.secustor.dev/oauth/*` (in
+`wrangler.jsonc`). The handler strips one leading `/oauth` segment, so
+`/oauth/exchange` and a bare `/exchange` are the same endpoint, and it pins the
+cookie `Path` to the mount it was reached through — that is what keeps the
+refresh token off the GitHub Pages requests sharing the hostname, and why the
+cookie name uses `__Secure-` rather than `__Host-` (which would force `Path=/`).
+
+A Workers route only fires on **proxied (orange-cloud) DNS**: while the
+`renovate` record is DNS-only the route is inert and every request falls
+through to GitHub Pages. Proxying needs SSL mode Full (strict) — GitHub Pages
+holds a valid cert for the hostname.
+
+For the Docker image the same switch is the `REFRESH_COOKIE=true` environment
+variable, and the same rule applies: only set it where the proxy is served
+over TLS under the app's own origin (a reverse proxy in front of both).
+
 ## Running it without Cloudflare
 
 ```bash
@@ -106,14 +145,19 @@ before GitHub is contacted. Responses reflect the exact matched origin (never
   `expires_in`, `refresh_token`, `refresh_token_expires_in`, `token_type`,
   `scope`) or an `{ error, ... }` passthrough.
 - `POST /refresh`: body `{ refresh_token }` → `refresh_token` grant, same
-  response shape.
+  response shape. In cookie mode the token may instead come from the cookie
+  (body `{}`); an explicit body token always wins.
+- `POST /logout`: clears the refresh cookie in cookie mode. `204` either way.
 - Everything else → `404`. `OPTIONS` preflights are answered for allowed
-  origins.
+  origins. Each path is also served under an `/oauth` prefix (the Workers
+  route); responses always send `access-control-allow-credentials: true`
+  alongside the exact reflected origin.
 
 | Name                   | Kind   | Notes                                                       |
 | ---------------------- | ------ | ----------------------------------------------------------- |
 | `GITHUB_CLIENT_ID`     | var    | GitHub App client id (public).                              |
 | `ALLOWED_ORIGINS`      | var    | Comma-separated exact origins allowed to call the Worker.   |
+| `REFRESH_COOKIE`       | var    | `true` enables the refresh cookie above. Same-site only.    |
 | `GITHUB_CLIENT_SECRET` | secret | GitHub App client secret. Never in `wrangler.jsonc` or git. |
 
 </details>

--- a/packages/oauth-worker/server.mjs
+++ b/packages/oauth-worker/server.mjs
@@ -21,6 +21,12 @@ const env = {
   GITHUB_CLIENT_ID: process.env.GITHUB_CLIENT_ID ?? "",
   GITHUB_CLIENT_SECRET: process.env.GITHUB_CLIENT_SECRET ?? "",
   ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS ?? "",
+  // Roadmap 065 — `"true"` opts into the HttpOnly refresh-token cookie. Left
+  // empty by default: the cookie is `Secure` + `SameSite=Strict`, so it only
+  // works where the proxy is served over TLS on the app's own site. A
+  // self-hoster who reverse-proxies this under the app's origin can switch it
+  // on; anything else keeps the 009 body-carries-the-token protocol.
+  REFRESH_COOKIE: process.env.REFRESH_COOKIE ?? "",
 };
 
 /** Bodies here are OAuth JSON (a few hundred bytes), so buffering is fine. */
@@ -41,7 +47,9 @@ function toRequest(req, body) {
       }
     }
   }
-  // Only the pathname is read downstream; a malformed Host must not 500.
+  // Only the pathname and hostname are read downstream (the hostname solely
+  // for the workers.dev cookie-mode exclusion, which can never match here);
+  // a malformed Host must not 500.
   let url;
   try {
     url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);

--- a/packages/oauth-worker/src/index.ts
+++ b/packages/oauth-worker/src/index.ts
@@ -13,6 +13,12 @@
  * The request handler is a pure function so it can be unit-tested without
  * wrangler (stub `globalThis.fetch`); the default export wires it to the
  * Workers runtime.
+ *
+ * Roadmap 065 — opt-in `REFRESH_COOKIE=true` moves the refresh token out of
+ * the JSON body and into an `HttpOnly` cookie, so a tab close no longer signs
+ * the user out while the long-lived token stays unreadable to JS. The Worker
+ * remains stateless: the cookie IS the storage. With the var unset every
+ * observable behavior is the 009 one.
  */
 
 export interface Env {
@@ -22,9 +28,33 @@ export interface Env {
   GITHUB_CLIENT_SECRET: string;
   /** Comma-separated list of exact origins allowed to call this Worker. */
   ALLOWED_ORIGINS: string;
+  /**
+   * Roadmap 065 — `"true"` enables refresh-token-cookie mode. Anything else
+   * (including unset) keeps the 009 protocol byte-for-byte, which is what the
+   * stock Docker image and cross-site deployments need: a cross-site cookie
+   * is dropped outright by Safari and by every browser running
+   * third-party-cookie blocking. A `*.workers.dev` host keeps 009 even with
+   * the var set ({@link cookieMode}) — that URL is the cross-site fallback by
+   * definition.
+   */
+  REFRESH_COOKIE?: string;
 }
 
 const GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token";
+
+/**
+ * `__Secure-` and deliberately NOT `__Host-`: the `__Host-` prefix would force
+ * `Path=/`, and on the shared `renovate.secustor.dev` hostname that would send
+ * the refresh token along with every GitHub Pages asset request. The cookie
+ * `Path` must stay pinned to the Worker's mount (roadmap 065).
+ */
+const REFRESH_COOKIE_NAME = "__Secure-rcv-refresh";
+
+/** Fallback lifetime when GitHub omits `refresh_token_expires_in` (180 days). */
+const REFRESH_COOKIE_MAX_AGE = 15_552_000;
+
+/** The `/oauth/*` Workers route prefix; stripped once, never recursively. */
+const MOUNT_PREFIX = "/oauth";
 
 interface ExchangeBody {
   code?: unknown;
@@ -60,22 +90,160 @@ function corsHeaders(origin: string): Headers {
   headers.set("vary", "Origin");
   headers.set("access-control-allow-methods", "POST, OPTIONS");
   headers.set("access-control-allow-headers", "Content-Type");
+  // Roadmap 065: a `credentials: "include"` fetch requires this header AND an
+  // exact origin (the browser rejects the pair with `*`) — which is what
+  // `access-control-allow-origin` above already is. Sent unconditionally so
+  // the app can use one fetch shape against both cookie and non-cookie
+  // deployments; it grants nothing on its own, the allow-list still gates.
+  headers.set("access-control-allow-credentials", "true");
   headers.set("access-control-max-age", "86400");
   return headers;
 }
 
-function jsonResponse(body: unknown, status: number, origin: string | null): Response {
+function jsonResponse(
+  body: unknown,
+  status: number,
+  origin: string | null,
+  setCookie?: string,
+): Response {
   const headers = origin ? corsHeaders(origin) : new Headers();
   headers.set("content-type", "application/json");
+  if (setCookie) {
+    headers.set("set-cookie", setCookie);
+  }
   return new Response(JSON.stringify(body), { status, headers });
+}
+
+/**
+ * True only for the exact opt-in string — an unset/typo'd var means 009 — and
+ * never on a `*.workers.dev` host. That fallback URL is only ever reached
+ * cross-site (the same-site deployment is the `/oauth` route on the app's own
+ * hostname), and a cross-site `SameSite=Strict` cookie is stored nowhere and
+ * sent never: engaging cookie mode there would trade the in-body refresh
+ * token for a cookie the browser drops, silently capping the session at one
+ * access token. Excluding the host structurally makes `REFRESH_COOKIE=true`
+ * safe to publish while `workers.dev` is still the live entry point.
+ */
+function cookieMode(env: Env, hostname: string): boolean {
+  return env.REFRESH_COOKIE === "true" && !hostname.endsWith(".workers.dev");
+}
+
+/**
+ * The Worker answers both `/exchange` (workers.dev, the Node image) and
+ * `/oauth/exchange` (the `renovate.secustor.dev/oauth/*` route). Exactly one
+ * leading `/oauth` segment is stripped, and the mount it was stripped from
+ * becomes the cookie `Path` — that is what keeps the refresh cookie off the
+ * GitHub Pages requests sharing the hostname (roadmap 065).
+ */
+interface Route {
+  /** Pathname with the mount removed: always a bare `/exchange` etc. */
+  path: string;
+  /** `/oauth` when the request arrived prefixed, `/` otherwise. */
+  mount: string;
+}
+
+function routeOf(url: URL): Route {
+  const { pathname } = url;
+  if (pathname === MOUNT_PREFIX || pathname.startsWith(`${MOUNT_PREFIX}/`)) {
+    return { path: pathname.slice(MOUNT_PREFIX.length) || "/", mount: MOUNT_PREFIX };
+  }
+  return { path: pathname, mount: "/" };
+}
+
+/**
+ * The `Set-Cookie` value. `SameSite=Strict` is affordable because the intended
+ * deployment is same-origin; `Max-Age=0` with an empty value is the clear.
+ * The value is percent-encoded so no token can ever inject a cookie attribute.
+ */
+function refreshCookie(value: string, maxAge: number, mount: string): string {
+  return [
+    `${REFRESH_COOKIE_NAME}=${encodeURIComponent(value)}`,
+    "HttpOnly",
+    "Secure",
+    "SameSite=Strict",
+    `Path=${mount}`,
+    `Max-Age=${maxAge}`,
+  ].join("; ");
+}
+
+function clearRefreshCookie(mount: string): string {
+  return refreshCookie("", 0, mount);
+}
+
+/** The refresh token from the request's cookie jar, or "" when absent. */
+function readRefreshCookie(req: Request): string {
+  const header = req.headers.get("cookie");
+  if (!header) {
+    return "";
+  }
+  for (const pair of header.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq < 0 || pair.slice(0, eq).trim() !== REFRESH_COOKIE_NAME) {
+      continue;
+    }
+    const raw = pair.slice(eq + 1).trim();
+    try {
+      return decodeURIComponent(raw);
+    } catch {
+      // A malformed escape means the cookie is not one we wrote — ignore it
+      // rather than 500, the caller then falls through to the 400.
+      return "";
+    }
+  }
+  return "";
+}
+
+/**
+ * Rewrites a successful GitHub payload for cookie mode: the `refresh_token`
+ * leaves the body and becomes the `Set-Cookie`, `refresh_token_cookie: true`
+ * tells the SPA which mode it is talking to, and `refresh_token_expires_in`
+ * stays so the app can persist its non-secret "a session exists until" marker.
+ * Returns null when there is nothing to move (no refresh token in the grant),
+ * leaving the 009 passthrough untouched.
+ */
+function toCookieResponse(
+  payload: Record<string, unknown>,
+  mount: string,
+): { body: Record<string, unknown>; setCookie: string } | null {
+  const token = payload.refresh_token;
+  if (typeof token !== "string" || token.length === 0) {
+    return null;
+  }
+  const expiresIn = payload.refresh_token_expires_in;
+  const maxAge =
+    typeof expiresIn === "number" && Number.isFinite(expiresIn) && expiresIn > 0
+      ? Math.floor(expiresIn)
+      : REFRESH_COOKIE_MAX_AGE;
+  const body: Record<string, unknown> = { ...payload, refresh_token_cookie: true };
+  delete body.refresh_token;
+  return { body, setCookie: refreshCookie(token, maxAge, mount) };
+}
+
+/** How a response may touch the cookie — present only in cookie mode. */
+interface CookieOptions {
+  /** Cookie `Path` — the mount this request arrived on. */
+  mount: string;
+  /**
+   * Clear the cookie when GitHub rejects the grant. True for /refresh only:
+   * the cookie IS what was rejected, so clearing it stops the client probing a
+   * dead grant. A failed /exchange says nothing about an existing session.
+   */
+  clearOnError: boolean;
 }
 
 /**
  * Forwards a completed grant to GitHub and passes its JSON back verbatim.
  * GitHub replies 200 even for `{ error: ... }` on this endpoint, so an error
  * body is downgraded to 400. No body or token is ever logged.
+ *
+ * `cookie` is non-null only in cookie mode (roadmap 065); it then rewrites a
+ * successful body as above.
  */
-async function forwardToGitHub(params: URLSearchParams, origin: string): Promise<Response> {
+async function forwardToGitHub(
+  params: URLSearchParams,
+  origin: string,
+  cookie: CookieOptions | null,
+): Promise<Response> {
   let ghRes: Response;
   try {
     ghRes = await fetch(GITHUB_TOKEN_URL, {
@@ -97,15 +265,32 @@ async function forwardToGitHub(params: URLSearchParams, origin: string): Promise
     return jsonResponse({ error: "github_bad_response" }, 502, origin);
   }
 
-  const isError =
-    typeof payload === "object" &&
-    payload !== null &&
-    "error" in (payload as Record<string, unknown>);
+  const record =
+    typeof payload === "object" && payload !== null ? (payload as Record<string, unknown>) : null;
+  const isError = record !== null && "error" in record;
   const status = isError ? 400 : ghRes.ok ? 200 : ghRes.status;
+
+  if (cookie !== null && record !== null) {
+    if (isError) {
+      return cookie.clearOnError
+        ? jsonResponse(payload, status, origin, clearRefreshCookie(cookie.mount))
+        : jsonResponse(payload, status, origin);
+    }
+    const cookied = toCookieResponse(record, cookie.mount);
+    if (cookied) {
+      return jsonResponse(cookied.body, status, origin, cookied.setCookie);
+    }
+  }
   return jsonResponse(payload, status, origin);
 }
 
-async function handleExchange(req: Request, env: Env, origin: string): Promise<Response> {
+async function handleExchange(
+  req: Request,
+  env: Env,
+  origin: string,
+  mount: string,
+  cookies: boolean,
+): Promise<Response> {
   let body: ExchangeBody;
   try {
     body = (await req.json()) as ExchangeBody;
@@ -136,10 +321,16 @@ async function handleExchange(req: Request, env: Env, origin: string): Promise<R
   if (redirectUri) {
     params.set("redirect_uri", redirectUri);
   }
-  return forwardToGitHub(params, origin);
+  return forwardToGitHub(params, origin, cookies ? { mount, clearOnError: false } : null);
 }
 
-async function handleRefresh(req: Request, env: Env, origin: string): Promise<Response> {
+async function handleRefresh(
+  req: Request,
+  env: Env,
+  origin: string,
+  mount: string,
+  cookies: boolean,
+): Promise<Response> {
   let body: RefreshBody;
   try {
     body = (await req.json()) as RefreshBody;
@@ -150,7 +341,11 @@ async function handleRefresh(req: Request, env: Env, origin: string): Promise<Re
       origin,
     );
   }
-  const refreshToken = typeof body.refresh_token === "string" ? body.refresh_token : "";
+  // An explicit body token always wins: 009 clients and cookie-off deployments
+  // send one, and a client that holds its own token must be able to use it
+  // even where a (possibly stale) cookie also exists.
+  const fromBody = typeof body.refresh_token === "string" ? body.refresh_token : "";
+  const refreshToken = fromBody || (cookies ? readRefreshCookie(req) : "");
   if (!refreshToken) {
     return jsonResponse(
       { error: "invalid_request", error_description: "refresh_token is required" },
@@ -164,13 +359,31 @@ async function handleRefresh(req: Request, env: Env, origin: string): Promise<Re
     grant_type: "refresh_token",
     refresh_token: refreshToken,
   });
-  return forwardToGitHub(params, origin);
+  // GitHub rotates the refresh token on every use, so cookie mode re-sets the
+  // cookie on each success — an un-rotated cookie would be dead on next boot.
+  return forwardToGitHub(params, origin, cookies ? { mount, clearOnError: true } : null);
 }
 
 /**
- * Pure request handler. Answers only same-listed-origin POSTs to /exchange and
- * /refresh; a preflight from an allowed origin gets the CORS headers; anything
- * from a non-listed origin is refused (403) before GitHub is ever contacted.
+ * Roadmap 065 — ends the cookie session. Always 204 (the SPA fires it
+ * best-effort on sign-out and must not care about the answer); the clearing
+ * `Set-Cookie` only exists in cookie mode, where the cookie is the session.
+ * Nothing server-side is touched — there is nothing server-side.
+ */
+function handleLogout(origin: string, mount: string, cookies: boolean): Response {
+  const headers = corsHeaders(origin);
+  if (cookies) {
+    headers.set("set-cookie", clearRefreshCookie(mount));
+  }
+  return new Response(null, { status: 204, headers });
+}
+
+/**
+ * Pure request handler. Answers only same-listed-origin POSTs to /exchange,
+ * /refresh and /logout; a preflight from an allowed origin gets the CORS
+ * headers; anything from a non-listed origin is refused (403) before GitHub is
+ * ever contacted. Paths are matched after the optional `/oauth` mount is
+ * stripped, so the same code serves the route and a bare deployment.
  */
 export async function handleRequest(req: Request, env: Env): Promise<Response> {
   const origin = matchOrigin(req, env);
@@ -187,12 +400,19 @@ export async function handleRequest(req: Request, env: Env): Promise<Response> {
     return jsonResponse({ error: "origin_not_allowed" }, 403, null);
   }
 
-  const { pathname } = new URL(req.url);
-  if (req.method === "POST" && pathname === "/exchange") {
-    return handleExchange(req, env, origin);
+  const url = new URL(req.url);
+  const { path, mount } = routeOf(url);
+  // Resolved once per request: the env opt-in AND a host cookie mode is
+  // actually correct on ({@link cookieMode}).
+  const cookies = cookieMode(env, url.hostname);
+  if (req.method === "POST" && path === "/exchange") {
+    return handleExchange(req, env, origin, mount, cookies);
   }
-  if (req.method === "POST" && pathname === "/refresh") {
-    return handleRefresh(req, env, origin);
+  if (req.method === "POST" && path === "/refresh") {
+    return handleRefresh(req, env, origin, mount, cookies);
+  }
+  if (req.method === "POST" && path === "/logout") {
+    return handleLogout(origin, mount, cookies);
   }
   return jsonResponse({ error: "not_found" }, 404, origin);
 }

--- a/packages/oauth-worker/test/handler.test.ts
+++ b/packages/oauth-worker/test/handler.test.ts
@@ -11,6 +11,11 @@ const env: Env = {
   ALLOWED_ORIGINS: `${ALLOWED}, ${DEV}`,
 };
 
+/** Roadmap 065 — the same deployment with the opt-in cookie mode switched on. */
+const cookieEnv: Env = { ...env, REFRESH_COOKIE: "true" };
+
+const COOKIE_NAME = "__Secure-rcv-refresh";
+
 const ACCESS_TOKEN = "ghu_thisisasecrettokenvalue";
 
 /** A successful GitHub token response. */
@@ -28,12 +33,21 @@ function ghTokenResponse() {
   );
 }
 
-function post(path: string, body: unknown, origin: string | null): Request {
+function post(
+  path: string,
+  body: unknown,
+  origin: string | null,
+  cookie?: string,
+  base = "https://worker.example",
+): Request {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (origin) {
     headers.origin = origin;
   }
-  return new Request(`https://worker.example${path}`, {
+  if (cookie) {
+    headers.cookie = cookie;
+  }
+  return new Request(`${base}${path}`, {
     method: "POST",
     headers,
     body: JSON.stringify(body),
@@ -228,6 +242,307 @@ describe("routing", () => {
     expect(res.status).toBe(404);
     const json = (await res.json()) as { error?: string };
     expect(json.error).toBe("not_found");
+  });
+
+  it("404s an unknown route under the /oauth mount too", async () => {
+    const res = await handleRequest(post("/oauth/nope", {}, ALLOWED), cookieEnv);
+    expect(res.status).toBe(404);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("serves the /oauth-prefixed path from a Workers route", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ghTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(
+      post("/oauth/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---- Roadmap 065: refresh-token cookie mode -----------------------------
+
+describe("allow-credentials", () => {
+  it("is sent on a preflight, alongside an exact (never wildcard) origin", async () => {
+    const req = new Request("https://worker.example/exchange", {
+      method: "OPTIONS",
+      headers: { origin: ALLOWED },
+    });
+    const res = await handleRequest(req, env);
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED);
+  });
+
+  it("is sent on a real response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ghTokenResponse()));
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      env,
+    );
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+});
+
+describe("cookie mode off (the 009 protocol)", () => {
+  it("never sets a cookie and leaves the refresh token in the body", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ghTokenResponse()));
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      env,
+    );
+    expect(res.headers.get("set-cookie")).toBeNull();
+    const json = (await res.json()) as { refresh_token?: string; refresh_token_cookie?: boolean };
+    expect(json.refresh_token).toBe("ghr_refreshsecret");
+    expect(json.refresh_token_cookie).toBeUndefined();
+  });
+
+  it("ignores a refresh cookie: an empty /refresh body is still a 400", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(
+      post("/refresh", {}, ALLOWED, `${COOKIE_NAME}=ghr_fromcookie`),
+      env,
+    );
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("answers /logout with 204 and no cookie header", async () => {
+    const res = await handleRequest(post("/logout", {}, ALLOWED), env);
+    expect(res.status).toBe(204);
+    expect(res.headers.get("set-cookie")).toBeNull();
+    expect(res.headers.get("access-control-allow-origin")).toBe(ALLOWED);
+  });
+});
+
+describe("cookie mode on", () => {
+  it("moves the refresh token out of the body and into an HttpOnly cookie", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ghTokenResponse()));
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      cookieEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`${COOKIE_NAME}=ghr_refreshsecret`);
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure");
+    expect(setCookie).toContain("SameSite=Strict");
+    expect(setCookie).toContain("Path=/");
+    expect(setCookie).toContain("Max-Age=15897600");
+    // __Host- would force Path=/, which the shared hostname forbids.
+    expect(setCookie).not.toContain("__Host-");
+
+    const json = (await res.json()) as {
+      access_token?: string;
+      refresh_token?: string;
+      refresh_token_cookie?: boolean;
+      refresh_token_expires_in?: number;
+    };
+    expect(json.access_token).toBe(ACCESS_TOKEN);
+    expect(json.refresh_token).toBeUndefined();
+    expect(json.refresh_token_cookie).toBe(true);
+    // Kept: it feeds the app's non-secret localStorage marker.
+    expect(json.refresh_token_expires_in).toBe(15897600);
+    assertNothingLogged();
+  });
+
+  it("pins the cookie Path to the /oauth mount it was reached through", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ghTokenResponse()));
+    const res = await handleRequest(
+      post("/oauth/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      cookieEnv,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toContain("Path=/oauth");
+  });
+
+  it("falls back to the fixed 180-day Max-Age when GitHub omits the expiry", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ access_token: ACCESS_TOKEN, refresh_token: "ghr_x" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      cookieEnv,
+    );
+    expect(res.headers.get("set-cookie")).toContain("Max-Age=15552000");
+  });
+
+  it("leaves a refresh-token-less payload alone", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ access_token: ACCESS_TOKEN, expires_in: 28800 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      cookieEnv,
+    );
+    expect(res.headers.get("set-cookie")).toBeNull();
+    const json = (await res.json()) as { refresh_token_cookie?: boolean };
+    expect(json.refresh_token_cookie).toBeUndefined();
+  });
+
+  it("refreshes from the cookie on an empty body, and rotates the cookie", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ghTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await handleRequest(
+      post("/refresh", {}, ALLOWED, `other=1; ${COOKIE_NAME}=ghr_fromcookie; another=2`),
+      cookieEnv,
+    );
+
+    expect(res.status).toBe(200);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(init.body)).toContain("refresh_token=ghr_fromcookie");
+    // GitHub rotates the token, so the cookie must carry the NEW one.
+    expect(res.headers.get("set-cookie")).toContain(`${COOKIE_NAME}=ghr_refreshsecret`);
+    assertNothingLogged();
+  });
+
+  it("prefers an explicit body refresh_token over the cookie", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ghTokenResponse());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleRequest(
+      post("/refresh", { refresh_token: "ghr_frombody" }, ALLOWED, `${COOKIE_NAME}=ghr_fromcookie`),
+      cookieEnv,
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(init.body)).toContain("refresh_token=ghr_frombody");
+    expect(String(init.body)).not.toContain("ghr_fromcookie");
+  });
+
+  it("still 400s a /refresh with neither body token nor cookie", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(post("/refresh", {}, ALLOWED), cookieEnv);
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("clears the cookie when GitHub rejects the grant", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "bad_refresh_token" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const res = await handleRequest(
+      post("/refresh", {}, ALLOWED, `${COOKIE_NAME}=ghr_dead`),
+      cookieEnv,
+    );
+    expect(res.status).toBe(400);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`${COOKIE_NAME}=;`);
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("HttpOnly");
+    assertNothingLogged();
+  });
+
+  it("keeps an existing session when an /exchange fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "bad_verification_code" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      ),
+    );
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED),
+      cookieEnv,
+    );
+    expect(res.status).toBe(400);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("clears the cookie on /logout and answers 204", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(post("/logout", {}, ALLOWED), cookieEnv);
+    expect(res.status).toBe(204);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`${COOKIE_NAME}=;`);
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("Path=/");
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("clears the /oauth-mounted cookie on a prefixed /logout", async () => {
+    const res = await handleRequest(post("/oauth/logout", {}, ALLOWED), cookieEnv);
+    expect(res.status).toBe(204);
+    expect(res.headers.get("set-cookie")).toContain("Path=/oauth");
+  });
+
+  it("refuses /logout from a disallowed origin", async () => {
+    const res = await handleRequest(post("/logout", {}, EVIL), cookieEnv);
+    expect(res.status).toBe(403);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});
+
+describe("cookie mode never engages on a *.workers.dev host", () => {
+  // The workers.dev URL stays live (and cross-site) until the DNS switch puts
+  // the Worker on the app's own hostname. If cookie mode engaged there, the
+  // refresh token would leave the body for a SameSite=Strict cookie the
+  // browser drops — capping the session at one access token. The host
+  // exclusion is what makes REFRESH_COOKIE=true safe to publish ahead of the
+  // switch.
+  const WORKERS_DEV = "https://rcv-oauth-worker.secustor.workers.dev";
+
+  it("keeps the 009 protocol: refresh token in the body, no cookie", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(ghTokenResponse()));
+    const res = await handleRequest(
+      post("/exchange", { code: "c", code_verifier: "v" }, ALLOWED, undefined, WORKERS_DEV),
+      cookieEnv,
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toBeNull();
+    const json = (await res.json()) as { refresh_token?: string; refresh_token_cookie?: boolean };
+    expect(json.refresh_token).toBe("ghr_refreshsecret");
+    expect(json.refresh_token_cookie).toBeUndefined();
+  });
+
+  it("never reads a cookie on /refresh: an empty body is still a 400", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await handleRequest(
+      post("/refresh", {}, ALLOWED, `${COOKIE_NAME}=ghr_fromcookie`, WORKERS_DEV),
+      cookieEnv,
+    );
+    expect(res.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("answers /logout without a clearing cookie header", async () => {
+    const res = await handleRequest(
+      post("/logout", {}, ALLOWED, undefined, WORKERS_DEV),
+      cookieEnv,
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("set-cookie")).toBeNull();
   });
 });
 

--- a/packages/oauth-worker/wrangler.jsonc
+++ b/packages/oauth-worker/wrangler.jsonc
@@ -20,10 +20,41 @@
   //   ALLOWED_ORIGINS   — comma-separated exact origins allowed to call this
   //                       Worker; requests from any other origin get 403 and
   //                       never reach GitHub.
+  //   REFRESH_COOKIE    — roadmap 065: "true" returns the refresh token as an
+  //                       HttpOnly `__Secure-rcv-refresh` cookie instead of in
+  //                       the JSON body, so a closed tab no longer ends the
+  //                       session. Only correct on a SAME-SITE deployment —
+  //                       here the route below puts the Worker on the app's
+  //                       own hostname. Unset (or any other value) = the 009
+  //                       protocol, byte-for-byte, which is what a cross-site
+  //                       workers.dev deployment needs (Safari and every
+  //                       third-party-cookie blocker drop such a cookie).
+  //                       The handler enforces that itself: on a
+  //                       `*.workers.dev` host cookie mode never engages, so
+  //                       publishing "true" here is safe while the fallback
+  //                       URL is still the live entry point.
   "vars": {
     "GITHUB_CLIENT_ID": "",
     "ALLOWED_ORIGINS": "https://renovate.secustor.dev,http://localhost:5173",
+    "REFRESH_COOKIE": "true",
   },
+
+  // Same-origin mount: the SPA (GitHub Pages) and this Worker share one
+  // hostname, so there is no cross-site cookie and no third-party context.
+  // The handler strips the `/oauth` segment and pins the cookie `Path` to it,
+  // so the refresh cookie is never sent with a Pages asset request.
+  //
+  // A Workers route only fires on PROXIED (orange-cloud) DNS — with the
+  // `renovate` record DNS-only the route is inert and every request falls
+  // through to GitHub Pages, so this entry is safe to ship ahead of the DNS
+  // switch. `workers_dev` is pinned true because adding a route would
+  // otherwise flip its default to false, and the `*.workers.dev` URL is the
+  // fallback while that is the case. It is NOT a cookie-mode entry point
+  // though: cookie mode is same-site-only, and the handler refuses to engage
+  // it on a `*.workers.dev` host — requests there keep the 009 body protocol
+  // regardless of REFRESH_COOKIE above.
+  "routes": [{ "pattern": "renovate.secustor.dev/oauth/*", "zone_name": "secustor.dev" }],
+  "workers_dev": true,
 
   // GITHUB_CLIENT_SECRET is NOT stored here. Set it as an encrypted secret:
   //   pnpm exec wrangler secret put GITHUB_CLIENT_SECRET

--- a/roadmap/065-persistent-sign-in.md
+++ b/roadmap/065-persistent-sign-in.md
@@ -1,0 +1,117 @@
+# 065 — Persistent sign-in: HttpOnly refresh-token cookie
+
+Renumbered from 053 (2026-08-05): main took that number for the analytics
+localhost-exclusion item while this work sat in review, and 054–061 went to
+items that landed or were reserved since. The `feat/persistent-sign-in-cookie`
+branch name predates the renumber and stays as-is.
+
+## Problem
+
+The 009 session lives in memory + `sessionStorage`, so closing the tab signs
+the user out even though GitHub issued a 6-month refresh token. The BCP-aligned
+reason was to keep tokens out of persistent, XSS-readable storage — putting the
+refresh token in `localStorage` would trade that away.
+
+## Decision
+
+Keep every token out of persistent JS-readable storage AND survive tab
+closure: the **refresh token moves into an `HttpOnly` cookie set by the
+oauth-worker**, opt-in per deployment (`REFRESH_COOKIE=true`). The access
+token stays in memory + `sessionStorage` exactly as in 009. The only thing the
+app persists in `localStorage` is a non-secret marker ("a cookie session
+exists until \<epoch ms\>") so boot knows a silent refresh is worth trying.
+
+This is the OAuth-BCP "BFF-lite" shape: XSS can still use the session while
+the page is open (it can always call `/refresh` itself), but it can no longer
+**exfiltrate** the long-lived refresh token — possession stays with the
+browser's cookie jar.
+
+### Deployment shape (production)
+
+Same-origin path routing, not a second hostname: the worker is routed at
+`renovate.secustor.dev/oauth/*` (Cloudflare Workers route; the zone moved to
+Cloudflare DNS for this). Same-origin means no CORS preflight coupling, no
+third-party-cookie exposure in any browser, and `SameSite=Strict`.
+
+Consequences the code must honor:
+
+- **Route prefix**: on a route the worker receives `/oauth/exchange` etc., on
+  `workers.dev` or the Node image it receives `/exchange`. The handler strips
+  one leading `/oauth` segment; the cookie `Path` mirrors the mount
+  (`/oauth` when prefixed, `/` otherwise) so the cookie is **never sent to
+  GitHub Pages requests** on the shared hostname.
+- **Cookie name** uses the `__Secure-` prefix (not `__Host-`, which would
+  force `Path=/` — exactly what the previous point forbids).
+- **Orange-cloud dependency**: a Workers route only fires on proxied traffic,
+  so the `renovate` DNS record must be proxied (SSL mode Full (strict);
+  GitHub Pages holds a valid cert for the hostname). The record stays
+  DNS-only until Cloudflare's Universal SSL cert for the zone is issued.
+
+### Protocol changes (worker)
+
+All behind `REFRESH_COOKIE=true`; with it unset the worker is byte-identical
+to 009 — the stock Docker image and `workers.dev` deployments are unaffected.
+A `*.workers.dev` host keeps 009 **even with the var set**: that URL is only
+ever reached cross-site, where the `SameSite=Strict` cookie would be stored
+nowhere and sent never — engaging cookie mode there would strip the in-body
+refresh token in exchange for a cookie the browser drops, capping the session
+at one access token. The handler excludes the host structurally, which is what
+makes publishing `REFRESH_COOKIE=true` safe while `workers.dev` is still the
+live entry point (before the DNS switch).
+
+- `POST /exchange`, `POST /refresh` (success): the `refresh_token` is removed
+  from the JSON body and set as
+  `__Secure-rcv-refresh=<token>; HttpOnly; Secure; SameSite=Strict;
+Path=<mount>; Max-Age=<refresh_token_expires_in>`; the body instead carries
+  `refresh_token_cookie: true` (how the SPA knows which mode it is talking
+  to) and keeps `refresh_token_expires_in` (feeds the localStorage marker).
+  GitHub rotates refresh tokens, so every successful refresh re-sets the
+  cookie.
+- `POST /refresh`: `refresh_token` may come from the body (009 clients,
+  cookie-off deployments) or, in cookie mode, from the cookie. A GitHub
+  "bad grant" error clears the cookie (`Max-Age=0`) so clients stop probing.
+- `POST /logout` (new): clears the cookie, 204. Origin-gated like everything
+  else.
+- CORS: `access-control-allow-headers` unchanged;
+  `access-control-allow-credentials: true` is always sent (with the exact
+  reflected origin, never `*`) so same-site-but-cross-origin deployments
+  (e.g. an `oauth.` subdomain) also work with `credentials: "include"`.
+
+The worker stays **stateless**: the cookie IS the storage; nothing is
+persisted server-side and the never-sees-content boundary is unchanged.
+
+### App changes
+
+- Worker calls send `credentials: "include"` (harmless when no cookie
+  exists; requires the allow-credentials header above).
+- `applyTokenResponse`: when the response says `refresh_token_cookie`, no
+  refresh token is stored; instead the marker
+  `rcv.oauth.cookieSession = <refresh horizon epoch ms>` goes to
+  `localStorage` (non-secret; validated like every stored value).
+- Boot restore: on mount, signed out + live marker → one silent `/refresh`
+  (then the profile fetch for the chip). **Single-flight** like 009's
+  callback exchange: StrictMode double-mounts the effect, and because GitHub
+  rotates refresh tokens, a second concurrent refresh would burn the session
+  it was trying to restore. Runs before the share-link decode so an auto-run
+  sees the restored token. Failure = signed out for this boot, but only a
+  **definitive** rejection (a 4xx — the grant is dead) also drops the marker;
+  a maybe-transient failure (offline boot, a 5xx) keeps it so the next boot
+  retries instead of stranding a still-good cookie.
+- `getValidToken()`: an expired access token with no in-JS refresh token but
+  a live marker refreshes through the cookie (empty `/refresh` body) instead
+  of signing out. The same transient/definitive split applies: only a 4xx
+  signs out (which fires `/logout`); a transient failure answers null for
+  that one call and leaves the session to retry — signing out on a blip
+  could burn a still-good cookie.
+- `signOut()`: also clears the marker and fires `POST /logout` (best-effort)
+  so the cookie dies with the session.
+
+### Out of scope
+
+- Encrypting the cookie value: it only ever travels browser ↔ worker over
+  TLS and is `HttpOnly`; a stolen cookie is replayable against `/refresh`
+  regardless of encryption, so a worker-side secret would add key management
+  without a matching threat reduction.
+- Per-host PATs stay session-only: they don't rotate and are often broadly
+  scoped — 009's storage rules for them are unchanged.
+- GitLab (tracked by 007/010).

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -69,6 +69,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [062](062-results-tab-taxonomy.md)                      | Results tabs: `Simulator` → `packageRules`, + `Extraction`        | M17                  | proposed |
 | [063](063-custom-manager-extraction.md)                 | Custom-manager extraction simulator                               | M17                  | proposed |
 | [064](064-extraction-fidelity-and-mismatch.md)          | Extraction fidelity: RE2 gap + unmatched comments                 | M17                  | proposed |
+| [065](065-persistent-sign-in.md)                        | Persistent sign-in: HttpOnly refresh-token cookie                 | M14                  | done     |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
## What

The worker half of persistent sign-in (roadmap 065; the app half is #73, stacked on top). Opt-in `REFRESH_COOKIE=true` moves the 6-month GitHub refresh token out of the JSON body into an `HttpOnly` `__Secure-rcv-refresh` cookie, out of JS reach entirely. Design doc: `roadmap/065-persistent-sign-in.md` (included in this PR).

## How

- `/exchange` & `/refresh` strip `refresh_token` from the body into the cookie (`HttpOnly; Secure; SameSite=Strict; Path=<mount>; Max-Age=<refresh_token_expires_in>`), flag the body with `refresh_token_cookie: true`, and keep `refresh_token_expires_in`.
- `/refresh` accepts an empty body and reads the cookie (a body token wins when present); every success rotates the cookie (GitHub rotates refresh tokens); a rejected grant clears it. New `/logout` clears it explicitly (204).
- Paths are also answered under a `/oauth/*` prefix, and `wrangler.jsonc` routes `renovate.secustor.dev/oauth/*`, same-origin with the app, so the cookie is first-party in every browser incl. Safari. The cookie `Path` mirrors the mount, so GitHub Pages requests on the shared hostname never carry it.
- Cookie mode never engages on a `*.workers.dev` host: that URL is only ever reached cross-site, where the `SameSite=Strict` cookie would be dropped, so shipping `REFRESH_COOKIE=true` in `vars` is safe while workers.dev is still the live entry point (ultrareview finding).
- `access-control-allow-credentials: true` is always sent with the exact reflected origin.
- Stateless as before: the cookie IS the storage; the never-sees-content boundary is untouched. With the var unset, behavior is the 009 protocol byte-for-byte (stock Docker image and workers.dev deployments unaffected).

## Deployment notes (after merge)

1. Cloudflare zone `secustor.dev`: switch the `renovate` DNS record to **proxied** (orange cloud) and set SSL/TLS mode to **Full (strict)**; the Workers route only fires on proxied traffic.
2. Change the repo Actions variable `VITE_OAUTH_WORKER_URL` to `https://renovate.secustor.dev/oauth`.
3. `wrangler deploy` (CI job) provisions the route; `REFRESH_COOKIE=true` ships in `wrangler.jsonc` vars.

Until 1-3 happen, deployed behavior is unchanged: the workers.dev guard keeps every request on the 009 protocol, so merge order relative to #73 is safe in both directions.

## Testing

- oauth-worker: 33/33 (cookie set/strip/rotate/clear, prefix mount pins `Path=/oauth`, body-wins-over-cookie, `/logout`, allow-credentials, cookie-off unchanged, workers.dev exclusion)
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)