### PR TITLE
feat(cli): rcd mcp — the debugger as an MCP stdio server (060)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -138,6 +138,32 @@ when the config under inspection chooses the endpoint, tokens are withheld and
 the CLI says so on stderr. Pass `--platform-override` to impose your own
 endpoint, or `--trust-endpoints` when the config is yours.
 
+## MCP server
+
+`rcd mcp` speaks MCP over stdio — the same answers as the subcommands, better
+economics for a session. Point any MCP-capable client at it as a stdio server;
+it takes no arguments and writes nothing but the protocol to stdout.
+
+`run_config` resolves a config and returns a small summary plus a **runId**;
+`get_final_config`, `get_preset_tree`, `get_preset_node`, `get_provenance`,
+`get_resolved_config`, `simulate`, `compare_simulations`, `explain_message` and
+`get_option_docs` all take that runId and query the HELD trace. That buys two
+things a series of CLI invocations cannot give: the module graph and the
+preset-fetch cache are paid once, and every answer describes the same run — two
+separate `rcd` calls can silently describe different worlds if a remote preset
+changed between them.
+
+The server speaks the 2026-07-28 protocol and the legacy 2025-era `initialize`
+handshake, with the era chosen per connection, so older clients keep working
+against the same process.
+
+Worth knowing before your first call: **preset-node bodies are large — query
+one node at a time.** The tool descriptions say so too.
+
+The server holds a small number of recent runs (an LRU), so an agent can
+compare the run before an edit with the run after it. A `runId` that has been
+evicted says so, and lists the ones still held.
+
 ## Read-only, on purpose
 
 There is no `fix` or `migrate-file` verb. Agents edit configs with their own

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -164,15 +164,26 @@ The server holds a small number of recent runs (an LRU), so an agent can
 compare the run before an edit with the run after it. A `runId` that has been
 evicted says so, and lists the ones still held.
 
-Three properties the tools guarantee, because an agent cannot check them:
+Four properties the tools guarantee, because an agent cannot check them:
 
-- **Every answer fits.** A tool result is capped at ~100 kB. Over that it is
-  elided _structurally_ — the largest arrays lose their tail, the omission is a
-  `{ "truncated": true, "shown": …, "omitted": … }` object in place, and the
-  top of the document names the parameter that narrows the question. Nothing is
-  ever cut mid-JSON, and nothing is dropped silently. Small answers are
-  indented for the transcript; large ones are compact, because indentation on
-  100 kB is pure token overhead.
+- **The default answer is the question you asked.** `simulate` returns the
+  verdicts, `flattened` and `finalDependencyConfig`; the step-by-step merge
+  trace (`mergeSteps`, `rawFinalConfig`) is ~1 MB on a `config:recommended` run
+  and comes only with `detail: "full"`. `compare_simulations` leads with
+  `summary`, the whole verdict in one line.
+
+- **Every answer fits.** A tool result is capped at ~65 kB — derived from the
+  host's own tool-output cap (~25k tokens), not chosen, because a bigger
+  payload would be truncated by the host mid-JSON and the guarantee would be
+  worth nothing. Over the cap the answer is elided _structurally_: the largest
+  arrays keep a head window AND a tail window, and the omission is a
+  `{ "truncated": true, "shown": …, "omitted": …, "omittedFrom": …, "items": [] }`
+  object in place. The tail window is not decoration — a merged `packageRules`
+  array is the presets' rules first and _your_ rules last. The top of the
+  document names the parameter that narrows the question. Nothing is ever cut
+  mid-JSON, and nothing is dropped silently. Small answers are indented for the
+  transcript; large ones are compact, because indentation at that size is pure
+  token overhead.
 - **Unknown parameters are errors.** Every input schema is strict, including
   `dep` — `depname` is a validation error naming the key, not a simulation
   where no matcher had any input.
@@ -180,8 +191,12 @@ Three properties the tools guarantee, because an agent cannot check them:
   credentials a run may use travel on that run's pipeline input and are
   installed inside the engine's serialized queue. A run whose global config
   chose the endpoint sends no token, whatever a concurrent trusted run is
-  doing. On this transport the opt-ins are the `platformOverride` and
-  `trustEndpoints` parameters (the flags of the same name are the CLI's).
+  doing — and so does a run whose `endpoint` came in as a tool PARAMETER,
+  because over MCP that value was written by the model, possibly out of the
+  config it was asked to inspect. On this transport the opt-ins are the
+  `platformOverride` and `trustEndpoints` parameters (the flags of the same
+  name are the CLI's); only `trustEndpoints` vouches for an endpoint the caller
+  supplied.
 
 ## Read-only, on purpose
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -164,6 +164,25 @@ The server holds a small number of recent runs (an LRU), so an agent can
 compare the run before an edit with the run after it. A `runId` that has been
 evicted says so, and lists the ones still held.
 
+Three properties the tools guarantee, because an agent cannot check them:
+
+- **Every answer fits.** A tool result is capped at ~100 kB. Over that it is
+  elided _structurally_ — the largest arrays lose their tail, the omission is a
+  `{ "truncated": true, "shown": …, "omitted": … }` object in place, and the
+  top of the document names the parameter that narrows the question. Nothing is
+  ever cut mid-JSON, and nothing is dropped silently. Small answers are
+  indented for the transcript; large ones are compact, because indentation on
+  100 kB is pure token overhead.
+- **Unknown parameters are errors.** Every input schema is strict, including
+  `dep` — `depname` is a validation error naming the key, not a simulation
+  where no matcher had any input.
+- **Credentials belong to one run.** Tool handlers run concurrently, so the
+  credentials a run may use travel on that run's pipeline input and are
+  installed inside the engine's serialized queue. A run whose global config
+  chose the endpoint sends no token, whatever a concurrent trusted run is
+  doing. On this transport the opt-ins are the `platformOverride` and
+  `trustEndpoints` parameters (the flags of the same name are the CLI's).
+
 ## Read-only, on purpose
 
 There is no `fix` or `migrate-file` verb. Agents edit configs with their own

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -148,8 +148,10 @@ it takes no arguments and writes nothing but the protocol to stdout.
 `get_final_config`, `get_preset_tree`, `get_preset_node`, `get_provenance`,
 `get_resolved_config`, `simulate`, `compare_simulations`, `explain_message` and
 `get_option_docs` all take that runId and query the HELD trace. That buys two
-things a series of CLI invocations cannot give: the module graph and the
-preset-fetch cache are paid once, and every answer describes the same run — two
+things a series of CLI invocations cannot give: the module graph is paid once
+per session — only the engine boot is amortized, since Renovate's own preset
+`memCache` resets on every run, so a fresh `run_config` still fetches its
+presets over the network — and every answer describes the same run — two
 separate `rcd` calls can silently describe different worlds if a remote preset
 changed between them.
 
@@ -158,7 +160,11 @@ handshake, with the era chosen per connection, so older clients keep working
 against the same process.
 
 Worth knowing before your first call: **preset-node bodies are large — query
-one node at a time.** The tool descriptions say so too.
+one node at a time.** The tool descriptions say so too. `simulate` takes the
+same `verdict`/`source` scoping as `rcd simulate --verdict/--source` (see
+[above](#simulate-and-compare)) — `source: "repo"` is the fix for a
+`config:best-practices` run's several-hundred-rule list when the question is
+about your own config's rules, not the presets it pulled in.
 
 The server holds a small number of recent runs (an LRU), so an agent can
 compare the run before an edit with the run after it. A `runId` that has been

--- a/packages/cli/bin/rcd.mjs
+++ b/packages/cli/bin/rcd.mjs
@@ -51,9 +51,10 @@ try {
 
 /**
  * A stream with no `'error'` listener turns a write failure into an UNCAUGHT
- * exception — so a peer that closes the pipe (`rcd digest … | head`) crashes
- * the process on the next line of stderr, from inside a `write` nobody
- * awaited. stderr has that failure mode and no owner.
+ * exception — so a peer that closes the pipe (`rcd digest … | head`, or an MCP
+ * host that stops reading our diagnostics) crashes the process on the next
+ * line of stderr, from inside a `write` nobody awaited. The SDK guards stdout
+ * for exactly this reason; stderr has the same failure mode and no owner.
  *
  * Silence is the whole point: there is nowhere left to report a broken stderr
  * to. The process keeps running and its own exit code still speaks.
@@ -66,8 +67,9 @@ function guardStderr() {
 
 /**
  * The stdio peer going away, as an event `src/` can observe without touching a
- * process global. A long-lived command — one that serves a peer rather than
- * answering and returning — has no other way to learn that the peer left.
+ * process global. Only `rcd mcp` needs it: the MCP SDK's stdio transport
+ * listens for `data` and `error` only, so a client that closes the pipe never
+ * reaches `transport.onclose` and the command would wait forever.
  *
  * Registration is per call and never eager — a SIGINT/SIGTERM listener is a
  * libuv handle that refs the loop, so a command that does not ask to be told

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,9 +13,12 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "2.0.0",
+    "@modelcontextprotocol/server": "2.0.0",
     "@renovate-config-debugger/app": "workspace:*",
     "@renovate-config-debugger/engine": "workspace:*",
-    "commander": "15.0.0"
+    "commander": "15.0.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@types/node": "26.1.2",

--- a/packages/cli/src/commands/digest.ts
+++ b/packages/cli/src/commands/digest.ts
@@ -1,26 +1,13 @@
-import { computeProvenance } from "@renovate-config-debugger/engine";
-import {
-  buildDigestInput,
-  buildRunDigest,
-  clauseText,
-  deriveRunFacts,
-  digestText,
-  effectiveTally,
-} from "@renovate-config-debugger/app/headless";
 import { outputFormat } from "../args";
 import type { Command } from "../command";
 import { EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
+import { digestPayload } from "../projections/digest";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
  * The Overview tab's paragraph, in a terminal — the cheapest orientation
  * before deciding what to drill into.
- *
- * Every number here is produced by the SAME functions the web app renders
- * (`@renovate-config-debugger/app/headless`), which is why 058 hoisted the
- * effective-config tally out of `EffectiveConfig.tsx`: a re-implementation
- * would be a second source of truth for a number the paragraph quotes.
  */
 export const digestCommand: Command = {
   name: "digest",
@@ -31,32 +18,11 @@ export const digestCommand: Command = {
     const format = outputFormat(args);
     const { result, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
-
-    const facts = deriveRunFacts(result);
-    const provenance = computeProvenance(result);
-    const tally = provenance ? effectiveTally(provenance.values()) : null;
-    const clauses = buildRunDigest(buildDigestInput(result, facts, tally));
-
+    const payload = digestPayload(result);
     if (format === "json") {
-      emitJson(io, {
-        digest: digestText(clauses),
-        clauses: clauses.map((clause) => ({
-          id: clause.id,
-          tone: clause.tone,
-          text: clauseText(clause),
-        })),
-        accepted: !wouldRefuse(result),
-        counts: {
-          errors: facts.errorCount,
-          warnings: facts.warningCount,
-          rewrites: facts.migrateSteps.length,
-          presets: facts.presetCount,
-          effectiveOptions: tally?.keys ?? null,
-          overridden: tally?.overridden ?? null,
-        },
-      });
+      emitJson(io, payload);
     } else {
-      emitLines(io, [digestText(clauses)]);
+      emitLines(io, [payload.digest]);
     }
     return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;
   },

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -20,8 +20,8 @@ import { createMcpServer } from "../mcp/server";
  * protocol. Diagnostics go to stderr, which is why the server takes `io` and
  * uses only `io.err`.
  *
- * The process stays alive until the client closes the transport, so this
- * command returns only when the session ends.
+ * The process stays alive until the client goes away, so this command returns
+ * only when the session ends.
  */
 export const mcpCommand: Command = {
   name: "mcp",
@@ -48,23 +48,36 @@ export const mcpCommand: Command = {
     const transport = new StdioServerTransport();
     // ONE factory serves both eras; a probe instance the entry discards costs
     // a run store and nothing else.
-    serveStdio(() => createMcpServer(io), {
+    const handle = serveStdio(() => createMcpServer(io), {
       transport,
       onerror: (error) => io.err(`rcd: MCP server: ${errorMessage(error)}\n`),
     });
     io.err("rcd: MCP server ready on stdio.\n");
-    await new Promise<void>((resolve) => {
-      // MCP's Transport is not an EventTarget: `onclose` is the SDK's own
-      // callback property, and `serveStdio` already installed the entry's
-      // own handler on it — hence the chain rather than an assignment.
-      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
-      const closeEntry = transport.onclose;
-      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
-      transport.onclose = () => {
-        closeEntry?.();
-        resolve();
-      };
-    });
+    // Two ways a session ends, and the SDK only reports one of them: its stdio
+    // transport listens for `data` and `error`, so a client that closes the
+    // pipe reaches `io.onDisconnect` and never the transport's `onclose`.
+    // Whichever arrives first ends the wait.
+    let disposeDisconnect: (() => void) | undefined;
+    try {
+      await new Promise<void>((resolve) => {
+        // MCP's Transport is not an EventTarget: `onclose` is the SDK's own
+        // callback property, and `serveStdio` already installed the entry's
+        // own handler on it — hence the chain rather than an assignment.
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
+        const closeEntry = transport.onclose;
+        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
+        transport.onclose = () => {
+          closeEntry?.();
+          resolve();
+        };
+        disposeDisconnect = io.onDisconnect?.(resolve);
+      });
+    } finally {
+      disposeDisconnect?.();
+    }
+    // Flushes whatever the transport still owes and drops its stdin listeners,
+    // so the process can reach its own exit rather than being killed at one.
+    await handle.close();
     return EXIT_OK;
   },
 };

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1,0 +1,70 @@
+import { serveStdio, StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import type { Command } from "../command";
+import { errorMessage, EXIT_OK } from "../io";
+import { createMcpServer } from "../mcp/server";
+
+/**
+ * Roadmap 060: the MCP server, as a subcommand rather than a second package —
+ * one entry point to install, document and hint at.
+ *
+ * SDK v2 serves it through the stdio ENTRY (`serveStdio`) rather than by
+ * connecting a server to a transport directly, because the entry owns the era
+ * decision for the connection: an opening `server/discover` pins a 2026-07-28
+ * instance, a plain `initialize` pins a 2025-era one, and both come from the
+ * same factory — so a client that speaks either revision is served by one
+ * process, with no branching in the tool code. `legacy: 'reject'` would turn
+ * the old handshake off; the default that keeps it is deliberate, since that
+ * is still what most hosts speak.
+ *
+ * NOTHING may be written to stdout here: on a stdio transport, stdout IS the
+ * protocol. Diagnostics go to stderr, which is why the server takes `io` and
+ * uses only `io.err`.
+ *
+ * The process stays alive until the client closes the transport, so this
+ * command returns only when the session ends.
+ */
+export const mcpCommand: Command = {
+  name: "mcp",
+  summary: "run as an MCP server over stdio (for agent sessions)",
+  usage: ["mcp"],
+  details: [
+    "Register it once and every later session has the tools:",
+    "  claude mcp add rcd -- pnpm dlx @renovate-config-debugger/cli mcp",
+    "",
+    "Same answers as the subcommands, better economics for a session: the",
+    "engine boots once, and `run_config` HOLDS the trace so the drill-down",
+    "tools query one consistent run instead of re-resolving per question.",
+    "",
+    "Speaks MCP 2026-07-28 and the legacy 2025-era handshake; the era is",
+    "chosen per connection, so older clients keep working.",
+  ],
+  options: [],
+  async run(_args, io) {
+    // The wire is built here rather than left to `serveStdio`'s default for
+    // one reason: the command has to observe it closing (below), and the
+    // entry's handle reports only its own teardown. From the call on, the
+    // entry owns it — it starts it, pumps every inbound message through it
+    // and closes it when the connection ends.
+    const transport = new StdioServerTransport();
+    // ONE factory serves both eras; a probe instance the entry discards costs
+    // a run store and nothing else.
+    serveStdio(() => createMcpServer(io), {
+      transport,
+      onerror: (error) => io.err(`rcd: MCP server: ${errorMessage(error)}\n`),
+    });
+    io.err("rcd: MCP server ready on stdio.\n");
+    await new Promise<void>((resolve) => {
+      // MCP's Transport is not an EventTarget: `onclose` is the SDK's own
+      // callback property, and `serveStdio` already installed the entry's
+      // own handler on it — hence the chain rather than an assignment.
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
+      const closeEntry = transport.onclose;
+      // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
+      transport.onclose = () => {
+        closeEntry?.();
+        resolve();
+      };
+    });
+    return EXIT_OK;
+  },
+};

--- a/packages/cli/src/commands/provenance.ts
+++ b/packages/cli/src/commands/provenance.ts
@@ -1,53 +1,17 @@
-import {
-  computeProvenance,
-  computeRuleProvenance,
-  type KeyProvenance,
-  type ProvenanceLayer,
-} from "@renovate-config-debugger/engine";
-import {
-  effectiveTally,
-  isOverridden,
-  multiContribBadgeKind,
-} from "@renovate-config-debugger/app/headless";
+import { computeRuleProvenance } from "@renovate-config-debugger/engine";
+import { effectiveTally } from "@renovate-config-debugger/app/headless";
 import { outputFormat } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, preview, writeNotes } from "../output";
+import { entryView, layerLabel, provenanceOf } from "../projections/provenance";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
  * "Who set this key, and who overrode whom?" — the question behind most real
  * debugging sessions, and the one the web app answers with its effective-config
- * ledger. Same computation (`computeProvenance`), same badges: 016 established
- * that calling an appended array "overridden" is misleading, so the label
- * comes from `multiContribBadgeKind` rather than from "more than one layer
- * touched it".
+ * ledger.
  */
-
-function layerLabel(layer: ProvenanceLayer): string {
-  return layer.kind === "preset" ? `preset ${layer.name}` : layer.kind;
-}
-
-function entryView(entry: KeyProvenance) {
-  const winner = entry.chain.findLast((s) => !s.noop) ?? entry.chain.at(-1);
-  return {
-    key: entry.key,
-    finalValue: entry.finalValue,
-    isDefaultOnly: entry.isDefaultOnly,
-    winner: winner ? layerLabel(winner.layer) : null,
-    badge: isOverridden(entry) ? multiContribBadgeKind(entry) : null,
-    chain: entry.chain
-      .filter((step) => !step.noop)
-      .map((step) => ({
-        layer: layerLabel(step.layer),
-        action: step.action,
-        before: step.before,
-        after: step.after,
-        ...(step.expandedNested ? { expandedNested: true } : {}),
-      })),
-  };
-}
-
 export const provenanceCommand: Command = {
   name: "provenance",
   summary: "per-key provenance: which layer set each option, and who overrode whom",
@@ -64,12 +28,7 @@ export const provenanceCommand: Command = {
     writeNotes(io, notes);
     const key = rest[0];
 
-    const provenance = computeProvenance(result);
-    if (!provenance) {
-      throw new CliError(
-        "provenance needs a completed preset resolution — see `rcd validate` for why it stopped",
-      );
-    }
+    const provenance = provenanceOf(result);
     const tally = effectiveTally(provenance.values());
     const entries = [...provenance.values()];
 

--- a/packages/cli/src/commands/tree.ts
+++ b/packages/cli/src/commands/tree.ts
@@ -1,9 +1,15 @@
-import type { PresetNode } from "@renovate-config-debugger/engine";
-import { computeTreeStats, type TreeStats } from "@renovate-config-debugger/app/headless";
 import { outputFormat, stringOption } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, json, writeNotes } from "../output";
+import {
+  DEFAULT_TREE_DEPTH,
+  findNode,
+  parseBody,
+  treeLines,
+  treeStatsOf,
+  viewOf,
+} from "../projections/tree";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
@@ -15,75 +21,9 @@ import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
  * human or model. Same reason the tree defaults to two levels deep.
  */
 
-const BODIES = ["fetched", "afterParams", "input", "resolved"] as const;
-type BodyKind = (typeof BODIES)[number];
-
-interface NodeView {
-  name: string;
-  identity: string;
-  state: string;
-  depth: number;
-  source?: string;
-  duplicate?: true;
-  nested?: true;
-  error?: string;
-  ownOptions: number;
-  optionKeys: string[];
-  ownRules: number;
-  descendants: { resolved: number; rules: number };
-  children?: NodeView[];
-  /** Set when children were cut by `--depth`. */
-  childrenOmitted?: number;
-}
-
-function viewOf(node: PresetNode, stats: TreeStats, depthLimit: number): NodeView {
-  const st = stats.statsById.get(node.id);
-  const view: NodeView = {
-    name: node.name,
-    identity: stats.identityById.get(node.id) ?? "",
-    state: node.state,
-    depth: st?.depth ?? 0,
-    ...(node.source?.presetSource ? { source: node.source.presetSource } : {}),
-    ...(node.duplicate ? { duplicate: true as const } : {}),
-    ...(node.nested ? { nested: true as const } : {}),
-    ...(node.error ? { error: `${node.error.topic}: ${node.error.message}` } : {}),
-    ownOptions: st?.ownOptions ?? 0,
-    optionKeys: st?.optionKeys ?? [],
-    ownRules: st?.ownRules ?? 0,
-    descendants: { resolved: st?.descResolved ?? 0, rules: st?.descRules ?? 0 },
-  };
-  if (node.children.length === 0) {
-    return view;
-  }
-  if ((st?.depth ?? 0) >= depthLimit) {
-    return { ...view, childrenOmitted: node.children.length };
-  }
-  return { ...view, children: node.children.map((c) => viewOf(c, stats, depthLimit)) };
-}
-
-function treeLines(view: NodeView, out: string[]): string[] {
-  const indent = "  ".repeat(view.depth);
-  const facts = [
-    view.state === "resolved" ? null : view.state,
-    view.ownOptions > 0 ? `${view.ownOptions} option(s): ${view.optionKeys.join(", ")}` : null,
-    view.ownRules > 0 ? `${view.ownRules} rule(s)` : null,
-    view.descendants.resolved > 0 ? `+${view.descendants.resolved} below` : null,
-    view.duplicate ? "duplicate" : null,
-    view.error,
-  ].filter((part) => part !== null && part !== undefined);
-  out.push(`${indent}${view.name}${facts.length > 0 ? `  — ${facts.join("; ")}` : ""}`);
-  for (const child of view.children ?? []) {
-    treeLines(child, out);
-  }
-  if (view.childrenOmitted) {
-    out.push(`${indent}  … ${view.childrenOmitted} more (raise --depth, or query --node)`);
-  }
-  return out;
-}
-
 function parseDepth(raw: string | undefined): number {
   if (raw === undefined) {
-    return 2;
+    return DEFAULT_TREE_DEPTH;
   }
   if (raw === "all") {
     return Number.POSITIVE_INFINITY;
@@ -93,28 +33,6 @@ function parseDepth(raw: string | undefined): number {
     throw new CliError(`--depth must be a non-negative integer or "all" (got "${raw}")`);
   }
   return value;
-}
-
-function parseBody(raw: string | undefined): BodyKind | undefined {
-  if (raw === undefined) {
-    return undefined;
-  }
-  const found = BODIES.find((b) => b === raw);
-  if (!found) {
-    throw new CliError(`--body must be one of ${BODIES.join(", ")} (got "${raw}")`);
-  }
-  return found;
-}
-
-function findNode(stats: TreeStats, query: string): PresetNode {
-  const byIdentity = stats.idByIdentity.get(query);
-  const node = byIdentity
-    ? stats.nodesById.get(byIdentity)
-    : stats.occurrencesByName.get(query)?.[0];
-  if (!node) {
-    throw new CliError(`--node: no preset named "${query}" in this run's tree`);
-  }
-  return node;
 }
 
 export const treeCommand: Command = {
@@ -132,11 +50,7 @@ export const treeCommand: Command = {
     }
     const { result, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
-    const root = result.presetTree;
-    if (!root) {
-      throw new CliError("this run produced no preset tree — see `rcd validate`");
-    }
-    const stats = computeTreeStats(root);
+    const { root, stats } = treeStatsOf(result);
 
     if (nodeQuery) {
       const node = findNode(stats, nodeQuery);

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,14 +1,9 @@
-import {
-  applyFixToText,
-  findMentionedOption,
-  translateMessage,
-  type ValidationMessage,
-} from "@renovate-config-debugger/engine";
 import { validatedConfigOf } from "@renovate-config-debugger/app/headless";
 import { outputFormat } from "../args";
 import type { Command } from "../command";
 import { EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
+import { describeMessage, type ReportedMessage } from "../projections/messages";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
@@ -21,54 +16,6 @@ import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
  * fix. The fix is reported, never applied: agents edit configs with their own
  * tools and come back to `validate`/`compare` as the oracle.
  */
-
-interface ReportedMessage {
-  severity: "error" | "warning";
-  topic: string;
-  message: string;
-  explanation?: string;
-  docsUrl?: string;
-  fix?: {
-    summary: string;
-    path: (string | number)[];
-    fixedConfig: Record<string, unknown>;
-    /** The FILE with the fix applied, when the edit could be located in the
-     *  original text (comments and formatting preserved). */
-    fixedText?: string;
-  };
-}
-
-function describe(
-  message: ValidationMessage,
-  severity: "error" | "warning",
-  config: Record<string, unknown> | null,
-  text: string,
-): ReportedMessage {
-  const translated = translateMessage(message, config);
-  const mentioned = translated ? undefined : findMentionedOption(message);
-  const applied = translated?.fix ? applyFixToText(text, translated.fix) : null;
-  return {
-    severity,
-    topic: message.topic,
-    message: message.message,
-    ...(translated ? { explanation: translated.explanation } : {}),
-    ...(translated?.docsUrl
-      ? { docsUrl: translated.docsUrl }
-      : mentioned
-        ? { docsUrl: mentioned.url }
-        : {}),
-    ...(translated?.fix
-      ? {
-          fix: {
-            summary: translated.fix.summary,
-            path: translated.fix.path,
-            fixedConfig: translated.fix.fixedConfig,
-            ...(applied ? { fixedText: applied.text } : {}),
-          },
-        }
-      : {}),
-  };
-}
 
 export const validateCommand: Command = {
   name: "validate",
@@ -89,8 +36,8 @@ export const validateCommand: Command = {
     // path resolves against the same document (`packageRules[N]` included).
     const validated = validatedConfigOf(result);
     const messages: ReportedMessage[] = [
-      ...result.errors.map((m) => describe(m, "error", validated, input.content)),
-      ...result.warnings.map((m) => describe(m, "warning", validated, input.content)),
+      ...result.errors.map((m) => describeMessage(m, "error", validated, input.content)),
+      ...result.warnings.map((m) => describeMessage(m, "warning", validated, input.content)),
     ];
     const presetErrors = result.events.filter((e) => e.kind === "preset-error").map((e) => e.title);
     const refused = wouldRefuse(result);

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -21,9 +21,10 @@ export interface CliIo {
   /**
    * Calls back once when the stdio peer goes away — stdin EOF, or a shutdown
    * signal — and returns the disposer that unregisters it. Optional because
-   * only a bin can observe that, and only a command that outlives its own
-   * answer needs to. The disposer must be called once the wait is over,
-   * however it ended: the listeners behind it hold the process open.
+   * only a bin can observe that, and only `rcd mcp` needs to: the MCP SDK's
+   * stdio transport never reports a closed pipe of its own accord. The
+   * disposer must be called once the wait is over, however it ended: the
+   * listeners behind it hold the process open.
    */
   onDisconnect?(callback: () => void): () => void;
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -6,6 +6,7 @@ import type { Command } from "./command";
 import { compareCommand } from "./commands/compare";
 import { digestCommand } from "./commands/digest";
 import { docsCommand } from "./commands/docs";
+import { mcpCommand } from "./commands/mcp";
 import { provenanceCommand } from "./commands/provenance";
 import { resolvedCommand } from "./commands/resolved";
 import { runCommand } from "./commands/run";
@@ -38,6 +39,7 @@ const COMMANDS: readonly Command[] = [
   simulateCommand,
   compareCommand,
   docsCommand,
+  mcpCommand,
 ];
 
 const BANNER = [

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -5,11 +5,26 @@ import { RESULT_BUDGET_BYTES, serializeResult } from "./result";
  *  `server.test.ts`, where a real `config:recommended` run supplies the
  *  payloads this module was written for. */
 
+interface ElidedArray {
+  truncated: boolean;
+  shown: number;
+  omitted: number;
+  omittedFrom: number;
+  items: unknown[];
+}
+
 describe("serializeResult", () => {
   test("small answers are indented, large ones are not", () => {
     expect(serializeResult({ a: 1 })).toContain("\n  ");
     const big = { items: Array.from({ length: 2_000 }, (_, i) => ({ i, pad: "x".repeat(20) })) };
     expect(serializeResult(big)).not.toContain("\n");
+  });
+
+  test("the budget stays under the host's own tool-output cap", () => {
+    // ~25k tokens at ~3 bytes each. A budget above it would be truncated by
+    // the HOST, mid-JSON — the one thing this module promises never happens.
+    expect(RESULT_BUDGET_BYTES).toBeLessThanOrEqual(75_000);
+    expect(RESULT_BUDGET_BYTES).toBeGreaterThan(50_000);
   });
 
   test("an over-budget payload is elided, never cut mid-JSON", () => {
@@ -23,15 +38,24 @@ describe("serializeResult", () => {
       truncated: boolean;
       hint: string;
       keep: string;
-      rules: { truncated: boolean; shown: number; omitted: number; items: unknown[] };
+      rules: ElidedArray;
     };
     expect(parsed.truncated).toBe(true);
-    expect(parsed.hint).toBe("pass `key` to narrow it");
+    expect(parsed.hint).toContain("pass `key` to narrow it");
     // The rest of the document survives intact.
     expect(parsed.keep).toBe("small");
     expect(parsed.rules.truncated).toBe(true);
     expect(parsed.rules.shown + parsed.rules.omitted).toBe(5_000);
     expect(parsed.rules.items).toHaveLength(parsed.rules.shown);
+  });
+
+  test("the hint names the shape an elided array takes", () => {
+    const text = serializeResult({
+      rules: Array.from({ length: 5_000 }, (_, i) => ({ i, pad: "y".repeat(60) })),
+    });
+    const parsed = JSON.parse(text) as { hint: string };
+    expect(parsed.hint).toContain("omittedFrom");
+    expect(parsed.hint).toContain("FIRST and the LAST");
   });
 
   test("without a hint it still says how to proceed", () => {
@@ -50,5 +74,80 @@ describe("serializeResult", () => {
     };
     expect(parsed.truncated).toBe(true);
     expect(parsed.omittedKeys.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Relevance inversion (roadmap 068): a merged `packageRules` array is the
+   * presets' rules first and the repo's OWN rules last, so a head-only
+   * truncation drops exactly the rules the caller wrote — with no parameter
+   * that could ask for them back.
+   */
+  test("the elision keeps a head AND a tail window, and says where the gap is", () => {
+    const rules = Array.from({ length: 4_000 }, (_, i) => ({ i, pad: "y".repeat(60) }));
+    const text = serializeResult({ rules });
+    const parsed = JSON.parse(text) as { rules: ElidedArray };
+    const items = parsed.rules.items as { i: number }[];
+    expect(parsed.rules.omitted).toBeGreaterThan(0);
+    // The array's own last element is still in the answer.
+    expect(items.at(-1)?.i).toBe(3_999);
+    expect(items[0]?.i).toBe(0);
+    // The gap is where the wrapper says it is: head below it, tail above.
+    const gap = parsed.rules.omittedFrom;
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThan(items.length);
+    expect(items[gap - 1]?.i).toBe(gap - 1);
+    expect(items[gap]?.i).toBe(4_000 - (items.length - gap));
+  });
+
+  /**
+   * The H1 mechanism: when the payload is over budget by more than the array
+   * weighs, the allowance goes NEGATIVE. The array used to refuse to shrink
+   * below two elements, report `removed === 0`, and hand the whole payload to
+   * the blunt key-dropping — which is how a simulate answer came back with 2
+   * of 713 rules and no merge trace, on a third of the budget.
+   */
+  test("an array that cannot afford one element still converges, without dropping keys", () => {
+    const payload = {
+      answer: { a: "b" },
+      rules: Array.from({ length: 700 }, (_, i) => ({ i, pad: "r".repeat(400) })),
+      trace: Array.from({ length: 700 }, (_, i) => ({ i, pad: "t".repeat(400) })),
+    };
+    const text = serializeResult(payload);
+    expect(text.length).toBeLessThanOrEqual(RESULT_BUDGET_BYTES);
+    const parsed = JSON.parse(text) as {
+      omittedKeys?: string[];
+      answer: unknown;
+      rules: ElidedArray;
+      trace: ElidedArray;
+    };
+    // Every key survives — the arrays gave the bytes back themselves.
+    expect(parsed.omittedKeys).toBeUndefined();
+    expect(parsed.answer).toEqual({ a: "b" });
+    expect(parsed.rules.shown).toBeGreaterThan(0);
+    expect(parsed.trace.shown).toBeGreaterThan(0);
+  });
+
+  /**
+   * The escape the head/tail windows must not break: a dozen small nodes next
+   * to one enormous subtree. Truncating around the trunk would answer with the
+   * leaves; the pass leaves the array alone and elides INSIDE the big element.
+   */
+  test("one enormous element is kept, and elided inside", () => {
+    const payload = {
+      children: [
+        ...Array.from({ length: 12 }, (_, i) => ({ name: `leaf-${i}` })),
+        {
+          name: "trunk",
+          body: Array.from({ length: 5_000 }, (_, i) => ({ i, pad: "p".repeat(60) })),
+        },
+      ],
+    };
+    const parsed = JSON.parse(serializeResult(payload)) as {
+      children: { name: string; body?: ElidedArray }[];
+    };
+    const trunk = parsed.children.find((child) => child.name === "trunk");
+    expect(trunk).toBeDefined();
+    expect(trunk?.body?.truncated).toBe(true);
+    expect(parsed.children).toHaveLength(13);
   });
 });

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { RESULT_BUDGET_BYTES, serializeResult } from "./result";
+
+/** The size budget, on its own — the tool-level assertions live in
+ *  `server.test.ts`, where a real `config:recommended` run supplies the
+ *  payloads this module was written for. */
+
+describe("serializeResult", () => {
+  test("small answers are indented, large ones are not", () => {
+    expect(serializeResult({ a: 1 })).toContain("\n  ");
+    const big = { items: Array.from({ length: 2_000 }, (_, i) => ({ i, pad: "x".repeat(20) })) };
+    expect(serializeResult(big)).not.toContain("\n");
+  });
+
+  test("an over-budget payload is elided, never cut mid-JSON", () => {
+    const payload = {
+      keep: "small",
+      rules: Array.from({ length: 5_000 }, (_, i) => ({ i, pad: "y".repeat(60) })),
+    };
+    const text = serializeResult(payload, "pass `key` to narrow it");
+    expect(text.length).toBeLessThanOrEqual(RESULT_BUDGET_BYTES);
+    const parsed = JSON.parse(text) as {
+      truncated: boolean;
+      hint: string;
+      keep: string;
+      rules: { truncated: boolean; shown: number; omitted: number; items: unknown[] };
+    };
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.hint).toBe("pass `key` to narrow it");
+    // The rest of the document survives intact.
+    expect(parsed.keep).toBe("small");
+    expect(parsed.rules.truncated).toBe(true);
+    expect(parsed.rules.shown + parsed.rules.omitted).toBe(5_000);
+    expect(parsed.rules.items).toHaveLength(parsed.rules.shown);
+  });
+
+  test("without a hint it still says how to proceed", () => {
+    const text = serializeResult({ rules: Array.from({ length: 5_000 }, () => "z".repeat(80)) });
+    const parsed = JSON.parse(text) as { hint: string };
+    expect(parsed.hint).toContain("narrower question");
+  });
+
+  test("a payload with no array to elide drops whole keys, and names them", () => {
+    const huge = Object.fromEntries(
+      Array.from({ length: 40 }, (_, i) => [`k${i}`, "q".repeat(5_000)]),
+    );
+    const parsed = JSON.parse(serializeResult(huge)) as {
+      truncated: boolean;
+      omittedKeys: string[];
+    };
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.omittedKeys.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -123,8 +123,17 @@ describe("serializeResult", () => {
     // Every key survives — the arrays gave the bytes back themselves.
     expect(parsed.omittedKeys).toBeUndefined();
     expect(parsed.answer).toEqual({ a: "b" });
-    expect(parsed.rules.shown).toBeGreaterThan(0);
-    expect(parsed.trace.shown).toBeGreaterThan(0);
+    // The floor keeps BOTH ends — the exact promise ELIDED_ARRAY_SHAPE ships,
+    // and the tail is where a merged packageRules array keeps the repo's own
+    // rules. The gap marker must sit inside `items`, never past its end.
+    for (const elided of [parsed.rules, parsed.trace]) {
+      const items = elided.items as { i: number }[];
+      expect(elided.shown).toBeGreaterThanOrEqual(2);
+      expect(items[0]?.i).toBe(0);
+      expect(items.at(-1)?.i).toBe(699);
+      expect(elided.omittedFrom).toBeGreaterThan(0);
+      expect(elided.omittedFrom).toBeLessThan(items.length);
+    }
   });
 
   /**

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -2,11 +2,10 @@
  * The one JSON document every MCP tool answers with — and its size budget.
  *
  * Two economics, one module. A model consumer pays for every byte, and the
- * host truncates what it cannot fit (Claude Code caps tool output at 25k
- * tokens by default), so:
+ * host truncates what it cannot fit, so:
  *
  * - small answers are pretty-printed, because a human reads them in the
- *   transcript; large ones are compact, because indentation on a 100 kB
+ *   transcript; large ones are compact, because indentation on a 60 kB
  *   payload is pure token overhead;
  * - an answer that would blow the budget is elided STRUCTURALLY — never cut
  *   mid-JSON — and says so, with the parameter that narrows the question.
@@ -17,8 +16,25 @@
 /** Above this, indentation stops paying for itself. */
 const PRETTY_LIMIT_BYTES = 4_000;
 
-/** The most any single tool result may carry. */
-export const RESULT_BUDGET_BYTES = 100_000;
+/** Claude Code's default cap on a tool result, in tokens; the hosts that
+ *  publish a number are all in this range. */
+const HOST_TOKEN_CAP = 25_000;
+
+/** Compact JSON of this shape measures out at roughly three bytes to the
+ *  token — identifiers and punctuation tokenize worse than prose. */
+const BYTES_PER_TOKEN = 3;
+
+/**
+ * The most any single tool result may carry: the host's own cap, with head
+ * room for the transport framing around the payload and for a tokenizer that
+ * does worse than the average on a given answer.
+ *
+ * DERIVED, not picked. A budget above the host's cap defeats the one guarantee
+ * this module makes — the host truncates the overflow mid-JSON, and an agent
+ * is left holding a document it cannot parse, from a module that promised it
+ * never would.
+ */
+export const RESULT_BUDGET_BYTES = Math.round(HOST_TOKEN_CAP * BYTES_PER_TOKEN * 0.87);
 
 /** Elide to slightly under, so the wrapper keys still fit. */
 const ELISION_TARGET_BYTES = RESULT_BUDGET_BYTES - 2_000;
@@ -28,6 +44,27 @@ const MAX_ELISION_ROUNDS = 500;
 const DEFAULT_HINT =
   "this answer was elided to fit the tool-output budget — ask a narrower question " +
   "(one key, one node, a smaller depth) and call again.";
+
+/**
+ * What an elided array LOOKS like, said once and appended to whichever hint
+ * the tool supplied. A model that meets `{truncated, shown, omitted, …}`
+ * without being told what it is reads it as data the config contained.
+ */
+const ELIDED_ARRAY_SHAPE =
+  "An elided array is replaced by `{truncated, shown, omitted, omittedFrom, items}`: `items` " +
+  "holds the FIRST and the LAST elements of the original array, `omitted` counts the ones " +
+  "dropped between them, and `omittedFrom` is the index in `items` where they were.";
+
+/** How much of a shrinking array's allowance the TAIL window may claim. */
+const TAIL_SHARE = 0.25;
+
+/** What one array lost, across every round that shrank it. */
+interface Elision {
+  /** Elements dropped in total. */
+  omitted: number;
+  /** Where the gap sits among the elements that remain. */
+  from: number;
+}
 
 function byteLength(text: string): number {
   return new TextEncoder().encode(text).length;
@@ -70,11 +107,19 @@ function largestArray(value: unknown, skip: Set<unknown[]>): unknown[] | null {
 
 /** Rewrites every shortened array into a self-describing wrapper, so the
  *  omission is a fact in the document rather than a missing element. */
-function applyElisions(value: unknown, elided: Map<unknown[], number>): unknown {
+function applyElisions(value: unknown, elided: Map<unknown[], Elision>): unknown {
   if (Array.isArray(value)) {
     const items = value.map((item) => applyElisions(item, elided));
-    const omitted = elided.get(value);
-    return omitted ? { truncated: true, shown: items.length, omitted, items } : items;
+    const elision = elided.get(value);
+    return elision
+      ? {
+          truncated: true,
+          shown: items.length,
+          omitted: elision.omitted,
+          omittedFrom: elision.from,
+          items,
+        }
+      : items;
   }
   if (isRecord(value)) {
     return Object.fromEntries(
@@ -108,41 +153,88 @@ function dropLargestKeys(payload: Record<string, unknown>): string[] {
   return dropped;
 }
 
+/** Everything but the first element, so the next round can work inside it. */
+function collapseToFirst(array: unknown[]): Elision | null {
+  const removed = array.length - 1;
+  if (removed <= 0) {
+    return null;
+  }
+  array.splice(1, removed);
+  return { omitted: removed, from: 1 };
+}
+
 /**
- * Keeps the longest leading run of elements that fits in `allowance`, and at
- * least one — the shape of an answer is part of the answer.
+ * Keeps a HEAD window and a TAIL window of the array — as much of each as
+ * `allowance` affords — and removes the span between them. Returns null when
+ * the array has nothing to give back.
  *
- * Measured, not counted: an array's bytes are never spread evenly across it,
- * so "keep half" either throws away a document to save nothing (a preset
- * tree's fat child is last) or saves nothing at all (it is first). Returns how
- * many elements went.
+ * Two properties earn the bookkeeping:
+ *
+ * - Measured, not counted. An array's bytes are never spread evenly across it,
+ *   so "keep half" either throws away a document to save nothing (a preset
+ *   tree's fat child is last) or saves nothing at all (it is first).
+ * - A tail window AT ALL, because relevance is not spread evenly either. A
+ *   merged `packageRules` array is the presets' rules first and the repo's OWN
+ *   rules last, so a head-only truncation drops precisely the rules the person
+ *   asking wrote — `get_resolved_config` kept rules 0–329 of 714 and lost the
+ *   caller's own rule at index 713, with no parameter that could ask for it.
  */
-function shrinkArray(array: unknown[], allowance: number): number {
+function shrinkArray(array: unknown[], allowance: number): Elision | null {
+  const sizes = array.map((item) => byteLength(stringify(item)) + 1);
+  const first = sizes[0] ?? 0;
+
+  if (sizes.some((size) => size > allowance)) {
+    // An element that alone blows the whole allowance IS the answer — a preset
+    // tree is one enormous child next to a dozen small ones. Truncating AROUND
+    // it returns the leaves and drops the trunk, so this array gives nothing
+    // back and the next round elides INSIDE the big element instead.
+    //
+    // Unless the allowance will not even cover the array's FIRST element: then
+    // nothing here fits, and "give nothing back" is how the pass stalls —
+    // `removed === 0` marks the array exhausted, no array can shrink, and the
+    // blunt key-dropping below inherits the whole problem. That is how a
+    // simulate answer came back holding 2 of 713 rules and no merge trace at
+    // all, on a third of the budget. One element is the honest floor.
+    return allowance >= first ? null : collapseToFirst(array);
+  }
+
+  const last = array.length - 1;
+  // The tail is measured first, so a long head cannot eat the room it needs.
+  const tailAllowance = Math.max(0, Math.floor(allowance * TAIL_SHARE));
   let used = 0;
-  let keep = 0;
-  for (const item of array) {
-    const size = byteLength(stringify(item)) + 1;
-    if (keep > 0 && used + size > allowance) {
-      // An element that alone blows the whole allowance IS the answer — a
-      // preset tree is one enormous child next to a dozen small ones. Keep it
-      // and let the next round elide inside it, rather than returning the
-      // twelve leaves and dropping the trunk.
-      if (size > allowance) {
-        keep += 1;
-      }
+  let tail = 0;
+  while (tail < last) {
+    const size = sizes[last - tail] ?? 0;
+    if (used + size > tailAllowance) {
       break;
     }
     used += size;
-    keep += 1;
+    tail += 1;
   }
-  const removed = array.length - keep;
-  array.length = keep;
-  return removed;
+
+  let head = 0;
+  while (head < array.length - tail) {
+    const size = sizes[head] ?? 0;
+    // The first element is always kept: the shape of an answer is part of the
+    // answer.
+    if (head > 0 && used + size > allowance) {
+      break;
+    }
+    used += size;
+    head += 1;
+  }
+
+  const removed = array.length - head - tail;
+  if (removed <= 0) {
+    return null;
+  }
+  array.splice(head, removed);
+  return { omitted: removed, from: head };
 }
 
 function elideToBudget(compact: string, hint: string | undefined): Record<string, unknown> {
   const clone = JSON.parse(compact) as unknown;
-  const elided = new Map<unknown[], number>();
+  const elided = new Map<unknown[], Elision>();
   // Arrays that cannot give anything back — one oversized element is all they
   // hold. The next round looks inside it instead.
   const exhausted = new Set<unknown[]>();
@@ -157,19 +249,23 @@ function elideToBudget(compact: string, hint: string | undefined): Record<string
     }
     // What this array may still weigh once the payload fits.
     const allowance = byteLength(stringify(largest)) - (size - ELISION_TARGET_BYTES);
-    const removed = shrinkArray(largest, allowance);
-    if (removed === 0) {
+    const shrunk = shrinkArray(largest, allowance);
+    if (!shrunk) {
       exhausted.add(largest);
       continue;
     }
-    elided.set(largest, (elided.get(largest) ?? 0) + removed);
+    const before = elided.get(largest);
+    // `from` is an index into what REMAINS, so the latest round's is the one
+    // that describes the array a caller reads; the counts accumulate.
+    elided.set(largest, { omitted: (before?.omitted ?? 0) + shrunk.omitted, from: shrunk.from });
   }
   const body = applyElisions(clone, elided);
   const payload = isRecord(body) ? { ...body } : { result: body };
   const droppedKeys = dropLargestKeys(payload);
+  const base = hint ?? DEFAULT_HINT;
   return {
     truncated: true,
-    hint: hint ?? DEFAULT_HINT,
+    hint: elided.size > 0 ? `${base} ${ELIDED_ARRAY_SHAPE}` : base,
     ...(droppedKeys.length > 0 ? { omittedKeys: droppedKeys } : {}),
     ...payload,
   };

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -1,0 +1,198 @@
+/**
+ * The one JSON document every MCP tool answers with — and its size budget.
+ *
+ * Two economics, one module. A model consumer pays for every byte, and the
+ * host truncates what it cannot fit (Claude Code caps tool output at 25k
+ * tokens by default), so:
+ *
+ * - small answers are pretty-printed, because a human reads them in the
+ *   transcript; large ones are compact, because indentation on a 100 kB
+ *   payload is pure token overhead;
+ * - an answer that would blow the budget is elided STRUCTURALLY — never cut
+ *   mid-JSON — and says so, with the parameter that narrows the question.
+ *   Silent truncation is the failure mode worth avoiding: an agent cannot
+ *   tell a short list from a shortened one.
+ */
+
+/** Above this, indentation stops paying for itself. */
+const PRETTY_LIMIT_BYTES = 4_000;
+
+/** The most any single tool result may carry. */
+export const RESULT_BUDGET_BYTES = 100_000;
+
+/** Elide to slightly under, so the wrapper keys still fit. */
+const ELISION_TARGET_BYTES = RESULT_BUDGET_BYTES - 2_000;
+
+const MAX_ELISION_ROUNDS = 500;
+
+const DEFAULT_HINT =
+  "this answer was elided to fit the tool-output budget — ask a narrower question " +
+  "(one key, one node, a smaller depth) and call again.";
+
+function byteLength(text: string): number {
+  return new TextEncoder().encode(text).length;
+}
+
+function stringify(value: unknown): string {
+  return JSON.stringify(value) ?? "null";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** The biggest array anywhere in the payload that is still worth shrinking —
+ *  `skip` holds the ones a round could not shrink any further. */
+function largestArray(value: unknown, skip: Set<unknown[]>): unknown[] | null {
+  let best: unknown[] | null = null;
+  let bestSize = 0;
+  const visit = (node: unknown): void => {
+    if (Array.isArray(node)) {
+      const size = byteLength(stringify(node));
+      if (node.length > 1 && size > bestSize && !skip.has(node)) {
+        best = node;
+        bestSize = size;
+      }
+      for (const item of node) {
+        visit(item);
+      }
+      return;
+    }
+    if (isRecord(node)) {
+      for (const item of Object.values(node)) {
+        visit(item);
+      }
+    }
+  };
+  visit(value);
+  return best;
+}
+
+/** Rewrites every shortened array into a self-describing wrapper, so the
+ *  omission is a fact in the document rather than a missing element. */
+function applyElisions(value: unknown, elided: Map<unknown[], number>): unknown {
+  if (Array.isArray(value)) {
+    const items = value.map((item) => applyElisions(item, elided));
+    const omitted = elided.get(value);
+    return omitted ? { truncated: true, shown: items.length, omitted, items } : items;
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, applyElisions(item, elided)]),
+    );
+  }
+  return value;
+}
+
+/**
+ * Drops whole top-level keys, biggest first — the last resort for a payload
+ * with no array big enough to elide (one enormous object).
+ *
+ * It measures against the hard cap, not the elision target: the array pass
+ * aims a little under, and a key is far too blunt an instrument to reach for
+ * over the few hundred bytes the wrapper adds.
+ */
+function dropLargestKeys(payload: Record<string, unknown>): string[] {
+  const dropped: string[] = [];
+  while (byteLength(stringify(payload)) > RESULT_BUDGET_BYTES - 1_000) {
+    const entries = Object.entries(payload);
+    if (entries.length === 0) {
+      break;
+    }
+    const [key] = entries.reduce((a, b) =>
+      byteLength(stringify(a[1])) >= byteLength(stringify(b[1])) ? a : b,
+    );
+    delete payload[key];
+    dropped.push(key);
+  }
+  return dropped;
+}
+
+/**
+ * Keeps the longest leading run of elements that fits in `allowance`, and at
+ * least one — the shape of an answer is part of the answer.
+ *
+ * Measured, not counted: an array's bytes are never spread evenly across it,
+ * so "keep half" either throws away a document to save nothing (a preset
+ * tree's fat child is last) or saves nothing at all (it is first). Returns how
+ * many elements went.
+ */
+function shrinkArray(array: unknown[], allowance: number): number {
+  let used = 0;
+  let keep = 0;
+  for (const item of array) {
+    const size = byteLength(stringify(item)) + 1;
+    if (keep > 0 && used + size > allowance) {
+      // An element that alone blows the whole allowance IS the answer — a
+      // preset tree is one enormous child next to a dozen small ones. Keep it
+      // and let the next round elide inside it, rather than returning the
+      // twelve leaves and dropping the trunk.
+      if (size > allowance) {
+        keep += 1;
+      }
+      break;
+    }
+    used += size;
+    keep += 1;
+  }
+  const removed = array.length - keep;
+  array.length = keep;
+  return removed;
+}
+
+function elideToBudget(compact: string, hint: string | undefined): Record<string, unknown> {
+  const clone = JSON.parse(compact) as unknown;
+  const elided = new Map<unknown[], number>();
+  // Arrays that cannot give anything back — one oversized element is all they
+  // hold. The next round looks inside it instead.
+  const exhausted = new Set<unknown[]>();
+  for (let round = 0; round < MAX_ELISION_ROUNDS; round += 1) {
+    const size = byteLength(stringify(clone));
+    if (size <= ELISION_TARGET_BYTES) {
+      break;
+    }
+    const largest = largestArray(clone, exhausted);
+    if (!largest) {
+      break;
+    }
+    // What this array may still weigh once the payload fits.
+    const allowance = byteLength(stringify(largest)) - (size - ELISION_TARGET_BYTES);
+    const removed = shrinkArray(largest, allowance);
+    if (removed === 0) {
+      exhausted.add(largest);
+      continue;
+    }
+    elided.set(largest, (elided.get(largest) ?? 0) + removed);
+  }
+  const body = applyElisions(clone, elided);
+  const payload = isRecord(body) ? { ...body } : { result: body };
+  const droppedKeys = dropLargestKeys(payload);
+  return {
+    truncated: true,
+    hint: hint ?? DEFAULT_HINT,
+    ...(droppedKeys.length > 0 ? { omittedKeys: droppedKeys } : {}),
+    ...payload,
+  };
+}
+
+/**
+ * `hint` is the narrowing a caller should apply if this particular tool's
+ * answer had to be elided — naming the parameter beats "output truncated".
+ */
+export function serializeResult(payload: unknown, hint?: string): string {
+  const compact = stringify(payload);
+  const size = byteLength(compact);
+  if (size <= PRETTY_LIMIT_BYTES) {
+    return JSON.stringify(payload, null, 2) ?? "null";
+  }
+  if (size <= RESULT_BUDGET_BYTES) {
+    return compact;
+  }
+  return stringify(elideToBudget(compact, hint));
+}
+
+/** Deliberately un-annotated: an interface here would not satisfy the SDK's
+ *  `CallToolResult` index signature, an inferred object type does. */
+export function textResult(payload: unknown, hint?: string) {
+  return { content: [{ type: "text" as const, text: serializeResult(payload, hint) }] };
+}

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -153,9 +153,15 @@ function dropLargestKeys(payload: Record<string, unknown>): string[] {
   return dropped;
 }
 
-/** Everything but the first element, so the next round can work inside it. */
-function collapseToFirst(array: unknown[]): Elision | null {
-  const removed = array.length - 1;
+/**
+ * Everything but the first and the last element, so the next round can work
+ * inside them. Both ends survive on purpose: `ELIDED_ARRAY_SHAPE` promises
+ * the caller exactly that, and the tail is where a merged `packageRules`
+ * array keeps the repo's own rules — the floor case must not be the one
+ * branch that breaks the promise.
+ */
+function collapseToEnds(array: unknown[]): Elision | null {
+  const removed = array.length - 2;
   if (removed <= 0) {
     return null;
   }
@@ -194,8 +200,8 @@ function shrinkArray(array: unknown[], allowance: number): Elision | null {
     // `removed === 0` marks the array exhausted, no array can shrink, and the
     // blunt key-dropping below inherits the whole problem. That is how a
     // simulate answer came back holding 2 of 713 rules and no merge trace at
-    // all, on a third of the budget. One element is the honest floor.
-    return allowance >= first ? null : collapseToFirst(array);
+    // all, on a third of the budget. First-and-last is the honest floor.
+    return allowance >= first ? null : collapseToEnds(array);
   }
 
   const last = array.length - 1;

--- a/packages/cli/src/mcp/run-store.ts
+++ b/packages/cli/src/mcp/run-store.ts
@@ -14,9 +14,11 @@ import { CliError } from "../io";
  * different worlds if a remote preset changed between them, two `{runId}`
  * lookups cannot.
  *
- * Small on purpose. A debugging session works on one config at a time; the
- * older entries exist so an agent can compare the run before its edit with the
- * run after it.
+ * Small on purpose, and measured. A `config:recommended` trace costs ~165 MB
+ * of heap, so the old limit of 8 held ~1.4 GB in a long session — in a process
+ * the host keeps alive for as long as the agent is working. A debugging
+ * session works on one config at a time and the documented before/after oracle
+ * needs two, so three is the whole requirement plus one.
  */
 
 export interface HeldRun {
@@ -27,7 +29,25 @@ export interface HeldRun {
   facts: RunFacts;
 }
 
-export const DEFAULT_RUN_LIMIT = 8;
+export const DEFAULT_RUN_LIMIT = 3;
+
+/**
+ * The held copy, without the logger shim's raw `log` events.
+ *
+ * Measured on a `config:recommended` run: 76.1 MB of events, 74.8 MB of it
+ * `kind: "log"` — and NOTHING on the MCP path reads them. The trace's own
+ * derivations index `stage-complete`, `migration-applied` and `preset-error`;
+ * the preset tree, the provenance replay and the resolved-config projection
+ * read no events at all. `rcd run --slice events` does print them, but that is
+ * the CLI's own one-shot path, which never touches this store.
+ *
+ * A COPY, never a mutation: the caller still holds the result it handed over,
+ * and a store is no place to decide what that caller may still look at.
+ */
+function heldTrace(result: TraceResult): TraceResult {
+  const events = result.events.filter((event) => event.kind !== "log");
+  return events.length === result.events.length ? result : { ...result, events };
+}
 
 export class RunStore {
   readonly #runs = new Map<string, HeldRun>();
@@ -40,11 +60,12 @@ export class RunStore {
 
   put(result: TraceResult, input: PipelineInput): HeldRun {
     this.#counter += 1;
+    const held = heldTrace(result);
     const run: HeldRun = {
       runId: `run-${this.#counter}`,
-      result,
+      result: held,
       input,
-      facts: deriveRunFacts(result),
+      facts: deriveRunFacts(held),
     };
     this.#runs.set(run.runId, run);
     // Map iterates in insertion order, so the first key is the oldest.

--- a/packages/cli/src/mcp/run-store.ts
+++ b/packages/cli/src/mcp/run-store.ts
@@ -1,0 +1,84 @@
+import type { PipelineInput, TraceResult } from "@renovate-config-debugger/engine";
+import type { RunFacts } from "@renovate-config-debugger/app/headless";
+import { deriveRunFacts } from "@renovate-config-debugger/app/headless";
+import { CliError } from "../io";
+
+/**
+ * Roadmap 060: the runs the server is holding.
+ *
+ * Handles, not payloads. A full trace for `config:recommended` is over a
+ * thousand nodes with four config bodies each; `run_config` returns a summary
+ * and a `runId`, and the drill-down tools query the trace that stays here.
+ * That is the web app's progressive disclosure, as tool calls — and it buys
+ * run CONSISTENCY as well as size: two `rcd` invocations can describe
+ * different worlds if a remote preset changed between them, two `{runId}`
+ * lookups cannot.
+ *
+ * Small on purpose. A debugging session works on one config at a time; the
+ * older entries exist so an agent can compare the run before its edit with the
+ * run after it.
+ */
+
+export interface HeldRun {
+  runId: string;
+  result: TraceResult;
+  input: PipelineInput;
+  /** Derived once per run — every tool that quotes a number reads these. */
+  facts: RunFacts;
+}
+
+export const DEFAULT_RUN_LIMIT = 8;
+
+export class RunStore {
+  readonly #runs = new Map<string, HeldRun>();
+  readonly #limit: number;
+  #counter = 0;
+
+  constructor(limit: number = DEFAULT_RUN_LIMIT) {
+    this.#limit = limit;
+  }
+
+  put(result: TraceResult, input: PipelineInput): HeldRun {
+    this.#counter += 1;
+    const run: HeldRun = {
+      runId: `run-${this.#counter}`,
+      result,
+      input,
+      facts: deriveRunFacts(result),
+    };
+    this.#runs.set(run.runId, run);
+    // Map iterates in insertion order, so the first key is the oldest.
+    while (this.#runs.size > this.#limit) {
+      const oldest = this.#runs.keys().next().value;
+      if (oldest === undefined) {
+        break;
+      }
+      this.#runs.delete(oldest);
+    }
+    return run;
+  }
+
+  /** Throws with the ids still held — an expired handle is a common, and
+   *  entirely recoverable, mistake for an agent to make. */
+  get(runId: string): HeldRun {
+    const run = this.#runs.get(runId);
+    if (!run) {
+      const held = [...this.#runs.keys()];
+      throw new CliError(
+        `no run "${runId}" — it has been evicted or never existed. ` +
+          (held.length > 0
+            ? `Currently held: ${held.join(", ")}. Call run_config again.`
+            : "Call run_config first."),
+      );
+    }
+    // Refresh recency so the run an agent keeps drilling into is never the one
+    // evicted next.
+    this.#runs.delete(runId);
+    this.#runs.set(runId, run);
+    return run;
+  }
+
+  get size(): number {
+    return this.#runs.size;
+  }
+}

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1,0 +1,285 @@
+import { Client } from "@modelcontextprotocol/client";
+import { InMemoryTransport } from "@modelcontextprotocol/server";
+import { serveStdio, type StdioServerHandle } from "@modelcontextprotocol/server/stdio";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createMcpServer } from "./server";
+import { RunStore } from "./run-store";
+import { recordingIo } from "../test-harness";
+
+/**
+ * Roadmap 060: the tool surface, driven through a real MCP client over the
+ * SDK's in-memory transport pair — so the schemas, the handlers and the
+ * result shapes are exercised exactly as a client would.
+ *
+ * Under SDK v2 the server side is the PRODUCTION entry point — `serveStdio`
+ * over that in-memory pair rather than over a process's stdio — because the
+ * entry, not the server, owns the era decision. So the suite drives the exact
+ * wiring `rcd mcp` does, including the choice between the 2026-07-28 protocol
+ * and the legacy 2025-era handshake. The v2 client negotiates `legacy` unless
+ * told otherwise, so every test below is a legacy-era run; "the tool surface"
+ * adds one that pins 2026-07-28.
+ *
+ * Thin, like the CLI's own tests: the answers themselves come from the shared
+ * projection modules the subcommands use, and the engine's golden↔shimmed
+ * suite owns the semantics underneath.
+ */
+
+const CONFIG = '{"extends":[":dependencyDashboard"],"labels":["deps"]}';
+const GROUPED =
+  '{"labels":["deps"],"packageRules":[{"matchPackageNames":["react"],"groupName":"react"}]}';
+
+/** The revision the modern era negotiates. */
+const MODERN_PROTOCOL_VERSION = "2026-07-28";
+
+let client: Client;
+let close: () => Promise<void>;
+
+interface ConnectOptions {
+  /** Omitted: the client's default, the 2025-era `initialize` handshake. */
+  era?: "modern";
+}
+
+async function connect(options?: ConnectOptions): Promise<void> {
+  const io = recordingIo();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  // One factory, both eras — the entry pins ONE instance per connection.
+  const handle: StdioServerHandle = serveStdio(() => createMcpServer(io), {
+    transport: serverTransport,
+  });
+  client = new Client(
+    { name: "test", version: "0" },
+    options?.era === "modern"
+      ? { versionNegotiation: { mode: { pin: MODERN_PROTOCOL_VERSION } } }
+      : {},
+  );
+  await client.connect(clientTransport);
+  close = async () => {
+    await client.close();
+    await handle.close();
+  };
+}
+
+/** The one JSON document every tool answers with. */
+async function call(name: string, args: Record<string, unknown>): Promise<unknown> {
+  const result = (await client.callTool({ name, arguments: args })) as {
+    isError?: boolean;
+    content: { type: string; text: string }[];
+  };
+  const text = result.content[0]?.text ?? "";
+  if (result.isError) {
+    throw new Error(text);
+  }
+  return JSON.parse(text) as unknown;
+}
+
+async function runConfig(content: string): Promise<string> {
+  const summary = (await call("run_config", { fileName: "renovate.json", content })) as {
+    runId: string;
+  };
+  return summary.runId;
+}
+
+beforeEach(() => connect());
+afterEach(() => close());
+
+describe("tool surface", () => {
+  test("advertises every tool the roadmap names, with its domain hints", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).toSorted()).toEqual([
+      "compare_simulations",
+      "explain_message",
+      "get_final_config",
+      "get_option_docs",
+      "get_preset_node",
+      "get_preset_tree",
+      "get_provenance",
+      "get_resolved_config",
+      "run_config",
+      "simulate",
+    ]);
+    const node = tools.find((t) => t.name === "get_preset_node");
+    expect(node?.description).toContain("one node at a time");
+  });
+
+  /**
+   * Every other test here drives the 2025-era `initialize` handshake (the v2
+   * client's default), which is what today's hosts speak; this one pins
+   * 2026-07-28, so ONE process provably answers both. The entry decides per
+   * connection off the same factory and the same registrations, so what is
+   * worth asserting is that the surface and the answers do not move with it.
+   */
+  test("the same server answers the 2026-07-28 era, not just the legacy handshake", async () => {
+    await close();
+    await connect({ era: "modern" });
+    expect(client.getProtocolEra()).toBe("modern");
+    expect(client.getNegotiatedProtocolVersion()).toBe(MODERN_PROTOCOL_VERSION);
+
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name).toSorted()).toEqual([
+      "compare_simulations",
+      "explain_message",
+      "get_final_config",
+      "get_option_docs",
+      "get_preset_node",
+      "get_preset_tree",
+      "get_provenance",
+      "get_resolved_config",
+      "run_config",
+      "simulate",
+    ]);
+
+    // A whole drill-down, not just a handshake: the held run survives the era.
+    const runId = await runConfig(CONFIG);
+    const entry = (await call("get_provenance", { runId, key: "labels" })) as { winner: string };
+    expect(entry.winner).toBe("repo");
+  });
+});
+
+describe("run_config", () => {
+  test("returns a handle and a summary, not the trace", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: CONFIG,
+    })) as Record<string, unknown>;
+    expect(summary.runId).toBe("run-1");
+    expect(summary.accepted).toBe(true);
+    expect(summary.digest).toContain("Renovate accepted this config");
+    expect(summary.treeSummary).toMatchObject({ resolved: 1 });
+    expect(summary).not.toHaveProperty("events");
+    expect(summary).not.toHaveProperty("finalConfig");
+  });
+
+  test("a config Renovate would refuse says so instead of failing", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"labels":5}',
+    })) as { accepted: boolean; errors: { message: string }[] };
+    expect(summary.accepted).toBe(false);
+    expect(summary.errors[0]?.message).toContain("labels");
+  });
+});
+
+describe("drill-down", () => {
+  test("the tree comes without bodies; a body is one node at a time", async () => {
+    const runId = await runConfig(CONFIG);
+    const tree = (await call("get_preset_tree", { runId })) as {
+      root: { children: { name: string }[] };
+    };
+    expect(tree.root.children[0]?.name).toBe(":dependencyDashboard");
+    expect(JSON.stringify(tree)).not.toContain("dependencyDashboardTitle");
+
+    const node = (await call("get_preset_node", {
+      runId,
+      node: ":dependencyDashboard",
+      body: "input",
+    })) as { input: { dependencyDashboard: boolean } };
+    expect(node.input.dependencyDashboard).toBe(true);
+  });
+
+  test("provenance answers who set a key", async () => {
+    const runId = await runConfig(CONFIG);
+    const entry = (await call("get_provenance", { runId, key: "labels" })) as {
+      winner: string;
+    };
+    expect(entry.winner).toBe("repo");
+  });
+
+  test("the resolved document keeps internal presets by default", async () => {
+    const runId = await runConfig(CONFIG);
+    const output = (await call("get_resolved_config", { runId })) as {
+      config: { extends: string[] };
+    };
+    expect(output.config.extends).toEqual([":dependencyDashboard"]);
+  });
+
+  test("an expired or invented runId says which runs are held", async () => {
+    await expect(call("get_final_config", { runId: "run-404" })).rejects.toThrow(
+      /no run "run-404"/,
+    );
+  });
+});
+
+describe("simulate and compare", () => {
+  test("updateType is derived, and the verdict carries clause evidence", async () => {
+    const runId = await runConfig(GROUPED);
+    const sim = (await call("simulate", {
+      runId,
+      dep: {
+        depName: "react",
+        packageName: "react",
+        currentValue: "17.0.0",
+        newValue: "18.0.0",
+      },
+    })) as {
+      dep: { updateType: string };
+      rules: { verdict: string; clauses: { key: string; state: string }[] }[];
+    };
+    expect(sim.dep.updateType).toBe("major");
+    expect(sim.rules[0]?.verdict).toBe("matched");
+    expect(sim.rules[0]?.clauses[0]).toMatchObject({ key: "matchPackageNames" });
+  });
+
+  test("two runs, one dependency: the edit oracle", async () => {
+    const before = await runConfig(CONFIG);
+    const after = await runConfig(GROUPED);
+    const dep = { depName: "react", packageName: "react" };
+    const comparison = (await call("compare_simulations", {
+      runId: before,
+      runIdB: after,
+      dep,
+    })) as { noChange: boolean; matchedOnlyInB: { label: string }[] };
+    expect(comparison.noChange).toBe(false);
+    expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
+  });
+
+  test("the same run twice changes nothing", async () => {
+    const runId = await runConfig(GROUPED);
+    const comparison = (await call("compare_simulations", {
+      runId,
+      dep: { depName: "react", packageName: "react" },
+    })) as { noChange: boolean };
+    expect(comparison.noChange).toBe(true);
+  });
+});
+
+describe("explain_message and get_option_docs", () => {
+  test("a validator message is explained against the run it came from", async () => {
+    const runId = await runConfig('{"labels":5}');
+    const explained = (await call("explain_message", {
+      runId,
+      topic: "Configuration Error",
+      message: "Configuration option `labels` should be a list (Array)",
+    })) as { docsUrl?: string; message: string };
+    expect(explained.docsUrl).toContain("docs.renovatebot.com");
+  });
+
+  test("option docs are for the pinned Renovate, and misses point at search", async () => {
+    const doc = (await call("get_option_docs", { name: "packageRules" })) as {
+      name: string;
+      renovateVersion: string;
+    };
+    expect(doc.name).toBe("packageRules");
+    expect(doc.renovateVersion).toMatch(/^\d+\./);
+    await expect(call("get_option_docs", { name: "nopeNotAnOption" })).rejects.toThrow(/search/);
+  });
+});
+
+describe("RunStore", () => {
+  test("evicts the oldest run, and keeps the one being drilled into", () => {
+    const store = new RunStore(2);
+    // eslint-disable-next-line — the store only ever reads `result`/`input` back out
+    const fake = { events: [], errors: [], warnings: [] } as unknown as Parameters<
+      RunStore["put"]
+    >[0];
+    const input = { fileName: "renovate.json", content: "{}" };
+    const a = store.put(fake, input);
+    const b = store.put(fake, input);
+    // Touching `a` makes `b` the least recently used.
+    store.get(a.runId);
+    const c = store.put(fake, input);
+    expect(store.size).toBe(2);
+    expect(() => store.get(b.runId)).toThrow(/no run/);
+    expect(store.get(a.runId).runId).toBe(a.runId);
+    expect(store.get(c.runId).runId).toBe(c.runId);
+  });
+});

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -444,6 +444,26 @@ describe("simulate and compare", () => {
     expect(sim.rules[0]?.clauses[0]).toMatchObject({ key: "matchPackageNames" });
   });
 
+  test("verdict/source scope the rule list and say what they hid", async () => {
+    const runId = await runConfig(GROUPED);
+    const dep = { depName: "react", currentValue: "17.0.0", newValue: "18.0.0" };
+    const full = (await call("simulate", { runId, dep })) as { rules: unknown[] };
+    // GROUPED's rules all match this dep, so `no-match` is the facet that
+    // provably hides something.
+    const scoped = (await call("simulate", { runId, dep, verdict: "no-match" })) as {
+      rules: { verdict: string }[];
+      ruleFilter: { verdict: string; total: number; shown: number; hidden: number };
+    };
+    // An unflagged call keeps the exact payload scripts already parse.
+    expect(full).not.toHaveProperty("ruleFilter");
+    expect(full.rules.length).toBeGreaterThan(0);
+    expect(scoped.rules.every((rule) => rule.verdict === "no-match")).toBe(true);
+    expect(scoped.ruleFilter.total).toBe(full.rules.length);
+    expect(scoped.ruleFilter.shown).toBe(scoped.rules.length);
+    expect(scoped.ruleFilter.hidden).toBe(full.rules.length - scoped.rules.length);
+    expect(scoped.ruleFilter.hidden).toBeGreaterThan(0);
+  });
+
   test("two runs, one dependency: the edit oracle", async () => {
     const before = await runConfig(CONFIG);
     const after = await runConfig(GROUPED);

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1,8 +1,11 @@
 import { Client } from "@modelcontextprotocol/client";
 import { InMemoryTransport } from "@modelcontextprotocol/server";
 import { serveStdio, type StdioServerHandle } from "@modelcontextprotocol/server/stdio";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { getPresetAuth, setPresetAuth } from "@renovate-config-debugger/engine";
+import pkg from "../../package.json";
 import { createMcpServer } from "./server";
+import { RESULT_BUDGET_BYTES } from "./result";
 import { RunStore } from "./run-store";
 import { recordingIo } from "../test-harness";
 
@@ -22,12 +25,16 @@ import { recordingIo } from "../test-harness";
  *
  * Thin, like the CLI's own tests: the answers themselves come from the shared
  * projection modules the subcommands use, and the engine's golden↔shimmed
- * suite owns the semantics underneath.
+ * suite owns the semantics underneath. What is NOT thin is the property tests
+ * below — size budget, strictness, the credential guard — because those are
+ * this transport's own failure modes.
  */
 
 const CONFIG = '{"extends":[":dependencyDashboard"],"labels":["deps"]}';
 const GROUPED =
   '{"labels":["deps"],"packageRules":[{"matchPackageNames":["react"],"groupName":"react"}]}';
+/** The big one — every size assertion in this file is measured against it. */
+const RECOMMENDED = '{"extends":["config:recommended"],"labels":["deps"]}';
 
 /** The revision the modern era negotiates. */
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
@@ -36,12 +43,13 @@ let client: Client;
 let close: () => Promise<void>;
 
 interface ConnectOptions {
+  env?: Record<string, string | undefined>;
   /** Omitted: the client's default, the 2025-era `initialize` handshake. */
   era?: "modern";
 }
 
 async function connect(options?: ConnectOptions): Promise<void> {
-  const io = recordingIo();
+  const io = recordingIo(options?.env ? { env: options.env } : undefined);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   // One factory, both eras — the entry pins ONE instance per connection.
   const handle: StdioServerHandle = serveStdio(() => createMcpServer(io), {
@@ -60,17 +68,24 @@ async function connect(options?: ConnectOptions): Promise<void> {
   };
 }
 
-/** The one JSON document every tool answers with. */
-async function call(name: string, args: Record<string, unknown>): Promise<unknown> {
-  const result = (await client.callTool({ name, arguments: args })) as {
-    isError?: boolean;
-    content: { type: string; text: string }[];
-  };
+interface ToolText {
+  isError?: boolean;
+  content: { type: string; text: string }[];
+}
+
+/** The raw text a tool answered with — what the model's context actually pays for. */
+async function callText(name: string, args: Record<string, unknown>): Promise<string> {
+  const result = (await client.callTool({ name, arguments: args })) as ToolText;
   const text = result.content[0]?.text ?? "";
   if (result.isError) {
     throw new Error(text);
   }
-  return JSON.parse(text) as unknown;
+  return text;
+}
+
+/** The one JSON document every tool answers with. */
+async function call(name: string, args: Record<string, unknown>): Promise<unknown> {
+  return JSON.parse(await callText(name, args)) as unknown;
 }
 
 async function runConfig(content: string): Promise<string> {
@@ -81,7 +96,10 @@ async function runConfig(content: string): Promise<string> {
 }
 
 beforeEach(() => connect());
-afterEach(() => close());
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await close();
+});
 
 describe("tool surface", () => {
   test("advertises every tool the roadmap names, with its domain hints", async () => {
@@ -100,6 +118,29 @@ describe("tool surface", () => {
     ]);
     const node = tools.find((t) => t.name === "get_preset_node");
     expect(node?.description).toContain("one node at a time");
+  });
+
+  test("the workflow is in `instructions`, and the server names its own version", () => {
+    const info = client.getServerVersion();
+    expect(info?.name).toBe("renovate-config-debugger");
+    // The SERVER's version, by convention — Renovate's lives in the title.
+    expect(info?.version).toBe(pkg.version);
+    expect(info?.title).toMatch(/^Renovate Config Debugger \(Renovate \d+\./);
+    const instructions = client.getInstructions() ?? "";
+    expect(instructions).toContain("run_config FIRST");
+    expect(instructions).toContain("compare_simulations");
+    // A paragraph, not a manual.
+    expect(instructions.length).toBeLessThan(1_200);
+  });
+
+  test("every tool declares itself read-only; only run_config reaches the network", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.annotations?.readOnlyHint, tool.name).toBe(true);
+      expect(tool.annotations?.destructiveHint, tool.name).toBe(false);
+      expect(tool.annotations?.openWorldHint, tool.name).toBe(tool.name === "run_config");
+      expect(tool.annotations?.idempotentHint, tool.name).toBe(tool.name !== "run_config");
+    }
   });
 
   /**
@@ -133,6 +174,9 @@ describe("tool surface", () => {
     const runId = await runConfig(CONFIG);
     const entry = (await call("get_provenance", { runId, key: "labels" })) as { winner: string };
     expect(entry.winner).toBe("repo");
+    // The strictness the tool descriptions promise is schema-level, so it has
+    // to hold on both wires.
+    await expect(call("get_preset_tree", { runId, dept: 3 })).rejects.toThrow(/dept/);
   });
 });
 
@@ -158,6 +202,78 @@ describe("run_config", () => {
     expect(summary.accepted).toBe(false);
     expect(summary.errors[0]?.message).toContain("labels");
   });
+
+  test("the withheld-credentials note names THIS transport's opt-ins, not the CLI flags", async () => {
+    await close();
+    await connect({ env: { GITHUB_TOKEN: "gh-token" } });
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: "{}",
+      globalConfig: { endpoint: "https://not-mine.example/api/v3/" },
+    })) as { notes?: string[] };
+    const note = summary.notes?.join(" ") ?? "";
+    expect(note).toContain("credentials withheld");
+    expect(note).toContain("trustEndpoints: true");
+    expect(note).toContain("platformOverride: true");
+    expect(note).not.toContain("--trust-endpoints");
+  });
+});
+
+describe("credential isolation", () => {
+  /**
+   * The race the endpoint guard used to lose. Handlers run CONCURRENTLY, so a
+   * trusted run installing tokens while an untrusted run is still fetching
+   * presets would put those tokens on the untrusted run's remaining requests —
+   * to the endpoint that config chose. The credentials now travel on the
+   * pipeline input, so no run can observe another's.
+   */
+  test("two interleaved runs: no request carries the other run's token", async () => {
+    await close();
+    await connect({ env: { GITHUB_TOKEN: "gh-token" } });
+    const before = getPresetAuth();
+    const requests: { url: string; authorization: string | null }[] = [];
+    vi.stubGlobal("fetch", (input: unknown, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+      });
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    const [untrusted, trusted] = await Promise.all([
+      call("run_config", {
+        fileName: "renovate.json",
+        content: '{"extends":["github>attacker/untrusted"]}',
+        globalConfig: { endpoint: "https://not-mine.example/api/v3/" },
+      }),
+      call("run_config", {
+        fileName: "renovate.json",
+        content: '{"extends":["github>mine/trusted"]}',
+        trustEndpoints: true,
+      }),
+    ]);
+    expect((untrusted as { notes?: string[] }).notes?.join(" ")).toContain("credentials withheld");
+    expect(trusted).not.toHaveProperty("notes");
+
+    const forUntrusted = requests.filter((r) => r.url.includes("attacker"));
+    const forTrusted = requests.filter((r) => r.url.includes("mine"));
+    expect(forUntrusted.length).toBeGreaterThan(0);
+    expect(forTrusted.length).toBeGreaterThan(0);
+    // The whole point: the run whose config chose the endpoint never sent a
+    // token, no matter what the concurrent trusted run installed.
+    expect(forUntrusted.map((r) => r.authorization)).toEqual(forUntrusted.map(() => null));
+    expect(forTrusted.map((r) => r.authorization)).toEqual(forTrusted.map(() => "Bearer gh-token"));
+    // Module state is exactly what it was: a run owns its auth for the length
+    // of its own queued task and hands it back.
+    expect(getPresetAuth()).toEqual(before);
+  });
+
+  test("a run never installs its credentials outside the engine's queue", async () => {
+    await close();
+    await connect({ env: { GITHUB_TOKEN: "gh-token" } });
+    setPresetAuth({});
+    await runConfig(CONFIG);
+    expect(getPresetAuth()).toEqual({});
+  });
 });
 
 describe("drill-down", () => {
@@ -181,8 +297,10 @@ describe("drill-down", () => {
     const runId = await runConfig(CONFIG);
     const entry = (await call("get_provenance", { runId, key: "labels" })) as {
       winner: string;
+      chain: { layer: string }[];
     };
     expect(entry.winner).toBe("repo");
+    expect(entry.chain.length).toBeGreaterThan(0);
   });
 
   test("the resolved document keeps internal presets by default", async () => {
@@ -197,6 +315,112 @@ describe("drill-down", () => {
     await expect(call("get_final_config", { runId: "run-404" })).rejects.toThrow(
       /no run "run-404"/,
     );
+  });
+});
+
+describe("honest empties", () => {
+  test("a run that never merged says so instead of answering `{}`", async () => {
+    // A parse failure stops the pipeline long before the merge stage.
+    const runId = await runConfig("{ not json");
+    await expect(call("get_final_config", { runId })).rejects.toThrow(
+      /produced no effective config/,
+    );
+    await expect(call("simulate", { runId, dep: { depName: "react" } })).rejects.toThrow(
+      /produced no effective config/,
+    );
+  });
+
+  test("a body the run never recorded is an explicit null with a note", async () => {
+    // An unknown INTERNAL preset: it fails without a network round-trip, so
+    // the fixture cannot flake on a rate limit.
+    const runId = await runConfig('{"extends":[":nope"]}');
+    const node = (await call("get_preset_node", {
+      runId,
+      node: ":nope",
+      body: "resolved",
+    })) as { body: string; resolved: unknown; note?: string };
+    expect(node.body).toBe("resolved");
+    expect(node.resolved).toBeNull();
+    expect(node.note).toContain("no `resolved` body");
+  });
+});
+
+describe("size budget", () => {
+  test("a big answer is compact, a small one is readable", async () => {
+    const runId = await runConfig(CONFIG);
+    expect(await callText("get_provenance", { runId, key: "labels" })).toContain("\n  ");
+    const tree = await callText("get_preset_tree", { runId: await runConfig(RECOMMENDED) });
+    expect(tree.length).toBeGreaterThan(4_000);
+    expect(tree).not.toContain("\n");
+  });
+
+  test("keyless provenance is an index, not every chain", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const text = await callText("get_provenance", { runId });
+    // Was ~634 kB: every non-noop chain step of every key, before and after.
+    expect(text.length).toBeLessThan(10_000);
+    const payload = JSON.parse(text) as {
+      note: string;
+      keys: { key: string; winner: string; preview: string }[];
+    };
+    expect(payload.note).toContain("pass `key`");
+    const labels = payload.keys.find((k) => k.key === "labels");
+    expect(labels).toMatchObject({ winner: "repo", preview: '["deps"]' });
+    expect(labels).not.toHaveProperty("chain");
+  });
+
+  test("depth is capped, and the cap explains itself", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    await expect(call("get_preset_tree", { runId, depth: 99 })).rejects.toThrow(
+      /depth|less than or equal to 6|<=6/i,
+    );
+    const { tools } = await client.listTools();
+    const tree = tools.find((t) => t.name === "get_preset_tree");
+    expect(JSON.stringify(tree?.inputSchema)).toContain("max 6");
+  });
+
+  test("an answer over the budget is elided structurally, and says how to narrow", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const text = await callText("get_provenance", { runId, key: "packageRules" });
+    expect(text.length).toBeLessThanOrEqual(RESULT_BUDGET_BYTES);
+    // Never cut mid-JSON.
+    const payload = JSON.parse(text) as { truncated?: boolean; hint?: string };
+    expect(payload.truncated).toBe(true);
+    expect(payload.hint).toContain("get_preset_node");
+  });
+
+  test("the elision marks what it dropped, in place", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const payload = (await call("get_final_config", { runId })) as {
+      truncated: boolean;
+      finalConfig: { packageRules: { truncated: boolean; shown: number; omitted: number } };
+    };
+    expect(payload.truncated).toBe(true);
+    const rules = payload.finalConfig.packageRules;
+    expect(rules.truncated).toBe(true);
+    expect(rules.omitted).toBeGreaterThan(0);
+    expect(rules.shown).toBeGreaterThan(0);
+  });
+});
+
+describe("strict input schemas", () => {
+  test("a typo'd dependency field is named, not silently dropped", async () => {
+    const runId = await runConfig(GROUPED);
+    await expect(
+      call("simulate", { runId, dep: { depname: "react", currentValue: "17.0.0" } }),
+    ).rejects.toThrow(/depname/);
+  });
+
+  test("a typo'd tool parameter is named too", async () => {
+    const runId = await runConfig(CONFIG);
+    await expect(call("get_preset_tree", { runId, dept: 3 })).rejects.toThrow(/dept/);
+  });
+
+  test("the advertised schemas forbid unknown keys", async () => {
+    const { tools } = await client.listTools();
+    for (const tool of tools) {
+      expect(tool.inputSchema.additionalProperties, tool.name).toBe(false);
+    }
   });
 });
 
@@ -250,8 +474,26 @@ describe("explain_message and get_option_docs", () => {
       runId,
       topic: "Configuration Error",
       message: "Configuration option `labels` should be a list (Array)",
-    })) as { docsUrl?: string; message: string };
+    })) as { docsUrl?: string; message: string; severity: string };
     expect(explained.docsUrl).toContain("docs.renovatebot.com");
+    expect(explained.severity).toBe("error");
+  });
+
+  test("a warning explained through the tool comes back a warning", async () => {
+    // A globalOnly option in a repo config is a warning, not an error.
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"dryRun":"full"}',
+    })) as { runId: string; warnings: { topic: string; message: string }[] };
+    const runId = summary.runId;
+    const warning = summary.warnings[0];
+    expect(warning).toBeDefined();
+    const explained = (await call("explain_message", {
+      runId,
+      topic: warning?.topic,
+      message: warning?.message,
+    })) as { severity: string };
+    expect(explained.severity).toBe("warning");
   });
 
   test("option docs are for the pinned Renovate, and misses point at search", async () => {

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -6,7 +6,7 @@ import { getPresetAuth, setPresetAuth } from "@renovate-config-debugger/engine";
 import pkg from "../../package.json";
 import { createMcpServer } from "./server";
 import { RESULT_BUDGET_BYTES } from "./result";
-import { RunStore } from "./run-store";
+import { DEFAULT_RUN_LIMIT, RunStore } from "./run-store";
 import { recordingIo } from "../test-harness";
 
 /**
@@ -46,15 +46,18 @@ interface ConnectOptions {
   env?: Record<string, string | undefined>;
   /** Omitted: the client's default, the 2025-era `initialize` handshake. */
   era?: "modern";
+  /** A store the test can read back — what the server HELD, not what it answered. */
+  store?: RunStore;
 }
 
 async function connect(options?: ConnectOptions): Promise<void> {
   const io = recordingIo(options?.env ? { env: options.env } : undefined);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   // One factory, both eras — the entry pins ONE instance per connection.
-  const handle: StdioServerHandle = serveStdio(() => createMcpServer(io), {
-    transport: serverTransport,
-  });
+  const handle: StdioServerHandle = serveStdio(
+    () => createMcpServer(io, options?.store ? { store: options.store } : undefined),
+    { transport: serverTransport },
+  );
   client = new Client(
     { name: "test", version: "0" },
     options?.era === "modern"
@@ -267,6 +270,51 @@ describe("credential isolation", () => {
     expect(getPresetAuth()).toEqual(before);
   });
 
+  /**
+   * M3 (roadmap 068). The guard used to inspect the GLOBAL CONFIG only — but
+   * `endpoint` is also a parameter of this tool, and over MCP the model fills
+   * it in, plausibly from text in the repository it was asked to inspect.
+   * `run_config({content: '{"extends":["local>me/presets"]}', endpoint:
+   * "https://ghe.attacker.example/api/v3/"})` sent RCD_GITHUB_TOKEN there with
+   * no opt-in at all. The CLI is unaffected: a person typed the flag.
+   */
+  test("an endpoint the CALLER chose withholds tokens until it is vouched for", async () => {
+    await close();
+    await connect({ env: { GITHUB_TOKEN: "gh-token" } });
+    const requests: { url: string; authorization: string | null }[] = [];
+    vi.stubGlobal("fetch", (input: unknown, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+      });
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    const args = {
+      fileName: "renovate.json",
+      content: '{"extends":["github>elsewhere/presets"]}',
+      endpoint: "https://ghe.attacker.example/api/v3/",
+    };
+
+    const guarded = (await call("run_config", args)) as { notes?: string[] };
+    expect(guarded.notes?.join(" ")).toContain("credentials withheld");
+    // `platformOverride` is NOT the opt-in here: it only decides whose
+    // endpoint wins, and both candidates are values this caller supplied.
+    const overridden = (await call("run_config", { ...args, platformOverride: true })) as {
+      notes?: string[];
+    };
+    expect(overridden.notes?.join(" ")).toContain("credentials withheld");
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.map((r) => r.authorization)).toEqual(requests.map(() => null));
+
+    requests.length = 0;
+    const vouched = (await call("run_config", { ...args, trustEndpoints: true })) as {
+      notes?: string[];
+    };
+    expect(vouched).not.toHaveProperty("notes");
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.every((r) => r.authorization === "Bearer gh-token")).toBe(true);
+  });
+
   test("a run never installs its credentials outside the engine's queue", async () => {
     await close();
     await connect({ env: { GITHUB_TOKEN: "gh-token" } });
@@ -301,6 +349,23 @@ describe("drill-down", () => {
     };
     expect(entry.winner).toBe("repo");
     expect(entry.chain.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Roadmap 068 (2 persona sessions + the review): provenance answers "which
+   * LAYER set this", and both personas read a static winner as "the value
+   * Renovate will use" for an update a packageRule actually overrides.
+   */
+  test("a key packageRules can also set says so, and points at the simulator", async () => {
+    const runId = await runConfig(GROUPED);
+    const grouped = (await call("get_provenance", { runId, key: "groupName" })) as {
+      note?: string;
+    };
+    expect(grouped.note).toContain("1 packageRule can set `groupName` per-dependency");
+    expect(grouped.note).toContain("Simulate a dependency");
+    // A key no rule touches carries no such caveat.
+    const labels = (await call("get_provenance", { runId, key: "labels" })) as { note?: string };
+    expect(labels.note).toBeUndefined();
   });
 
   test("the resolved document keeps internal presets by default", async () => {
@@ -422,6 +487,44 @@ describe("strict input schemas", () => {
       expect(tool.inputSchema.additionalProperties, tool.name).toBe(false);
     }
   });
+
+  /**
+   * Roadmap 068, from the persona study: two sessions burned actions on an
+   * "Invalid input, Invalid input" rejection that named no field. This pins
+   * what the SDK actually reports for the shapes those sessions produced —
+   * the zod issue PATH, joined and prefixed — so a schema change that loses
+   * the field name is a failing test rather than a lost session. The commonest
+   * mistake by far is the first one: `content` is the file's TEXT.
+   */
+  test("a rejected argument names the field, and its type", async () => {
+    const errorFor = async (name: string, args: Record<string, unknown>): Promise<string> => {
+      const result = (await client.callTool({ name, arguments: args })) as ToolText;
+      expect(result.isError, JSON.stringify(args)).toBe(true);
+      return result.content[0]?.text ?? "";
+    };
+    expect(
+      await errorFor("run_config", { content: { extends: ["config:recommended"] } }),
+    ).toContain("content: Invalid input: expected string, received object");
+    expect(await errorFor("run_config", { fileName: "renovate.json" })).toContain(
+      "content: Invalid input: expected string, received undefined",
+    );
+    expect(await errorFor("simulate", { runId: "run-1", dep: { depName: 5 } })).toContain(
+      "dep.depName: Invalid input: expected string, received number",
+    );
+    expect(await errorFor("simulate", { runId: "run-1", dep: {}, verdict: "sometimes" })).toContain(
+      'verdict: Invalid option: expected one of "notable"',
+    );
+  });
+
+  test("the content parameter says it wants the file's text", async () => {
+    const { tools } = await client.listTools();
+    const runConfigTool = tools.find((t) => t.name === "run_config");
+    const content = (
+      runConfigTool?.inputSchema.properties as { content?: { description?: string } } | undefined
+    )?.content;
+    expect(content?.description).toContain("JSON *string*");
+    expect(content?.description).toContain("not the parsed object");
+  });
 });
 
 describe("simulate and compare", () => {
@@ -442,6 +545,62 @@ describe("simulate and compare", () => {
     expect(sim.dep.updateType).toBe("major");
     expect(sim.rules[0]?.verdict).toBe("matched");
     expect(sim.rules[0]?.clauses[0]).toMatchObject({ key: "matchPackageNames" });
+  });
+
+  /**
+   * H1 (roadmap 068, 6 of 9 persona sessions). The whole `SimulationResult`
+   * for `config:recommended` + a react update is 1.36 MB, of which
+   * `mergeSteps` is 797 kB and `rawFinalConfig` 199 kB — and the elision spent
+   * the budget on them, answering with 2 of 713 rules and no merge trace
+   * anyway. The default answer is now the question that was asked.
+   */
+  test("the merge trace is opt-in, so the verdict is what comes back", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const dep = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
+    const text = await callText("simulate", { runId, dep });
+    const parsed = JSON.parse(text) as {
+      truncated?: boolean;
+      omittedKeys?: string[];
+      detailNote: string;
+      finalDependencyConfig: Record<string, unknown>;
+      flattened: unknown;
+      rules: { truncated: boolean; shown: number; omitted: number } | unknown[];
+    };
+    expect(parsed).not.toHaveProperty("mergeSteps");
+    expect(parsed).not.toHaveProperty("rawFinalConfig");
+    // The omission is stated, with the parameter that undoes it.
+    expect(parsed.detailNote).toContain('detail: "full"');
+    // The answer itself survives WHOLE — no key was dropped to make room.
+    expect(parsed.omittedKeys).toBeUndefined();
+    expect(parsed.flattened).toBeDefined();
+    expect(Object.keys(parsed.finalDependencyConfig).length).toBeGreaterThan(10);
+    // And the rule list is a real sample of 713, not a token two.
+    const rules = parsed.rules as { shown: number; omitted: number };
+    expect(rules.shown + rules.omitted).toBeGreaterThan(700);
+    expect(rules.shown).toBeGreaterThan(20);
+  });
+
+  /**
+   * And the other half of the argument for the default: `full` asks for the
+   * merge trace, and a merge step is a whole config snapshot — even this
+   * three-line config's is far over the budget, so the answer comes back with
+   * the trace elided or dropped BY NAME. That is the honest outcome of asking
+   * for it; it is not the shape to spend a call on by accident.
+   */
+  test('detail: "full" asks for the merge trace, and pays for it', async () => {
+    const runId = await runConfig(GROUPED);
+    const dep = { depName: "react", packageName: "react" };
+    const full = (await call("simulate", { runId, dep, detail: "full" })) as {
+      truncated?: boolean;
+      omittedKeys?: string[];
+      detailNote?: string;
+    };
+    expect(full.detailNote).toBeUndefined();
+    expect(full.truncated).toBe(true);
+    expect(full.omittedKeys).toContain("mergeSteps");
+    // The default answer for the same question never got that big.
+    const verdict = (await call("simulate", { runId, dep })) as { truncated?: boolean };
+    expect(verdict.truncated).toBeUndefined();
   });
 
   test("verdict/source scope the rule list and say what they hid", async () => {
@@ -472,9 +631,13 @@ describe("simulate and compare", () => {
       runId: before,
       runIdB: after,
       dep,
-    })) as { noChange: boolean; matchedOnlyInB: { label: string }[] };
+    })) as { noChange: boolean; summary: string; matchedOnlyInB: { label: string }[] };
     expect(comparison.noChange).toBe(false);
     expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
+    // Roadmap 068 (4 of 9 persona sessions): the net effect, before anyone has
+    // to assemble it out of six arrays.
+    expect(comparison.summary).toContain("differs: ");
+    expect(comparison.summary).toContain("groupName");
   });
 
   test("the same run twice changes nothing", async () => {
@@ -482,8 +645,11 @@ describe("simulate and compare", () => {
     const comparison = (await call("compare_simulations", {
       runId,
       dep: { depName: "react", packageName: "react" },
-    })) as { noChange: boolean };
+    })) as { noChange: boolean; summary: string };
     expect(comparison.noChange).toBe(true);
+    expect(comparison.summary).toBe(
+      "identical: the same rules matched and the same effective config results",
+    );
   });
 });
 
@@ -524,6 +690,60 @@ describe("explain_message and get_option_docs", () => {
     expect(doc.name).toBe("packageRules");
     expect(doc.renovateVersion).toMatch(/^\d+\./);
     await expect(call("get_option_docs", { name: "nopeNotAnOption" })).rejects.toThrow(/search/);
+  });
+});
+
+/**
+ * H2 (roadmap 068): a held `config:recommended` trace measured ~165 MB, 76 MB
+ * of it events and 75 MB of THAT the logger shim's raw `log` records — which
+ * nothing on this path reads. Four held runs were 713 MB of heap, in a process
+ * an MCP host keeps alive for the length of a working session.
+ */
+describe("held runs carry only what the tools read", () => {
+  test("a session holds three runs — the before/after oracle needs two", () => {
+    expect(DEFAULT_RUN_LIMIT).toBe(3);
+  });
+
+  test("the held trace has no log events, and every tool still answers", async () => {
+    const store = new RunStore();
+    await close();
+    await connect({ store });
+
+    const runId = await runConfig(CONFIG);
+    const held = store.get(runId);
+    expect(held.result.events.length).toBeGreaterThan(0);
+    expect(held.result.events.some((event) => event.kind === "log")).toBe(false);
+
+    // Every drill-down answers from the stripped trace: the derivations index
+    // stage/migration/preset events, and the tree, provenance and resolved
+    // projections read no events at all.
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: CONFIG,
+    })) as { digest: string; treeSummary: { resolved: number } };
+    expect(summary.digest).toContain("Renovate accepted this config");
+    expect(summary.treeSummary.resolved).toBe(1);
+    const tree = (await call("get_preset_tree", { runId })) as {
+      root: { children: unknown[] };
+    };
+    expect(tree.root.children).toHaveLength(1);
+    const provenance = (await call("get_provenance", { runId, key: "labels" })) as {
+      winner: string;
+    };
+    expect(provenance.winner).toBe("repo");
+    const resolved = (await call("get_resolved_config", { runId })) as {
+      config: { extends: string[] };
+    };
+    expect(resolved.config.extends).toEqual([":dependencyDashboard"]);
+    const explained = (await call("explain_message", {
+      runId,
+      message: "Configuration option `labels` should be a list (Array)",
+    })) as { severity: string };
+    expect(explained.severity).toBe("error");
+    const sim = (await call("simulate", { runId, dep: { depName: "react" } })) as {
+      rules: unknown[];
+    };
+    expect(Array.isArray(sim.rules)).toBe(true);
   });
 });
 

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -341,6 +341,32 @@ describe("drill-down", () => {
     expect(node.input.dependencyDashboard).toBe(true);
   });
 
+  test("a node's own children are one level, not zero — depth is relative to the query", async () => {
+    // Regression: get_preset_node used to pass viewOf an ABSOLUTE depth limit
+    // of 1, but config:recommended already sits at depth 1 (root is depth 0),
+    // so every real preset was cut before its children ever showed.
+    const runId = await runConfig(RECOMMENDED);
+    const node = (await call("get_preset_node", {
+      runId,
+      node: "config:recommended",
+    })) as {
+      node: {
+        children?: { name: string; children?: unknown; childrenOmitted?: number }[];
+        childrenOmitted?: number;
+      };
+    };
+    expect(node.node.childrenOmitted).toBeUndefined();
+    expect(node.node.children).toBeDefined();
+    const children = node.node.children ?? [];
+    expect(children.length).toBeGreaterThan(0);
+    expect(children.map((c) => c.name)).toContain(":dependencyDashboard");
+    // One level only: a grandchild-bearing child summarizes its own children
+    // as childrenOmitted rather than recursing into them.
+    const grandparent = children.find((c) => c.name === "group:monorepos");
+    expect(grandparent?.children).toBeUndefined();
+    expect(grandparent?.childrenOmitted).toBeGreaterThan(0);
+  });
+
   test("provenance answers who set a key", async () => {
     const runId = await runConfig(CONFIG);
     const entry = (await call("get_provenance", { runId, key: "labels" })) as {

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -17,7 +17,8 @@ import { recordingIo } from "../test-harness";
  * wiring `rcd mcp` does, including the choice between the 2026-07-28 protocol
  * and the legacy 2025-era handshake. The v2 client negotiates `legacy` unless
  * told otherwise, so every test below is a legacy-era run; "the tool surface"
- * adds one that pins 2026-07-28.
+ * adds one that pins 2026-07-28, and `test/bin.test.ts` proves the legacy era
+ * over a real pipe.
  *
  * Thin, like the CLI's own tests: the answers themselves come from the shared
  * projection modules the subcommands use, and the engine's golden↔shimmed

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -1,0 +1,454 @@
+import { McpServer } from "@modelcontextprotocol/server";
+import { z } from "zod";
+import {
+  compareSimulations,
+  computeResolvedConfig,
+  computeRuleProvenance,
+  type DependencyDescriptor,
+  deriveUpdateType,
+  getOptionIndex,
+  type PipelineInput,
+  type ResolvedConfigMode,
+  renovateVersion,
+  runPipeline,
+  simulatePackageRules,
+  type SimulationResult,
+  type TraceResult,
+} from "@renovate-config-debugger/engine";
+import { validatedConfigOf } from "@renovate-config-debugger/app/headless";
+import { errorMessage, type CliIo } from "../io";
+import { digestPayload } from "../projections/digest";
+import { describeMessage } from "../projections/messages";
+import { entryView, layerLabel, provenanceOf } from "../projections/provenance";
+import {
+  BODIES,
+  DEFAULT_TREE_DEPTH,
+  findNode,
+  parseBody,
+  searchNodes,
+  treeStatsOf,
+  viewOf,
+} from "../projections/tree";
+import { applyRunAuth } from "../run-input";
+import { type HeldRun, RunStore } from "./run-store";
+
+/**
+ * Roadmap 060: the same answers as the subcommands, over MCP.
+ *
+ * No new functionality — every tool below is a projection module the CLI
+ * already uses — so the justification is purely interaction economics: the
+ * module graph and the preset-fetch cache are paid once per session, and the
+ * drill-down tools query a HELD run instead of re-running the pipeline (and a
+ * fresh round of preset API calls) per question.
+ *
+ * The tool descriptions carry the domain hints an agent would otherwise learn
+ * the hard way — above all: preset-node bodies are large, query one node at a
+ * time.
+ *
+ * Nothing below is era-aware, deliberately: `../commands/mcp` hands this
+ * function to the SDK's stdio entry as a factory, and the entry pins one
+ * instance per connection to either the 2026-07-28 protocol or the legacy
+ * 2025-era handshake. These registrations serve both unchanged.
+ */
+
+const RUN_ID = z.string().describe("A runId returned by run_config.");
+
+function textResult(payload: unknown) {
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+function errorResult(err: unknown) {
+  return {
+    content: [{ type: "text" as const, text: errorMessage(err) }],
+    isError: true,
+  };
+}
+
+/** Every tool answers or explains itself; nothing throws across the wire. */
+function answer<Args extends unknown[]>(
+  // `unknown` covers a promise too — every result is awaited below.
+  fn: (...args: Args) => unknown,
+): (...args: Args) => Promise<ReturnType<typeof textResult>> {
+  return async (...args: Args) => {
+    try {
+      return textResult(await fn(...args));
+    } catch (err) {
+      return errorResult(err);
+    }
+  };
+}
+
+/** The dependency descriptor, with `updateType` derived the way a real lookup
+ *  would when the caller did not set it. */
+function toDependency(dep: Record<string, unknown>): DependencyDescriptor {
+  const descriptor = dep as DependencyDescriptor;
+  if (descriptor.updateType) {
+    return descriptor;
+  }
+  const derived = deriveUpdateType(
+    descriptor.currentValue,
+    descriptor.newValue,
+    descriptor.versioning,
+  );
+  return derived ? { ...descriptor, updateType: derived } : descriptor;
+}
+
+function simulateRun(run: HeldRun, dep: Record<string, unknown>): Promise<SimulationResult> {
+  const config = run.result.finalConfig;
+  if (!config) {
+    throw new Error(`${run.runId} produced no effective config — nothing to simulate`);
+  }
+  return simulatePackageRules({ config, dep: toDependency(dep) });
+}
+
+function runSummary(run: HeldRun, notes: string[]) {
+  const { result, facts } = run;
+  const payload = digestPayload(result, facts);
+  const stats = result.presetTree ? treeStatsOf(result).stats : null;
+  return {
+    runId: run.runId,
+    renovateVersion: result.renovateVersion,
+    accepted: payload.accepted,
+    digest: payload.digest,
+    stageStatus: result.stageStatus,
+    errors: result.errors,
+    warnings: result.warnings,
+    presetErrors: facts.presetErrors.map((event) => event.title),
+    treeSummary: stats?.summary ?? null,
+    ...(notes.length > 0 ? { notes } : {}),
+  };
+}
+
+const DEP_DESCRIPTION =
+  "The hypothetical update, as an object: depName, packageName, datasource, manager, depType, " +
+  "packageFile, currentValue, currentVersion, newValue, updateType, versioning, sourceUrl, " +
+  "registryUrls, categories, baseBranch, currentVersionTimestamp. Every field is optional; a " +
+  "matcher whose fields you left unset reports `no-input` rather than silently passing. " +
+  "updateType is derived from currentValue/newValue when you omit it.";
+
+export interface McpServerOptions {
+  /** Overrides the run store, for tests. */
+  store?: RunStore;
+}
+
+export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServer {
+  const store = options?.store ?? new RunStore();
+  const server = new McpServer({
+    name: "renovate-config-debugger",
+    version: renovateVersion,
+    title: "Renovate config debugger",
+  });
+
+  server.registerTool(
+    "run_config",
+    {
+      title: "Run a Renovate config",
+      description:
+        "Resolves a Renovate config exactly as the visualizer does — parse, migrate, massage, " +
+        "validate, resolve presets, merge — and HOLDS the trace. Returns a small summary plus a " +
+        "runId; every other tool takes that runId, so a whole debugging session describes ONE " +
+        "run instead of re-resolving (and re-fetching remote presets) per question. Start here.",
+      inputSchema: z.object({
+        fileName: z
+          .string()
+          .default("renovate.json")
+          .describe("Drives format detection — renovate.json, renovate.json5, .renovaterc, …"),
+        content: z.string().describe("The config file's contents."),
+        globalConfig: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Self-hosted global config layer (roadmap 008)."),
+        inheritedConfig: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("Inherited config layer."),
+        platform: z
+          .string()
+          .optional()
+          .describe("Platform context for `local>` presets. Defaults to github."),
+        endpoint: z.string().optional().describe("API endpoint for that platform."),
+        platformOverride: z
+          .boolean()
+          .optional()
+          .describe("Let platform/endpoint here win over the global config's own values."),
+        trustEndpoints: z
+          .boolean()
+          .optional()
+          .describe(
+            "Send host tokens even when the global config chooses the endpoint. Off by default: " +
+              "a config you did not write must not decide where your credentials go.",
+          ),
+      }),
+    },
+    answer(async (args) => {
+      const input: PipelineInput = {
+        fileName: args.fileName,
+        content: args.content,
+        ...(args.globalConfig ? { globalConfig: args.globalConfig } : {}),
+        ...(args.inheritedConfig ? { inheritedConfig: args.inheritedConfig } : {}),
+        ...(args.platform ? { platform: args.platform } : {}),
+        ...(args.endpoint ? { endpoint: args.endpoint } : {}),
+        ...(args.platformOverride ? { platformOverride: true } : {}),
+      };
+      const notes = applyRunAuth(io.env, input.globalConfig, {
+        trustEndpoints: args.trustEndpoints ?? false,
+        platformOverride: args.platformOverride ?? false,
+      });
+      const result: TraceResult = await runPipeline(input);
+      return runSummary(store.put(result, input), notes);
+    }),
+  );
+
+  server.registerTool(
+    "get_final_config",
+    {
+      title: "Effective config",
+      description:
+        "The effective config the run produced — everything merged, Renovate's defaults " +
+        "included. Large. If the question is 'who set this option', get_provenance answers it " +
+        "better; if it is 'what would I write instead of these presets', use get_resolved_config.",
+      inputSchema: z.object({ runId: RUN_ID }),
+    },
+    answer(({ runId }) => ({ finalConfig: store.get(runId).result.finalConfig })),
+  );
+
+  server.registerTool(
+    "get_preset_tree",
+    {
+      title: "Preset expansion",
+      description:
+        "What `extends` expanded into: structure plus per-node contribution stats, NO config " +
+        "bodies. A `config:recommended` expansion is over a thousand nodes, so this is depth-" +
+        `limited (default ${DEFAULT_TREE_DEPTH}); pass a query to search the whole tree by name ` +
+        "instead. Use get_preset_node for one node's body.",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        depth: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(`Levels to include (default ${DEFAULT_TREE_DEPTH}).`),
+        query: z
+          .string()
+          .optional()
+          .describe("Return a flat list of matching preset names instead of the tree."),
+      }),
+    },
+    answer(({ runId, depth, query }) => {
+      const { root, stats } = treeStatsOf(store.get(runId).result);
+      return query
+        ? { summary: stats.summary, matches: searchNodes(stats, query) }
+        : { summary: stats.summary, root: viewOf(root, stats, depth ?? DEFAULT_TREE_DEPTH) };
+    }),
+  );
+
+  server.registerTool(
+    "get_preset_node",
+    {
+      title: "One preset's contribution",
+      description:
+        "One node of the expansion, by preset name or by the structural identity get_preset_tree " +
+        "reports. PRESET-NODE BODIES ARE LARGE — query one node at a time, and only ask for a " +
+        `body when the stats are not enough. Bodies: ${BODIES.join(", ")} (fetched = as served, ` +
+        "input = migrated/massaged, resolved = with its own sub-presets merged in).",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        node: z.string().describe("Preset name, or a `a>b>c` structural identity."),
+        body: z.enum(BODIES).optional().describe("Omit for structure and stats only."),
+      }),
+    },
+    answer(({ runId, node, body }) => {
+      const { stats } = treeStatsOf(store.get(runId).result);
+      const found = findNode(stats, node);
+      const kind = parseBody(body);
+      return {
+        node: viewOf(found, stats, 1),
+        occurrences: stats.occurrencesByName.get(found.name)?.length ?? 1,
+        ...(kind ? { body: kind, [kind]: found[kind] } : {}),
+      };
+    }),
+  );
+
+  server.registerTool(
+    "get_provenance",
+    {
+      title: "Who set this option",
+      description:
+        "Per-key provenance: which layer (defaults / global / inherited / each preset / the repo " +
+        "config) set each option, and who overrode whom. Without a key: every option some layer " +
+        "beyond the defaults set, with the winning layer. With a key: the full override chain — " +
+        "and for `packageRules`, which layer contributed each merged rule. This is the tool for " +
+        "'why is this value what it is'.",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        key: z.string().optional().describe("A top-level config option, e.g. `labels`."),
+      }),
+    },
+    answer(({ runId, key }) => {
+      const { result } = store.get(runId);
+      const provenance = provenanceOf(result);
+      if (!key) {
+        return {
+          keys: [...provenance.values()].filter((e) => !e.isDefaultOnly).map(entryView),
+        };
+      }
+      const entry = provenance.get(key);
+      if (!entry) {
+        throw new Error(`no key "${key}" in the effective config`);
+      }
+      const rules =
+        key === "packageRules"
+          ? (computeRuleProvenance(result) ?? []).map((attr) => ({
+              index: attr.index,
+              layer: layerLabel(attr.layer),
+            }))
+          : [];
+      return { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) };
+    }),
+  );
+
+  server.registerTool(
+    "get_resolved_config",
+    {
+      title: "Config without external references",
+      description:
+        "The equivalent config with hosted presets inlined — what you would write instead of the " +
+        "`extends` entries. `keep-internal` (default) keeps Renovate's own `config:*` references; " +
+        "`full` expands everything. Defaults may only be included in a fully expanded document " +
+        "(in one that still extends presets they would merge after them and override them).",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        mode: z.enum(["keep-internal", "full"]).optional(),
+        includeDefaults: z.boolean().optional(),
+      }),
+    },
+    answer(({ runId, mode, includeDefaults }) => {
+      const resolvedMode: ResolvedConfigMode = mode ?? "keep-internal";
+      if (includeDefaults && resolvedMode !== "full") {
+        throw new Error('includeDefaults needs mode "full"');
+      }
+      const output = computeResolvedConfig(store.get(runId).result, resolvedMode, {
+        includeDefaults: includeDefaults ?? false,
+      });
+      if (!output) {
+        throw new Error("this document needs a completed preset resolution — validate the config");
+      }
+      return { mode: resolvedMode, ...output };
+    }),
+  );
+
+  server.registerTool(
+    "simulate",
+    {
+      title: "Would this update match the rules?",
+      description:
+        "Evaluates every packageRule of the run's effective config against one hypothetical " +
+        "dependency update: a verdict per rule with clause-level evidence (which matcher fired, " +
+        "what it read), and the options the matching rules set for that dependency.",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        dep: z.record(z.string(), z.unknown()).describe(DEP_DESCRIPTION),
+      }),
+    },
+    answer(async ({ runId, dep }) => {
+      const run = store.get(runId);
+      const sim = await simulateRun(run, dep);
+      return { dep: toDependency(dep), ...sim };
+    }),
+  );
+
+  server.registerTool(
+    "compare_simulations",
+    {
+      title: "Did my edit change anything?",
+      description:
+        "The edit oracle. Run the config before your edit and the config after it, then compare " +
+        "the two runs against the same dependency — you get the rules that started or stopped " +
+        "matching and the key-level delta of the resulting config, or an explicit 'no behavioral " +
+        "change'. Pass runIdB to compare two configs, or depB to compare two dependencies " +
+        "against the same config.",
+      inputSchema: z.object({
+        runId: RUN_ID,
+        dep: z.record(z.string(), z.unknown()).describe(DEP_DESCRIPTION),
+        runIdB: z.string().optional().describe("The B-side run. Defaults to runId."),
+        depB: z
+          .record(z.string(), z.unknown())
+          .optional()
+          .describe("The B-side dependency. Defaults to dep."),
+      }),
+    },
+    answer(async ({ runId, dep, runIdB, depB }) => {
+      const a = store.get(runId);
+      const b = runIdB ? store.get(runIdB) : a;
+      const [simA, simB] = await Promise.all([simulateRun(a, dep), simulateRun(b, depB ?? dep)]);
+      return {
+        a: { runId: a.runId, dep: toDependency(dep) },
+        b: { runId: b.runId, dep: toDependency(depB ?? dep) },
+        ...compareSimulations(simA, simB),
+      };
+    }),
+  );
+
+  server.registerTool(
+    "explain_message",
+    {
+      title: "Explain a validation message",
+      description:
+        "Translates one of Renovate's validator messages into what it actually means, with a " +
+        "docs link and — when the library knows one — a concrete fix. Pass the runId the message " +
+        "came from and the fix is computed against that exact config snapshot, including the " +
+        "edited file text.",
+      inputSchema: z.object({
+        message: z.string().describe("The message text, verbatim."),
+        topic: z.string().optional().describe("The message's topic, e.g. `Configuration Error`."),
+        runId: z.string().optional().describe("The run the message came from."),
+      }),
+    },
+    answer(({ message, topic, runId }) => {
+      const run = runId ? store.get(runId) : null;
+      return describeMessage(
+        { topic: topic ?? "Configuration Error", message },
+        "error",
+        run ? validatedConfigOf(run.result) : null,
+        run?.input.content ?? null,
+      );
+    }),
+  );
+
+  server.registerTool(
+    "get_option_docs",
+    {
+      title: "What does this option mean?",
+      description:
+        `Renovate's own metadata for an option, for the exact pinned version (${renovateVersion}) ` +
+        "— type, default, allowed values, where it may appear, deprecation. Use this instead of " +
+        "recalling option semantics: they change between Renovate releases.",
+      inputSchema: z.object({
+        name: z.string().describe("An option name, or a substring with search: true."),
+        search: z.boolean().optional().describe("List every option whose name contains `name`."),
+      }),
+    },
+    answer(({ name, search }) => {
+      const index = getOptionIndex();
+      if (search) {
+        const needle = name.toLowerCase();
+        return {
+          renovateVersion,
+          matches: [...index.options.values()]
+            .filter((doc) => doc.name.toLowerCase().includes(needle))
+            .map((doc) => ({ name: doc.name, type: doc.type, description: doc.description })),
+        };
+      }
+      const doc = index.options.get(name);
+      if (!doc) {
+        throw new Error(
+          `Renovate ${renovateVersion} has no option "${name}" — retry with search: true`,
+        );
+      }
+      return { renovateVersion, ...doc, isContainer: index.containers.has(doc.name) };
+    }),
+  );
+
+  return server;
+}

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -27,7 +27,13 @@ import { errorMessage, type CliIo } from "../io";
 import { buildRuleView, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
 import { describeMessage } from "../projections/messages";
-import { entryView, indexView, layerLabel, provenanceOf } from "../projections/provenance";
+import {
+  entryView,
+  indexView,
+  layerLabel,
+  perDependencyNote,
+  provenanceOf,
+} from "../projections/provenance";
 import {
   BODIES,
   type BodyKind,
@@ -47,9 +53,11 @@ import { type HeldRun, RunStore } from "./run-store";
  *
  * No new functionality — every tool below is a projection module the CLI
  * already uses — so the justification is purely interaction economics: the
- * module graph and the preset-fetch cache are paid once per session, and the
- * drill-down tools query a HELD run instead of re-running the pipeline (and a
- * fresh round of preset API calls) per question.
+ * engine boots once, and `run_config` HOLDS the trace so the drill-down tools
+ * query one consistent run instead of re-resolving (and re-fetching remote
+ * presets) per question. Only the module graph is amortized across runs;
+ * renovate's own preset cache is memCache, which the pipeline initializes and
+ * resets per run, so a SECOND `run_config` refetches everything.
  *
  * The tool descriptions carry the domain hints an agent would otherwise learn
  * the hard way — above all: preset-node bodies are large, query one node at a
@@ -125,18 +133,50 @@ function errorResult(err: unknown) {
 }
 
 /**
+ * The slice of the SDK's handler context this file reads. Narrow on purpose:
+ * a structural subset keeps the handlers assignable on both protocol eras.
+ */
+export interface ToolContext {
+  mcpReq: { signal: AbortSignal };
+}
+
+class CancelledError extends Error {
+  constructor() {
+    super("the client cancelled this request");
+  }
+}
+
+/**
+ * The client sent `notifications/cancelled`; the SDK aborted the signal and
+ * will drop whatever we answer.
+ *
+ * Checked twice — on entry, and again immediately before an engine call — for
+ * a reason the abort alone does not cover: engine work is SERIALIZED through
+ * one queue, so a cancelled call that still enqueues does not merely waste
+ * its own time, it holds up every question asked after it. Renovate's config
+ * modules are synchronous and stateful, so a run already inside them cannot be
+ * interrupted; not starting one is the whole of what is achievable.
+ */
+function throwIfCancelled(ctx: ToolContext | undefined): void {
+  if (ctx?.mcpReq.signal.aborted) {
+    throw new CancelledError();
+  }
+}
+
+/**
  * Every tool answers or explains itself; nothing throws across the wire.
  * `hint` names the narrowing to apply when this tool's answer is too large to
  * return whole (see `./result`).
  */
-function answer<Args extends unknown[]>(
+function answer<Args>(
   // `unknown` covers a promise too — every result is awaited below.
-  fn: (...args: Args) => unknown,
+  fn: (args: Args, ctx: ToolContext) => unknown,
   hint?: string,
-): (...args: Args) => Promise<ReturnType<typeof textResult>> {
-  return async (...args: Args) => {
+): (args: Args, ctx: ToolContext) => Promise<ReturnType<typeof textResult>> {
+  return async (args: Args, ctx: ToolContext) => {
     try {
-      return textResult(await fn(...args), hint);
+      throwIfCancelled(ctx);
+      return textResult(await fn(args, ctx), hint);
     } catch (err) {
       return errorResult(err);
     }
@@ -247,8 +287,52 @@ function finalConfigOf(run: HeldRun): Record<string, unknown> {
   return config;
 }
 
-function simulateRun(run: HeldRun, dep: DepInput): Promise<SimulationResult> {
-  return simulatePackageRules({ config: finalConfigOf(run), dep: toDependency(dep) });
+function simulateRun(run: HeldRun, dep: DepInput, ctx: ToolContext): Promise<SimulationResult> {
+  const input = { config: finalConfigOf(run), dep: toDependency(dep) };
+  throwIfCancelled(ctx);
+  return simulatePackageRules(input, ctx.mcpReq.signal);
+}
+
+/**
+ * H1 (roadmap 068, 6 of 9 persona sessions): what a simulate answer carries by
+ * default.
+ *
+ * Measured on `config:recommended` + a react update, the whole
+ * `SimulationResult` is 1.36 MB — of which `mergeSteps` is 797 kB (two
+ * elements, each a full config snapshot) and `rawFinalConfig` 199 kB. Those
+ * two answer "how did the merge proceed", a question nobody asked, and they
+ * drowned the one that was: the elision spent its budget on them and returned
+ * 2 of 713 rules, with the merge trace dropped whole anyway. Personas at every
+ * level asked for the same shape by hand — the matched rules, `flattened` and
+ * `finalDependencyConfig`.
+ *
+ * So the merge trace is opt-in. `full` is the old payload, unchanged, for the
+ * caller who is actually stepping through the merge.
+ */
+const SIMULATE_DETAIL = ["verdict", "full"] as const;
+type SimulateDetail = (typeof SIMULATE_DETAIL)[number];
+
+const VERDICT_DETAIL_NOTE =
+  "`mergeSteps` and `rawFinalConfig` are omitted at this detail level — on a `config:recommended` " +
+  'run they are ~1 MB of the payload and describe how the merge proceeded. Pass detail: "full" ' +
+  "for them.";
+
+/** The simulation, at the requested detail. Listed key by key rather than
+ *  subtracted from the result, so the default shape is legible here and a
+ *  future field has to be admitted on purpose. */
+function simulationPayload(sim: SimulationResult, detail: SimulateDetail) {
+  if (detail === "full") {
+    return sim;
+  }
+  return {
+    rules: sim.rules,
+    flattened: sim.flattened,
+    finalDependencyConfig: sim.finalDependencyConfig,
+    errors: sim.errors,
+    warnings: sim.warnings,
+    notes: sim.notes,
+    detailNote: VERDICT_DETAIL_NOTE,
+  };
 }
 
 function runSummary(run: HeldRun, notes: string[]) {
@@ -346,7 +430,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .string()
           .default("renovate.json")
           .describe("Drives format detection — renovate.json, renovate.json5, .renovaterc, …"),
-        content: z.string().describe("The config file's contents."),
+        content: z
+          .string()
+          .describe(
+            "The config file's contents, as a JSON *string* — the file's text, not the parsed " +
+              "object. Pass it exactly as written, comments and all; parsing it is this tool's job.",
+          ),
         globalConfig: z
           .record(z.string(), z.unknown())
           .optional()
@@ -359,7 +448,14 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .string()
           .optional()
           .describe("Platform context for `local>` presets. Defaults to github."),
-        endpoint: z.string().optional().describe("API endpoint for that platform."),
+        endpoint: z
+          .string()
+          .optional()
+          .describe(
+            "API endpoint for that platform. Setting it WITHHOLDS this server's host tokens " +
+              "unless you also set trustEndpoints — you are choosing where credentials would be " +
+              "sent, and the config under inspection is allowed to suggest an endpoint.",
+          ),
         platformOverride: z
           .boolean()
           .optional()
@@ -368,18 +464,23 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .boolean()
           .optional()
           .describe(
-            "Send host tokens even when the global config chooses the endpoint. Off by default: " +
-              "a config you did not write must not decide where your credentials go.",
+            "Send host tokens even when the global config — or this call's own `endpoint` — " +
+              "chooses where preset requests go. Off by default: neither a config you did not " +
+              "write nor a value you read out of one may decide where your credentials go.",
           ),
       }),
     },
-    answer(async (args) => {
+    answer(async (args, ctx) => {
       const { auth, notes } = resolveRunAuth(
         io.env,
         args.globalConfig,
         {
           trustEndpoints: args.trustEndpoints ?? false,
           platformOverride: args.platformOverride ?? false,
+          // The endpoint arrived as a tool PARAMETER: over MCP that is the
+          // model's choice, not the user's, and the model may have read it out
+          // of the config it is inspecting. Same guard, one layer earlier.
+          ...(args.endpoint ? { callerEndpoint: args.endpoint } : {}),
         },
         "mcp",
       );
@@ -397,7 +498,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         ...(args.endpoint ? { endpoint: args.endpoint } : {}),
         ...(args.platformOverride ? { platformOverride: true } : {}),
       };
-      const result: TraceResult = await runPipeline(input);
+      throwIfCancelled(ctx);
+      const result: TraceResult = await runPipeline(input, ctx.mcpReq.signal);
       return runSummary(store.put(result, input), notes);
     }),
   );
@@ -521,7 +623,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
               layer: layerLabel(attr.layer),
             }))
           : [];
-      return { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) };
+      const perDependency = perDependencyNote(key, result.finalConfig);
+      return {
+        ...entryView(entry),
+        ...(perDependency ? { note: perDependency } : {}),
+        ...(rules.length > 0 ? { rules } : {}),
+      };
     }, HINTS.provenance),
   );
 
@@ -563,31 +670,44 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       description:
         "Evaluates every packageRule of the run's effective config against one hypothetical " +
         "dependency update: a verdict per rule with clause-level evidence (which matcher fired, " +
-        "what it read), and the options the matching rules set for that dependency. " +
+        "what it read), the options the matching rules set for that dependency " +
+        "(`finalDependencyConfig`) and how they got there (`flattened`). " +
         "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
-        '(`source: "repo"` is "just my own config\'s rules").',
+        '(`source: "repo"` is "just my own config\'s rules"). The step-by-step merge trace is ' +
+        'NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
         dep: DEP,
         verdict: RULE_VERDICT,
         source: RULE_SOURCE,
+        detail: z
+          .enum(SIMULATE_DETAIL)
+          .optional()
+          .describe(
+            '`verdict` (the default) answers "what matched and what does this dependency end up ' +
+              'with"; `full` adds `mergeSteps` and `rawFinalConfig` — ~1 MB on a ' +
+              "`config:recommended` run, so ask for it only when you are stepping through the " +
+              "merge itself.",
+          ),
       }),
     },
-    answer(async ({ runId, dep, verdict, source }) => {
+    answer(async ({ runId, dep, verdict, source, detail }, ctx) => {
       const run = store.get(runId);
-      const sim = await simulateRun(run, dep);
+      const sim = await simulateRun(run, dep, ctx);
+      const payload = simulationPayload(sim, detail ?? "verdict");
       if (verdict === undefined && source === undefined) {
-        return { dep: toDependency(dep), ...sim };
+        return { dep: toDependency(dep), ...payload };
       }
       const view = buildRuleView(sim, run.result, {
         verdict: verdict ?? "all",
         source: source ?? "all",
         explicit: true,
+        transport: "mcp",
       });
       return {
         dep: toDependency(dep),
-        ...sim,
+        ...payload,
         rules: view.rules,
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
         ...ruleFilterPayload(view),
@@ -601,10 +721,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Did my edit change anything?",
       description:
         "The edit oracle. Run the config before your edit and the config after it, then compare " +
-        "the two runs against the same dependency — you get the rules that started or stopped " +
-        "matching and the key-level delta of the resulting config, or an explicit 'no behavioral " +
-        "change'. Pass runIdB to compare two configs, or depB to compare two dependencies " +
-        "against the same config.",
+        "the two runs against the same dependency — `summary` is the whole verdict in one line " +
+        "(`identical: …` / `differs: …`), with the rules that started or stopped matching and " +
+        "the key-level delta of the resulting config underneath it. Pass runIdB to compare two " +
+        "configs, or depB to compare two dependencies against the same config.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
@@ -613,10 +733,13 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         depB: DEP.optional().describe("The B-side dependency. Defaults to dep."),
       }),
     },
-    answer(async ({ runId, dep, runIdB, depB }) => {
+    answer(async ({ runId, dep, runIdB, depB }, ctx) => {
       const a = store.get(runId);
       const b = runIdB ? store.get(runIdB) : a;
-      const [simA, simB] = await Promise.all([simulateRun(a, dep), simulateRun(b, depB ?? dep)]);
+      const [simA, simB] = await Promise.all([
+        simulateRun(a, dep, ctx),
+        simulateRun(b, depB ?? dep, ctx),
+      ]);
       return {
         a: { runId: a.runId, dep: toDependency(dep) },
         b: { runId: b.runId, dep: toDependency(depB ?? dep) },
@@ -690,7 +813,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         );
       }
       return { renovateVersion, ...doc, isContainer: index.containers.has(doc.name) };
-    }, "too many options matched — search for a longer substring."),
+    }, HINTS.optionDocs),
   );
 
   return server;

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -8,20 +8,24 @@ import {
   deriveUpdateType,
   getOptionIndex,
   type PipelineInput,
+  type PresetNode,
   type ResolvedConfigMode,
   renovateVersion,
   runPipeline,
   simulatePackageRules,
   type SimulationResult,
   type TraceResult,
+  type ValidationMessage,
 } from "@renovate-config-debugger/engine";
 import { validatedConfigOf } from "@renovate-config-debugger/app/headless";
+import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
 import { digestPayload } from "../projections/digest";
 import { describeMessage } from "../projections/messages";
-import { entryView, layerLabel, provenanceOf } from "../projections/provenance";
+import { entryView, indexView, layerLabel, provenanceOf } from "../projections/provenance";
 import {
   BODIES,
+  type BodyKind,
   DEFAULT_TREE_DEPTH,
   findNode,
   parseBody,
@@ -29,7 +33,8 @@ import {
   treeStatsOf,
   viewOf,
 } from "../projections/tree";
-import { applyRunAuth } from "../run-input";
+import { resolveRunAuth } from "../run-input";
+import { textResult } from "./result";
 import { type HeldRun, RunStore } from "./run-store";
 
 /**
@@ -49,13 +54,42 @@ import { type HeldRun, RunStore } from "./run-store";
  * function to the SDK's stdio entry as a factory, and the entry pins one
  * instance per connection to either the 2026-07-28 protocol or the legacy
  * 2025-era handshake. These registrations serve both unchanged.
+ *
+ * Three protocol details this file takes seriously:
+ *
+ * - Handlers run CONCURRENTLY. Nothing here mutates shared state except the
+ *   run store; the credentials a run may use travel ON the pipeline input
+ *   (`presetAuth`), because installing them in the engine's module state from
+ *   here would let one run's tokens ride along on another run's fetches.
+ * - Input schemas are STRICT. A silently stripped typo gives the agent no
+ *   signal; a validation error naming the unknown key lets it self-correct.
+ * - Annotations are hints a client trusts by default only in their
+ *   worst-case reading, so every tool declares them: read-only,
+ *   non-destructive, and open-world only where a run can fetch a remote
+ *   preset.
  */
+
+/** Same args + same held run = same answer. */
+const HELD_RUN_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+} as const;
 
 const RUN_ID = z.string().describe("A runId returned by run_config.");
 
-function textResult(payload: unknown) {
-  return { content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }] };
-}
+const INSTRUCTIONS =
+  "Debug one Renovate config at a time. Call run_config FIRST: it resolves the config the way " +
+  "Renovate would and returns a runId plus a small summary — `accepted` is the validation " +
+  "verdict, `errors`/`warnings` are Renovate's own messages, `digest` is the orientation " +
+  "paragraph. Every other tool takes that runId and queries the HELD run, so the whole session " +
+  "describes one resolution instead of re-resolving per question. Then drill down ONE question " +
+  "at a time: get_provenance with a key for 'who set this value', get_preset_tree and " +
+  "get_preset_node for what `extends` expanded into (preset bodies are large — one node per " +
+  "call), get_option_docs instead of recalling option semantics, which change between Renovate " +
+  "releases. Before you propose an edit, prove it: run_config the edited text and " +
+  "compare_simulations the two runs against the same dependency. Everything here is read-only.";
 
 function errorResult(err: unknown) {
   return {
@@ -64,24 +98,84 @@ function errorResult(err: unknown) {
   };
 }
 
-/** Every tool answers or explains itself; nothing throws across the wire. */
+/**
+ * Every tool answers or explains itself; nothing throws across the wire.
+ * `hint` names the narrowing to apply when this tool's answer is too large to
+ * return whole (see `./result`).
+ */
 function answer<Args extends unknown[]>(
   // `unknown` covers a promise too — every result is awaited below.
   fn: (...args: Args) => unknown,
+  hint?: string,
 ): (...args: Args) => Promise<ReturnType<typeof textResult>> {
   return async (...args: Args) => {
     try {
-      return textResult(await fn(...args));
+      return textResult(await fn(...args), hint);
     } catch (err) {
       return errorResult(err);
     }
   };
 }
 
+/**
+ * The dependency, as strict as the simulator's own descriptor: a typo'd field
+ * is a validation error naming the key, not a matcher that quietly reports
+ * `no-input` because nothing it reads was ever set.
+ */
+const DEP = z
+  .strictObject({
+    depName: z.string().optional(),
+    packageName: z.string().optional(),
+    datasource: z.string().optional(),
+    manager: z.string().optional(),
+    depType: z.string().optional(),
+    packageFile: z.string().optional(),
+    currentValue: z.string().optional(),
+    currentVersion: z.string().optional(),
+    lockedVersion: z.string().optional(),
+    newValue: z.string().optional(),
+    updateType: z
+      .enum([
+        "major",
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+        "pinDigest",
+        "lockFileMaintenance",
+        "lockfileUpdate",
+        "rollback",
+        "bump",
+        "replacement",
+      ])
+      .optional(),
+    isBump: z.boolean().optional(),
+    versioning: z.string().optional(),
+    sourceUrl: z.string().optional(),
+    registryUrls: z.array(z.string()).optional(),
+    categories: z.array(z.string()).optional(),
+    lockFiles: z.array(z.string()).optional(),
+    repository: z.string().optional(),
+    baseBranch: z.string().optional(),
+    currentVersionTimestamp: z.string().optional(),
+    mergeConfidenceLevel: z.string().optional(),
+  })
+  .describe(
+    "The hypothetical update. Every field is optional; a matcher whose fields you left unset " +
+      "reports `no-input` rather than silently passing. updateType is derived from " +
+      "currentValue/newValue when you omit it. Unknown fields are rejected — the field names are " +
+      "Renovate's own (depName, packageName, datasource, manager, depType, packageFile, " +
+      "currentValue, currentVersion, newValue, updateType, versioning, sourceUrl, registryUrls, " +
+      "categories, baseBranch, currentVersionTimestamp, and lockedVersion/lockFiles/isBump/" +
+      "repository/mergeConfidenceLevel for the matchers that read them).",
+  );
+
+type DepInput = z.infer<typeof DEP>;
+
 /** The dependency descriptor, with `updateType` derived the way a real lookup
  *  would when the caller did not set it. */
-function toDependency(dep: Record<string, unknown>): DependencyDescriptor {
-  const descriptor = dep as DependencyDescriptor;
+function toDependency(dep: DepInput): DependencyDescriptor {
+  const descriptor: DependencyDescriptor = dep;
   if (descriptor.updateType) {
     return descriptor;
   }
@@ -93,12 +187,21 @@ function toDependency(dep: Record<string, unknown>): DependencyDescriptor {
   return derived ? { ...descriptor, updateType: derived } : descriptor;
 }
 
-function simulateRun(run: HeldRun, dep: Record<string, unknown>): Promise<SimulationResult> {
+/** The run's effective config, or the reason there is none — an empty object
+ *  would read as "Renovate set nothing", which is never what happened. */
+function finalConfigOf(run: HeldRun): Record<string, unknown> {
   const config = run.result.finalConfig;
   if (!config) {
-    throw new Error(`${run.runId} produced no effective config — nothing to simulate`);
+    throw new Error(
+      `${run.runId} produced no effective config — the run stopped before the merge stage. ` +
+        "Check `accepted`, `errors` and `stageStatus` from run_config.",
+    );
   }
-  return simulatePackageRules({ config, dep: toDependency(dep) });
+  return config;
+}
+
+function simulateRun(run: HeldRun, dep: DepInput): Promise<SimulationResult> {
+  return simulatePackageRules({ config: finalConfigOf(run), dep: toDependency(dep) });
 }
 
 function runSummary(run: HeldRun, notes: string[]) {
@@ -119,12 +222,40 @@ function runSummary(run: HeldRun, notes: string[]) {
   };
 }
 
-const DEP_DESCRIPTION =
-  "The hypothetical update, as an object: depName, packageName, datasource, manager, depType, " +
-  "packageFile, currentValue, currentVersion, newValue, updateType, versioning, sourceUrl, " +
-  "registryUrls, categories, baseBranch, currentVersionTimestamp. Every field is optional; a " +
-  "matcher whose fields you left unset reports `no-input` rather than silently passing. " +
-  "updateType is derived from currentValue/newValue when you omit it.";
+const sameMessage = (candidate: ValidationMessage, message: string, topic?: string): boolean =>
+  candidate.message === message && (topic === undefined || candidate.topic === topic);
+
+/**
+ * Which list the message came from. A warning explained as an error is a
+ * misreport an agent then acts on, so the run — when one is given — decides.
+ */
+function severityOf(
+  run: HeldRun | null,
+  message: string,
+  topic: string | undefined,
+): "error" | "warning" {
+  if (run?.result.warnings.some((w) => sameMessage(w, message, topic))) {
+    return "warning";
+  }
+  return "error";
+}
+
+/** The body a node holds, or an explicit null saying it holds none — a key
+ *  that just vanishes from the JSON is indistinguishable from a bug. */
+function bodyOf(node: PresetNode, kind: BodyKind) {
+  const body = node[kind];
+  if (body === undefined) {
+    return {
+      body: kind,
+      [kind]: null,
+      note:
+        `this node has no \`${kind}\` body (state: ${node.state}) — it was never reached in that ` +
+        `form. The bodies a run records are ${BODIES.join(", ")}; a node that failed to fetch, ` +
+        "or a duplicate that was not re-resolved, holds fewer of them.",
+    };
+  }
+  return { body: kind, [kind]: body };
+}
 
 export interface McpServerOptions {
   /** Overrides the run store, for tests. */
@@ -133,11 +264,16 @@ export interface McpServerOptions {
 
 export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServer {
   const store = options?.store ?? new RunStore();
-  const server = new McpServer({
-    name: "renovate-config-debugger",
-    version: renovateVersion,
-    title: "Renovate config debugger",
-  });
+  const server = new McpServer(
+    {
+      name: "renovate-config-debugger",
+      // The SERVER's version — the Renovate it speaks for is in the title and
+      // in every answer that quotes a version.
+      version: pkg.version,
+      title: `Renovate Config Debugger (Renovate ${renovateVersion})`,
+    },
+    { instructions: INSTRUCTIONS },
+  );
 
   server.registerTool(
     "run_config",
@@ -148,7 +284,17 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "validate, resolve presets, merge — and HOLDS the trace. Returns a small summary plus a " +
         "runId; every other tool takes that runId, so a whole debugging session describes ONE " +
         "run instead of re-resolving (and re-fetching remote presets) per question. Start here.",
-      inputSchema: z.object({
+      // The one tool that reaches the network: `extends` can name a preset on
+      // GitHub, GitLab, Gitea or Forgejo. Not idempotent for the same reason —
+      // a remote preset can change between two runs, which is exactly why the
+      // other tools query a held run.
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+      inputSchema: z.strictObject({
         fileName: z
           .string()
           .default("renovate.json")
@@ -181,19 +327,29 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       }),
     },
     answer(async (args) => {
+      const { auth, notes } = resolveRunAuth(
+        io.env,
+        args.globalConfig,
+        {
+          trustEndpoints: args.trustEndpoints ?? false,
+          platformOverride: args.platformOverride ?? false,
+        },
+        "mcp",
+      );
       const input: PipelineInput = {
         fileName: args.fileName,
         content: args.content,
+        // Per-run credentials, installed by the pipeline inside its own
+        // serialized queue: handlers run concurrently here, so module-level
+        // auth would let a trusting run's tokens leak into a run whose
+        // untrusted global config picked the endpoint.
+        presetAuth: auth,
         ...(args.globalConfig ? { globalConfig: args.globalConfig } : {}),
         ...(args.inheritedConfig ? { inheritedConfig: args.inheritedConfig } : {}),
         ...(args.platform ? { platform: args.platform } : {}),
         ...(args.endpoint ? { endpoint: args.endpoint } : {}),
         ...(args.platformOverride ? { platformOverride: true } : {}),
       };
-      const notes = applyRunAuth(io.env, input.globalConfig, {
-        trustEndpoints: args.trustEndpoints ?? false,
-        platformOverride: args.platformOverride ?? false,
-      });
       const result: TraceResult = await runPipeline(input);
       return runSummary(store.put(result, input), notes);
     }),
@@ -207,9 +363,14 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "The effective config the run produced — everything merged, Renovate's defaults " +
         "included. Large. If the question is 'who set this option', get_provenance answers it " +
         "better; if it is 'what would I write instead of these presets', use get_resolved_config.",
-      inputSchema: z.object({ runId: RUN_ID }),
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({ runId: RUN_ID }),
     },
-    answer(({ runId }) => ({ finalConfig: store.get(runId).result.finalConfig })),
+    answer(
+      ({ runId }) => ({ finalConfig: finalConfigOf(store.get(runId)) }),
+      "the effective config is too large to return whole — ask get_provenance for one `key`, " +
+        "or get_resolved_config for the document without the defaults.",
+    ),
   );
 
   server.registerTool(
@@ -221,14 +382,20 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "bodies. A `config:recommended` expansion is over a thousand nodes, so this is depth-" +
         `limited (default ${DEFAULT_TREE_DEPTH}); pass a query to search the whole tree by name ` +
         "instead. Use get_preset_node for one node's body.",
-      inputSchema: z.object({
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         runId: RUN_ID,
         depth: z
           .number()
           .int()
           .min(0)
+          .max(6)
           .optional()
-          .describe(`Levels to include (default ${DEFAULT_TREE_DEPTH}).`),
+          .describe(
+            `Levels to include (default ${DEFAULT_TREE_DEPTH}, max 6). The cap is a size one: ` +
+              "a fully expanded `config:recommended` tree is hundreds of kilobytes of JSON. " +
+              "To reach deeper, query one node with get_preset_node or search with `query`.",
+          ),
         query: z
           .string()
           .optional()
@@ -240,7 +407,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       return query
         ? { summary: stats.summary, matches: searchNodes(stats, query) }
         : { summary: stats.summary, root: viewOf(root, stats, depth ?? DEFAULT_TREE_DEPTH) };
-    }),
+    }, "the tree is too large at this depth — lower `depth`, pass a `query`, or query one node " + "with get_preset_node."),
   );
 
   server.registerTool(
@@ -252,7 +419,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "reports. PRESET-NODE BODIES ARE LARGE — query one node at a time, and only ask for a " +
         `body when the stats are not enough. Bodies: ${BODIES.join(", ")} (fetched = as served, ` +
         "input = migrated/massaged, resolved = with its own sub-presets merged in).",
-      inputSchema: z.object({
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         runId: RUN_ID,
         node: z.string().describe("Preset name, or a `a>b>c` structural identity."),
         body: z.enum(BODIES).optional().describe("Omit for structure and stats only."),
@@ -265,9 +433,9 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       return {
         node: viewOf(found, stats, 1),
         occurrences: stats.occurrencesByName.get(found.name)?.length ?? 1,
-        ...(kind ? { body: kind, [kind]: found[kind] } : {}),
+        ...(kind ? bodyOf(found, kind) : {}),
       };
-    }),
+    }, "this node's body is too large to return whole — ask for a deeper child instead, or omit " + "`body` and read the contribution stats."),
   );
 
   server.registerTool(
@@ -276,13 +444,18 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Who set this option",
       description:
         "Per-key provenance: which layer (defaults / global / inherited / each preset / the repo " +
-        "config) set each option, and who overrode whom. Without a key: every option some layer " +
-        "beyond the defaults set, with the winning layer. With a key: the full override chain — " +
-        "and for `packageRules`, which layer contributed each merged rule. This is the tool for " +
-        "'why is this value what it is'.",
-      inputSchema: z.object({
+        "config) set each option, and who overrode whom. Without a key: a compact INDEX — every " +
+        "option some layer beyond the defaults set, with its winning layer and a short value " +
+        "preview. With a key: the full override chain, every layer's before/after — and for " +
+        "`packageRules`, which layer contributed each merged rule. This is the tool for 'why is " +
+        "this value what it is': read the index, then ask for the one key.",
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         runId: RUN_ID,
-        key: z.string().optional().describe("A top-level config option, e.g. `labels`."),
+        key: z
+          .string()
+          .optional()
+          .describe("A top-level config option, e.g. `labels`. Omit for the index."),
       }),
     },
     answer(({ runId, key }) => {
@@ -290,7 +463,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const provenance = provenanceOf(result);
       if (!key) {
         return {
-          keys: [...provenance.values()].filter((e) => !e.isDefaultOnly).map(entryView),
+          note: "index only — pass `key` for that option's full override chain.",
+          keys: [...provenance.values()].filter((e) => !e.isDefaultOnly).map(indexView),
         };
       }
       const entry = provenance.get(key);
@@ -305,7 +479,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
             }))
           : [];
       return { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) };
-    }),
+    }, "this key's override chain is too large to return whole — the layers that contributed are " + "listed; ask get_preset_node for the body of the one you care about."),
   );
 
   server.registerTool(
@@ -317,7 +491,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "`extends` entries. `keep-internal` (default) keeps Renovate's own `config:*` references; " +
         "`full` expands everything. Defaults may only be included in a fully expanded document " +
         "(in one that still extends presets they would merge after them and override them).",
-      inputSchema: z.object({
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         runId: RUN_ID,
         mode: z.enum(["keep-internal", "full"]).optional(),
         includeDefaults: z.boolean().optional(),
@@ -335,7 +510,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         throw new Error("this document needs a completed preset resolution — validate the config");
       }
       return { mode: resolvedMode, ...output };
-    }),
+    }, 'the resolved document is too large to return whole — try mode "keep-internal" without ' + "includeDefaults, or read one preset's contribution with get_preset_node."),
   );
 
   server.registerTool(
@@ -346,16 +521,14 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "Evaluates every packageRule of the run's effective config against one hypothetical " +
         "dependency update: a verdict per rule with clause-level evidence (which matcher fired, " +
         "what it read), and the options the matching rules set for that dependency.",
-      inputSchema: z.object({
-        runId: RUN_ID,
-        dep: z.record(z.string(), z.unknown()).describe(DEP_DESCRIPTION),
-      }),
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({ runId: RUN_ID, dep: DEP }),
     },
     answer(async ({ runId, dep }) => {
       const run = store.get(runId);
       const sim = await simulateRun(run, dep);
       return { dep: toDependency(dep), ...sim };
-    }),
+    }, "this config has too many packageRules to report whole — the omission is marked; narrow " + "the dependency (a datasource, a depType) so fewer rules report `no-input`."),
   );
 
   server.registerTool(
@@ -368,14 +541,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "matching and the key-level delta of the resulting config, or an explicit 'no behavioral " +
         "change'. Pass runIdB to compare two configs, or depB to compare two dependencies " +
         "against the same config.",
-      inputSchema: z.object({
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         runId: RUN_ID,
-        dep: z.record(z.string(), z.unknown()).describe(DEP_DESCRIPTION),
+        dep: DEP,
         runIdB: z.string().optional().describe("The B-side run. Defaults to runId."),
-        depB: z
-          .record(z.string(), z.unknown())
-          .optional()
-          .describe("The B-side dependency. Defaults to dep."),
+        depB: DEP.optional().describe("The B-side dependency. Defaults to dep."),
       }),
     },
     answer(async ({ runId, dep, runIdB, depB }) => {
@@ -387,7 +558,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         b: { runId: b.runId, dep: toDependency(depB ?? dep) },
         ...compareSimulations(simA, simB),
       };
-    }),
+    }, "the comparison is too large to return whole — narrow the dependency, or ask simulate for " + "one side at a time."),
   );
 
   server.registerTool(
@@ -398,8 +569,9 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "Translates one of Renovate's validator messages into what it actually means, with a " +
         "docs link and — when the library knows one — a concrete fix. Pass the runId the message " +
         "came from and the fix is computed against that exact config snapshot, including the " +
-        "edited file text.",
-      inputSchema: z.object({
+        "edited file text, and the reported severity is the list the run itself put it in.",
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
         message: z.string().describe("The message text, verbatim."),
         topic: z.string().optional().describe("The message's topic, e.g. `Configuration Error`."),
         runId: z.string().optional().describe("The run the message came from."),
@@ -409,7 +581,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const run = runId ? store.get(runId) : null;
       return describeMessage(
         { topic: topic ?? "Configuration Error", message },
-        "error",
+        severityOf(run, message, topic),
         run ? validatedConfigOf(run.result) : null,
         run?.input.content ?? null,
       );
@@ -424,7 +596,14 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         `Renovate's own metadata for an option, for the exact pinned version (${renovateVersion}) ` +
         "— type, default, allowed values, where it may appear, deprecation. Use this instead of " +
         "recalling option semantics: they change between Renovate releases.",
-      inputSchema: z.object({
+      // No held run involved — the answer depends only on the pinned Renovate.
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inputSchema: z.strictObject({
         name: z.string().describe("An option name, or a substring with search: true."),
         search: z.boolean().optional().describe("List every option whose name contains `name`."),
       }),
@@ -447,7 +626,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         );
       }
       return { renovateVersion, ...doc, isContainer: index.containers.has(doc.name) };
-    }),
+    }, "too many options matched — search for a longer substring."),
   );
 
   return server;

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -754,9 +754,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Explain a validation message",
       description:
         "Translates one of Renovate's validator messages into what it actually means, with a " +
-        "docs link and — when the library knows one — a concrete fix. Pass the runId the message " +
-        "came from and the fix is computed against that exact config snapshot, including the " +
-        "edited file text, and the reported severity is the list the run itself put it in.",
+        "docs link and — when the library knows one — a concrete fix. It always says which you " +
+        "got: `translationKnown` is false, with a `note` explaining why, when the curated " +
+        "library has no entry for the message, so a bare echo is never ambiguous. Pass the " +
+        "runId the message came from and the fix is computed against that exact config " +
+        "snapshot, including the edited file text, and the reported severity is the list the " +
+        "run itself put it in.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         message: z.string().describe("The message text, verbatim."),

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -77,6 +77,27 @@ const HELD_RUN_ANNOTATIONS = {
   openWorldHint: false,
 } as const;
 
+/**
+ * What to do when an answer did not fit the budget (see `./result`): the
+ * narrowing THIS tool takes, named. "Output truncated" tells an agent nothing
+ * it can act on.
+ */
+const HINTS = {
+  finalConfig:
+    "the effective config is too large to return whole — ask get_provenance for one `key`, or get_resolved_config for the document without the defaults.",
+  tree: "the tree is too large at this depth — lower `depth`, pass a `query`, or query one node with get_preset_node.",
+  node: "this node's body is too large to return whole — ask for a deeper child instead, or omit `body` and read the contribution stats.",
+  provenance:
+    "this key's override chain is too large to return whole — the layers that contributed are listed; ask get_preset_node for the body of the one you care about.",
+  resolved:
+    'the resolved document is too large to return whole — try mode "keep-internal" without includeDefaults, or read one preset\'s contribution with get_preset_node.',
+  simulate:
+    "this config has too many packageRules to report whole — the omission is marked; narrow the dependency (a datasource, a depType) so fewer rules report `no-input`.",
+  compare:
+    "the comparison is too large to return whole — narrow the dependency, or ask simulate for one side at a time.",
+  optionDocs: "too many options matched — search for a longer substring.",
+} as const;
+
 const RUN_ID = z.string().describe("A runId returned by run_config.");
 
 const INSTRUCTIONS =
@@ -366,11 +387,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({ runId: RUN_ID }),
     },
-    answer(
-      ({ runId }) => ({ finalConfig: finalConfigOf(store.get(runId)) }),
-      "the effective config is too large to return whole — ask get_provenance for one `key`, " +
-        "or get_resolved_config for the document without the defaults.",
-    ),
+    answer(({ runId }) => ({ finalConfig: finalConfigOf(store.get(runId)) }), HINTS.finalConfig),
   );
 
   server.registerTool(
@@ -407,7 +424,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       return query
         ? { summary: stats.summary, matches: searchNodes(stats, query) }
         : { summary: stats.summary, root: viewOf(root, stats, depth ?? DEFAULT_TREE_DEPTH) };
-    }, "the tree is too large at this depth — lower `depth`, pass a `query`, or query one node " + "with get_preset_node."),
+    }, HINTS.tree),
   );
 
   server.registerTool(
@@ -435,7 +452,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         occurrences: stats.occurrencesByName.get(found.name)?.length ?? 1,
         ...(kind ? bodyOf(found, kind) : {}),
       };
-    }, "this node's body is too large to return whole — ask for a deeper child instead, or omit " + "`body` and read the contribution stats."),
+    }, HINTS.node),
   );
 
   server.registerTool(
@@ -479,7 +496,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
             }))
           : [];
       return { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) };
-    }, "this key's override chain is too large to return whole — the layers that contributed are " + "listed; ask get_preset_node for the body of the one you care about."),
+    }, HINTS.provenance),
   );
 
   server.registerTool(
@@ -510,7 +527,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         throw new Error("this document needs a completed preset resolution — validate the config");
       }
       return { mode: resolvedMode, ...output };
-    }, 'the resolved document is too large to return whole — try mode "keep-internal" without ' + "includeDefaults, or read one preset's contribution with get_preset_node."),
+    }, HINTS.resolved),
   );
 
   server.registerTool(
@@ -528,7 +545,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const run = store.get(runId);
       const sim = await simulateRun(run, dep);
       return { dep: toDependency(dep), ...sim };
-    }, "this config has too many packageRules to report whole — the omission is marked; narrow " + "the dependency (a datasource, a depType) so fewer rules report `no-input`."),
+    }, HINTS.simulate),
   );
 
   server.registerTool(
@@ -558,7 +575,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         b: { runId: b.runId, dep: toDependency(depB ?? dep) },
         ...compareSimulations(simA, simB),
       };
-    }, "the comparison is too large to return whole — narrow the dependency, or ask simulate for " + "one side at a time."),
+    }, HINTS.compare),
   );
 
   server.registerTool(

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -17,9 +17,14 @@ import {
   type TraceResult,
   type ValidationMessage,
 } from "@renovate-config-debugger/engine";
-import { validatedConfigOf } from "@renovate-config-debugger/app/headless";
+import {
+  type SourceFilter,
+  validatedConfigOf,
+  type VerdictFilter,
+} from "@renovate-config-debugger/app/headless";
 import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
+import { buildRuleView, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
 import { describeMessage } from "../projections/messages";
 import { entryView, indexView, layerLabel, provenanceOf } from "../projections/provenance";
@@ -192,6 +197,27 @@ const DEP = z
   );
 
 type DepInput = z.infer<typeof DEP>;
+
+/**
+ * The rule-list scoping facets, shared with `rcd simulate --verdict/--source`
+ * and the web app's rules drawer (both go through `buildRuleView`). The
+ * literals are spelled out for zod; `satisfies` keeps them from drifting ahead
+ * of the app's `VerdictFilter`/`SourceFilter` unions.
+ */
+const RULE_VERDICT = z
+  .enum(["notable", "all", "matched", "no-input", "no-match"] satisfies readonly VerdictFilter[])
+  .optional()
+  .describe(
+    "Scope the returned rules by verdict: `notable` (matched + unresolved — the app's default " +
+      "view), `matched`, `no-input`, `no-match`, or `all`. Omit for the full list.",
+  );
+const RULE_SOURCE = z
+  .enum(["all", "repo", "presets"] satisfies readonly SourceFilter[])
+  .optional()
+  .describe(
+    "Scope the returned rules by origin: `repo` (rules your config wrote) or `presets` " +
+      "(rules `extends` pulled in). Omit for all.",
+  );
 
 /** The dependency descriptor, with `updateType` derived the way a real lookup
  *  would when the caller did not set it. */
@@ -537,14 +563,35 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       description:
         "Evaluates every packageRule of the run's effective config against one hypothetical " +
         "dependency update: a verdict per rule with clause-level evidence (which matcher fired, " +
-        "what it read), and the options the matching rules set for that dependency.",
+        "what it read), and the options the matching rules set for that dependency. " +
+        "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
+        '(`source: "repo"` is "just my own config\'s rules").',
       annotations: HELD_RUN_ANNOTATIONS,
-      inputSchema: z.strictObject({ runId: RUN_ID, dep: DEP }),
+      inputSchema: z.strictObject({
+        runId: RUN_ID,
+        dep: DEP,
+        verdict: RULE_VERDICT,
+        source: RULE_SOURCE,
+      }),
     },
-    answer(async ({ runId, dep }) => {
+    answer(async ({ runId, dep, verdict, source }) => {
       const run = store.get(runId);
       const sim = await simulateRun(run, dep);
-      return { dep: toDependency(dep), ...sim };
+      if (verdict === undefined && source === undefined) {
+        return { dep: toDependency(dep), ...sim };
+      }
+      const view = buildRuleView(sim, run.result, {
+        verdict: verdict ?? "all",
+        source: source ?? "all",
+        explicit: true,
+      });
+      return {
+        dep: toDependency(dep),
+        ...sim,
+        rules: view.rules,
+        ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
+        ...ruleFilterPayload(view),
+      };
     }, HINTS.simulate),
   );
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -575,8 +575,9 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const { stats } = treeStatsOf(store.get(runId).result);
       const found = findNode(stats, node);
       const kind = parseBody(body);
+      const foundDepth = stats.statsById.get(found.id)?.depth ?? 0;
       return {
-        node: viewOf(found, stats, 1),
+        node: viewOf(found, stats, foundDepth + 1),
         occurrences: stats.occurrencesByName.get(found.name)?.length ?? 1,
         ...(kind ? bodyOf(found, kind) : {}),
       };

--- a/packages/cli/src/projections/digest.ts
+++ b/packages/cli/src/projections/digest.ts
@@ -1,0 +1,57 @@
+import { computeProvenance, type TraceResult } from "@renovate-config-debugger/engine";
+import {
+  buildDigestInput,
+  buildRunDigest,
+  clauseText,
+  deriveRunFacts,
+  digestText,
+  effectiveTally,
+  type RunFacts,
+} from "@renovate-config-debugger/app/headless";
+import { wouldRefuse } from "../run-input";
+
+/**
+ * The Overview tab's paragraph and the numbers behind it — shared by
+ * `rcd digest` and the MCP server's `run_config` summary.
+ *
+ * Every number is produced by the functions the web app renders with, which is
+ * what roadmap 058's hoist bought: a re-implementation here would be a second
+ * source of truth for a number the paragraph quotes.
+ */
+export interface DigestPayload {
+  digest: string;
+  clauses: { id: string; tone: string; text: string }[];
+  accepted: boolean;
+  counts: {
+    errors: number;
+    warnings: number;
+    rewrites: number;
+    presets: number;
+    effectiveOptions: number | null;
+    overridden: number | null;
+  };
+}
+
+export function digestPayload(result: TraceResult, facts: RunFacts = deriveRunFacts(result)) {
+  const provenance = computeProvenance(result);
+  const tally = provenance ? effectiveTally(provenance.values()) : null;
+  const clauses = buildRunDigest(buildDigestInput(result, facts, tally));
+  const payload: DigestPayload = {
+    digest: digestText(clauses),
+    clauses: clauses.map((clause) => ({
+      id: clause.id,
+      tone: clause.tone,
+      text: clauseText(clause),
+    })),
+    accepted: !wouldRefuse(result),
+    counts: {
+      errors: facts.errorCount,
+      warnings: facts.warningCount,
+      rewrites: facts.migrateSteps.length,
+      presets: facts.presetCount,
+      effectiveOptions: tally?.keys ?? null,
+      overridden: tally?.overridden ?? null,
+    },
+  };
+  return payload;
+}

--- a/packages/cli/src/projections/messages.test.ts
+++ b/packages/cli/src/projections/messages.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { describeMessage } from "./messages";
+
+/**
+ * Roadmap 068: `explain_message` promises "a docs link and — when the library
+ * knows one — a concrete fix". These cover both halves of that promise: the
+ * common `group:` WARNING now arrives with an explanation and a ready-to-apply
+ * fix, and a message the library has no entry for says so out loud instead of
+ * returning a bare echo of the input.
+ */
+
+const GROUP_WARNING = 'packageRules[0].extends: you should not extend "group:" presets';
+
+describe("describeMessage — a known warning", () => {
+  const config = { packageRules: [{ extends: ["group:jestMonorepo"], automerge: true }] };
+  const text =
+    '{\n  "packageRules": [{ "extends": ["group:jestMonorepo"], "automerge": true }]\n}\n';
+
+  test("the group: warning carries an explanation, a docs link and a fix", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Warning", message: GROUP_WARNING },
+      "warning",
+      config,
+      text,
+    );
+    expect(reported.translationKnown).toBe(true);
+    expect(reported.note).toBeUndefined();
+    expect(reported.explanation).toMatch(/`packageRules` array/);
+    expect(reported.docsUrl).toBe("https://docs.renovatebot.com/config-presets/");
+    expect(reported.fix?.fixedConfig).toEqual({
+      packageRules: [
+        {
+          extends: ["monorepo:jest"],
+          groupName: "jest monorepo",
+          matchUpdateTypes: ["digest", "patch", "minor", "major"],
+          automerge: true,
+        },
+      ],
+    });
+    // The edit replaces a whole array element, which the surgical text patcher
+    // does not address — the document is re-serialized, and says so.
+    expect(reported.fix?.fixedTextRewritesDocument).toBe(true);
+    expect(JSON.parse(reported.fix?.fixedText ?? "null")).toEqual(reported.fix?.fixedConfig);
+  });
+
+  test("without a config snapshot it explains, and says why there is no fix", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Warning", message: GROUP_WARNING },
+      "warning",
+      null,
+      null,
+    );
+    expect(reported.translationKnown).toBe(true);
+    expect(reported.fix).toBeUndefined();
+    expect(reported.note).toMatch(/runId/);
+  });
+});
+
+describe("describeMessage — no translation known", () => {
+  test("says so explicitly instead of echoing the message alone", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Error", message: "Something else entirely" },
+      "error",
+      {},
+      null,
+    );
+    expect(reported).toEqual({
+      severity: "error",
+      topic: "Configuration Error",
+      message: "Something else entirely",
+      translationKnown: false,
+      note: expect.stringContaining("No translation for this message"),
+    });
+    expect(reported.note).toMatch(/Renovate's own/);
+  });
+
+  test("still offers the option's docs link when the message names one", () => {
+    const reported = describeMessage(
+      {
+        topic: "Configuration Warning",
+        message: "Setting `registryUrls` at the top level of your config will apply it broadly.",
+      },
+      "warning",
+      {},
+      null,
+    );
+    expect(reported.translationKnown).toBe(false);
+    expect(reported.docsUrl).toContain("#registryurls");
+    expect(reported.note).toMatch(/No translation for this message/);
+  });
+});

--- a/packages/cli/src/projections/messages.ts
+++ b/packages/cli/src/projections/messages.ts
@@ -1,0 +1,68 @@
+import {
+  applyFixToText,
+  findMentionedOption,
+  translateMessage,
+  type ValidationMessage,
+} from "@renovate-config-debugger/engine";
+
+/**
+ * A validator message with everything roadmap 014 knows about it — shared by
+ * `rcd validate` and the MCP server's `explain_message`.
+ *
+ * The fix is reported, never applied: agents edit configs with their own tools
+ * and come back to `validate`/`compare` as the oracle.
+ */
+export interface ReportedMessage {
+  severity: "error" | "warning";
+  topic: string;
+  message: string;
+  explanation?: string;
+  docsUrl?: string;
+  fix?: {
+    summary: string;
+    path: (string | number)[];
+    fixedConfig: Record<string, unknown>;
+    /** The FILE with the fix applied, when the edit could be located in the
+     *  original text (comments and formatting preserved). */
+    fixedText?: string;
+  };
+}
+
+/**
+ * `config` should be the exact snapshot the message was validated against
+ * (`validatedConfigOf`) so a fix's path resolves against the same document;
+ * `text` is the original file, for the formatting-preserving text fix. Pass
+ * `null`/`undefined` for either when they are not available — the translation
+ * and the docs link still work.
+ */
+export function describeMessage(
+  message: ValidationMessage,
+  severity: "error" | "warning",
+  config: Record<string, unknown> | null,
+  text: string | null,
+): ReportedMessage {
+  const translated = translateMessage(message, config);
+  const mentioned = translated ? undefined : findMentionedOption(message);
+  const applied = translated?.fix && text ? applyFixToText(text, translated.fix) : null;
+  return {
+    severity,
+    topic: message.topic,
+    message: message.message,
+    ...(translated ? { explanation: translated.explanation } : {}),
+    ...(translated?.docsUrl
+      ? { docsUrl: translated.docsUrl }
+      : mentioned
+        ? { docsUrl: mentioned.url }
+        : {}),
+    ...(translated?.fix
+      ? {
+          fix: {
+            summary: translated.fix.summary,
+            path: translated.fix.path,
+            fixedConfig: translated.fix.fixedConfig,
+            ...(applied ? { fixedText: applied.text } : {}),
+          },
+        }
+      : {}),
+  };
+}

--- a/packages/cli/src/projections/messages.ts
+++ b/packages/cli/src/projections/messages.ts
@@ -11,13 +11,26 @@ import {
  *
  * The fix is reported, never applied: agents edit configs with their own tools
  * and come back to `validate`/`compare` as the oracle.
+ *
+ * The absence of an explanation or a fix is reported EXPLICITLY (068):
+ * `translationKnown` plus a `note` saying why, so a caller that was promised
+ * "a docs link and — when the library knows one — a concrete fix" can tell
+ * "the library has nothing for this message" from "the tool silently dropped
+ * half its answer". Three replay sessions read the silent shape as a broken
+ * promise.
  */
 export interface ReportedMessage {
   severity: "error" | "warning";
   topic: string;
   message: string;
+  /** Whether roadmap 014's curated library has an entry for this message.
+   *  When false, `message`/`topic`/`severity` are Renovate's own and nothing
+   *  else here is derived. */
+  translationKnown: boolean;
   explanation?: string;
   docsUrl?: string;
+  /** Present exactly when there is no `fix` — why there isn't one. */
+  note?: string;
   fix?: {
     summary: string;
     path: (string | number)[];
@@ -25,8 +38,25 @@ export interface ReportedMessage {
     /** The FILE with the fix applied, when the edit could be located in the
      *  original text (comments and formatting preserved). */
     fixedText?: string;
+    /** True when `fixedText` is the whole document re-serialized from
+     *  `fixedConfig` because the edit couldn't be located in the original
+     *  text — still correct, but comments and formatting are lost. */
+    fixedTextRewritesDocument?: true;
   };
 }
+
+const NO_TRANSLATION_NOTE =
+  "No translation for this message — the message text and severity are Renovate's own, " +
+  "unedited, and this library knows no explanation or fix for it. Use get_option_docs on the " +
+  "option it names, or read Renovate's docs.";
+
+const NO_SNAPSHOT_NOTE =
+  "No fix was computed: this message was explained without the config it came from. Pass the " +
+  "runId the message belongs to and the fix is computed against that exact snapshot.";
+
+const NO_SAFE_FIX_NOTE =
+  "The library explains this message but cannot compute a safe automatic fix for this config — " +
+  "the edit would be a guess. Apply the explanation by hand, then use compare as the oracle.";
 
 /**
  * `config` should be the exact snapshot the message was validated against
@@ -48,6 +78,7 @@ export function describeMessage(
     severity,
     topic: message.topic,
     message: message.message,
+    translationKnown: translated !== null,
     ...(translated ? { explanation: translated.explanation } : {}),
     ...(translated?.docsUrl
       ? { docsUrl: translated.docsUrl }
@@ -61,8 +92,16 @@ export function describeMessage(
             path: translated.fix.path,
             fixedConfig: translated.fix.fixedConfig,
             ...(applied ? { fixedText: applied.text } : {}),
+            ...(applied && !applied.surgical ? { fixedTextRewritesDocument: true as const } : {}),
           },
         }
-      : {}),
+      : { note: noteFor(translated !== null, config) }),
   };
+}
+
+function noteFor(known: boolean, config: Record<string, unknown> | null): string {
+  if (!known) {
+    return NO_TRANSLATION_NOTE;
+  }
+  return config === null ? NO_SNAPSHOT_NOTE : NO_SAFE_FIX_NOTE;
 }

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -1,0 +1,68 @@
+import {
+  computeProvenance,
+  type KeyProvenance,
+  type ProvenanceLayer,
+  type TraceResult,
+} from "@renovate-config-debugger/engine";
+import { isOverridden, multiContribBadgeKind } from "@renovate-config-debugger/app/headless";
+import { CliError } from "../io";
+
+/**
+ * Per-key provenance, projected — shared by `rcd provenance` and the MCP
+ * server's `get_provenance`.
+ *
+ * The badge comes from `multiContribBadgeKind`, not from "more than one layer
+ * touched it": roadmap 016 established that calling an appended array
+ * "overridden" is misleading, and the CLI must not re-learn that lesson
+ * separately from the app.
+ */
+
+export function layerLabel(layer: ProvenanceLayer): string {
+  return layer.kind === "preset" ? `preset ${layer.name}` : layer.kind;
+}
+
+export interface ProvenanceView {
+  key: string;
+  finalValue: unknown;
+  isDefaultOnly: boolean;
+  winner: string | null;
+  badge: string | null;
+  chain: {
+    layer: string;
+    action: string;
+    before: unknown;
+    after: unknown;
+    expandedNested?: true;
+  }[];
+}
+
+export function entryView(entry: KeyProvenance): ProvenanceView {
+  const winner = entry.chain.findLast((s) => !s.noop) ?? entry.chain.at(-1);
+  return {
+    key: entry.key,
+    finalValue: entry.finalValue,
+    isDefaultOnly: entry.isDefaultOnly,
+    winner: winner ? layerLabel(winner.layer) : null,
+    badge: isOverridden(entry) ? multiContribBadgeKind(entry) : null,
+    chain: entry.chain
+      .filter((step) => !step.noop)
+      .map((step) => ({
+        layer: layerLabel(step.layer),
+        action: step.action,
+        before: step.before,
+        after: step.after,
+        ...(step.expandedNested ? { expandedNested: true as const } : {}),
+      })),
+  };
+}
+
+/** The run's provenance map, or a legible error explaining why there is none. */
+export function provenanceOf(result: TraceResult): Map<string, KeyProvenance> {
+  const provenance = computeProvenance(result);
+  if (!provenance) {
+    throw new CliError(
+      "provenance needs a completed preset resolution — validate the config to see why it stopped",
+    );
+  }
+  return provenance;
+}

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -56,6 +56,41 @@ export function entryView(entry: KeyProvenance): ProvenanceView {
   };
 }
 
+export interface ProvenanceIndexEntry {
+  key: string;
+  winner: string | null;
+  badge: string | null;
+  /** Layers that actually changed the value — the chain's length, unexpanded. */
+  contributors: number;
+  /** Enough of the final value to recognise it; the chain is one call away. */
+  preview: string;
+}
+
+/** A value, short enough to scan. */
+export function previewValue(value: unknown, max = 60): string {
+  const text = JSON.stringify(value) ?? String(value);
+  return text.length <= max ? text : `${text.slice(0, max)}… (${text.length} chars)`;
+}
+
+/**
+ * The keyless answer: one line per key instead of every layer's before/after.
+ *
+ * A `config:recommended` run has ~200 keys with long override chains — the
+ * full {@link entryView} of all of them is over half a megabyte, which is not
+ * an answer, it is a haystack. This is the index; ask for a key to get its
+ * chain.
+ */
+export function indexView(entry: KeyProvenance): ProvenanceIndexEntry {
+  const view = entryView(entry);
+  return {
+    key: view.key,
+    winner: view.winner,
+    badge: view.badge,
+    contributors: view.chain.length,
+    preview: previewValue(entry.finalValue),
+  };
+}
+
 /** The run's provenance map, or a legible error explaining why there is none. */
 export function provenanceOf(result: TraceResult): Map<string, KeyProvenance> {
   const provenance = computeProvenance(result);

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -91,6 +91,40 @@ export function indexView(entry: KeyProvenance): ProvenanceIndexEntry {
   };
 }
 
+/**
+ * Roadmap 068 (2026-07 persona study, 2 of 9 sessions, plus the review):
+ * provenance answers "which LAYER set this option", and two personas read that
+ * as "this is the value Renovate will use". For any key a packageRule can also
+ * set, it is not: the layer chain produces the repository-wide value, and a
+ * rule then overrides it for the dependencies it matches. Both personas
+ * reported a static value as the effective one for an update it did not apply
+ * to.
+ *
+ * Cheap and exact: the key appears inside a rule of the run's OWN final
+ * `packageRules`, so the count is this config's, not Renovate's option
+ * metadata. The clauses of those rules are the simulator's business, which is
+ * what the note points at.
+ */
+export function perDependencyNote(
+  key: string,
+  finalConfig: Record<string, unknown> | undefined,
+): string | undefined {
+  if (key === "packageRules" || !Array.isArray(finalConfig?.packageRules)) {
+    return undefined;
+  }
+  const setters = finalConfig.packageRules.filter(
+    (rule) => rule !== null && typeof rule === "object" && key in rule,
+  ).length;
+  if (setters === 0) {
+    return undefined;
+  }
+  return (
+    `${setters} packageRule${setters === 1 ? "" : "s"} can set \`${key}\` per-dependency — this ` +
+    "chain is the repository-wide value. Simulate a dependency to see the value an actual " +
+    "update would get."
+  );
+}
+
 /** The run's provenance map, or a legible error explaining why there is none. */
 export function provenanceOf(result: TraceResult): Map<string, KeyProvenance> {
   const provenance = computeProvenance(result);

--- a/packages/cli/src/projections/tree.ts
+++ b/packages/cli/src/projections/tree.ts
@@ -1,0 +1,139 @@
+import type { PresetNode, TraceResult } from "@renovate-config-debugger/engine";
+import { computeTreeStats, type TreeStats } from "@renovate-config-debugger/app/headless";
+import { CliError } from "../io";
+
+/**
+ * The preset tree, projected. Shared by `rcd tree` and the MCP server's
+ * `get_preset_tree`/`get_preset_node` (roadmap 060), so the two answer the
+ * same question with the same shape — the CLI and the MCP server are one
+ * surface with two transports, not two implementations.
+ *
+ * The projection exists because the raw tree is unusable as an answer: a
+ * `config:recommended` expansion is over a thousand nodes carrying four config
+ * bodies each. Structure and contribution stats by default; bodies one node at
+ * a time.
+ */
+
+export const BODIES = ["fetched", "afterParams", "input", "resolved"] as const;
+export type BodyKind = (typeof BODIES)[number];
+
+export const DEFAULT_TREE_DEPTH = 2;
+
+export interface NodeView {
+  name: string;
+  identity: string;
+  state: string;
+  depth: number;
+  source?: string;
+  duplicate?: true;
+  nested?: true;
+  error?: string;
+  ownOptions: number;
+  optionKeys: string[];
+  ownRules: number;
+  descendants: { resolved: number; rules: number };
+  children?: NodeView[];
+  /** Set when children were cut by the depth limit. */
+  childrenOmitted?: number;
+}
+
+export function viewOf(node: PresetNode, stats: TreeStats, depthLimit: number): NodeView {
+  const st = stats.statsById.get(node.id);
+  const view: NodeView = {
+    name: node.name,
+    identity: stats.identityById.get(node.id) ?? "",
+    state: node.state,
+    depth: st?.depth ?? 0,
+    ...(node.source?.presetSource ? { source: node.source.presetSource } : {}),
+    ...(node.duplicate ? { duplicate: true as const } : {}),
+    ...(node.nested ? { nested: true as const } : {}),
+    ...(node.error ? { error: `${node.error.topic}: ${node.error.message}` } : {}),
+    ownOptions: st?.ownOptions ?? 0,
+    optionKeys: st?.optionKeys ?? [],
+    ownRules: st?.ownRules ?? 0,
+    descendants: { resolved: st?.descResolved ?? 0, rules: st?.descRules ?? 0 },
+  };
+  if (node.children.length === 0) {
+    return view;
+  }
+  if ((st?.depth ?? 0) >= depthLimit) {
+    return { ...view, childrenOmitted: node.children.length };
+  }
+  return { ...view, children: node.children.map((c) => viewOf(c, stats, depthLimit)) };
+}
+
+/** Indented one-line-per-node rendering of a {@link NodeView}. */
+export function treeLines(view: NodeView, out: string[]): string[] {
+  const indent = "  ".repeat(view.depth);
+  const facts = [
+    view.state === "resolved" ? null : view.state,
+    view.ownOptions > 0 ? `${view.ownOptions} option(s): ${view.optionKeys.join(", ")}` : null,
+    view.ownRules > 0 ? `${view.ownRules} rule(s)` : null,
+    view.descendants.resolved > 0 ? `+${view.descendants.resolved} below` : null,
+    view.duplicate ? "duplicate" : null,
+    view.error,
+  ].filter((part) => part !== null && part !== undefined);
+  out.push(`${indent}${view.name}${facts.length > 0 ? `  — ${facts.join("; ")}` : ""}`);
+  for (const child of view.children ?? []) {
+    treeLines(child, out);
+  }
+  if (view.childrenOmitted) {
+    out.push(`${indent}  … ${view.childrenOmitted} more (raise the depth, or query one node)`);
+  }
+  return out;
+}
+
+export function parseBody(raw: string | undefined): BodyKind | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const found = BODIES.find((b) => b === raw);
+  if (!found) {
+    throw new CliError(`body must be one of ${BODIES.join(", ")} (got "${raw}")`);
+  }
+  return found;
+}
+
+/** The run's tree root + stats, or a legible error when it produced no tree. */
+export function treeStatsOf(result: TraceResult): { root: PresetNode; stats: TreeStats } {
+  const root = result.presetTree;
+  if (!root) {
+    throw new CliError("this run produced no preset tree — validate the config first");
+  }
+  return { root, stats: computeTreeStats(root) };
+}
+
+/** A node by structural identity (`a>b>c`) or by preset name. */
+export function findNode(stats: TreeStats, query: string): PresetNode {
+  const byIdentity = stats.idByIdentity.get(query);
+  const node = byIdentity
+    ? stats.nodesById.get(byIdentity)
+    : stats.occurrencesByName.get(query)?.[0];
+  if (!node) {
+    throw new CliError(`no preset named "${query}" in this run's tree`);
+  }
+  return node;
+}
+
+/** Flat name+identity list of the nodes whose name matches `query`. */
+export function searchNodes(
+  stats: TreeStats,
+  query: string,
+): { name: string; identity: string; state: string; ownOptions: number; ownRules: number }[] {
+  const needle = query.toLowerCase();
+  const found: ReturnType<typeof searchNodes> = [];
+  for (const [id, node] of stats.nodesById) {
+    if (!node.name.toLowerCase().includes(needle)) {
+      continue;
+    }
+    const st = stats.statsById.get(id);
+    found.push({
+      name: node.name,
+      identity: stats.identityById.get(id) ?? "",
+      state: node.state,
+      ownOptions: st?.ownOptions ?? 0,
+      ownRules: st?.ownRules ?? 0,
+    });
+  }
+  return found;
+}

--- a/packages/cli/src/rule-view.test.ts
+++ b/packages/cli/src/rule-view.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import type {
+  RuleEvaluation,
+  SimulationResult,
+  TraceResult,
+} from "@renovate-config-debugger/engine";
+import { buildRuleView } from "./rule-view";
+
+/**
+ * The facets themselves are the app's shared predicates, covered where they
+ * live. What is this module's own is the DIAGNOSTIC it emits when `--source`
+ * has nothing to filter with — and, roadmap 068 (M2), whose vocabulary that
+ * diagnostic speaks: an agent over MCP cannot pass a flag, and telling it to
+ * is worse than saying nothing.
+ */
+
+function rule(index: number, verdict: RuleEvaluation["verdict"]): RuleEvaluation {
+  return { index, verdict, clauses: [], notes: [] };
+}
+
+function sim(rules: RuleEvaluation[]): SimulationResult {
+  return {
+    rules,
+    rawFinalConfig: {},
+    finalDependencyConfig: {},
+    flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    mergeSteps: [],
+    errors: [],
+    warnings: [],
+    notes: [],
+  };
+}
+
+/** A run whose preset resolution never completed: no rule can be attributed to
+ *  a config level, which is exactly when the note fires. */
+const UNATTRIBUTABLE = {
+  events: [],
+  finalConfig: { packageRules: [{ groupName: "x" }] },
+  errors: [],
+  warnings: [],
+  presetTree: undefined,
+} as unknown as TraceResult;
+
+describe("buildRuleView", () => {
+  test("`--source` with no provenance is dropped, and the CLI note says so in flags", () => {
+    const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
+      verdict: "all",
+      source: "repo",
+      explicit: true,
+      transport: "cli",
+    });
+    expect(view.notes[0]).toContain("--source repo ignored");
+    // Dropped, not applied: filtering every rule away because the attribution
+    // is missing would be a wrong answer, not a narrow one.
+    expect(view.source).toBe("all");
+    expect(view.rules).toHaveLength(1);
+  });
+
+  test("the same note over MCP names the tool parameter instead", () => {
+    const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
+      verdict: "all",
+      source: "presets",
+      explicit: true,
+      transport: "mcp",
+    });
+    expect(view.notes[0]).toContain('source: "presets" ignored');
+    expect(view.notes[0]).not.toContain("--source");
+  });
+
+  test("the verdict facet counts what it hid", () => {
+    const view = buildRuleView(sim([rule(0, "matched"), rule(1, "no-match")]), UNATTRIBUTABLE, {
+      verdict: "matched",
+      source: "all",
+      explicit: true,
+      transport: "cli",
+    });
+    expect(view.rules).toHaveLength(1);
+    expect(view.total).toBe(2);
+    expect(view.hidden).toBe(1);
+    expect(view.notes).toEqual([]);
+  });
+});

--- a/packages/cli/src/rule-view.ts
+++ b/packages/cli/src/rule-view.ts
@@ -15,6 +15,7 @@ import {
 } from "@renovate-config-debugger/app/headless";
 import { type OutputFormat, type ParsedArgs, stringOption } from "./args";
 import { CliError } from "./io";
+import type { RunTransport } from "./run-input";
 
 /**
  * Roadmap 062 (2026-07 persona study, top friction — 6 of 9 sessions): a
@@ -39,6 +40,18 @@ export interface RuleFilterSelection {
   source: SourceFilter;
   /** Either flag was passed explicitly — the JSON payload filters only then. */
   explicit: boolean;
+  /**
+   * How the caller asked. The facets are one implementation with two
+   * spellings — `--source repo` on the CLI, `source: "repo"` over MCP — and a
+   * note that quotes the wrong one is a dead end for whoever reads it: an
+   * agent cannot pass a flag, and telling it to is worse than saying nothing.
+   */
+  transport: RunTransport;
+}
+
+/** The facet as the caller would have to spell it on THEIR surface. */
+function facetText(transport: RunTransport, facet: string, value: string): string {
+  return transport === "mcp" ? `${facet}: "${value}"` : `--${facet} ${value}`;
 }
 
 function parseChoice<T extends string>(
@@ -69,6 +82,7 @@ export function ruleFilterSelection(args: ParsedArgs, format: OutputFormat): Rul
     ),
     source: parseChoice(rawSource, SOURCE_FILTERS, "source", "all"),
     explicit: rawVerdict !== undefined || rawSource !== undefined,
+    transport: "cli",
   };
 }
 
@@ -105,8 +119,9 @@ export function buildRuleView(
     const layerByIndex = ruleLayerIndex(computeRuleProvenance(result));
     if (layerByIndex.size === 0) {
       notes.push(
-        `--source ${source} ignored: this run has no per-rule provenance ` +
-          "(the preset tree is incomplete, so no rule can be attributed to a config level)",
+        `${facetText(selection.transport, "source", source)} ignored: this run has no per-rule ` +
+          "provenance (the preset tree is incomplete, so no rule can be attributed to a config " +
+          "level)",
       );
       source = "all";
     } else {

--- a/packages/cli/src/run-input.test.ts
+++ b/packages/cli/src/run-input.test.ts
@@ -78,37 +78,31 @@ describe("tokensFromEnv", () => {
   });
 });
 
-const guardArgs = (argv: string[]) =>
-  parseCommandArgs(argv, ["trust-endpoints", "platform-override"]);
-
 describe("endpointTokenPolicy", () => {
-  const args = guardArgs;
-
   test("no global config: the endpoint is ours, tokens flow", () => {
-    expect(endpointTokenPolicy(args([]), undefined).suppress).toBe(false);
+    expect(endpointTokenPolicy({}, undefined).suppress).toBe(false);
   });
 
   test("a global config that chooses the endpoint withholds the tokens", () => {
-    const policy = endpointTokenPolicy(args([]), { endpoint: "https://evil.example" });
+    const policy = endpointTokenPolicy({}, { endpoint: "https://evil.example" });
     expect(policy.suppress).toBe(true);
     expect(policy.reason).toContain("--trust-endpoints");
   });
 
   test("--platform-override puts us back in charge", () => {
     expect(
-      endpointTokenPolicy(args(["--platform-override"]), { endpoint: "https://evil.example" })
+      endpointTokenPolicy({ platformOverride: true }, { endpoint: "https://evil.example" })
         .suppress,
     ).toBe(false);
   });
 
   test("--trust-endpoints is the explicit opt-in", () => {
     expect(
-      endpointTokenPolicy(args(["--trust-endpoints"]), { endpoint: "https://mine.example" })
-        .suppress,
+      endpointTokenPolicy({ trustEndpoints: true }, { endpoint: "https://mine.example" }).suppress,
     ).toBe(false);
   });
 
   test("a global config that sets neither platform nor endpoint is harmless", () => {
-    expect(endpointTokenPolicy(args([]), { onboarding: false }).suppress).toBe(false);
+    expect(endpointTokenPolicy({}, { onboarding: false }).suppress).toBe(false);
   });
 });

--- a/packages/cli/src/run-input.test.ts
+++ b/packages/cli/src/run-input.test.ts
@@ -105,4 +105,41 @@ describe("endpointTokenPolicy", () => {
   test("a global config that sets neither platform nor endpoint is harmless", () => {
     expect(endpointTokenPolicy({}, { onboarding: false }).suppress).toBe(false);
   });
+
+  /**
+   * Roadmap 068 (M3). `--endpoint` on the CLI is a person's explicit choice —
+   * `callerEndpoint` stays unset there. Over MCP the same value arrives as a
+   * tool parameter the MODEL chose, plausibly copied out of the config under
+   * inspection, so it gets the same treatment as an endpoint a config chose.
+   */
+  test("an endpoint the caller supplied over MCP withholds the tokens", () => {
+    const policy = endpointTokenPolicy(
+      { callerEndpoint: "https://ghe.attacker.example/api/v3/" },
+      undefined,
+      "mcp",
+    );
+    expect(policy.suppress).toBe(true);
+    expect(policy.reason).toContain("ghe.attacker.example");
+    expect(policy.reason).toContain("trustEndpoints: true");
+  });
+
+  test("platformOverride does not vouch for an endpoint the caller invented", () => {
+    expect(
+      endpointTokenPolicy(
+        { callerEndpoint: "https://ghe.attacker.example/api/v3/", platformOverride: true },
+        undefined,
+        "mcp",
+      ).suppress,
+    ).toBe(true);
+  });
+
+  test("trustEndpoints is the one opt-in that does", () => {
+    expect(
+      endpointTokenPolicy(
+        { callerEndpoint: "https://ghe.mine.example/api/v3/", trustEndpoints: true },
+        undefined,
+        "mcp",
+      ).suppress,
+    ).toBe(false);
+  });
 });

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -83,6 +83,19 @@ export interface EndpointTrust {
   trustEndpoints?: boolean;
   /** The caller's own platform/endpoint wins over the global config's. */
   platformOverride?: boolean;
+  /**
+   * The endpoint the CALLER supplied, when the caller is not a person.
+   *
+   * On the CLI this stays unset: a human typed `--endpoint`, which is exactly
+   * the "explicit flag" the guard trusts. Over MCP the same value is a tool
+   * PARAMETER the model chose — plausibly from text in the very repository it
+   * is inspecting — so it is not the user's choice at all, and the guard has
+   * to treat it the way it treats an endpoint a config chose.
+   *
+   * Only the endpoint. `platform` on its own moves a token to that platform's
+   * own public API, which is where a token for that platform already goes.
+   */
+  callerEndpoint?: string;
 }
 
 /**
@@ -97,12 +110,37 @@ const OPT_IN_WORDING: Record<RunTransport, string> = {
   mcp: "Set `platformOverride: true` to impose your own endpoint, or `trustEndpoints: true` if the config is yours.",
 };
 
+/** The only opt-in that applies when the CALLER, not the config, picked the
+ *  endpoint — imposing it harder changes nothing about who chose it. */
+const TRUST_WORDING: Record<RunTransport, string> = {
+  cli: "Pass `--trust-endpoints` if that endpoint is yours.",
+  mcp: "Set `trustEndpoints: true` if that endpoint is yours.",
+};
+
 export function endpointTokenPolicy(
   trust: EndpointTrust,
   globalConfig: Record<string, unknown> | undefined,
   transport: RunTransport = "cli",
 ): { suppress: boolean; reason?: string } {
-  if (trust.trustEndpoints || !globalConfig) {
+  if (trust.trustEndpoints) {
+    return { suppress: false };
+  }
+  // The same rule as below, one layer out: the guard asks "did the person
+  // whose tokens these are choose where they go?", and over MCP an `endpoint`
+  // tool parameter is not that person's answer — the model wrote it, and a
+  // config it just read can suggest one. `platformOverride` deliberately does
+  // NOT unlock this: it only says whose endpoint wins between two untrusted
+  // sources. `trustEndpoints` is the one opt-in that means "I vouch for it".
+  if (trust.callerEndpoint) {
+    return {
+      suppress: true,
+      reason:
+        `\`endpoint\` was chosen by the caller (${trust.callerEndpoint}) rather than by the ` +
+        "environment this server runs in, so host tokens were NOT sent there. " +
+        TRUST_WORDING[transport],
+    };
+  }
+  if (!globalConfig) {
     return { suppress: false };
   }
   const chosen = ["endpoint", "platform"].filter((key) =>

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -85,9 +85,22 @@ export interface EndpointTrust {
   platformOverride?: boolean;
 }
 
+/**
+ * How the caller reached us. The guard is one rule with two spellings: on the
+ * CLI the opt-ins are flags, over MCP they are tool parameters, and a note
+ * that names the wrong one is a dead end for whoever reads it.
+ */
+export type RunTransport = "cli" | "mcp";
+
+const OPT_IN_WORDING: Record<RunTransport, string> = {
+  cli: "Pass `--platform-override` to impose your own endpoint, or `--trust-endpoints` if the config is yours.",
+  mcp: "Set `platformOverride: true` to impose your own endpoint, or `trustEndpoints: true` if the config is yours.",
+};
+
 export function endpointTokenPolicy(
   trust: EndpointTrust,
   globalConfig: Record<string, unknown> | undefined,
+  transport: RunTransport = "cli",
 ): { suppress: boolean; reason?: string } {
   if (trust.trustEndpoints || !globalConfig) {
     return { suppress: false };
@@ -102,27 +115,41 @@ export function endpointTokenPolicy(
     suppress: true,
     reason:
       `the global config sets ${chosen.map((k) => `\`${k}\``).join(" and ")}, so it — not you — ` +
-      "chooses where preset requests go; host tokens were NOT sent. Pass --platform-override " +
-      "to impose your own endpoint, or --trust-endpoints if the config is yours.",
+      `chooses where preset requests go; host tokens were NOT sent. ${OPT_IN_WORDING[transport]}`,
   };
 }
 
+export interface RunAuth {
+  /** The credentials this run may use — `{}` when the guard withheld them. */
+  auth: PresetAuth;
+  /** Diagnostics for the caller; never part of an answer. */
+  notes: string[];
+}
+
 /**
- * Installs the credentials a run may use, and reports what was withheld.
- * Shared by the CLI's input path and the MCP server's `run_config`, so the
- * guard cannot be enforced on one transport and forgotten on the other.
+ * The credentials a run may use, and what was withheld. Shared by the CLI's
+ * input path and the MCP server's `run_config`, so the guard cannot be
+ * enforced on one transport and forgotten on the other.
+ *
+ * It RESOLVES, it does not install: the auth travels on the `PipelineInput`,
+ * and the engine installs it inside its own serialized queue. Installing it
+ * here would publish it to every run that starts before this one finishes —
+ * which, with concurrent MCP handlers, is how run B's tokens end up on run A's
+ * fetches to an endpoint A's untrusted global config chose.
  */
-export function applyRunAuth(
+export function resolveRunAuth(
   env: Readonly<Record<string, string | undefined>>,
   globalConfig: Record<string, unknown> | undefined,
   trust: EndpointTrust,
-): string[] {
+  transport: RunTransport,
+): RunAuth {
   const auth = tokensFromEnv(env);
-  const policy = endpointTokenPolicy(trust, globalConfig);
-  // Overwrite, never skip: `setPresetAuth` replaces module state a previous
-  // run in this process may have populated.
-  setPresetAuth(policy.suppress ? {} : auth);
-  return policy.suppress && hasTokens(auth) ? [`credentials withheld: ${policy.reason ?? ""}`] : [];
+  const policy = endpointTokenPolicy(trust, globalConfig, transport);
+  return {
+    auth: policy.suppress ? {} : auth,
+    notes:
+      policy.suppress && hasTokens(auth) ? [`credentials withheld: ${policy.reason ?? ""}`] : [],
+  };
 }
 
 async function readTextFile(path: string, what: string): Promise<string> {
@@ -190,10 +217,20 @@ export async function loadPipelineInput(
   const globalConfig = await readLayer(stringOption(args, "global-config"), "--global-config");
   const inheritedConfig = await readLayer(stringOption(args, "inherited"), "--inherited");
 
-  const notes = applyRunAuth(io.env, globalConfig, {
-    trustEndpoints: boolOption(args, "trust-endpoints"),
-    platformOverride: boolOption(args, "platform-override"),
-  });
+  const { auth, notes } = resolveRunAuth(
+    io.env,
+    globalConfig,
+    {
+      trustEndpoints: boolOption(args, "trust-endpoints"),
+      platformOverride: boolOption(args, "platform-override"),
+    },
+    "cli",
+  );
+  // `--repo` loads the config through the engine's repo-config fetcher, which
+  // reads the module-level auth and runs OUTSIDE the pipeline — so the CLI
+  // still installs it globally. The run itself is scoped by `presetAuth` on
+  // the input below; one process, one config at a time, so the two agree.
+  setPresetAuth(auth);
 
   const repo = stringOption(args, "repo");
   let fileName: string;
@@ -222,6 +259,7 @@ export async function loadPipelineInput(
     input: {
       fileName,
       content,
+      presetAuth: auth,
       ...(globalConfig ? { globalConfig } : {}),
       ...(inheritedConfig ? { inheritedConfig } : {}),
       ...(stringOption(args, "platform") ? { platform: stringOption(args, "platform") } : {}),

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -78,17 +78,24 @@ export function hasTokens(auth: PresetAuth): boolean {
  * never to one the config under inspection chose, unless the user says the
  * config is trusted.
  */
+export interface EndpointTrust {
+  /** The caller vouched for the config under inspection. */
+  trustEndpoints?: boolean;
+  /** The caller's own platform/endpoint wins over the global config's. */
+  platformOverride?: boolean;
+}
+
 export function endpointTokenPolicy(
-  args: ParsedArgs,
+  trust: EndpointTrust,
   globalConfig: Record<string, unknown> | undefined,
 ): { suppress: boolean; reason?: string } {
-  if (boolOption(args, "trust-endpoints") || !globalConfig) {
+  if (trust.trustEndpoints || !globalConfig) {
     return { suppress: false };
   }
   const chosen = ["endpoint", "platform"].filter((key) =>
     Object.prototype.hasOwnProperty.call(globalConfig, key),
   );
-  if (chosen.length === 0 || boolOption(args, "platform-override")) {
+  if (chosen.length === 0 || trust.platformOverride) {
     return { suppress: false };
   }
   return {
@@ -98,6 +105,24 @@ export function endpointTokenPolicy(
       "chooses where preset requests go; host tokens were NOT sent. Pass --platform-override " +
       "to impose your own endpoint, or --trust-endpoints if the config is yours.",
   };
+}
+
+/**
+ * Installs the credentials a run may use, and reports what was withheld.
+ * Shared by the CLI's input path and the MCP server's `run_config`, so the
+ * guard cannot be enforced on one transport and forgotten on the other.
+ */
+export function applyRunAuth(
+  env: Readonly<Record<string, string | undefined>>,
+  globalConfig: Record<string, unknown> | undefined,
+  trust: EndpointTrust,
+): string[] {
+  const auth = tokensFromEnv(env);
+  const policy = endpointTokenPolicy(trust, globalConfig);
+  // Overwrite, never skip: `setPresetAuth` replaces module state a previous
+  // run in this process may have populated.
+  setPresetAuth(policy.suppress ? {} : auth);
+  return policy.suppress && hasTokens(auth) ? [`credentials withheld: ${policy.reason ?? ""}`] : [];
 }
 
 async function readTextFile(path: string, what: string): Promise<string> {
@@ -162,18 +187,13 @@ export async function loadPipelineInput(
   io: CliIo,
   file: string | undefined,
 ): Promise<LoadedInput> {
-  const notes: string[] = [];
   const globalConfig = await readLayer(stringOption(args, "global-config"), "--global-config");
   const inheritedConfig = await readLayer(stringOption(args, "inherited"), "--inherited");
 
-  const auth = tokensFromEnv(io.env);
-  const policy = endpointTokenPolicy(args, globalConfig);
-  if (policy.suppress && hasTokens(auth)) {
-    notes.push(`credentials withheld: ${policy.reason ?? ""}`);
-  }
-  // Overwrite, never skip: `setPresetAuth` replaces module state a previous
-  // run in this process may have populated.
-  setPresetAuth(policy.suppress ? {} : auth);
+  const notes = applyRunAuth(io.env, globalConfig, {
+    trustEndpoints: boolOption(args, "trust-endpoints"),
+    platformOverride: boolOption(args, "platform-override"),
+  });
 
   const repo = stringOption(args, "repo");
   let fileName: string;

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -1,4 +1,6 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import { fixture } from "../src/test-harness";
@@ -114,5 +116,91 @@ describe("bin/rcd.mjs", () => {
     expect(run.stdout.length).toBeGreaterThan(64 * 1024);
     const result = JSON.parse(run.stdout) as { finalConfig: { extends?: string[] } };
     expect(result.finalConfig).toBeTypeOf("object");
+  }, 120_000);
+});
+
+/**
+ * `rcd mcp` over a real pipe. Nothing in-process can cover it: the command's
+ * whole subject is stdio — the SDK owns stdout as the protocol, and the
+ * session ends on an EOF only a bin can see.
+ */
+
+interface JsonRpcMessage {
+  jsonrpc: string;
+  id?: number;
+  result?: { tools?: { name: string }[] };
+  error?: unknown;
+}
+
+describe("bin/rcd.mjs mcp", () => {
+  test("answers JSON-RPC on stdout and exits 0 when the client disconnects", async () => {
+    const child = spawn(process.execPath, [BIN, "mcp"], {
+      cwd: CLI_DIR,
+      env: CHILD_ENV,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Piped and never asserted on, but it has to be drained: a stderr nobody
+    // reads fills its own pipe buffer and stalls the child.
+    child.stderr.resume();
+
+    const messages: JsonRpcMessage[] = [];
+    let toolsList: JsonRpcMessage | undefined;
+    const answered = new Promise<void>((resolve) => {
+      const lines = createInterface({ input: child.stdout });
+      lines.on("line", (line) => {
+        if (line.trim() === "") {
+          return;
+        }
+        // Every line is protocol: a stray log or hint on stdout is a bug the
+        // parse below is here to catch.
+        const message = JSON.parse(line) as JsonRpcMessage;
+        messages.push(message);
+        if (message.id === 2) {
+          toolsList = message;
+          resolve();
+        }
+      });
+    });
+
+    for (const message of [
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "rcd-test", version: "0" },
+        },
+      },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    ]) {
+      child.stdin.write(`${JSON.stringify(message)}\n`);
+    }
+
+    await answered;
+    expect(messages.every((message) => message.jsonrpc === "2.0")).toBe(true);
+    expect(messages.filter((message) => message.error !== undefined)).toEqual([]);
+    expect(toolsList?.result?.tools?.map((tool) => tool.name)).toEqual([
+      "run_config",
+      "get_final_config",
+      "get_preset_tree",
+      "get_preset_node",
+      "get_provenance",
+      "get_resolved_config",
+      "simulate",
+      "compare_simulations",
+      "explain_message",
+      "get_option_docs",
+    ]);
+
+    // The regression: the SDK's stdio transport ignores EOF, so the command
+    // used to wait forever and Node killed the process at 13 — with the dev
+    // runner's Vite teardown never reached.
+    child.stdin.end();
+    const [code] = (await once(child, "exit")) as [number | null, string | null];
+    expect(code).toBe(0);
   }, 120_000);
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
     },
   },
   plugins: [renovateShims()],
+  // The MCP SDK ships sourcemaps whose sources it does not ship; Vite warns
+  // once per module and buries the test output. Errors still print.
+  logLevel: "error",
   test: {
     name: "cli",
     include: ["src/**/*.test.ts", "test/*.test.ts"],

--- a/packages/engine/src/error-fix-text.ts
+++ b/packages/engine/src/error-fix-text.ts
@@ -299,7 +299,10 @@ function locateEntry(text: string, path: ConfigPathSegment[]): EntryLocation | n
     } else {
       const found = findArrayElement(text, containerStart, seg);
       if (!found || isLast) {
-        // Our curated fixes always end on an object key, never an array index.
+        // A path ending on an array index has no surgical patch here — the
+        // one curated fix shaped that way (the `group:`-preset rule rewrite)
+        // deliberately falls back to re-serializing the document, and says so
+        // via `fixedTextRewritesDocument`.
         return null;
       }
       containerStart = found.valueStart;

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -19,6 +19,7 @@
  * "Apply fix" button.
  */
 
+import { getInternalPreset, parsePreset } from "./renovate-adapter";
 import { snapshot } from "./trace/delta";
 import type { ValidationMessage } from "./trace/model";
 import { getOptionIndex, type OptionDoc } from "./option-docs";
@@ -166,6 +167,14 @@ function withKeyRenamed(
   delete parent[last];
   parent[newKey] = value;
   return clone;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
 /** Unique `` `identifier` `` tokens mentioned in a free-text message. */
@@ -376,6 +385,227 @@ const globalOnlyOption: ErrorTranslation = {
 };
 
 // ---------------------------------------------------------------------------
+// 4. `group:` preset extended from inside a packageRules entry
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js, `parentName === "packageRules"`):
+// `${currentPath}: you should not extend "group:" presets`
+// Topic is "Configuration Warning", but the matcher deliberately does NOT
+// require it: `explain_message` callers routinely pass the text alone, and the
+// sentence is unique enough in Renovate's validator to stand on its own.
+//
+// The structural reason: a `group:` preset's body is a `packageRules` ARRAY
+// (`group:jestMonorepo` is `{"packageRules":[{extends:["monorepo:jest"], …}]}`),
+// not a flat fragment of one rule. Merged into a single rule it becomes a
+// `packageRules` key nested inside a package rule, which Renovate never reads
+// — the group's matchers and `groupName` are silently dropped.
+
+const GROUP_PRESET_RE = /^(.+?): you should not extend "group:" presets$/;
+
+const GROUP_PRESET_DOCS_URL = "https://docs.renovatebot.com/config-presets/";
+const GROUP_PRESET_LIST_URL = "https://docs.renovatebot.com/presets-group/";
+
+/**
+ * The single package rule a `group:` preset's body consists of, with its
+ * `description` dropped — i.e. exactly what has to be restated inside the
+ * user's own rule. `null` whenever the group isn't collapsible into one rule:
+ * an unbundled/unknown name, a body carrying top-level options besides
+ * `packageRules` (e.g. `group:all`'s `separateMajorMinor`), or a body whose
+ * `packageRules` holds anything other than exactly one rule (e.g.
+ * `group:monorepos`, which is a fan-out over ~500 other group presets).
+ */
+function collapsibleGroupRule(preset: string): Record<string, unknown> | null {
+  let parsed;
+  try {
+    parsed = parsePreset(preset);
+  } catch {
+    return null;
+  }
+  if (parsed.presetSource !== "internal" || parsed.repo !== "group") {
+    return null;
+  }
+  if (parsed.params !== undefined && parsed.params.length > 0) {
+    return null;
+  }
+  const body = getInternalPreset({ repo: parsed.repo, presetName: parsed.presetName });
+  if (!isPlainObject(body)) {
+    return null;
+  }
+  if (Object.keys(body).some((key) => key !== "description" && key !== "packageRules")) {
+    return null;
+  }
+  const rules = body.packageRules;
+  if (!Array.isArray(rules) || rules.length !== 1) {
+    return null;
+  }
+  const [only] = rules;
+  if (!isPlainObject(only)) {
+    return null;
+  }
+  const rule = { ...only };
+  delete rule.description;
+  return Object.keys(rule).length > 0 ? rule : null;
+}
+
+const groupPresetInPackageRule: ErrorTranslation = {
+  id: "group-preset-in-package-rule",
+  matches: (m) => GROUP_PRESET_RE.test(m.message),
+
+  explain: (m) => {
+    const path = GROUP_PRESET_RE.exec(m.message)?.[1] ?? "this rule's `extends`";
+    return (
+      `\`${path}\` extends a \`group:\` preset from inside a \`packageRules\` entry, and a ` +
+      `\`group:\` preset's body is itself a \`packageRules\` array — not a flat fragment of one ` +
+      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule. Renovate ` +
+      `matches a rule on that rule's own \`match*\` keys, and after the merge yours has none: the ` +
+      `group's matchers, its \`groupName\` and its \`matchUpdateTypes\` all sit one level down, ` +
+      `where the pass that just matched the rule doesn't read them. The rule matches EVERY ` +
+      `dependency and applies whatever else you put in it — an \`automerge: true\` meant for one ` +
+      `monorepo now applies to everything — and the grouping you asked for doesn't happen. ` +
+      `Write the group out inside the rule instead: extend the underlying ` +
+      `\`monorepo:\`/\`packages:\` preset the group uses — those are pure match criteria and are ` +
+      `safe inside a rule — or copy the group's matchers, then restate \`groupName\` and the ` +
+      `group's own \`matchUpdateTypes\` alongside your own options. That last part is not ` +
+      `cosmetic: the built-in monorepo groups carry ` +
+      `\`matchUpdateTypes: ["digest", "patch", "minor", "major"]\`, which deliberately EXCLUDES ` +
+      `\`pin\`; a replacement rule that omits it silently widens the group to pin updates too. ` +
+      `See ${GROUP_PRESET_DOCS_URL} for how \`extends\` merges, and ${GROUP_PRESET_LIST_URL} for ` +
+      `the exact body of the group being replaced.`
+    );
+  },
+
+  docsUrl: GROUP_PRESET_DOCS_URL,
+
+  optionNames: () => ["extends"],
+
+  suggestFix: (m, config) => {
+    const pathStr = GROUP_PRESET_RE.exec(m.message)?.[1];
+    if (pathStr === undefined) {
+      return null;
+    }
+    const extendsPath = parseConfigPath(pathStr);
+    if (extendsPath.at(-1) !== "extends" || extendsPath.length < 2) {
+      return null;
+    }
+    const rulePath = extendsPath.slice(0, -1);
+    const rule = getAtPath(config, rulePath);
+    if (!isPlainObject(rule) || !isStringArray(rule.extends)) {
+      return null;
+    }
+    const groupEntries = rule.extends.filter((e) => e.startsWith("group:"));
+    const [groupEntry] = groupEntries;
+    // Two groups in one rule can't collapse into one rule — the user has to
+    // decide which grouping wins, so explain without guessing.
+    if (groupEntry === undefined || groupEntries.length > 1) {
+      return null;
+    }
+    const groupRule = collapsibleGroupRule(groupEntry);
+    if (!groupRule) {
+      return null;
+    }
+    const groupExtends = isStringArray(groupRule.extends) ? groupRule.extends : [];
+    const inherited = { ...groupRule };
+    delete inherited.extends;
+    const own = { ...rule };
+    delete own.extends;
+    const keptExtends = rule.extends.filter((e) => e !== groupEntry);
+    const mergedExtends = [...new Set([...groupExtends, ...keptExtends])];
+
+    // `extends` first (it's the criteria carrier), then the group's own keys,
+    // then the user's — the user's value wins any key they set explicitly.
+    const merged: Record<string, unknown> = {};
+    if (mergedExtends.length > 0) {
+      merged.extends = mergedExtends;
+    }
+    Object.assign(merged, inherited, own);
+
+    return {
+      path: rulePath,
+      value: merged,
+      before: rule,
+      after: merged,
+      summary: `Replace \`${groupEntry}\` in \`${pathStr}\` with the group's own rule contents`,
+      fixedConfig: withValueAtPath(config, rulePath, merged),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 5. `global:` preset extended from a repository config
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js, `configType !== "global"`):
+// `${currentPath}: you cannot extend from "global:" presets in a repository config's "extends"`
+// The sibling of pattern 3 (a global-only OPTION set in a repo config), one
+// level up: a whole preset of global-only options, pulled in by name.
+
+const GLOBAL_PRESET_RE =
+  /^(.+?): you cannot extend from "global:" presets in a repository config's "extends"$/;
+
+const GLOBAL_PRESET_DOCS_URL = "https://docs.renovatebot.com/presets-global/";
+
+const globalPresetInExtends: ErrorTranslation = {
+  id: "global-preset-in-extends",
+  matches: (m) => GLOBAL_PRESET_RE.test(m.message),
+
+  explain: (m) => {
+    const path = GLOBAL_PRESET_RE.exec(m.message)?.[1] ?? "this `extends`";
+    return (
+      `\`${path}\` extends a \`global:\` preset. \`global:\` presets are bundles of ` +
+      `self-hosted-only options (the same options roadmap 008's global config layer holds), and ` +
+      `Renovate refuses them in a repository's own config rather than ignoring them — so this is ` +
+      `an error, not a warning, and the whole config is rejected. Move the \`global:\` entry to ` +
+      `the self-hosted global configuration (\`config.js\` / \`RENOVATE_CONFIG\`), where it does ` +
+      `what you meant, and drop it here. See ${GLOBAL_PRESET_DOCS_URL} for what each \`global:\` ` +
+      `preset actually sets.`
+    );
+  },
+
+  docsUrl: GLOBAL_PRESET_DOCS_URL,
+
+  optionNames: () => ["extends"],
+
+  suggestFix: (m, config) => {
+    const pathStr = GLOBAL_PRESET_RE.exec(m.message)?.[1];
+    if (pathStr === undefined) {
+      return null;
+    }
+    const path = parseConfigPath(pathStr);
+    if (path.at(-1) !== "extends") {
+      return null;
+    }
+    const list = getAtPath(config, path);
+    if (!isStringArray(list)) {
+      return null;
+    }
+    const removed = list.filter((e) => e.startsWith("global:"));
+    const kept = list.filter((e) => !e.startsWith("global:"));
+    if (removed.length === 0) {
+      return null;
+    }
+    const summary = `Remove ${removed.map((e) => `\`${e}\``).join(" and ")} from \`${pathStr}\``;
+    if (kept.length === 0) {
+      // An `extends` that held nothing but global: presets: drop the key
+      // rather than leave an empty array behind.
+      return {
+        path,
+        remove: true,
+        before: list,
+        after: undefined,
+        summary,
+        fixedConfig: withKeyRemoved(config, path),
+      };
+    }
+    return {
+      path,
+      value: kept,
+      before: list,
+      after: kept,
+      summary,
+      fixedConfig: withValueAtPath(config, path, kept),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -383,6 +613,8 @@ export const ERROR_TRANSLATIONS: ErrorTranslation[] = [
   redundantGlobStar,
   deprecatedOption,
   globalOnlyOption,
+  groupPresetInPackageRule,
+  globalPresetInExtends,
 ];
 
 /**

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -396,8 +396,13 @@ const globalOnlyOption: ErrorTranslation = {
 // The structural reason: a `group:` preset's body is a `packageRules` ARRAY
 // (`group:jestMonorepo` is `{"packageRules":[{extends:["monorepo:jest"], …}]}`),
 // not a flat fragment of one rule. Merged into a single rule it becomes a
-// `packageRules` key nested inside a package rule, which Renovate never reads
-// — the group's matchers and `groupName` are silently dropped.
+// `packageRules` key nested inside a package rule — a shape no option owns.
+// Renovate's config MIGRATION then flattens it (each inner rule merged over
+// the outer one, re-run after preset resolution), so on current Renovate the
+// construct happens to behave scoped — by migration side-effect, not by
+// contract, and it duplicates the group rule `config:recommended` already
+// ships. See `simulate-package-rules.ts`'s docblock and the golden fidelity
+// tests before "correcting" this account.
 
 const GROUP_PRESET_RE = /^(.+?): you should not extend "group:" presets$/;
 
@@ -455,13 +460,14 @@ const groupPresetInPackageRule: ErrorTranslation = {
     return (
       `\`${path}\` extends a \`group:\` preset from inside a \`packageRules\` entry, and a ` +
       `\`group:\` preset's body is itself a \`packageRules\` array — not a flat fragment of one ` +
-      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule. Renovate ` +
-      `matches a rule on that rule's own \`match*\` keys, and after the merge yours has none: the ` +
-      `group's matchers, its \`groupName\` and its \`matchUpdateTypes\` all sit one level down, ` +
-      `where the pass that just matched the rule doesn't read them. The rule matches EVERY ` +
-      `dependency and applies whatever else you put in it — an \`automerge: true\` meant for one ` +
-      `monorepo now applies to everything — and the grouping you asked for doesn't happen. ` +
-      `Write the group out inside the rule instead: extend the underlying ` +
+      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule — a shape ` +
+      `no rule option owns. On current Renovate that still behaves: a config-migration pass ` +
+      `flattens the nested rules (each inner rule merged over your outer one) after preset ` +
+      `resolution, so the matchers and \`groupName\` do land. But it works by migration ` +
+      `side-effect, not by contract — hence the warning — and it adds a DUPLICATE of a group ` +
+      `rule \`config:recommended\` already ships, so every option you set rides on a second copy ` +
+      `of the same rule; a \`group:\` preset with several inner rules would clone your options ` +
+      `onto each of them. Write the group out inside the rule instead: extend the underlying ` +
       `\`monorepo:\`/\`packages:\` preset the group uses — those are pure match criteria and are ` +
       `safe inside a rule — or copy the group's matchers, then restate \`groupName\` and the ` +
       `group's own \`matchUpdateTypes\` alongside your own options. That last part is not ` +

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -20,7 +20,7 @@ export {
   type SignatureChange,
   type SimulationComparison,
 } from "./simulate-compare";
-export { setPresetAuth, type PresetAuth } from "./auth";
+export { getPresetAuth, setPresetAuth, type PresetAuth } from "./auth";
 export { deriveUpdateType, renovateVersion } from "./version";
 export { getOptions, mergeChildConfig } from "./renovate-adapter";
 export { getOptionIndex, type OptionDoc, type OptionIndex } from "./option-docs";

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -91,19 +91,39 @@ function removeGlobalConfig(
 // the active trace collector), so runs must never overlap.
 let queue: Promise<unknown> = Promise.resolve();
 
+/** A task whose caller went away before the queue reached it. */
+export class EngineTaskCancelled extends Error {
+  constructor() {
+    super("cancelled before the engine ran it");
+    this.name = "EngineTaskCancelled";
+  }
+}
+
 /**
  * Serializes every engine entry point that touches renovate's stateful
  * modules through one queue, so e.g. a packageRules simulation (006) never
  * interleaves with a pipeline run.
+ *
+ * `signal` is checked once, at the moment the queue reaches the task — the
+ * only point where cancellation is both cheap and useful. Work already inside
+ * renovate's config modules is NOT interruptible (they are synchronous and
+ * hold module state), but a task that has been sitting in line while an
+ * earlier run finished should not start at all: with concurrent MCP handlers
+ * that is a cancelled call keeping every later question waiting.
  */
-export function enqueueEngineTask<T>(task: () => Promise<T>): Promise<T> {
-  const run = queue.then(() => task());
+export function enqueueEngineTask<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  const run = queue.then(() => {
+    if (signal?.aborted) {
+      throw new EngineTaskCancelled();
+    }
+    return task();
+  });
   queue = run.catch(() => undefined);
   return run;
 }
 
-export function runPipeline(input: PipelineInput): Promise<TraceResult> {
-  return enqueueEngineTask(() => execute(input));
+export function runPipeline(input: PipelineInput, signal?: AbortSignal): Promise<TraceResult> {
+  return enqueueEngineTask(() => execute(input), signal);
 }
 
 /**

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -12,6 +12,7 @@ import {
   resolveConfigPresets,
   validateConfig,
 } from "./renovate-adapter";
+import { getPresetAuth, setPresetAuth } from "./auth";
 import {
   getUsedInjectionKeys,
   resetInjectedPresets,
@@ -105,7 +106,38 @@ export function runPipeline(input: PipelineInput): Promise<TraceResult> {
   return enqueueEngineTask(() => execute(input));
 }
 
-async function execute(input: PipelineInput): Promise<TraceResult> {
+/**
+ * A run that brought its own credentials owns the module-level preset auth for
+ * the duration of the queued task — installed here, as the FIRST thing inside
+ * the queue, and restored when the run ends.
+ *
+ * Why it has to happen here and not at the call site: `setPresetAuth` is
+ * global module state, so a caller that installs credentials and then awaits
+ * `runPipeline` has published them to every run that starts in between. With
+ * concurrent callers (the MCP server's handlers run in parallel) that is a
+ * real credential leak — run B's tokens riding along on run A's remaining
+ * preset fetches, to an endpoint run A's untrusted global config chose. Inside
+ * the queue the pipeline is the only thing running, so the install and every
+ * fetch it feeds are one atomic unit.
+ */
+async function withRunAuth<T>(input: PipelineInput, task: () => Promise<T>): Promise<T> {
+  if (input.presetAuth === undefined) {
+    return task();
+  }
+  const previous = getPresetAuth();
+  setPresetAuth(input.presetAuth);
+  try {
+    return await task();
+  } finally {
+    setPresetAuth(previous);
+  }
+}
+
+function execute(input: PipelineInput): Promise<TraceResult> {
+  return withRunAuth(input, () => executeRun(input));
+}
+
+async function executeRun(input: PipelineInput): Promise<TraceResult> {
   const platformContext = resolvePlatformContext(input);
   const collector = new TraceCollector(parsePreset, platformContext);
   setCurrentCollector(collector);

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -13,6 +13,12 @@ export { massageConfig } from "renovate/dist/config/massage.js";
 export { validateConfig } from "renovate/dist/config/validation.js";
 export { resolveConfigPresets } from "renovate/dist/config/presets/index.js";
 export { parsePreset } from "renovate/dist/config/presets/parse.js";
+// Renovate's bundled preset bodies (`group:`, `monorepo:`, `packages:`, …).
+// Synchronous and network-free, and already in the module graph via
+// `presets/index.js` — roadmap 014's `group:`-preset translation reads the
+// flagged group's OWN body rather than restating it, so the suggested rule
+// can't drift from the pinned Renovate.
+export { getPreset as getInternalPreset } from "renovate/dist/config/presets/internal/index.js";
 export { mergeChildConfig } from "renovate/dist/config/utils.js";
 export { getConfig as getDefaultConfig } from "renovate/dist/config/defaults.js";
 export { GlobalConfig } from "renovate/dist/config/global.js";

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -300,8 +300,11 @@ const NOT_SIMULATED_NOTE =
   "not simulated — matchConfidence requires a Merge Confidence API token; " +
   "a real Renovate run without one throws instead of evaluating the rule";
 
-export function simulatePackageRules(input: SimulationInput): Promise<SimulationResult> {
-  return enqueueEngineTask(() => execute(input));
+export function simulatePackageRules(
+  input: SimulationInput,
+  signal?: AbortSignal,
+): Promise<SimulationResult> {
+  return enqueueEngineTask(() => execute(input), signal);
 }
 
 /**

--- a/packages/engine/src/trace/model.ts
+++ b/packages/engine/src/trace/model.ts
@@ -1,4 +1,5 @@
 import type { Operation } from "fast-json-patch";
+import type { PresetAuth } from "../auth";
 
 /**
  * Roadmap 033: the pipeline's stages, in execution order — the single runtime
@@ -172,6 +173,17 @@ export interface PipelineInput {
    * the canonical injection key (see `presetInjectionKey`).
    */
   injectedPresets?: Record<string, Record<string, unknown>>;
+  /**
+   * The credentials THIS run's preset fetches may use. Set it and the run owns
+   * its own auth: the pipeline installs it as the first step inside the
+   * serialized engine queue and restores the previous module state when the
+   * run ends, so concurrent callers (the MCP server holds several runs and its
+   * handlers run in parallel) cannot leak one run's tokens into another run's
+   * fetches — and, crucially, into an endpoint a config the caller does not
+   * trust has chosen. Omit it to keep using whatever `setPresetAuth` installed
+   * globally (the web app's single-run-at-a-time path).
+   */
+  presetAuth?: PresetAuth;
 }
 
 /** The platform + endpoint a run resolved `local>` presets against. */

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -99,6 +99,16 @@ declare module "renovate/dist/config/presets/parse.js" {
   export function parsePreset(input: string): ParsedPreset;
 }
 
+declare module "renovate/dist/config/presets/internal/index.js" {
+  /** Renovate's own bundled presets, keyed by `repo` (the part before the `:`)
+   *  and `presetName`. Synchronous — internal presets are data in `dist`, not
+   *  a fetch. `undefined` when the pair names no bundled preset. */
+  export function getPreset(config: {
+    repo?: string;
+    presetName?: string;
+  }): RenovateConfig | undefined;
+}
+
 declare module "renovate/dist/config/presets/util.js" {
   export const PRESET_DEP_NOT_FOUND: string;
   export const PRESET_INVALID: string;

--- a/packages/engine/test/engine-queue.node.test.ts
+++ b/packages/engine/test/engine-queue.node.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Golden project: the engine's task queue, and the one thing a caller can do
+ * about a task it no longer wants.
+ *
+ * Roadmap 068 (L4): renovate's config modules hold module-level state, so
+ * every engine entry point is serialized through one queue — which means a
+ * call whose client already went away does not merely waste its own time, it
+ * holds up every question asked after it. The work itself is synchronous and
+ * stateful and cannot be interrupted; NOT STARTING it is the whole of what is
+ * achievable, and it is checked at the one moment that matters: when the queue
+ * reaches the task.
+ */
+import { describe, expect, it } from "vitest";
+import { runPipeline, simulatePackageRules } from "../src/index";
+
+const CONFIG = { fileName: "renovate.json", content: '{"labels":["deps"]}' };
+
+describe("engine queue", () => {
+  it("never starts a run whose caller has gone away", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(runPipeline(CONFIG, controller.signal)).rejects.toThrow(/cancelled/);
+  });
+
+  it("…nor a simulation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      simulatePackageRules({ config: {}, dep: { depName: "react" } }, controller.signal),
+    ).rejects.toThrow(/cancelled/);
+  });
+
+  it("a cancelled task does not take the queue down with it", async () => {
+    const cancelled = new AbortController();
+    cancelled.abort();
+    const [refused, ran] = await Promise.allSettled([
+      runPipeline(CONFIG, cancelled.signal),
+      runPipeline(CONFIG, new AbortController().signal),
+    ]);
+    expect(refused.status).toBe("rejected");
+    expect(ran.status).toBe("fulfilled");
+    expect(ran.status === "fulfilled" && ran.value.finalConfig?.labels).toEqual(["deps"]);
+  });
+
+  it("a signal that is never aborted changes nothing", async () => {
+    const result = await runPipeline(CONFIG, new AbortController().signal);
+    expect(result.finalConfig?.labels).toEqual(["deps"]);
+  });
+});

--- a/packages/engine/test/error-translations.node.test.ts
+++ b/packages/engine/test/error-translations.node.test.ts
@@ -286,6 +286,222 @@ describe("global-only-option translation (008 boundary warning)", () => {
   });
 });
 
+function groupPresetMessage(path: string): ValidationMessage {
+  return {
+    topic: "Configuration Warning",
+    message: `${path}: you should not extend "group:" presets`,
+  };
+}
+
+describe("group-preset-in-package-rule translation (068 — the common WARNING)", () => {
+  const message = groupPresetMessage;
+
+  it("matches the exact upstream message shape, topic-independently", () => {
+    const translation = must(
+      ERROR_TRANSLATIONS.find((t) => t.id === "group-preset-in-package-rule"),
+      "the group-preset-in-package-rule translation",
+    );
+    expect(translation.matches(message("packageRules[0].extends"))).toBe(true);
+    // `explain_message` defaults the topic to "Configuration Error" when a
+    // caller passes only the text — the match must not depend on the topic.
+    expect(
+      translation.matches({
+        topic: "Configuration Error",
+        message: 'packageRules[0].extends: you should not extend "group:" presets',
+      }),
+    ).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains the structural reason: the preset body is a packageRules array", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), null),
+      "a translation for the group-preset message",
+    );
+    expect(translated.explanation).toContain("packageRules[0].extends");
+    expect(translated.explanation).toMatch(/`packageRules` array/);
+    expect(translated.explanation).toMatch(/matchUpdateTypes/);
+    expect(translated.explanation).toMatch(/pin/);
+    expect(translated.docsUrl).toBe("https://docs.renovatebot.com/config-presets/");
+    expect(translated.fix).toBeNull();
+  });
+
+  it("inlines a monorepo group: the underlying monorepo: preset, groupName AND matchUpdateTypes", () => {
+    const config = {
+      packageRules: [{ extends: ["group:jestMonorepo"], automerge: true }],
+    };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the group-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the jestMonorepo case");
+    expect(fix.path).toEqual(["packageRules", 0]);
+    expect(fix.after).toEqual({
+      extends: ["monorepo:jest"],
+      groupName: "jest monorepo",
+      // the group's own pin-excluding update types, restated verbatim
+      matchUpdateTypes: ["digest", "patch", "minor", "major"],
+      automerge: true,
+    });
+    expect(fix.fixedConfig).toEqual({
+      packageRules: [
+        {
+          extends: ["monorepo:jest"],
+          groupName: "jest monorepo",
+          matchUpdateTypes: ["digest", "patch", "minor", "major"],
+          automerge: true,
+        },
+      ],
+    });
+    expect(fix.summary).toContain("group:jestMonorepo");
+    // original untouched
+    expect(config.packageRules[0]?.extends).toEqual(["group:jestMonorepo"]);
+  });
+
+  it("copies a group's plain matchers when it has no underlying preset to extend", () => {
+    const config = { packageRules: [{ extends: ["group:definitelyTyped"] }] };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the definitelyTyped group message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the definitelyTyped case");
+    expect(fix.after).toEqual({
+      groupName: "definitelyTyped",
+      matchPackageNames: ["@types/**"],
+    });
+  });
+
+  it("keeps the rule's other presets and lets the user's own value win a conflict", () => {
+    const config = {
+      packageRules: [
+        {
+          extends: ["group:jestMonorepo", "schedule:weekly"],
+          matchUpdateTypes: ["minor", "patch"],
+        },
+      ],
+    };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the group-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix that keeps the sibling preset");
+    expect(fix.after).toEqual({
+      extends: ["monorepo:jest", "schedule:weekly"],
+      groupName: "jest monorepo",
+      // explicitly set by the user, so it survives the merge
+      matchUpdateTypes: ["minor", "patch"],
+    });
+  });
+
+  it("explains without a fix when the group is a fan-out over other groups (group:monorepos)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:monorepos"] }],
+      }),
+      "a translation for the group:monorepos message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix when the group carries top-level options (group:all)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:all"] }],
+      }),
+      "a translation for the group:all message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix when two group: presets share one rule (ambiguous)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:jestMonorepo", "group:definitelyTyped"] }],
+      }),
+      "a translation for the two-group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix for a group name this Renovate doesn't bundle", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:notARealGroupPreset"] }],
+      }),
+      "a translation for the unknown-group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("gives up when the named path isn't in this config (stale message vs. edited config)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[3].extends"), { packageRules: [] as unknown[] }),
+      "a translation for the stale group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+});
+
+function globalPresetMessage(path: string): ValidationMessage {
+  return {
+    topic: "Configuration Error",
+    message: `${path}: you cannot extend from "global:" presets in a repository config's "extends"`,
+  };
+}
+
+describe("global-preset-in-extends translation", () => {
+  const message = globalPresetMessage;
+
+  it("matches the exact upstream message shape", () => {
+    const translation = must(
+      ERROR_TRANSLATIONS.find((t) => t.id === "global-preset-in-extends"),
+      "the global-preset-in-extends translation",
+    );
+    expect(translation.matches(message("extends"))).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains that global: presets belong in the self-hosted config", () => {
+    const translated = must(
+      translateMessage(message("extends"), null),
+      "a translation for the global-preset message",
+    );
+    expect(translated.explanation).toMatch(/self-hosted/);
+    expect(translated.docsUrl).toBe("https://docs.renovatebot.com/presets-global/");
+  });
+
+  it("drops only the global: entries, keeping the rest of extends", () => {
+    const translated = must(
+      translateMessage(message("extends"), {
+        extends: ["config:recommended", "global:safeEnv"],
+      }),
+      "a translation for the global-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the global-preset case");
+    expect(fix.path).toEqual(["extends"]);
+    expect(fix.after).toEqual(["config:recommended"]);
+    expect(fix.fixedConfig).toEqual({ extends: ["config:recommended"] });
+  });
+
+  it("removes the key entirely when nothing but global: presets were listed", () => {
+    const translated = must(
+      translateMessage(message("extends"), { extends: ["global:safeEnv"], labels: ["deps"] }),
+      "a translation for the global-only extends message",
+    );
+    const fix = must(translated.fix, "a remove fix for the global-only extends");
+    expect(fix.remove).toBe(true);
+    expect(fix.fixedConfig).toEqual({ labels: ["deps"] });
+  });
+
+  it("gives up when the named path isn't a string array in this config", () => {
+    const translated = must(
+      translateMessage(message("extends"), { extends: "config:recommended" }),
+      "a translation for the non-array extends message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+});
+
 describe("translateMessage", () => {
   it("returns null for a message no curated pattern recognizes", () => {
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,12 @@ importers:
 
   packages/cli:
     dependencies:
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0
+        version: 2.0.0
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0
+        version: 2.0.0
       '@renovate-config-debugger/app':
         specifier: workspace:*
         version: link:../app
@@ -123,6 +129,9 @@ importers:
       commander:
         specifier: 15.0.0
         version: 15.0.0
+      zod:
+        specifier: 4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 26.1.2
@@ -847,6 +856,18 @@ packages:
 
   '@marijn/find-cluster-break@1.0.3':
     resolution: {integrity: sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==}
+
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2476,6 +2497,14 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -2918,6 +2947,9 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@6.2.8:
+    resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
   js-md4@0.3.2:
     resolution: {integrity: sha512-/GDnfQYsltsjRswQhN9fhv3EMw2sCpUdrdxyWDOUK7eyD++r3gRhzgiQgc/x4MAv2i1iuQ4lxO5mvqM3vj4bwA==}
@@ -3636,6 +3668,10 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   playwright-core@1.62.1:
     resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
@@ -5284,6 +5320,25 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.3': {}
 
+  '@modelcontextprotocol/client@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      jose: 6.2.8
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6752,6 +6807,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7253,6 +7314,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@6.2.8: {}
 
   js-md4@0.3.2: {}
 
@@ -8130,6 +8193,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   playwright-core@1.62.1: {}
 

--- a/roadmap/060-mcp-server-and-agent-discovery.md
+++ b/roadmap/060-mcp-server-and-agent-discovery.md
@@ -1,6 +1,6 @@
 # 060 — `rcd mcp` + pointing agents at the headless interface
 
-Milestone: M16 · Status: proposed
+Milestone: M16 · Status: MCP server done (2026-08-05), discovery pending
 
 ## Summary
 
@@ -59,3 +59,31 @@ out that this exists.
   Code only prompts for plugins in the official Anthropic marketplace; until
   a listing exists the marker is inert but forward-compatible, and
   README/AGENTS.md remain the working channel.
+
+## As built — the MCP server (2026-08-05)
+
+- **The tools are the CLI's projections, not a second implementation.** 058's
+  command modules were refactored first: `src/projections/{digest,tree,
+provenance,messages}.ts` now hold the shapes, and the subcommands and the
+  MCP tools both import them. So "no new functionality" is structural — a
+  change to what `get_preset_tree` answers is a change to what `rcv tree`
+  answers.
+- Same for credentials: `applyRunAuth` (with the endpoint guard inside it) is
+  shared, so the guard cannot be enforced on one transport and forgotten on
+  the other. `run_config` takes `trustEndpoints` for the same opt-in the CLI
+  spells `--trust-endpoints`.
+- **`RunStore` is a real LRU** (8 runs): a `get` refreshes recency, so the run
+  an agent keeps drilling into is never the one evicted next, and an expired
+  handle is reported with the ids still held rather than a bare miss. Holding
+  more than one run is what makes `compare_simulations` an edit oracle across
+  two runs.
+- Tested through a real MCP client over the SDK's in-memory transport pair
+  (`test/mcp.test.ts`), so schemas, handlers and result shapes are exercised
+  the way a client exercises them.
+- **Nothing is written to stdout by `rcv mcp`** — on a stdio transport stdout
+  IS the protocol. Diagnostics go to stderr, which is also what keeps them out
+  of a `--format json` document.
+
+Still open here: the discovery half — the app footer, the READMEs, llms.txt
+and the Claude Code hint marker — which lands once 059 has published the
+package every one-liner names.


### PR DESCRIPTION
## Protocol: SDK v2, both eras

The server is built on `@modelcontextprotocol/server@2.0.0` (with
`@modelcontextprotocol/client@2.0.0` driving the tests) from this commit on —
it was never an SDK v1 server that got migrated later.

`rcd mcp` serves through the SDK's stdio ENTRY (`serveStdio`) rather than
connecting a server to a transport itself, because the entry owns the era
decision **per connection**: an opening `server/discover` pins a 2026-07-28
instance, a plain `initialize` pins a 2025-era one, and both come from the same
factory — so one process serves today's hosts and tomorrow's with no branching
in the tool code. `legacy: 'reject'` is deliberately not set.

Both eras are covered by tests: `src/mcp/server.test.ts` drives the production
entry over an in-memory transport pair — every run there is a legacy-era one
(the v2 client's default), plus one that pins 2026-07-28. The legacy handshake
over a real pipe is the `rcd mcp` subprocess test in `test/bin.test.ts`,
which lands in this PR together with the disconnect seam.

## Hardened from introduction (folded from #161 and #165)

The server ships with the fixes two blinded persona studies (9 sessions each)
and two max-depth code reviews produced, rather than acquiring them later:

- **Verdict-first `simulate`** — `detail: "verdict"` by default (matched-rule
  evidence, `flattened`, `finalDependencyConfig`); the ~1 MB merge trace only
  with `detail: "full"`. `verdict`/`source` params scope the rule list
  (`source: "repo"` = "just my own config's rules").
- **Enforced size caps** — every result passes a structural elision budget
  derived in code from the host's 25k-token cap; arrays keep a head AND a tail
  window (repo rules append last), the floor case keeps both ends too, markers
  are `{truncated, shown, omitted, omittedFrom, items}`, and hints name the
  narrowing parameter. Nothing is cut mid-JSON.
- **Credential isolation** — preset auth rides per-run on the pipeline input,
  installed inside the serialized engine queue (race-proven by a fetch-spying
  test), and a caller-supplied `endpoint` parameter withholds host tokens
  unless `trustEndpoints: true`.
- **Bounded memory** — held runs are stripped of `kind:"log"` trace events
  (~98% of their weight) and the LRU holds 3.
- **Warning translations** — `explain_message` knows the `group:`-preset
  warning (fix computed from the preset's own bundled body, `matchUpdateTypes`
  carried by construction) and the `global:`-preset error, and always says
  when it has no translation (`translationKnown: false` + note).
- **Honest comparisons** — `compare_simulations` leads with a one-line
  `summary` net-effect verdict; behavior and rule-signature churn are separate
  axes.
- Strict input schemas with a typed 21-field `dep`, tool annotations,
  `instructions`, cancellation-aware queueing, per-dep provenance notes, and
  transport-correct wording in every note.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
