### PR TITLE
fix(app): keep the pinned A/B result visible across a pipeline re-run

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -5,7 +5,7 @@ import {
   MERGE_STEPS_CONFIG,
   PACKAGE_RULES_CONFIG,
 } from "./fixtures";
-import { drawer, openTab } from "./helpers";
+import { drawer, openTab, runAndAwaitResult, setEditorContent, tabButton } from "./helpers";
 
 /**
  * Journey 4 — the packageRules simulator. After a run whose config has a
@@ -126,6 +126,58 @@ test("A/B pin warns when the compared runs describe different simulated inputs",
   const inputsPanel = page.locator(".sim-compare-inputs");
   await expect(inputsPanel).toContainText("lodash");
   await expect(inputsPanel).toContainText("actions/checkout");
+});
+
+/**
+ * Roadmap 018/021 — the pin's whole workflow is pin → edit the config → run
+ * the pipeline again → simulate → compare. A new pipeline run clears the
+ * simulation, but the pinned A must visibly SURVIVE that step (with its own
+ * Unpin), or the workflow dead-ends exactly where the hint sends the user;
+ * the next Simulate then produces B and the real delta.
+ */
+test("a pinned result survives a pipeline re-run and compares against the next simulation", async ({
+  page,
+}) => {
+  const fragment = await encodeShareFragment({ config: PACKAGE_RULES_CONFIG });
+  await page.goto(fragment);
+
+  await openTab(page, "simulator");
+  const simulator = page.locator(".card", { hasText: "Update simulator" });
+  await expect(simulator).toBeVisible();
+
+  // Simulate the lodash patch update and pin it as A.
+  await simulator.getByRole("button", { name: "npm dependency" }).click();
+  await expect(page.locator(".sim-verdict-block")).toBeVisible({ timeout: 15_000 });
+  await simulator.getByRole("button", { name: "Pin result for comparison" }).click();
+  await expect(page.locator(".sim-compare")).toBeVisible();
+
+  // Edit the config (the rule now sets automerge: false) and re-run the
+  // pipeline — the step that used to make the pinned panel vanish.
+  await setEditorContent(
+    page,
+    PACKAGE_RULES_CONFIG.replace('"automerge": true', '"automerge": false'),
+  );
+  await runAndAwaitResult(page);
+  // The tab flipping to Overview is the sign the NEW result committed (the
+  // shell and badge runAndAwaitResult waits on were already there).
+  await expect(tabButton(page, "overview")).toHaveAttribute("aria-selected", "true");
+
+  // The run lands on Overview; back on the simulator, the pin is still there,
+  // says what remains to do, and offers its own Unpin.
+  await openTab(page, "simulator");
+  const compare = page.locator(".sim-compare");
+  await expect(compare).toBeVisible();
+  await expect(compare).toContainText("still pinned");
+  await expect(compare.getByRole("button", { name: "Unpin comparison" })).toBeVisible();
+
+  // The form kept its values, so one Simulate produces B against the edited
+  // config — and the delta names the setting the edit changed.
+  await simulator.getByRole("button", { name: "Simulate", exact: true }).click();
+  const configDelta = page.locator(".sim-compare-config");
+  await expect(configDelta).toBeVisible({ timeout: 15_000 });
+  await expect(configDelta).toContainText("automerge");
+  // Same simulated inputs on both sides — no mismatch warning.
+  await expect(page.locator(".sim-compare-mismatch")).toHaveCount(0);
 });
 
 /**

--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -138,16 +138,31 @@ export function ComparisonPanel({
   pinned,
   comparison,
   currentDescriptor,
+  awaitingSimulate,
+  onUnpin,
 }: {
   pinned: PinnedRun;
   comparison: SimulationComparison | null;
   currentDescriptor: DependencyDescriptor;
+  /** A new pipeline run cleared the simulation this panel used to sit under —
+   *  A is kept, and the hint names the one step left (Simulate). */
+  awaitingSimulate?: boolean;
+  /** The panel's own Unpin — needed while `awaitingSimulate`, when the verdict
+   *  card (the usual home of the pin controls) is not rendered at all. */
+  onUnpin?: () => void;
 }) {
   const pinnedDescriptor = toDescriptor(pinned.form, pinned.effectiveUpdateType);
   const diffKeys = new Set(descriptorDiffKeys(pinnedDescriptor, currentDescriptor));
   return (
     <div className="sim-compare">
-      <div className="sim-compare-title">A/B comparison — pinned (A) vs current (B)</div>
+      <div className="sim-compare-title">
+        A/B comparison — pinned (A) vs current (B)
+        {onUnpin ? (
+          <button type="button" className="sim-verdict-action" onClick={onUnpin}>
+            Unpin comparison
+          </button>
+        ) : null}
+      </div>
       {diffKeys.size > 0 ? (
         <p className="sim-compare-mismatch">
           ⚠ Inputs differ between A and B — this compares two different simulated dependencies, not
@@ -160,7 +175,12 @@ export function ComparisonPanel({
           ))}
         </p>
       ) : null}
-      {!comparison ? (
+      {!comparison && awaitingSimulate ? (
+        <p className="empty-note">
+          Result <strong>A</strong> is still pinned — the pipeline ran with the edited config.
+          Simulate to produce <strong>B</strong> and see the comparison.
+        </p>
+      ) : !comparison ? (
         <p className="empty-note">
           Pinned this result as <strong>A</strong>. Edit the config and run the pipeline again, then
           simulate to compare it against <strong>B</strong>.

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -500,6 +500,20 @@ export const RuleSimulator = memo(function RuleSimulator({
             />
           </div>
         </div>
+      ) : pinned ? (
+        // The pin's whole purpose is surviving a pipeline re-run (which clears
+        // `sim` above) — so the panel must not vanish with the results block,
+        // or the pin reads as deleted at exactly the step the workflow needs
+        // it. It carries its own Unpin here, since the verdict card is gone.
+        <div className="sim-results">
+          <ComparisonPanel
+            pinned={pinned}
+            comparison={null}
+            currentDescriptor={currentDescriptor}
+            awaitingSimulate
+            onUnpin={unpin}
+          />
+        </div>
       ) : null}
     </div>
   );

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -2967,11 +2967,22 @@ pre.config-view.prov-before {
 }
 
 .sim-compare-title {
+  align-items: center;
   color: var(--muted);
+  display: flex;
   font-size: 0.75rem;
   font-weight: 600;
+  gap: 0.6rem;
+  justify-content: space-between;
   letter-spacing: 0.02em;
   text-transform: uppercase;
+}
+
+/* The panel's own Unpin (shown while a pipeline re-run leaves it without a
+   verdict card) — a button, not part of the uppercase eyebrow it sits in. */
+.sim-compare-title .sim-verdict-action {
+  letter-spacing: normal;
+  text-transform: none;
 }
 
 /* Roadmap 021: prominent — A and B describe different simulated dependencies,


### PR DESCRIPTION
## Problem

The pin's intended workflow (roadmap 018/021) is **pin → edit the config → Run the pipeline → Simulate → compare**. But the comparison panel only rendered inside the results block that is gated on a current simulation — and a new pipeline run clears `sim` (`use-simulation-run.ts`), so the pinned run vanished at exactly the step the waiting hint sends the user to. It read as deleted, making the pin pointless for packageRules development.

The pinned state itself always survived the re-run (`useAbComparison` deliberately keeps it); only its rendering died with the results block.

## Fix

- `RuleSimulator`: while a pin exists and no simulation does, the `ComparisonPanel` renders on its own instead of disappearing with the results block.
- `ComparisonPanel`: grows an optional `onUnpin` (the verdict card that usually hosts the pin controls doesn't exist in that state) and an `awaitingSimulate` hint that names the one step left: *"Result A is still pinned — the pipeline ran with the edited config. Simulate to produce B and see the comparison."*
- e2e: new regression test walking the full loop — pin, edit config, Run, panel survives with its own Unpin, Simulate, and the delta names the edited setting (`automerge`) with no input-mismatch warning.

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm format:check` clean
- app vitest: 333 passed
- `playwright test e2e/04-simulator.spec.ts` against the production build: 9/9 passed (including the new test)