### PR TITLE
chore(deps): drop the miniflare>undici override, bump wrangler to 4.120.0

### DIFF
--- a/packages/oauth-worker/package.json
+++ b/packages/oauth-worker/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "typescript": "7.0.2",
     "vitest": "4.1.10",
-    "wrangler": "4.119.0"
+    "wrangler": "4.120.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  miniflare>undici: ^8.0.0
-
 patchedDependencies:
   codemirror-json-schema@0.8.1: cd887b4a6a4b99c759ce92bc254ab43ecc65d797bd6a53e55f71aaf567bbab47
 
@@ -149,8 +146,8 @@ importers:
         specifier: 4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(jsdom@30.0.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(yaml@2.9.0))
       wrangler:
-        specifier: 4.119.0
-        version: 4.119.0
+        specifier: 4.120.0
+        version: 4.120.0
 
 packages:
 
@@ -3300,8 +3297,8 @@ packages:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  miniflare@5.20260801.0-alpha:
-    resolution: {integrity: sha512-AfMrnQbJg81ESsGkGhOkHBtwTqCG+mosR+3GE+qDrhF1I/ieIvgg3ICxNyBvgHBZ3iapy6cysBQHNPykkzrfgw==}
+  miniflare@5.20260801.1-alpha:
+    resolution: {integrity: sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==}
     engines: {node: '>=22.0.0'}
 
   minimalistic-assert@1.0.1:
@@ -4182,6 +4179,10 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.9.0:
     resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
@@ -4388,8 +4389,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.119.0:
-    resolution: {integrity: sha512-ookClf+zly4DTc8pBMNrwGQzZKH8IpIYTXkjDw3XS7ZvBQ5mLYH6eOvfD5BEpk3U63zTbv91WRlo1UeRSKXa0g==}
+  wrangler@4.120.0:
+    resolution: {integrity: sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -7726,11 +7727,11 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
-  miniflare@5.20260801.0-alpha:
+  miniflare@5.20260801.1-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
-      undici: 8.9.0
+      undici: 7.29.0
       workerd: 1.20260801.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -8836,6 +8837,8 @@ snapshots:
 
   undici-types@8.3.0: {}
 
+  undici@7.29.0: {}
+
   undici@8.9.0: {}
 
   unenv@2.0.0-rc.24:
@@ -9007,13 +9010,13 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260801.1
       '@cloudflare/workerd-windows-64': 1.20260801.1
 
-  wrangler@4.119.0:
+  wrangler@4.120.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260801.0-alpha
+      miniflare: 5.20260801.1-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260801.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,9 +17,5 @@ ignoredBuiltDependencies:
   - re2
   - workerd
 
-overrides:
-  # miniflare directly pins a version so this is overwriting to an range starting with a not effected version
-  miniflare>undici: ^8.0.0
-
 patchedDependencies:
   codemirror-json-schema@0.8.1: patches/codemirror-json-schema@0.8.1.patch


### PR DESCRIPTION
Removes the `miniflare>undici` override from `pnpm-workspace.yaml`, together with the wrangler bump that makes it redundant.

## Why the bump is part of this

At wrangler 4.119.0 (what `main` has) the override was still load-bearing: that resolves to miniflare `5.20260801.0-alpha`, which pins undici **7.28.0** — affected by the advisories the override was added for in #117:

- CVE-2026-13697 (high) — cross-user info disclosure / parse-time crash via degenerate private cache directives
- CVE-2026-14643 — cross-user info disclosure via whitespace around `=` in Cache-Control directives
- CVE-2026-15157 — CRLF injection via blob-like body `type`
- CVE-2026-16728 — downstream response desync via retry interceptor
- CVE-2026-16729 — cookie attribute injection

All are patched in undici 7.29.0. Dropping the override on its own would have quietly put 7.28.0 back.

wrangler **4.120.0** pins miniflare `5.20260801.1-alpha`, which depends on undici 7.29.0 directly — so the override stops changing anything and can go.

## Verification

- `pnpm-lock.yaml` no longer carries an `overrides` block; miniflare resolves undici 7.29.0 unaided
- the only undici versions left in the tree are 7.29.0 and 8.9.0, both patched
- `oauth-worker` tests 33/33, typecheck clean