### PR TITLE
fix(cli,engine): round-2 MCP hardening — verdict-first simulate, honest elision, warning translations (068)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -208,15 +208,26 @@ The server holds a small number of recent runs (an LRU), so an agent can
 compare the run before an edit with the run after it. A `runId` that has been
 evicted says so, and lists the ones still held.
 
-Three properties the tools guarantee, because an agent cannot check them:
+Four properties the tools guarantee, because an agent cannot check them:
 
-- **Every answer fits.** A tool result is capped at ~100 kB. Over that it is
-  elided _structurally_ — the largest arrays lose their tail, the omission is a
-  `{ "truncated": true, "shown": …, "omitted": … }` object in place, and the
-  top of the document names the parameter that narrows the question. Nothing is
-  ever cut mid-JSON, and nothing is dropped silently. Small answers are
-  indented for the transcript; large ones are compact, because indentation on
-  100 kB is pure token overhead.
+- **The default answer is the question you asked.** `simulate` returns the
+  verdicts, `flattened` and `finalDependencyConfig`; the step-by-step merge
+  trace (`mergeSteps`, `rawFinalConfig`) is ~1 MB on a `config:recommended` run
+  and comes only with `detail: "full"`. `compare_simulations` leads with
+  `summary`, the whole verdict in one line.
+
+- **Every answer fits.** A tool result is capped at ~65 kB — derived from the
+  host's own tool-output cap (~25k tokens), not chosen, because a bigger
+  payload would be truncated by the host mid-JSON and the guarantee would be
+  worth nothing. Over the cap the answer is elided _structurally_: the largest
+  arrays keep a head window AND a tail window, and the omission is a
+  `{ "truncated": true, "shown": …, "omitted": …, "omittedFrom": …, "items": [] }`
+  object in place. The tail window is not decoration — a merged `packageRules`
+  array is the presets' rules first and _your_ rules last. The top of the
+  document names the parameter that narrows the question. Nothing is ever cut
+  mid-JSON, and nothing is dropped silently. Small answers are indented for the
+  transcript; large ones are compact, because indentation at that size is pure
+  token overhead.
 - **Unknown parameters are errors.** Every input schema is strict, including
   `dep` — `depname` is a validation error naming the key, not a simulation
   where no matcher had any input.
@@ -224,8 +235,12 @@ Three properties the tools guarantee, because an agent cannot check them:
   credentials a run may use travel on that run's pipeline input and are
   installed inside the engine's serialized queue. A run whose global config
   chose the endpoint sends no token, whatever a concurrent trusted run is
-  doing. On this transport the opt-ins are the `platformOverride` and
-  `trustEndpoints` parameters (the flags of the same name are the CLI's).
+  doing — and so does a run whose `endpoint` came in as a tool PARAMETER,
+  because over MCP that value was written by the model, possibly out of the
+  config it was asked to inspect. On this transport the opt-ins are the
+  `platformOverride` and `trustEndpoints` parameters (the flags of the same
+  name are the CLI's); only `trustEndpoints` vouches for an endpoint the caller
+  supplied.
 
 ## Two bins
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -176,8 +176,10 @@ $ claude mcp add rcd -- npx -y @renovate-config-debugger/cli@0 mcp
 `get_final_config`, `get_preset_tree`, `get_preset_node`, `get_provenance`,
 `get_resolved_config`, `simulate`, `compare_simulations`, `explain_message` and
 `get_option_docs` all take that runId and query the HELD trace. That buys two
-things a series of CLI invocations cannot give: the module graph and the
-preset-fetch cache are paid once, and every answer describes the same run — two
+things a series of CLI invocations cannot give: the module graph is paid once
+per session — only the engine boot is amortized, since Renovate's own preset
+`memCache` resets on every run, so a fresh `run_config` still fetches its
+presets over the network — and every answer describes the same run — two
 separate `rcd` calls can silently describe different worlds if a remote preset
 changed between them.
 
@@ -186,7 +188,11 @@ handshake, with the era chosen per connection, so older clients keep working
 against the same process.
 
 Worth knowing before your first call: **preset-node bodies are large — query
-one node at a time.** The tool descriptions say so too.
+one node at a time.** The tool descriptions say so too. `simulate` takes the
+same `verdict`/`source` scoping as `rcd simulate --verdict/--source` (see
+[above](#simulate-and-compare)) — `source: "repo"` is the fix for a
+`config:best-practices` run's several-hundred-rule list when the question is
+about your own config's rules, not the presets it pulled in.
 
 In Claude Code, the [plugin](../../plugins/renovate-config-debugger) registers
 this server and adds the skill that knows the call sequence. Not published

--- a/packages/cli/bin/io.mjs
+++ b/packages/cli/bin/io.mjs
@@ -6,6 +6,7 @@
  * can never read the environment itself.
  */
 export function processIo() {
+  guardStderr();
   return {
     out: (text) => process.stdout.write(text),
     err: (text) => process.stderr.write(text),
@@ -19,6 +20,22 @@ export function processIo() {
     },
     onDisconnect,
   };
+}
+
+/**
+ * A stream with no `'error'` listener turns a write failure into an UNCAUGHT
+ * exception — so a peer that closes the pipe (`rcd digest … | head`, or an MCP
+ * host that stops reading our diagnostics) crashes the process on the next
+ * line of stderr, from inside a `write` nobody awaited. The SDK guards stdout
+ * for exactly this reason; stderr has the same failure mode and no owner.
+ *
+ * Silence is the whole point: there is nowhere left to report a broken stderr
+ * to. The process keeps running and its own exit code still speaks.
+ */
+function guardStderr() {
+  if (process.stderr.listenerCount("error") === 0) {
+    process.stderr.on("error", () => {});
+  }
 }
 
 /**

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -62,9 +62,34 @@ describe("compare", () => {
         io,
       ),
     ).toBe(0);
-    expect(io.stdout.split("\n")[0]).toBe("Behavior differs between A and B.");
+    // The headline is the comparison's own one-liner: the verdict AND what it
+    // was about, so a reader never has to assemble it from the arrays below.
+    expect(io.stdout.split("\n")[0]).toBe(
+      "Behavior differs between A and B — dependencyDashboard, description, groupName.",
+    );
     expect(io.stdout).toContain("Matched only in B:");
     expect(io.stdout).toContain("groupName");
+  });
+
+  test("the JSON carries the same one-liner, so no consumer re-derives it", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "compare",
+          fixture("clean.json"),
+          fixture("grouped.json"),
+          "--dep",
+          '{"depName":"react","packageName":"react"}',
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const { summary } = io.json() as { summary: string };
+    expect(summary).toBe("differs: dependencyDashboard, description, groupName");
+    expect(io.stdout).toContain("summary");
   });
 });
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -24,18 +24,23 @@ import { simulateAgainst } from "./simulate";
  * dropping an entry from the very array a rule matches on — it is guaranteed
  * to be true and means nothing on its own.
  */
+/** The comparison's own one-liner without its `identical:`/`differs:` prefix —
+ *  the headline states the verdict in its own words. */
+function netEffect(comparison: SimulationComparison): string {
+  return comparison.summary.slice(comparison.summary.indexOf(": ") + 2);
+}
+
 export function comparisonHeadline(comparison: SimulationComparison): string {
   if (!comparison.noChange) {
-    return "Behavior differs between A and B.";
+    return `Behavior differs between A and B — ${netEffect(comparison)}.`;
   }
   if (comparison.rulesChanged) {
     return (
-      "✓ No behavioral change — the resulting config is identical and every rule still does " +
-      "what it did (a rule's pattern text changed, which is expected when you edit the array " +
-      "the rule matches on)."
+      `✓ No behavioral change — ${netEffect(comparison)}, which is expected when you edit the ` +
+      "array the rule matches on."
     );
   }
-  return "✓ No behavioral change: the same rules matched and the resulting config is identical.";
+  return `✓ No behavioral change: ${netEffect(comparison)}.`;
 }
 
 export const compareCommand: Command = {

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -5,11 +5,26 @@ import { RESULT_BUDGET_BYTES, serializeResult } from "./result";
  *  `server.test.ts`, where a real `config:recommended` run supplies the
  *  payloads this module was written for. */
 
+interface ElidedArray {
+  truncated: boolean;
+  shown: number;
+  omitted: number;
+  omittedFrom: number;
+  items: unknown[];
+}
+
 describe("serializeResult", () => {
   test("small answers are indented, large ones are not", () => {
     expect(serializeResult({ a: 1 })).toContain("\n  ");
     const big = { items: Array.from({ length: 2_000 }, (_, i) => ({ i, pad: "x".repeat(20) })) };
     expect(serializeResult(big)).not.toContain("\n");
+  });
+
+  test("the budget stays under the host's own tool-output cap", () => {
+    // ~25k tokens at ~3 bytes each. A budget above it would be truncated by
+    // the HOST, mid-JSON — the one thing this module promises never happens.
+    expect(RESULT_BUDGET_BYTES).toBeLessThanOrEqual(75_000);
+    expect(RESULT_BUDGET_BYTES).toBeGreaterThan(50_000);
   });
 
   test("an over-budget payload is elided, never cut mid-JSON", () => {
@@ -23,15 +38,24 @@ describe("serializeResult", () => {
       truncated: boolean;
       hint: string;
       keep: string;
-      rules: { truncated: boolean; shown: number; omitted: number; items: unknown[] };
+      rules: ElidedArray;
     };
     expect(parsed.truncated).toBe(true);
-    expect(parsed.hint).toBe("pass `key` to narrow it");
+    expect(parsed.hint).toContain("pass `key` to narrow it");
     // The rest of the document survives intact.
     expect(parsed.keep).toBe("small");
     expect(parsed.rules.truncated).toBe(true);
     expect(parsed.rules.shown + parsed.rules.omitted).toBe(5_000);
     expect(parsed.rules.items).toHaveLength(parsed.rules.shown);
+  });
+
+  test("the hint names the shape an elided array takes", () => {
+    const text = serializeResult({
+      rules: Array.from({ length: 5_000 }, (_, i) => ({ i, pad: "y".repeat(60) })),
+    });
+    const parsed = JSON.parse(text) as { hint: string };
+    expect(parsed.hint).toContain("omittedFrom");
+    expect(parsed.hint).toContain("FIRST and the LAST");
   });
 
   test("without a hint it still says how to proceed", () => {
@@ -50,5 +74,80 @@ describe("serializeResult", () => {
     };
     expect(parsed.truncated).toBe(true);
     expect(parsed.omittedKeys.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Relevance inversion (roadmap 068): a merged `packageRules` array is the
+   * presets' rules first and the repo's OWN rules last, so a head-only
+   * truncation drops exactly the rules the caller wrote — with no parameter
+   * that could ask for them back.
+   */
+  test("the elision keeps a head AND a tail window, and says where the gap is", () => {
+    const rules = Array.from({ length: 4_000 }, (_, i) => ({ i, pad: "y".repeat(60) }));
+    const text = serializeResult({ rules });
+    const parsed = JSON.parse(text) as { rules: ElidedArray };
+    const items = parsed.rules.items as { i: number }[];
+    expect(parsed.rules.omitted).toBeGreaterThan(0);
+    // The array's own last element is still in the answer.
+    expect(items.at(-1)?.i).toBe(3_999);
+    expect(items[0]?.i).toBe(0);
+    // The gap is where the wrapper says it is: head below it, tail above.
+    const gap = parsed.rules.omittedFrom;
+    expect(gap).toBeGreaterThan(0);
+    expect(gap).toBeLessThan(items.length);
+    expect(items[gap - 1]?.i).toBe(gap - 1);
+    expect(items[gap]?.i).toBe(4_000 - (items.length - gap));
+  });
+
+  /**
+   * The H1 mechanism: when the payload is over budget by more than the array
+   * weighs, the allowance goes NEGATIVE. The array used to refuse to shrink
+   * below two elements, report `removed === 0`, and hand the whole payload to
+   * the blunt key-dropping — which is how a simulate answer came back with 2
+   * of 713 rules and no merge trace, on a third of the budget.
+   */
+  test("an array that cannot afford one element still converges, without dropping keys", () => {
+    const payload = {
+      answer: { a: "b" },
+      rules: Array.from({ length: 700 }, (_, i) => ({ i, pad: "r".repeat(400) })),
+      trace: Array.from({ length: 700 }, (_, i) => ({ i, pad: "t".repeat(400) })),
+    };
+    const text = serializeResult(payload);
+    expect(text.length).toBeLessThanOrEqual(RESULT_BUDGET_BYTES);
+    const parsed = JSON.parse(text) as {
+      omittedKeys?: string[];
+      answer: unknown;
+      rules: ElidedArray;
+      trace: ElidedArray;
+    };
+    // Every key survives — the arrays gave the bytes back themselves.
+    expect(parsed.omittedKeys).toBeUndefined();
+    expect(parsed.answer).toEqual({ a: "b" });
+    expect(parsed.rules.shown).toBeGreaterThan(0);
+    expect(parsed.trace.shown).toBeGreaterThan(0);
+  });
+
+  /**
+   * The escape the head/tail windows must not break: a dozen small nodes next
+   * to one enormous subtree. Truncating around the trunk would answer with the
+   * leaves; the pass leaves the array alone and elides INSIDE the big element.
+   */
+  test("one enormous element is kept, and elided inside", () => {
+    const payload = {
+      children: [
+        ...Array.from({ length: 12 }, (_, i) => ({ name: `leaf-${i}` })),
+        {
+          name: "trunk",
+          body: Array.from({ length: 5_000 }, (_, i) => ({ i, pad: "p".repeat(60) })),
+        },
+      ],
+    };
+    const parsed = JSON.parse(serializeResult(payload)) as {
+      children: { name: string; body?: ElidedArray }[];
+    };
+    const trunk = parsed.children.find((child) => child.name === "trunk");
+    expect(trunk).toBeDefined();
+    expect(trunk?.body?.truncated).toBe(true);
+    expect(parsed.children).toHaveLength(13);
   });
 });

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -123,8 +123,17 @@ describe("serializeResult", () => {
     // Every key survives — the arrays gave the bytes back themselves.
     expect(parsed.omittedKeys).toBeUndefined();
     expect(parsed.answer).toEqual({ a: "b" });
-    expect(parsed.rules.shown).toBeGreaterThan(0);
-    expect(parsed.trace.shown).toBeGreaterThan(0);
+    // The floor keeps BOTH ends — the exact promise ELIDED_ARRAY_SHAPE ships,
+    // and the tail is where a merged packageRules array keeps the repo's own
+    // rules. The gap marker must sit inside `items`, never past its end.
+    for (const elided of [parsed.rules, parsed.trace]) {
+      const items = elided.items as { i: number }[];
+      expect(elided.shown).toBeGreaterThanOrEqual(2);
+      expect(items[0]?.i).toBe(0);
+      expect(items.at(-1)?.i).toBe(699);
+      expect(elided.omittedFrom).toBeGreaterThan(0);
+      expect(elided.omittedFrom).toBeLessThan(items.length);
+    }
   });
 
   /**

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -2,11 +2,10 @@
  * The one JSON document every MCP tool answers with — and its size budget.
  *
  * Two economics, one module. A model consumer pays for every byte, and the
- * host truncates what it cannot fit (Claude Code caps tool output at 25k
- * tokens by default), so:
+ * host truncates what it cannot fit, so:
  *
  * - small answers are pretty-printed, because a human reads them in the
- *   transcript; large ones are compact, because indentation on a 100 kB
+ *   transcript; large ones are compact, because indentation on a 60 kB
  *   payload is pure token overhead;
  * - an answer that would blow the budget is elided STRUCTURALLY — never cut
  *   mid-JSON — and says so, with the parameter that narrows the question.
@@ -17,8 +16,25 @@
 /** Above this, indentation stops paying for itself. */
 const PRETTY_LIMIT_BYTES = 4_000;
 
-/** The most any single tool result may carry. */
-export const RESULT_BUDGET_BYTES = 100_000;
+/** Claude Code's default cap on a tool result, in tokens; the hosts that
+ *  publish a number are all in this range. */
+const HOST_TOKEN_CAP = 25_000;
+
+/** Compact JSON of this shape measures out at roughly three bytes to the
+ *  token — identifiers and punctuation tokenize worse than prose. */
+const BYTES_PER_TOKEN = 3;
+
+/**
+ * The most any single tool result may carry: the host's own cap, with head
+ * room for the transport framing around the payload and for a tokenizer that
+ * does worse than the average on a given answer.
+ *
+ * DERIVED, not picked. A budget above the host's cap defeats the one guarantee
+ * this module makes — the host truncates the overflow mid-JSON, and an agent
+ * is left holding a document it cannot parse, from a module that promised it
+ * never would.
+ */
+export const RESULT_BUDGET_BYTES = Math.round(HOST_TOKEN_CAP * BYTES_PER_TOKEN * 0.87);
 
 /** Elide to slightly under, so the wrapper keys still fit. */
 const ELISION_TARGET_BYTES = RESULT_BUDGET_BYTES - 2_000;
@@ -28,6 +44,27 @@ const MAX_ELISION_ROUNDS = 500;
 const DEFAULT_HINT =
   "this answer was elided to fit the tool-output budget — ask a narrower question " +
   "(one key, one node, a smaller depth) and call again.";
+
+/**
+ * What an elided array LOOKS like, said once and appended to whichever hint
+ * the tool supplied. A model that meets `{truncated, shown, omitted, …}`
+ * without being told what it is reads it as data the config contained.
+ */
+const ELIDED_ARRAY_SHAPE =
+  "An elided array is replaced by `{truncated, shown, omitted, omittedFrom, items}`: `items` " +
+  "holds the FIRST and the LAST elements of the original array, `omitted` counts the ones " +
+  "dropped between them, and `omittedFrom` is the index in `items` where they were.";
+
+/** How much of a shrinking array's allowance the TAIL window may claim. */
+const TAIL_SHARE = 0.25;
+
+/** What one array lost, across every round that shrank it. */
+interface Elision {
+  /** Elements dropped in total. */
+  omitted: number;
+  /** Where the gap sits among the elements that remain. */
+  from: number;
+}
 
 function byteLength(text: string): number {
   return new TextEncoder().encode(text).length;
@@ -70,11 +107,19 @@ function largestArray(value: unknown, skip: Set<unknown[]>): unknown[] | null {
 
 /** Rewrites every shortened array into a self-describing wrapper, so the
  *  omission is a fact in the document rather than a missing element. */
-function applyElisions(value: unknown, elided: Map<unknown[], number>): unknown {
+function applyElisions(value: unknown, elided: Map<unknown[], Elision>): unknown {
   if (Array.isArray(value)) {
     const items = value.map((item) => applyElisions(item, elided));
-    const omitted = elided.get(value);
-    return omitted ? { truncated: true, shown: items.length, omitted, items } : items;
+    const elision = elided.get(value);
+    return elision
+      ? {
+          truncated: true,
+          shown: items.length,
+          omitted: elision.omitted,
+          omittedFrom: elision.from,
+          items,
+        }
+      : items;
   }
   if (isRecord(value)) {
     return Object.fromEntries(
@@ -108,41 +153,88 @@ function dropLargestKeys(payload: Record<string, unknown>): string[] {
   return dropped;
 }
 
+/** Everything but the first element, so the next round can work inside it. */
+function collapseToFirst(array: unknown[]): Elision | null {
+  const removed = array.length - 1;
+  if (removed <= 0) {
+    return null;
+  }
+  array.splice(1, removed);
+  return { omitted: removed, from: 1 };
+}
+
 /**
- * Keeps the longest leading run of elements that fits in `allowance`, and at
- * least one — the shape of an answer is part of the answer.
+ * Keeps a HEAD window and a TAIL window of the array — as much of each as
+ * `allowance` affords — and removes the span between them. Returns null when
+ * the array has nothing to give back.
  *
- * Measured, not counted: an array's bytes are never spread evenly across it,
- * so "keep half" either throws away a document to save nothing (a preset
- * tree's fat child is last) or saves nothing at all (it is first). Returns how
- * many elements went.
+ * Two properties earn the bookkeeping:
+ *
+ * - Measured, not counted. An array's bytes are never spread evenly across it,
+ *   so "keep half" either throws away a document to save nothing (a preset
+ *   tree's fat child is last) or saves nothing at all (it is first).
+ * - A tail window AT ALL, because relevance is not spread evenly either. A
+ *   merged `packageRules` array is the presets' rules first and the repo's OWN
+ *   rules last, so a head-only truncation drops precisely the rules the person
+ *   asking wrote — `get_resolved_config` kept rules 0–329 of 714 and lost the
+ *   caller's own rule at index 713, with no parameter that could ask for it.
  */
-function shrinkArray(array: unknown[], allowance: number): number {
+function shrinkArray(array: unknown[], allowance: number): Elision | null {
+  const sizes = array.map((item) => byteLength(stringify(item)) + 1);
+  const first = sizes[0] ?? 0;
+
+  if (sizes.some((size) => size > allowance)) {
+    // An element that alone blows the whole allowance IS the answer — a preset
+    // tree is one enormous child next to a dozen small ones. Truncating AROUND
+    // it returns the leaves and drops the trunk, so this array gives nothing
+    // back and the next round elides INSIDE the big element instead.
+    //
+    // Unless the allowance will not even cover the array's FIRST element: then
+    // nothing here fits, and "give nothing back" is how the pass stalls —
+    // `removed === 0` marks the array exhausted, no array can shrink, and the
+    // blunt key-dropping below inherits the whole problem. That is how a
+    // simulate answer came back holding 2 of 713 rules and no merge trace at
+    // all, on a third of the budget. One element is the honest floor.
+    return allowance >= first ? null : collapseToFirst(array);
+  }
+
+  const last = array.length - 1;
+  // The tail is measured first, so a long head cannot eat the room it needs.
+  const tailAllowance = Math.max(0, Math.floor(allowance * TAIL_SHARE));
   let used = 0;
-  let keep = 0;
-  for (const item of array) {
-    const size = byteLength(stringify(item)) + 1;
-    if (keep > 0 && used + size > allowance) {
-      // An element that alone blows the whole allowance IS the answer — a
-      // preset tree is one enormous child next to a dozen small ones. Keep it
-      // and let the next round elide inside it, rather than returning the
-      // twelve leaves and dropping the trunk.
-      if (size > allowance) {
-        keep += 1;
-      }
+  let tail = 0;
+  while (tail < last) {
+    const size = sizes[last - tail] ?? 0;
+    if (used + size > tailAllowance) {
       break;
     }
     used += size;
-    keep += 1;
+    tail += 1;
   }
-  const removed = array.length - keep;
-  array.length = keep;
-  return removed;
+
+  let head = 0;
+  while (head < array.length - tail) {
+    const size = sizes[head] ?? 0;
+    // The first element is always kept: the shape of an answer is part of the
+    // answer.
+    if (head > 0 && used + size > allowance) {
+      break;
+    }
+    used += size;
+    head += 1;
+  }
+
+  const removed = array.length - head - tail;
+  if (removed <= 0) {
+    return null;
+  }
+  array.splice(head, removed);
+  return { omitted: removed, from: head };
 }
 
 function elideToBudget(compact: string, hint: string | undefined): Record<string, unknown> {
   const clone = JSON.parse(compact) as unknown;
-  const elided = new Map<unknown[], number>();
+  const elided = new Map<unknown[], Elision>();
   // Arrays that cannot give anything back — one oversized element is all they
   // hold. The next round looks inside it instead.
   const exhausted = new Set<unknown[]>();
@@ -157,19 +249,23 @@ function elideToBudget(compact: string, hint: string | undefined): Record<string
     }
     // What this array may still weigh once the payload fits.
     const allowance = byteLength(stringify(largest)) - (size - ELISION_TARGET_BYTES);
-    const removed = shrinkArray(largest, allowance);
-    if (removed === 0) {
+    const shrunk = shrinkArray(largest, allowance);
+    if (!shrunk) {
       exhausted.add(largest);
       continue;
     }
-    elided.set(largest, (elided.get(largest) ?? 0) + removed);
+    const before = elided.get(largest);
+    // `from` is an index into what REMAINS, so the latest round's is the one
+    // that describes the array a caller reads; the counts accumulate.
+    elided.set(largest, { omitted: (before?.omitted ?? 0) + shrunk.omitted, from: shrunk.from });
   }
   const body = applyElisions(clone, elided);
   const payload = isRecord(body) ? { ...body } : { result: body };
   const droppedKeys = dropLargestKeys(payload);
+  const base = hint ?? DEFAULT_HINT;
   return {
     truncated: true,
-    hint: hint ?? DEFAULT_HINT,
+    hint: elided.size > 0 ? `${base} ${ELIDED_ARRAY_SHAPE}` : base,
     ...(droppedKeys.length > 0 ? { omittedKeys: droppedKeys } : {}),
     ...payload,
   };

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -153,9 +153,15 @@ function dropLargestKeys(payload: Record<string, unknown>): string[] {
   return dropped;
 }
 
-/** Everything but the first element, so the next round can work inside it. */
-function collapseToFirst(array: unknown[]): Elision | null {
-  const removed = array.length - 1;
+/**
+ * Everything but the first and the last element, so the next round can work
+ * inside them. Both ends survive on purpose: `ELIDED_ARRAY_SHAPE` promises
+ * the caller exactly that, and the tail is where a merged `packageRules`
+ * array keeps the repo's own rules — the floor case must not be the one
+ * branch that breaks the promise.
+ */
+function collapseToEnds(array: unknown[]): Elision | null {
+  const removed = array.length - 2;
   if (removed <= 0) {
     return null;
   }
@@ -194,8 +200,8 @@ function shrinkArray(array: unknown[], allowance: number): Elision | null {
     // `removed === 0` marks the array exhausted, no array can shrink, and the
     // blunt key-dropping below inherits the whole problem. That is how a
     // simulate answer came back holding 2 of 713 rules and no merge trace at
-    // all, on a third of the budget. One element is the honest floor.
-    return allowance >= first ? null : collapseToFirst(array);
+    // all, on a third of the budget. First-and-last is the honest floor.
+    return allowance >= first ? null : collapseToEnds(array);
   }
 
   const last = array.length - 1;

--- a/packages/cli/src/mcp/run-store.ts
+++ b/packages/cli/src/mcp/run-store.ts
@@ -14,9 +14,11 @@ import { CliError } from "../io";
  * different worlds if a remote preset changed between them, two `{runId}`
  * lookups cannot.
  *
- * Small on purpose. A debugging session works on one config at a time; the
- * older entries exist so an agent can compare the run before its edit with the
- * run after it.
+ * Small on purpose, and measured. A `config:recommended` trace costs ~165 MB
+ * of heap, so the old limit of 8 held ~1.4 GB in a long session — in a process
+ * the host keeps alive for as long as the agent is working. A debugging
+ * session works on one config at a time and the documented before/after oracle
+ * needs two, so three is the whole requirement plus one.
  */
 
 export interface HeldRun {
@@ -27,7 +29,25 @@ export interface HeldRun {
   facts: RunFacts;
 }
 
-export const DEFAULT_RUN_LIMIT = 8;
+export const DEFAULT_RUN_LIMIT = 3;
+
+/**
+ * The held copy, without the logger shim's raw `log` events.
+ *
+ * Measured on a `config:recommended` run: 76.1 MB of events, 74.8 MB of it
+ * `kind: "log"` — and NOTHING on the MCP path reads them. The trace's own
+ * derivations index `stage-complete`, `migration-applied` and `preset-error`;
+ * the preset tree, the provenance replay and the resolved-config projection
+ * read no events at all. `rcd run --slice events` does print them, but that is
+ * the CLI's own one-shot path, which never touches this store.
+ *
+ * A COPY, never a mutation: the caller still holds the result it handed over,
+ * and a store is no place to decide what that caller may still look at.
+ */
+function heldTrace(result: TraceResult): TraceResult {
+  const events = result.events.filter((event) => event.kind !== "log");
+  return events.length === result.events.length ? result : { ...result, events };
+}
 
 export class RunStore {
   readonly #runs = new Map<string, HeldRun>();
@@ -40,11 +60,12 @@ export class RunStore {
 
   put(result: TraceResult, input: PipelineInput): HeldRun {
     this.#counter += 1;
+    const held = heldTrace(result);
     const run: HeldRun = {
       runId: `run-${this.#counter}`,
-      result,
+      result: held,
       input,
-      facts: deriveRunFacts(result),
+      facts: deriveRunFacts(held),
     };
     this.#runs.set(run.runId, run);
     // Map iterates in insertion order, so the first key is the oldest.

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -6,7 +6,7 @@ import { getPresetAuth, setPresetAuth } from "@renovate-config-debugger/engine";
 import pkg from "../../package.json";
 import { createMcpServer } from "./server";
 import { RESULT_BUDGET_BYTES } from "./result";
-import { RunStore } from "./run-store";
+import { DEFAULT_RUN_LIMIT, RunStore } from "./run-store";
 import { recordingIo } from "../test-harness";
 
 /**
@@ -46,15 +46,18 @@ interface ConnectOptions {
   env?: Record<string, string | undefined>;
   /** Omitted: the client's default, the 2025-era `initialize` handshake. */
   era?: "modern";
+  /** A store the test can read back — what the server HELD, not what it answered. */
+  store?: RunStore;
 }
 
 async function connect(options?: ConnectOptions): Promise<void> {
   const io = recordingIo(options?.env ? { env: options.env } : undefined);
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   // One factory, both eras — the entry pins ONE instance per connection.
-  const handle: StdioServerHandle = serveStdio(() => createMcpServer(io), {
-    transport: serverTransport,
-  });
+  const handle: StdioServerHandle = serveStdio(
+    () => createMcpServer(io, options?.store ? { store: options.store } : undefined),
+    { transport: serverTransport },
+  );
   client = new Client(
     { name: "test", version: "0" },
     options?.era === "modern"
@@ -267,6 +270,51 @@ describe("credential isolation", () => {
     expect(getPresetAuth()).toEqual(before);
   });
 
+  /**
+   * M3 (roadmap 068). The guard used to inspect the GLOBAL CONFIG only — but
+   * `endpoint` is also a parameter of this tool, and over MCP the model fills
+   * it in, plausibly from text in the repository it was asked to inspect.
+   * `run_config({content: '{"extends":["local>me/presets"]}', endpoint:
+   * "https://ghe.attacker.example/api/v3/"})` sent RCD_GITHUB_TOKEN there with
+   * no opt-in at all. The CLI is unaffected: a person typed the flag.
+   */
+  test("an endpoint the CALLER chose withholds tokens until it is vouched for", async () => {
+    await close();
+    await connect({ env: { GITHUB_TOKEN: "gh-token" } });
+    const requests: { url: string; authorization: string | null }[] = [];
+    vi.stubGlobal("fetch", (input: unknown, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        authorization: new Headers(init?.headers).get("authorization"),
+      });
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    const args = {
+      fileName: "renovate.json",
+      content: '{"extends":["github>elsewhere/presets"]}',
+      endpoint: "https://ghe.attacker.example/api/v3/",
+    };
+
+    const guarded = (await call("run_config", args)) as { notes?: string[] };
+    expect(guarded.notes?.join(" ")).toContain("credentials withheld");
+    // `platformOverride` is NOT the opt-in here: it only decides whose
+    // endpoint wins, and both candidates are values this caller supplied.
+    const overridden = (await call("run_config", { ...args, platformOverride: true })) as {
+      notes?: string[];
+    };
+    expect(overridden.notes?.join(" ")).toContain("credentials withheld");
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.map((r) => r.authorization)).toEqual(requests.map(() => null));
+
+    requests.length = 0;
+    const vouched = (await call("run_config", { ...args, trustEndpoints: true })) as {
+      notes?: string[];
+    };
+    expect(vouched).not.toHaveProperty("notes");
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests.every((r) => r.authorization === "Bearer gh-token")).toBe(true);
+  });
+
   test("a run never installs its credentials outside the engine's queue", async () => {
     await close();
     await connect({ env: { GITHUB_TOKEN: "gh-token" } });
@@ -301,6 +349,23 @@ describe("drill-down", () => {
     };
     expect(entry.winner).toBe("repo");
     expect(entry.chain.length).toBeGreaterThan(0);
+  });
+
+  /**
+   * Roadmap 068 (2 persona sessions + the review): provenance answers "which
+   * LAYER set this", and both personas read a static winner as "the value
+   * Renovate will use" for an update a packageRule actually overrides.
+   */
+  test("a key packageRules can also set says so, and points at the simulator", async () => {
+    const runId = await runConfig(GROUPED);
+    const grouped = (await call("get_provenance", { runId, key: "groupName" })) as {
+      note?: string;
+    };
+    expect(grouped.note).toContain("1 packageRule can set `groupName` per-dependency");
+    expect(grouped.note).toContain("Simulate a dependency");
+    // A key no rule touches carries no such caveat.
+    const labels = (await call("get_provenance", { runId, key: "labels" })) as { note?: string };
+    expect(labels.note).toBeUndefined();
   });
 
   test("the resolved document keeps internal presets by default", async () => {
@@ -422,6 +487,44 @@ describe("strict input schemas", () => {
       expect(tool.inputSchema.additionalProperties, tool.name).toBe(false);
     }
   });
+
+  /**
+   * Roadmap 068, from the persona study: two sessions burned actions on an
+   * "Invalid input, Invalid input" rejection that named no field. This pins
+   * what the SDK actually reports for the shapes those sessions produced —
+   * the zod issue PATH, joined and prefixed — so a schema change that loses
+   * the field name is a failing test rather than a lost session. The commonest
+   * mistake by far is the first one: `content` is the file's TEXT.
+   */
+  test("a rejected argument names the field, and its type", async () => {
+    const errorFor = async (name: string, args: Record<string, unknown>): Promise<string> => {
+      const result = (await client.callTool({ name, arguments: args })) as ToolText;
+      expect(result.isError, JSON.stringify(args)).toBe(true);
+      return result.content[0]?.text ?? "";
+    };
+    expect(
+      await errorFor("run_config", { content: { extends: ["config:recommended"] } }),
+    ).toContain("content: Invalid input: expected string, received object");
+    expect(await errorFor("run_config", { fileName: "renovate.json" })).toContain(
+      "content: Invalid input: expected string, received undefined",
+    );
+    expect(await errorFor("simulate", { runId: "run-1", dep: { depName: 5 } })).toContain(
+      "dep.depName: Invalid input: expected string, received number",
+    );
+    expect(await errorFor("simulate", { runId: "run-1", dep: {}, verdict: "sometimes" })).toContain(
+      'verdict: Invalid option: expected one of "notable"',
+    );
+  });
+
+  test("the content parameter says it wants the file's text", async () => {
+    const { tools } = await client.listTools();
+    const runConfigTool = tools.find((t) => t.name === "run_config");
+    const content = (
+      runConfigTool?.inputSchema.properties as { content?: { description?: string } } | undefined
+    )?.content;
+    expect(content?.description).toContain("JSON *string*");
+    expect(content?.description).toContain("not the parsed object");
+  });
 });
 
 describe("simulate and compare", () => {
@@ -442,6 +545,62 @@ describe("simulate and compare", () => {
     expect(sim.dep.updateType).toBe("major");
     expect(sim.rules[0]?.verdict).toBe("matched");
     expect(sim.rules[0]?.clauses[0]).toMatchObject({ key: "matchPackageNames" });
+  });
+
+  /**
+   * H1 (roadmap 068, 6 of 9 persona sessions). The whole `SimulationResult`
+   * for `config:recommended` + a react update is 1.36 MB, of which
+   * `mergeSteps` is 797 kB and `rawFinalConfig` 199 kB — and the elision spent
+   * the budget on them, answering with 2 of 713 rules and no merge trace
+   * anyway. The default answer is now the question that was asked.
+   */
+  test("the merge trace is opt-in, so the verdict is what comes back", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const dep = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
+    const text = await callText("simulate", { runId, dep });
+    const parsed = JSON.parse(text) as {
+      truncated?: boolean;
+      omittedKeys?: string[];
+      detailNote: string;
+      finalDependencyConfig: Record<string, unknown>;
+      flattened: unknown;
+      rules: { truncated: boolean; shown: number; omitted: number } | unknown[];
+    };
+    expect(parsed).not.toHaveProperty("mergeSteps");
+    expect(parsed).not.toHaveProperty("rawFinalConfig");
+    // The omission is stated, with the parameter that undoes it.
+    expect(parsed.detailNote).toContain('detail: "full"');
+    // The answer itself survives WHOLE — no key was dropped to make room.
+    expect(parsed.omittedKeys).toBeUndefined();
+    expect(parsed.flattened).toBeDefined();
+    expect(Object.keys(parsed.finalDependencyConfig).length).toBeGreaterThan(10);
+    // And the rule list is a real sample of 713, not a token two.
+    const rules = parsed.rules as { shown: number; omitted: number };
+    expect(rules.shown + rules.omitted).toBeGreaterThan(700);
+    expect(rules.shown).toBeGreaterThan(20);
+  });
+
+  /**
+   * And the other half of the argument for the default: `full` asks for the
+   * merge trace, and a merge step is a whole config snapshot — even this
+   * three-line config's is far over the budget, so the answer comes back with
+   * the trace elided or dropped BY NAME. That is the honest outcome of asking
+   * for it; it is not the shape to spend a call on by accident.
+   */
+  test('detail: "full" asks for the merge trace, and pays for it', async () => {
+    const runId = await runConfig(GROUPED);
+    const dep = { depName: "react", packageName: "react" };
+    const full = (await call("simulate", { runId, dep, detail: "full" })) as {
+      truncated?: boolean;
+      omittedKeys?: string[];
+      detailNote?: string;
+    };
+    expect(full.detailNote).toBeUndefined();
+    expect(full.truncated).toBe(true);
+    expect(full.omittedKeys).toContain("mergeSteps");
+    // The default answer for the same question never got that big.
+    const verdict = (await call("simulate", { runId, dep })) as { truncated?: boolean };
+    expect(verdict.truncated).toBeUndefined();
   });
 
   test("verdict/source scope the rule list and say what they hid", async () => {
@@ -472,9 +631,13 @@ describe("simulate and compare", () => {
       runId: before,
       runIdB: after,
       dep,
-    })) as { noChange: boolean; matchedOnlyInB: { label: string }[] };
+    })) as { noChange: boolean; summary: string; matchedOnlyInB: { label: string }[] };
     expect(comparison.noChange).toBe(false);
     expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
+    // Roadmap 068 (4 of 9 persona sessions): the net effect, before anyone has
+    // to assemble it out of six arrays.
+    expect(comparison.summary).toContain("differs: ");
+    expect(comparison.summary).toContain("groupName");
   });
 
   test("the same run twice changes nothing", async () => {
@@ -482,8 +645,11 @@ describe("simulate and compare", () => {
     const comparison = (await call("compare_simulations", {
       runId,
       dep: { depName: "react", packageName: "react" },
-    })) as { noChange: boolean };
+    })) as { noChange: boolean; summary: string };
     expect(comparison.noChange).toBe(true);
+    expect(comparison.summary).toBe(
+      "identical: the same rules matched and the same effective config results",
+    );
   });
 });
 
@@ -524,6 +690,60 @@ describe("explain_message and get_option_docs", () => {
     expect(doc.name).toBe("packageRules");
     expect(doc.renovateVersion).toMatch(/^\d+\./);
     await expect(call("get_option_docs", { name: "nopeNotAnOption" })).rejects.toThrow(/search/);
+  });
+});
+
+/**
+ * H2 (roadmap 068): a held `config:recommended` trace measured ~165 MB, 76 MB
+ * of it events and 75 MB of THAT the logger shim's raw `log` records — which
+ * nothing on this path reads. Four held runs were 713 MB of heap, in a process
+ * an MCP host keeps alive for the length of a working session.
+ */
+describe("held runs carry only what the tools read", () => {
+  test("a session holds three runs — the before/after oracle needs two", () => {
+    expect(DEFAULT_RUN_LIMIT).toBe(3);
+  });
+
+  test("the held trace has no log events, and every tool still answers", async () => {
+    const store = new RunStore();
+    await close();
+    await connect({ store });
+
+    const runId = await runConfig(CONFIG);
+    const held = store.get(runId);
+    expect(held.result.events.length).toBeGreaterThan(0);
+    expect(held.result.events.some((event) => event.kind === "log")).toBe(false);
+
+    // Every drill-down answers from the stripped trace: the derivations index
+    // stage/migration/preset events, and the tree, provenance and resolved
+    // projections read no events at all.
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: CONFIG,
+    })) as { digest: string; treeSummary: { resolved: number } };
+    expect(summary.digest).toContain("Renovate accepted this config");
+    expect(summary.treeSummary.resolved).toBe(1);
+    const tree = (await call("get_preset_tree", { runId })) as {
+      root: { children: unknown[] };
+    };
+    expect(tree.root.children).toHaveLength(1);
+    const provenance = (await call("get_provenance", { runId, key: "labels" })) as {
+      winner: string;
+    };
+    expect(provenance.winner).toBe("repo");
+    const resolved = (await call("get_resolved_config", { runId })) as {
+      config: { extends: string[] };
+    };
+    expect(resolved.config.extends).toEqual([":dependencyDashboard"]);
+    const explained = (await call("explain_message", {
+      runId,
+      message: "Configuration option `labels` should be a list (Array)",
+    })) as { severity: string };
+    expect(explained.severity).toBe("error");
+    const sim = (await call("simulate", { runId, dep: { depName: "react" } })) as {
+      rules: unknown[];
+    };
+    expect(Array.isArray(sim.rules)).toBe(true);
   });
 });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -27,7 +27,13 @@ import { errorMessage, type CliIo } from "../io";
 import { buildRuleView, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
 import { describeMessage } from "../projections/messages";
-import { entryView, indexView, layerLabel, provenanceOf } from "../projections/provenance";
+import {
+  entryView,
+  indexView,
+  layerLabel,
+  perDependencyNote,
+  provenanceOf,
+} from "../projections/provenance";
 import {
   BODIES,
   type BodyKind,
@@ -47,9 +53,11 @@ import { type HeldRun, RunStore } from "./run-store";
  *
  * No new functionality — every tool below is a projection module the CLI
  * already uses — so the justification is purely interaction economics: the
- * module graph and the preset-fetch cache are paid once per session, and the
- * drill-down tools query a HELD run instead of re-running the pipeline (and a
- * fresh round of preset API calls) per question.
+ * engine boots once, and `run_config` HOLDS the trace so the drill-down tools
+ * query one consistent run instead of re-resolving (and re-fetching remote
+ * presets) per question. Only the module graph is amortized across runs;
+ * renovate's own preset cache is memCache, which the pipeline initializes and
+ * resets per run, so a SECOND `run_config` refetches everything.
  *
  * The tool descriptions carry the domain hints an agent would otherwise learn
  * the hard way — above all: preset-node bodies are large, query one node at a
@@ -125,18 +133,50 @@ function errorResult(err: unknown) {
 }
 
 /**
+ * The slice of the SDK's handler context this file reads. Narrow on purpose:
+ * a structural subset keeps the handlers assignable on both protocol eras.
+ */
+export interface ToolContext {
+  mcpReq: { signal: AbortSignal };
+}
+
+class CancelledError extends Error {
+  constructor() {
+    super("the client cancelled this request");
+  }
+}
+
+/**
+ * The client sent `notifications/cancelled`; the SDK aborted the signal and
+ * will drop whatever we answer.
+ *
+ * Checked twice — on entry, and again immediately before an engine call — for
+ * a reason the abort alone does not cover: engine work is SERIALIZED through
+ * one queue, so a cancelled call that still enqueues does not merely waste
+ * its own time, it holds up every question asked after it. Renovate's config
+ * modules are synchronous and stateful, so a run already inside them cannot be
+ * interrupted; not starting one is the whole of what is achievable.
+ */
+function throwIfCancelled(ctx: ToolContext | undefined): void {
+  if (ctx?.mcpReq.signal.aborted) {
+    throw new CancelledError();
+  }
+}
+
+/**
  * Every tool answers or explains itself; nothing throws across the wire.
  * `hint` names the narrowing to apply when this tool's answer is too large to
  * return whole (see `./result`).
  */
-function answer<Args extends unknown[]>(
+function answer<Args>(
   // `unknown` covers a promise too — every result is awaited below.
-  fn: (...args: Args) => unknown,
+  fn: (args: Args, ctx: ToolContext) => unknown,
   hint?: string,
-): (...args: Args) => Promise<ReturnType<typeof textResult>> {
-  return async (...args: Args) => {
+): (args: Args, ctx: ToolContext) => Promise<ReturnType<typeof textResult>> {
+  return async (args: Args, ctx: ToolContext) => {
     try {
-      return textResult(await fn(...args), hint);
+      throwIfCancelled(ctx);
+      return textResult(await fn(args, ctx), hint);
     } catch (err) {
       return errorResult(err);
     }
@@ -247,8 +287,52 @@ function finalConfigOf(run: HeldRun): Record<string, unknown> {
   return config;
 }
 
-function simulateRun(run: HeldRun, dep: DepInput): Promise<SimulationResult> {
-  return simulatePackageRules({ config: finalConfigOf(run), dep: toDependency(dep) });
+function simulateRun(run: HeldRun, dep: DepInput, ctx: ToolContext): Promise<SimulationResult> {
+  const input = { config: finalConfigOf(run), dep: toDependency(dep) };
+  throwIfCancelled(ctx);
+  return simulatePackageRules(input, ctx.mcpReq.signal);
+}
+
+/**
+ * H1 (roadmap 068, 6 of 9 persona sessions): what a simulate answer carries by
+ * default.
+ *
+ * Measured on `config:recommended` + a react update, the whole
+ * `SimulationResult` is 1.36 MB — of which `mergeSteps` is 797 kB (two
+ * elements, each a full config snapshot) and `rawFinalConfig` 199 kB. Those
+ * two answer "how did the merge proceed", a question nobody asked, and they
+ * drowned the one that was: the elision spent its budget on them and returned
+ * 2 of 713 rules, with the merge trace dropped whole anyway. Personas at every
+ * level asked for the same shape by hand — the matched rules, `flattened` and
+ * `finalDependencyConfig`.
+ *
+ * So the merge trace is opt-in. `full` is the old payload, unchanged, for the
+ * caller who is actually stepping through the merge.
+ */
+const SIMULATE_DETAIL = ["verdict", "full"] as const;
+type SimulateDetail = (typeof SIMULATE_DETAIL)[number];
+
+const VERDICT_DETAIL_NOTE =
+  "`mergeSteps` and `rawFinalConfig` are omitted at this detail level — on a `config:recommended` " +
+  'run they are ~1 MB of the payload and describe how the merge proceeded. Pass detail: "full" ' +
+  "for them.";
+
+/** The simulation, at the requested detail. Listed key by key rather than
+ *  subtracted from the result, so the default shape is legible here and a
+ *  future field has to be admitted on purpose. */
+function simulationPayload(sim: SimulationResult, detail: SimulateDetail) {
+  if (detail === "full") {
+    return sim;
+  }
+  return {
+    rules: sim.rules,
+    flattened: sim.flattened,
+    finalDependencyConfig: sim.finalDependencyConfig,
+    errors: sim.errors,
+    warnings: sim.warnings,
+    notes: sim.notes,
+    detailNote: VERDICT_DETAIL_NOTE,
+  };
 }
 
 function runSummary(run: HeldRun, notes: string[]) {
@@ -346,7 +430,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .string()
           .default("renovate.json")
           .describe("Drives format detection — renovate.json, renovate.json5, .renovaterc, …"),
-        content: z.string().describe("The config file's contents."),
+        content: z
+          .string()
+          .describe(
+            "The config file's contents, as a JSON *string* — the file's text, not the parsed " +
+              "object. Pass it exactly as written, comments and all; parsing it is this tool's job.",
+          ),
         globalConfig: z
           .record(z.string(), z.unknown())
           .optional()
@@ -359,7 +448,14 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .string()
           .optional()
           .describe("Platform context for `local>` presets. Defaults to github."),
-        endpoint: z.string().optional().describe("API endpoint for that platform."),
+        endpoint: z
+          .string()
+          .optional()
+          .describe(
+            "API endpoint for that platform. Setting it WITHHOLDS this server's host tokens " +
+              "unless you also set trustEndpoints — you are choosing where credentials would be " +
+              "sent, and the config under inspection is allowed to suggest an endpoint.",
+          ),
         platformOverride: z
           .boolean()
           .optional()
@@ -368,18 +464,23 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .boolean()
           .optional()
           .describe(
-            "Send host tokens even when the global config chooses the endpoint. Off by default: " +
-              "a config you did not write must not decide where your credentials go.",
+            "Send host tokens even when the global config — or this call's own `endpoint` — " +
+              "chooses where preset requests go. Off by default: neither a config you did not " +
+              "write nor a value you read out of one may decide where your credentials go.",
           ),
       }),
     },
-    answer(async (args) => {
+    answer(async (args, ctx) => {
       const { auth, notes } = resolveRunAuth(
         io.env,
         args.globalConfig,
         {
           trustEndpoints: args.trustEndpoints ?? false,
           platformOverride: args.platformOverride ?? false,
+          // The endpoint arrived as a tool PARAMETER: over MCP that is the
+          // model's choice, not the user's, and the model may have read it out
+          // of the config it is inspecting. Same guard, one layer earlier.
+          ...(args.endpoint ? { callerEndpoint: args.endpoint } : {}),
         },
         "mcp",
       );
@@ -397,7 +498,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         ...(args.endpoint ? { endpoint: args.endpoint } : {}),
         ...(args.platformOverride ? { platformOverride: true } : {}),
       };
-      const result: TraceResult = await runPipeline(input);
+      throwIfCancelled(ctx);
+      const result: TraceResult = await runPipeline(input, ctx.mcpReq.signal);
       return runSummary(store.put(result, input), notes);
     }),
   );
@@ -521,7 +623,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
               layer: layerLabel(attr.layer),
             }))
           : [];
-      return { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) };
+      const perDependency = perDependencyNote(key, result.finalConfig);
+      return {
+        ...entryView(entry),
+        ...(perDependency ? { note: perDependency } : {}),
+        ...(rules.length > 0 ? { rules } : {}),
+      };
     }, HINTS.provenance),
   );
 
@@ -563,31 +670,44 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       description:
         "Evaluates every packageRule of the run's effective config against one hypothetical " +
         "dependency update: a verdict per rule with clause-level evidence (which matcher fired, " +
-        "what it read), and the options the matching rules set for that dependency. " +
+        "what it read), the options the matching rules set for that dependency " +
+        "(`finalDependencyConfig`) and how they got there (`flattened`). " +
         "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
-        '(`source: "repo"` is "just my own config\'s rules").',
+        '(`source: "repo"` is "just my own config\'s rules"). The step-by-step merge trace is ' +
+        'NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
         dep: DEP,
         verdict: RULE_VERDICT,
         source: RULE_SOURCE,
+        detail: z
+          .enum(SIMULATE_DETAIL)
+          .optional()
+          .describe(
+            '`verdict` (the default) answers "what matched and what does this dependency end up ' +
+              'with"; `full` adds `mergeSteps` and `rawFinalConfig` — ~1 MB on a ' +
+              "`config:recommended` run, so ask for it only when you are stepping through the " +
+              "merge itself.",
+          ),
       }),
     },
-    answer(async ({ runId, dep, verdict, source }) => {
+    answer(async ({ runId, dep, verdict, source, detail }, ctx) => {
       const run = store.get(runId);
-      const sim = await simulateRun(run, dep);
+      const sim = await simulateRun(run, dep, ctx);
+      const payload = simulationPayload(sim, detail ?? "verdict");
       if (verdict === undefined && source === undefined) {
-        return { dep: toDependency(dep), ...sim };
+        return { dep: toDependency(dep), ...payload };
       }
       const view = buildRuleView(sim, run.result, {
         verdict: verdict ?? "all",
         source: source ?? "all",
         explicit: true,
+        transport: "mcp",
       });
       return {
         dep: toDependency(dep),
-        ...sim,
+        ...payload,
         rules: view.rules,
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
         ...ruleFilterPayload(view),
@@ -601,10 +721,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Did my edit change anything?",
       description:
         "The edit oracle. Run the config before your edit and the config after it, then compare " +
-        "the two runs against the same dependency — you get the rules that started or stopped " +
-        "matching and the key-level delta of the resulting config, or an explicit 'no behavioral " +
-        "change'. Pass runIdB to compare two configs, or depB to compare two dependencies " +
-        "against the same config.",
+        "the two runs against the same dependency — `summary` is the whole verdict in one line " +
+        "(`identical: …` / `differs: …`), with the rules that started or stopped matching and " +
+        "the key-level delta of the resulting config underneath it. Pass runIdB to compare two " +
+        "configs, or depB to compare two dependencies against the same config.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
@@ -613,10 +733,13 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         depB: DEP.optional().describe("The B-side dependency. Defaults to dep."),
       }),
     },
-    answer(async ({ runId, dep, runIdB, depB }) => {
+    answer(async ({ runId, dep, runIdB, depB }, ctx) => {
       const a = store.get(runId);
       const b = runIdB ? store.get(runIdB) : a;
-      const [simA, simB] = await Promise.all([simulateRun(a, dep), simulateRun(b, depB ?? dep)]);
+      const [simA, simB] = await Promise.all([
+        simulateRun(a, dep, ctx),
+        simulateRun(b, depB ?? dep, ctx),
+      ]);
       return {
         a: { runId: a.runId, dep: toDependency(dep) },
         b: { runId: b.runId, dep: toDependency(depB ?? dep) },
@@ -690,7 +813,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         );
       }
       return { renovateVersion, ...doc, isContainer: index.containers.has(doc.name) };
-    }, "too many options matched — search for a longer substring."),
+    }, HINTS.optionDocs),
   );
 
   return server;

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -754,9 +754,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Explain a validation message",
       description:
         "Translates one of Renovate's validator messages into what it actually means, with a " +
-        "docs link and — when the library knows one — a concrete fix. Pass the runId the message " +
-        "came from and the fix is computed against that exact config snapshot, including the " +
-        "edited file text, and the reported severity is the list the run itself put it in.",
+        "docs link and — when the library knows one — a concrete fix. It always says which you " +
+        "got: `translationKnown` is false, with a `note` explaining why, when the curated " +
+        "library has no entry for the message, so a bare echo is never ambiguous. Pass the " +
+        "runId the message came from and the fix is computed against that exact config " +
+        "snapshot, including the edited file text, and the reported severity is the list the " +
+        "run itself put it in.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         message: z.string().describe("The message text, verbatim."),

--- a/packages/cli/src/projections/messages.test.ts
+++ b/packages/cli/src/projections/messages.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { describeMessage } from "./messages";
+
+/**
+ * Roadmap 068: `explain_message` promises "a docs link and — when the library
+ * knows one — a concrete fix". These cover both halves of that promise: the
+ * common `group:` WARNING now arrives with an explanation and a ready-to-apply
+ * fix, and a message the library has no entry for says so out loud instead of
+ * returning a bare echo of the input.
+ */
+
+const GROUP_WARNING = 'packageRules[0].extends: you should not extend "group:" presets';
+
+describe("describeMessage — a known warning", () => {
+  const config = { packageRules: [{ extends: ["group:jestMonorepo"], automerge: true }] };
+  const text =
+    '{\n  "packageRules": [{ "extends": ["group:jestMonorepo"], "automerge": true }]\n}\n';
+
+  test("the group: warning carries an explanation, a docs link and a fix", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Warning", message: GROUP_WARNING },
+      "warning",
+      config,
+      text,
+    );
+    expect(reported.translationKnown).toBe(true);
+    expect(reported.note).toBeUndefined();
+    expect(reported.explanation).toMatch(/`packageRules` array/);
+    expect(reported.docsUrl).toBe("https://docs.renovatebot.com/config-presets/");
+    expect(reported.fix?.fixedConfig).toEqual({
+      packageRules: [
+        {
+          extends: ["monorepo:jest"],
+          groupName: "jest monorepo",
+          matchUpdateTypes: ["digest", "patch", "minor", "major"],
+          automerge: true,
+        },
+      ],
+    });
+    // The edit replaces a whole array element, which the surgical text patcher
+    // does not address — the document is re-serialized, and says so.
+    expect(reported.fix?.fixedTextRewritesDocument).toBe(true);
+    expect(JSON.parse(reported.fix?.fixedText ?? "null")).toEqual(reported.fix?.fixedConfig);
+  });
+
+  test("without a config snapshot it explains, and says why there is no fix", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Warning", message: GROUP_WARNING },
+      "warning",
+      null,
+      null,
+    );
+    expect(reported.translationKnown).toBe(true);
+    expect(reported.fix).toBeUndefined();
+    expect(reported.note).toMatch(/runId/);
+  });
+});
+
+describe("describeMessage — no translation known", () => {
+  test("says so explicitly instead of echoing the message alone", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Error", message: "Something else entirely" },
+      "error",
+      {},
+      null,
+    );
+    expect(reported).toEqual({
+      severity: "error",
+      topic: "Configuration Error",
+      message: "Something else entirely",
+      translationKnown: false,
+      note: expect.stringContaining("No translation for this message"),
+    });
+    expect(reported.note).toMatch(/Renovate's own/);
+  });
+
+  test("still offers the option's docs link when the message names one", () => {
+    const reported = describeMessage(
+      {
+        topic: "Configuration Warning",
+        message: "Setting `registryUrls` at the top level of your config will apply it broadly.",
+      },
+      "warning",
+      {},
+      null,
+    );
+    expect(reported.translationKnown).toBe(false);
+    expect(reported.docsUrl).toContain("#registryurls");
+    expect(reported.note).toMatch(/No translation for this message/);
+  });
+});

--- a/packages/cli/src/projections/messages.ts
+++ b/packages/cli/src/projections/messages.ts
@@ -11,13 +11,26 @@ import {
  *
  * The fix is reported, never applied: agents edit configs with their own tools
  * and come back to `validate`/`compare` as the oracle.
+ *
+ * The absence of an explanation or a fix is reported EXPLICITLY (068):
+ * `translationKnown` plus a `note` saying why, so a caller that was promised
+ * "a docs link and — when the library knows one — a concrete fix" can tell
+ * "the library has nothing for this message" from "the tool silently dropped
+ * half its answer". Three replay sessions read the silent shape as a broken
+ * promise.
  */
 export interface ReportedMessage {
   severity: "error" | "warning";
   topic: string;
   message: string;
+  /** Whether roadmap 014's curated library has an entry for this message.
+   *  When false, `message`/`topic`/`severity` are Renovate's own and nothing
+   *  else here is derived. */
+  translationKnown: boolean;
   explanation?: string;
   docsUrl?: string;
+  /** Present exactly when there is no `fix` — why there isn't one. */
+  note?: string;
   fix?: {
     summary: string;
     path: (string | number)[];
@@ -25,8 +38,25 @@ export interface ReportedMessage {
     /** The FILE with the fix applied, when the edit could be located in the
      *  original text (comments and formatting preserved). */
     fixedText?: string;
+    /** True when `fixedText` is the whole document re-serialized from
+     *  `fixedConfig` because the edit couldn't be located in the original
+     *  text — still correct, but comments and formatting are lost. */
+    fixedTextRewritesDocument?: true;
   };
 }
+
+const NO_TRANSLATION_NOTE =
+  "No translation for this message — the message text and severity are Renovate's own, " +
+  "unedited, and this library knows no explanation or fix for it. Use get_option_docs on the " +
+  "option it names, or read Renovate's docs.";
+
+const NO_SNAPSHOT_NOTE =
+  "No fix was computed: this message was explained without the config it came from. Pass the " +
+  "runId the message belongs to and the fix is computed against that exact snapshot.";
+
+const NO_SAFE_FIX_NOTE =
+  "The library explains this message but cannot compute a safe automatic fix for this config — " +
+  "the edit would be a guess. Apply the explanation by hand, then use compare as the oracle.";
 
 /**
  * `config` should be the exact snapshot the message was validated against
@@ -48,6 +78,7 @@ export function describeMessage(
     severity,
     topic: message.topic,
     message: message.message,
+    translationKnown: translated !== null,
     ...(translated ? { explanation: translated.explanation } : {}),
     ...(translated?.docsUrl
       ? { docsUrl: translated.docsUrl }
@@ -61,8 +92,16 @@ export function describeMessage(
             path: translated.fix.path,
             fixedConfig: translated.fix.fixedConfig,
             ...(applied ? { fixedText: applied.text } : {}),
+            ...(applied && !applied.surgical ? { fixedTextRewritesDocument: true as const } : {}),
           },
         }
-      : {}),
+      : { note: noteFor(translated !== null, config) }),
   };
+}
+
+function noteFor(known: boolean, config: Record<string, unknown> | null): string {
+  if (!known) {
+    return NO_TRANSLATION_NOTE;
+  }
+  return config === null ? NO_SNAPSHOT_NOTE : NO_SAFE_FIX_NOTE;
 }

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -91,6 +91,40 @@ export function indexView(entry: KeyProvenance): ProvenanceIndexEntry {
   };
 }
 
+/**
+ * Roadmap 068 (2026-07 persona study, 2 of 9 sessions, plus the review):
+ * provenance answers "which LAYER set this option", and two personas read that
+ * as "this is the value Renovate will use". For any key a packageRule can also
+ * set, it is not: the layer chain produces the repository-wide value, and a
+ * rule then overrides it for the dependencies it matches. Both personas
+ * reported a static value as the effective one for an update it did not apply
+ * to.
+ *
+ * Cheap and exact: the key appears inside a rule of the run's OWN final
+ * `packageRules`, so the count is this config's, not Renovate's option
+ * metadata. The clauses of those rules are the simulator's business, which is
+ * what the note points at.
+ */
+export function perDependencyNote(
+  key: string,
+  finalConfig: Record<string, unknown> | undefined,
+): string | undefined {
+  if (key === "packageRules" || !Array.isArray(finalConfig?.packageRules)) {
+    return undefined;
+  }
+  const setters = finalConfig.packageRules.filter(
+    (rule) => rule !== null && typeof rule === "object" && key in rule,
+  ).length;
+  if (setters === 0) {
+    return undefined;
+  }
+  return (
+    `${setters} packageRule${setters === 1 ? "" : "s"} can set \`${key}\` per-dependency — this ` +
+    "chain is the repository-wide value. Simulate a dependency to see the value an actual " +
+    "update would get."
+  );
+}
+
 /** The run's provenance map, or a legible error explaining why there is none. */
 export function provenanceOf(result: TraceResult): Map<string, KeyProvenance> {
   const provenance = computeProvenance(result);

--- a/packages/cli/src/rule-view.test.ts
+++ b/packages/cli/src/rule-view.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import type {
+  RuleEvaluation,
+  SimulationResult,
+  TraceResult,
+} from "@renovate-config-debugger/engine";
+import { buildRuleView } from "./rule-view";
+
+/**
+ * The facets themselves are the app's shared predicates, covered where they
+ * live. What is this module's own is the DIAGNOSTIC it emits when `--source`
+ * has nothing to filter with — and, roadmap 068 (M2), whose vocabulary that
+ * diagnostic speaks: an agent over MCP cannot pass a flag, and telling it to
+ * is worse than saying nothing.
+ */
+
+function rule(index: number, verdict: RuleEvaluation["verdict"]): RuleEvaluation {
+  return { index, verdict, clauses: [], notes: [] };
+}
+
+function sim(rules: RuleEvaluation[]): SimulationResult {
+  return {
+    rules,
+    rawFinalConfig: {},
+    finalDependencyConfig: {},
+    flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    mergeSteps: [],
+    errors: [],
+    warnings: [],
+    notes: [],
+  };
+}
+
+/** A run whose preset resolution never completed: no rule can be attributed to
+ *  a config level, which is exactly when the note fires. */
+const UNATTRIBUTABLE = {
+  events: [],
+  finalConfig: { packageRules: [{ groupName: "x" }] },
+  errors: [],
+  warnings: [],
+  presetTree: undefined,
+} as unknown as TraceResult;
+
+describe("buildRuleView", () => {
+  test("`--source` with no provenance is dropped, and the CLI note says so in flags", () => {
+    const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
+      verdict: "all",
+      source: "repo",
+      explicit: true,
+      transport: "cli",
+    });
+    expect(view.notes[0]).toContain("--source repo ignored");
+    // Dropped, not applied: filtering every rule away because the attribution
+    // is missing would be a wrong answer, not a narrow one.
+    expect(view.source).toBe("all");
+    expect(view.rules).toHaveLength(1);
+  });
+
+  test("the same note over MCP names the tool parameter instead", () => {
+    const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
+      verdict: "all",
+      source: "presets",
+      explicit: true,
+      transport: "mcp",
+    });
+    expect(view.notes[0]).toContain('source: "presets" ignored');
+    expect(view.notes[0]).not.toContain("--source");
+  });
+
+  test("the verdict facet counts what it hid", () => {
+    const view = buildRuleView(sim([rule(0, "matched"), rule(1, "no-match")]), UNATTRIBUTABLE, {
+      verdict: "matched",
+      source: "all",
+      explicit: true,
+      transport: "cli",
+    });
+    expect(view.rules).toHaveLength(1);
+    expect(view.total).toBe(2);
+    expect(view.hidden).toBe(1);
+    expect(view.notes).toEqual([]);
+  });
+});

--- a/packages/cli/src/rule-view.ts
+++ b/packages/cli/src/rule-view.ts
@@ -15,6 +15,7 @@ import {
 } from "@renovate-config-debugger/app/headless";
 import { type OutputFormat, type ParsedArgs, stringOption } from "./args";
 import { CliError } from "./io";
+import type { RunTransport } from "./run-input";
 
 /**
  * Roadmap 062 (2026-07 persona study, top friction — 6 of 9 sessions): a
@@ -39,6 +40,18 @@ export interface RuleFilterSelection {
   source: SourceFilter;
   /** Either flag was passed explicitly — the JSON payload filters only then. */
   explicit: boolean;
+  /**
+   * How the caller asked. The facets are one implementation with two
+   * spellings — `--source repo` on the CLI, `source: "repo"` over MCP — and a
+   * note that quotes the wrong one is a dead end for whoever reads it: an
+   * agent cannot pass a flag, and telling it to is worse than saying nothing.
+   */
+  transport: RunTransport;
+}
+
+/** The facet as the caller would have to spell it on THEIR surface. */
+function facetText(transport: RunTransport, facet: string, value: string): string {
+  return transport === "mcp" ? `${facet}: "${value}"` : `--${facet} ${value}`;
 }
 
 function parseChoice<T extends string>(
@@ -69,6 +82,7 @@ export function ruleFilterSelection(args: ParsedArgs, format: OutputFormat): Rul
     ),
     source: parseChoice(rawSource, SOURCE_FILTERS, "source", "all"),
     explicit: rawVerdict !== undefined || rawSource !== undefined,
+    transport: "cli",
   };
 }
 
@@ -105,8 +119,9 @@ export function buildRuleView(
     const layerByIndex = ruleLayerIndex(computeRuleProvenance(result));
     if (layerByIndex.size === 0) {
       notes.push(
-        `--source ${source} ignored: this run has no per-rule provenance ` +
-          "(the preset tree is incomplete, so no rule can be attributed to a config level)",
+        `${facetText(selection.transport, "source", source)} ignored: this run has no per-rule ` +
+          "provenance (the preset tree is incomplete, so no rule can be attributed to a config " +
+          "level)",
       );
       source = "all";
     } else {

--- a/packages/cli/src/run-input.test.ts
+++ b/packages/cli/src/run-input.test.ts
@@ -105,4 +105,41 @@ describe("endpointTokenPolicy", () => {
   test("a global config that sets neither platform nor endpoint is harmless", () => {
     expect(endpointTokenPolicy({}, { onboarding: false }).suppress).toBe(false);
   });
+
+  /**
+   * Roadmap 068 (M3). `--endpoint` on the CLI is a person's explicit choice —
+   * `callerEndpoint` stays unset there. Over MCP the same value arrives as a
+   * tool parameter the MODEL chose, plausibly copied out of the config under
+   * inspection, so it gets the same treatment as an endpoint a config chose.
+   */
+  test("an endpoint the caller supplied over MCP withholds the tokens", () => {
+    const policy = endpointTokenPolicy(
+      { callerEndpoint: "https://ghe.attacker.example/api/v3/" },
+      undefined,
+      "mcp",
+    );
+    expect(policy.suppress).toBe(true);
+    expect(policy.reason).toContain("ghe.attacker.example");
+    expect(policy.reason).toContain("trustEndpoints: true");
+  });
+
+  test("platformOverride does not vouch for an endpoint the caller invented", () => {
+    expect(
+      endpointTokenPolicy(
+        { callerEndpoint: "https://ghe.attacker.example/api/v3/", platformOverride: true },
+        undefined,
+        "mcp",
+      ).suppress,
+    ).toBe(true);
+  });
+
+  test("trustEndpoints is the one opt-in that does", () => {
+    expect(
+      endpointTokenPolicy(
+        { callerEndpoint: "https://ghe.mine.example/api/v3/", trustEndpoints: true },
+        undefined,
+        "mcp",
+      ).suppress,
+    ).toBe(false);
+  });
 });

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -83,6 +83,19 @@ export interface EndpointTrust {
   trustEndpoints?: boolean;
   /** The caller's own platform/endpoint wins over the global config's. */
   platformOverride?: boolean;
+  /**
+   * The endpoint the CALLER supplied, when the caller is not a person.
+   *
+   * On the CLI this stays unset: a human typed `--endpoint`, which is exactly
+   * the "explicit flag" the guard trusts. Over MCP the same value is a tool
+   * PARAMETER the model chose — plausibly from text in the very repository it
+   * is inspecting — so it is not the user's choice at all, and the guard has
+   * to treat it the way it treats an endpoint a config chose.
+   *
+   * Only the endpoint. `platform` on its own moves a token to that platform's
+   * own public API, which is where a token for that platform already goes.
+   */
+  callerEndpoint?: string;
 }
 
 /**
@@ -97,12 +110,37 @@ const OPT_IN_WORDING: Record<RunTransport, string> = {
   mcp: "Set `platformOverride: true` to impose your own endpoint, or `trustEndpoints: true` if the config is yours.",
 };
 
+/** The only opt-in that applies when the CALLER, not the config, picked the
+ *  endpoint — imposing it harder changes nothing about who chose it. */
+const TRUST_WORDING: Record<RunTransport, string> = {
+  cli: "Pass `--trust-endpoints` if that endpoint is yours.",
+  mcp: "Set `trustEndpoints: true` if that endpoint is yours.",
+};
+
 export function endpointTokenPolicy(
   trust: EndpointTrust,
   globalConfig: Record<string, unknown> | undefined,
   transport: RunTransport = "cli",
 ): { suppress: boolean; reason?: string } {
-  if (trust.trustEndpoints || !globalConfig) {
+  if (trust.trustEndpoints) {
+    return { suppress: false };
+  }
+  // The same rule as below, one layer out: the guard asks "did the person
+  // whose tokens these are choose where they go?", and over MCP an `endpoint`
+  // tool parameter is not that person's answer — the model wrote it, and a
+  // config it just read can suggest one. `platformOverride` deliberately does
+  // NOT unlock this: it only says whose endpoint wins between two untrusted
+  // sources. `trustEndpoints` is the one opt-in that means "I vouch for it".
+  if (trust.callerEndpoint) {
+    return {
+      suppress: true,
+      reason:
+        `\`endpoint\` was chosen by the caller (${trust.callerEndpoint}) rather than by the ` +
+        "environment this server runs in, so host tokens were NOT sent there. " +
+        TRUST_WORDING[transport],
+    };
+  }
+  if (!globalConfig) {
     return { suppress: false };
   }
   const chosen = ["endpoint", "platform"].filter((key) =>

--- a/packages/engine/src/error-fix-text.ts
+++ b/packages/engine/src/error-fix-text.ts
@@ -299,7 +299,10 @@ function locateEntry(text: string, path: ConfigPathSegment[]): EntryLocation | n
     } else {
       const found = findArrayElement(text, containerStart, seg);
       if (!found || isLast) {
-        // Our curated fixes always end on an object key, never an array index.
+        // A path ending on an array index has no surgical patch here — the
+        // one curated fix shaped that way (the `group:`-preset rule rewrite)
+        // deliberately falls back to re-serializing the document, and says so
+        // via `fixedTextRewritesDocument`.
         return null;
       }
       containerStart = found.valueStart;

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -19,6 +19,7 @@
  * "Apply fix" button.
  */
 
+import { getInternalPreset, parsePreset } from "./renovate-adapter";
 import { snapshot } from "./trace/delta";
 import type { ValidationMessage } from "./trace/model";
 import { getOptionIndex, type OptionDoc } from "./option-docs";
@@ -166,6 +167,14 @@ function withKeyRenamed(
   delete parent[last];
   parent[newKey] = value;
   return clone;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
 }
 
 /** Unique `` `identifier` `` tokens mentioned in a free-text message. */
@@ -376,6 +385,227 @@ const globalOnlyOption: ErrorTranslation = {
 };
 
 // ---------------------------------------------------------------------------
+// 4. `group:` preset extended from inside a packageRules entry
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js, `parentName === "packageRules"`):
+// `${currentPath}: you should not extend "group:" presets`
+// Topic is "Configuration Warning", but the matcher deliberately does NOT
+// require it: `explain_message` callers routinely pass the text alone, and the
+// sentence is unique enough in Renovate's validator to stand on its own.
+//
+// The structural reason: a `group:` preset's body is a `packageRules` ARRAY
+// (`group:jestMonorepo` is `{"packageRules":[{extends:["monorepo:jest"], …}]}`),
+// not a flat fragment of one rule. Merged into a single rule it becomes a
+// `packageRules` key nested inside a package rule, which Renovate never reads
+// — the group's matchers and `groupName` are silently dropped.
+
+const GROUP_PRESET_RE = /^(.+?): you should not extend "group:" presets$/;
+
+const GROUP_PRESET_DOCS_URL = "https://docs.renovatebot.com/config-presets/";
+const GROUP_PRESET_LIST_URL = "https://docs.renovatebot.com/presets-group/";
+
+/**
+ * The single package rule a `group:` preset's body consists of, with its
+ * `description` dropped — i.e. exactly what has to be restated inside the
+ * user's own rule. `null` whenever the group isn't collapsible into one rule:
+ * an unbundled/unknown name, a body carrying top-level options besides
+ * `packageRules` (e.g. `group:all`'s `separateMajorMinor`), or a body whose
+ * `packageRules` holds anything other than exactly one rule (e.g.
+ * `group:monorepos`, which is a fan-out over ~500 other group presets).
+ */
+function collapsibleGroupRule(preset: string): Record<string, unknown> | null {
+  let parsed;
+  try {
+    parsed = parsePreset(preset);
+  } catch {
+    return null;
+  }
+  if (parsed.presetSource !== "internal" || parsed.repo !== "group") {
+    return null;
+  }
+  if (parsed.params !== undefined && parsed.params.length > 0) {
+    return null;
+  }
+  const body = getInternalPreset({ repo: parsed.repo, presetName: parsed.presetName });
+  if (!isPlainObject(body)) {
+    return null;
+  }
+  if (Object.keys(body).some((key) => key !== "description" && key !== "packageRules")) {
+    return null;
+  }
+  const rules = body.packageRules;
+  if (!Array.isArray(rules) || rules.length !== 1) {
+    return null;
+  }
+  const [only] = rules;
+  if (!isPlainObject(only)) {
+    return null;
+  }
+  const rule = { ...only };
+  delete rule.description;
+  return Object.keys(rule).length > 0 ? rule : null;
+}
+
+const groupPresetInPackageRule: ErrorTranslation = {
+  id: "group-preset-in-package-rule",
+  matches: (m) => GROUP_PRESET_RE.test(m.message),
+
+  explain: (m) => {
+    const path = GROUP_PRESET_RE.exec(m.message)?.[1] ?? "this rule's `extends`";
+    return (
+      `\`${path}\` extends a \`group:\` preset from inside a \`packageRules\` entry, and a ` +
+      `\`group:\` preset's body is itself a \`packageRules\` array — not a flat fragment of one ` +
+      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule. Renovate ` +
+      `matches a rule on that rule's own \`match*\` keys, and after the merge yours has none: the ` +
+      `group's matchers, its \`groupName\` and its \`matchUpdateTypes\` all sit one level down, ` +
+      `where the pass that just matched the rule doesn't read them. The rule matches EVERY ` +
+      `dependency and applies whatever else you put in it — an \`automerge: true\` meant for one ` +
+      `monorepo now applies to everything — and the grouping you asked for doesn't happen. ` +
+      `Write the group out inside the rule instead: extend the underlying ` +
+      `\`monorepo:\`/\`packages:\` preset the group uses — those are pure match criteria and are ` +
+      `safe inside a rule — or copy the group's matchers, then restate \`groupName\` and the ` +
+      `group's own \`matchUpdateTypes\` alongside your own options. That last part is not ` +
+      `cosmetic: the built-in monorepo groups carry ` +
+      `\`matchUpdateTypes: ["digest", "patch", "minor", "major"]\`, which deliberately EXCLUDES ` +
+      `\`pin\`; a replacement rule that omits it silently widens the group to pin updates too. ` +
+      `See ${GROUP_PRESET_DOCS_URL} for how \`extends\` merges, and ${GROUP_PRESET_LIST_URL} for ` +
+      `the exact body of the group being replaced.`
+    );
+  },
+
+  docsUrl: GROUP_PRESET_DOCS_URL,
+
+  optionNames: () => ["extends"],
+
+  suggestFix: (m, config) => {
+    const pathStr = GROUP_PRESET_RE.exec(m.message)?.[1];
+    if (pathStr === undefined) {
+      return null;
+    }
+    const extendsPath = parseConfigPath(pathStr);
+    if (extendsPath.at(-1) !== "extends" || extendsPath.length < 2) {
+      return null;
+    }
+    const rulePath = extendsPath.slice(0, -1);
+    const rule = getAtPath(config, rulePath);
+    if (!isPlainObject(rule) || !isStringArray(rule.extends)) {
+      return null;
+    }
+    const groupEntries = rule.extends.filter((e) => e.startsWith("group:"));
+    const [groupEntry] = groupEntries;
+    // Two groups in one rule can't collapse into one rule — the user has to
+    // decide which grouping wins, so explain without guessing.
+    if (groupEntry === undefined || groupEntries.length > 1) {
+      return null;
+    }
+    const groupRule = collapsibleGroupRule(groupEntry);
+    if (!groupRule) {
+      return null;
+    }
+    const groupExtends = isStringArray(groupRule.extends) ? groupRule.extends : [];
+    const inherited = { ...groupRule };
+    delete inherited.extends;
+    const own = { ...rule };
+    delete own.extends;
+    const keptExtends = rule.extends.filter((e) => e !== groupEntry);
+    const mergedExtends = [...new Set([...groupExtends, ...keptExtends])];
+
+    // `extends` first (it's the criteria carrier), then the group's own keys,
+    // then the user's — the user's value wins any key they set explicitly.
+    const merged: Record<string, unknown> = {};
+    if (mergedExtends.length > 0) {
+      merged.extends = mergedExtends;
+    }
+    Object.assign(merged, inherited, own);
+
+    return {
+      path: rulePath,
+      value: merged,
+      before: rule,
+      after: merged,
+      summary: `Replace \`${groupEntry}\` in \`${pathStr}\` with the group's own rule contents`,
+      fixedConfig: withValueAtPath(config, rulePath, merged),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// 5. `global:` preset extended from a repository config
+// ---------------------------------------------------------------------------
+// Message shape (upstream's config/validation.js, `configType !== "global"`):
+// `${currentPath}: you cannot extend from "global:" presets in a repository config's "extends"`
+// The sibling of pattern 3 (a global-only OPTION set in a repo config), one
+// level up: a whole preset of global-only options, pulled in by name.
+
+const GLOBAL_PRESET_RE =
+  /^(.+?): you cannot extend from "global:" presets in a repository config's "extends"$/;
+
+const GLOBAL_PRESET_DOCS_URL = "https://docs.renovatebot.com/presets-global/";
+
+const globalPresetInExtends: ErrorTranslation = {
+  id: "global-preset-in-extends",
+  matches: (m) => GLOBAL_PRESET_RE.test(m.message),
+
+  explain: (m) => {
+    const path = GLOBAL_PRESET_RE.exec(m.message)?.[1] ?? "this `extends`";
+    return (
+      `\`${path}\` extends a \`global:\` preset. \`global:\` presets are bundles of ` +
+      `self-hosted-only options (the same options roadmap 008's global config layer holds), and ` +
+      `Renovate refuses them in a repository's own config rather than ignoring them — so this is ` +
+      `an error, not a warning, and the whole config is rejected. Move the \`global:\` entry to ` +
+      `the self-hosted global configuration (\`config.js\` / \`RENOVATE_CONFIG\`), where it does ` +
+      `what you meant, and drop it here. See ${GLOBAL_PRESET_DOCS_URL} for what each \`global:\` ` +
+      `preset actually sets.`
+    );
+  },
+
+  docsUrl: GLOBAL_PRESET_DOCS_URL,
+
+  optionNames: () => ["extends"],
+
+  suggestFix: (m, config) => {
+    const pathStr = GLOBAL_PRESET_RE.exec(m.message)?.[1];
+    if (pathStr === undefined) {
+      return null;
+    }
+    const path = parseConfigPath(pathStr);
+    if (path.at(-1) !== "extends") {
+      return null;
+    }
+    const list = getAtPath(config, path);
+    if (!isStringArray(list)) {
+      return null;
+    }
+    const removed = list.filter((e) => e.startsWith("global:"));
+    const kept = list.filter((e) => !e.startsWith("global:"));
+    if (removed.length === 0) {
+      return null;
+    }
+    const summary = `Remove ${removed.map((e) => `\`${e}\``).join(" and ")} from \`${pathStr}\``;
+    if (kept.length === 0) {
+      // An `extends` that held nothing but global: presets: drop the key
+      // rather than leave an empty array behind.
+      return {
+        path,
+        remove: true,
+        before: list,
+        after: undefined,
+        summary,
+        fixedConfig: withKeyRemoved(config, path),
+      };
+    }
+    return {
+      path,
+      value: kept,
+      before: list,
+      after: kept,
+      summary,
+      fixedConfig: withValueAtPath(config, path, kept),
+    };
+  },
+};
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -383,6 +613,8 @@ export const ERROR_TRANSLATIONS: ErrorTranslation[] = [
   redundantGlobStar,
   deprecatedOption,
   globalOnlyOption,
+  groupPresetInPackageRule,
+  globalPresetInExtends,
 ];
 
 /**

--- a/packages/engine/src/error-translations.ts
+++ b/packages/engine/src/error-translations.ts
@@ -396,8 +396,13 @@ const globalOnlyOption: ErrorTranslation = {
 // The structural reason: a `group:` preset's body is a `packageRules` ARRAY
 // (`group:jestMonorepo` is `{"packageRules":[{extends:["monorepo:jest"], …}]}`),
 // not a flat fragment of one rule. Merged into a single rule it becomes a
-// `packageRules` key nested inside a package rule, which Renovate never reads
-// — the group's matchers and `groupName` are silently dropped.
+// `packageRules` key nested inside a package rule — a shape no option owns.
+// Renovate's config MIGRATION then flattens it (each inner rule merged over
+// the outer one, re-run after preset resolution), so on current Renovate the
+// construct happens to behave scoped — by migration side-effect, not by
+// contract, and it duplicates the group rule `config:recommended` already
+// ships. See `simulate-package-rules.ts`'s docblock and the golden fidelity
+// tests before "correcting" this account.
 
 const GROUP_PRESET_RE = /^(.+?): you should not extend "group:" presets$/;
 
@@ -455,13 +460,14 @@ const groupPresetInPackageRule: ErrorTranslation = {
     return (
       `\`${path}\` extends a \`group:\` preset from inside a \`packageRules\` entry, and a ` +
       `\`group:\` preset's body is itself a \`packageRules\` array — not a flat fragment of one ` +
-      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule. Renovate ` +
-      `matches a rule on that rule's own \`match*\` keys, and after the merge yours has none: the ` +
-      `group's matchers, its \`groupName\` and its \`matchUpdateTypes\` all sit one level down, ` +
-      `where the pass that just matched the rule doesn't read them. The rule matches EVERY ` +
-      `dependency and applies whatever else you put in it — an \`automerge: true\` meant for one ` +
-      `monorepo now applies to everything — and the grouping you asked for doesn't happen. ` +
-      `Write the group out inside the rule instead: extend the underlying ` +
+      `rule. Resolving it therefore nests a \`packageRules\` key INSIDE a package rule — a shape ` +
+      `no rule option owns. On current Renovate that still behaves: a config-migration pass ` +
+      `flattens the nested rules (each inner rule merged over your outer one) after preset ` +
+      `resolution, so the matchers and \`groupName\` do land. But it works by migration ` +
+      `side-effect, not by contract — hence the warning — and it adds a DUPLICATE of a group ` +
+      `rule \`config:recommended\` already ships, so every option you set rides on a second copy ` +
+      `of the same rule; a \`group:\` preset with several inner rules would clone your options ` +
+      `onto each of them. Write the group out inside the rule instead: extend the underlying ` +
       `\`monorepo:\`/\`packages:\` preset the group uses — those are pure match criteria and are ` +
       `safe inside a rule — or copy the group's matchers, then restate \`groupName\` and the ` +
       `group's own \`matchUpdateTypes\` alongside your own options. That last part is not ` +

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -91,19 +91,39 @@ function removeGlobalConfig(
 // the active trace collector), so runs must never overlap.
 let queue: Promise<unknown> = Promise.resolve();
 
+/** A task whose caller went away before the queue reached it. */
+export class EngineTaskCancelled extends Error {
+  constructor() {
+    super("cancelled before the engine ran it");
+    this.name = "EngineTaskCancelled";
+  }
+}
+
 /**
  * Serializes every engine entry point that touches renovate's stateful
  * modules through one queue, so e.g. a packageRules simulation (006) never
  * interleaves with a pipeline run.
+ *
+ * `signal` is checked once, at the moment the queue reaches the task — the
+ * only point where cancellation is both cheap and useful. Work already inside
+ * renovate's config modules is NOT interruptible (they are synchronous and
+ * hold module state), but a task that has been sitting in line while an
+ * earlier run finished should not start at all: with concurrent MCP handlers
+ * that is a cancelled call keeping every later question waiting.
  */
-export function enqueueEngineTask<T>(task: () => Promise<T>): Promise<T> {
-  const run = queue.then(() => task());
+export function enqueueEngineTask<T>(task: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  const run = queue.then(() => {
+    if (signal?.aborted) {
+      throw new EngineTaskCancelled();
+    }
+    return task();
+  });
   queue = run.catch(() => undefined);
   return run;
 }
 
-export function runPipeline(input: PipelineInput): Promise<TraceResult> {
-  return enqueueEngineTask(() => execute(input));
+export function runPipeline(input: PipelineInput, signal?: AbortSignal): Promise<TraceResult> {
+  return enqueueEngineTask(() => execute(input), signal);
 }
 
 /**

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -13,6 +13,12 @@ export { massageConfig } from "renovate/dist/config/massage.js";
 export { validateConfig } from "renovate/dist/config/validation.js";
 export { resolveConfigPresets } from "renovate/dist/config/presets/index.js";
 export { parsePreset } from "renovate/dist/config/presets/parse.js";
+// Renovate's bundled preset bodies (`group:`, `monorepo:`, `packages:`, …).
+// Synchronous and network-free, and already in the module graph via
+// `presets/index.js` — roadmap 014's `group:`-preset translation reads the
+// flagged group's OWN body rather than restating it, so the suggested rule
+// can't drift from the pinned Renovate.
+export { getPreset as getInternalPreset } from "renovate/dist/config/presets/internal/index.js";
 export { mergeChildConfig } from "renovate/dist/config/utils.js";
 export { getConfig as getDefaultConfig } from "renovate/dist/config/defaults.js";
 export { GlobalConfig } from "renovate/dist/config/global.js";

--- a/packages/engine/src/simulate-compare.ts
+++ b/packages/engine/src/simulate-compare.ts
@@ -101,6 +101,16 @@ export interface SimulationComparison {
    * no longer allowed to speak for behavior.
    */
   noChange: boolean;
+  /**
+   * The whole verdict as one line, starting with `identical:` or `differs:`.
+   *
+   * Roadmap 068 (2026-07 persona study, 4 of 9 sessions): every consumer of
+   * this diff — the CLI's headline, the app's panel, an agent reading the JSON
+   * — was re-deriving "so did it change?" from six arrays and two booleans,
+   * and the readings disagreed. The net effect belongs in the comparison, once
+   * and in words, next to the fields that justify it.
+   */
+  summary: string;
 }
 
 function signatureOf(rule: RuleEvaluation): string {
@@ -149,6 +159,43 @@ function jsonEqual(a: unknown, b: unknown): boolean {
  *  the pre-rules base — not through the user's rules. */
 function inheritedIn(result: SimulationResult, key: string): boolean {
   return !result.mergeSteps.some((step) => step.merged.some((m) => m.key === key));
+}
+
+/** How many changed keys the one-liner names before it starts counting. */
+const SUMMARY_KEY_LIMIT = 6;
+
+function countOf(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * The net effect, in one line. Ordered by what a reader actually asked: the
+ * config delta is the citable answer when there is one, the rules that started
+ * or stopped doing something is the answer when the config came out the same,
+ * and the identity churn is a parenthetical either way — never the headline,
+ * because for the commonest behavior-preserving edit it is guaranteed true.
+ */
+function summaryOf(comparison: Omit<SimulationComparison, "summary">): string {
+  if (comparison.noChange) {
+    return comparison.rulesChanged
+      ? "identical: the same effective config results (a rule's pattern text changed)"
+      : "identical: the same rules matched and the same effective config results";
+  }
+  const keys = comparison.configDelta.map((delta) => delta.key);
+  if (keys.length > 0) {
+    const named = keys.slice(0, SUMMARY_KEY_LIMIT).join(", ");
+    const rest = keys.length - SUMMARY_KEY_LIMIT;
+    return `differs: ${named}${rest > 0 ? ` and ${rest} more` : ""}`;
+  }
+  const changes = [
+    ...(comparison.behaviorOnlyInB.length > 0
+      ? [`${countOf(comparison.behaviorOnlyInB.length, "rule")} started matching`]
+      : []),
+    ...(comparison.behaviorOnlyInA.length > 0
+      ? [`${countOf(comparison.behaviorOnlyInA.length, "rule")} stopped matching`]
+      : []),
+  ];
+  return `differs: ${changes.join(" and ")}, with no change to the effective config`;
 }
 
 /**
@@ -222,7 +269,7 @@ export function compareSimulations(a: SimulationResult, b: SimulationResult): Si
   const noChange =
     behaviorOnlyInA.length === 0 && behaviorOnlyInB.length === 0 && configDelta.length === 0;
 
-  return {
+  const comparison = {
     matchedOnlyInA,
     matchedOnlyInB,
     matchedInBoth,
@@ -233,4 +280,5 @@ export function compareSimulations(a: SimulationResult, b: SimulationResult): Si
     configDelta,
     noChange,
   };
+  return { ...comparison, summary: summaryOf(comparison) };
 }

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -288,8 +288,11 @@ const NOT_SIMULATED_NOTE =
   "not simulated — matchConfidence requires a Merge Confidence API token; " +
   "a real Renovate run without one throws instead of evaluating the rule";
 
-export function simulatePackageRules(input: SimulationInput): Promise<SimulationResult> {
-  return enqueueEngineTask(() => execute(input));
+export function simulatePackageRules(
+  input: SimulationInput,
+  signal?: AbortSignal,
+): Promise<SimulationResult> {
+  return enqueueEngineTask(() => execute(input), signal);
 }
 
 /**

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -99,6 +99,16 @@ declare module "renovate/dist/config/presets/parse.js" {
   export function parsePreset(input: string): ParsedPreset;
 }
 
+declare module "renovate/dist/config/presets/internal/index.js" {
+  /** Renovate's own bundled presets, keyed by `repo` (the part before the `:`)
+   *  and `presetName`. Synchronous — internal presets are data in `dist`, not
+   *  a fetch. `undefined` when the pair names no bundled preset. */
+  export function getPreset(config: {
+    repo?: string;
+    presetName?: string;
+  }): RenovateConfig | undefined;
+}
+
 declare module "renovate/dist/config/presets/util.js" {
   export const PRESET_DEP_NOT_FOUND: string;
   export const PRESET_INVALID: string;

--- a/packages/engine/test/engine-queue.node.test.ts
+++ b/packages/engine/test/engine-queue.node.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Golden project: the engine's task queue, and the one thing a caller can do
+ * about a task it no longer wants.
+ *
+ * Roadmap 068 (L4): renovate's config modules hold module-level state, so
+ * every engine entry point is serialized through one queue — which means a
+ * call whose client already went away does not merely waste its own time, it
+ * holds up every question asked after it. The work itself is synchronous and
+ * stateful and cannot be interrupted; NOT STARTING it is the whole of what is
+ * achievable, and it is checked at the one moment that matters: when the queue
+ * reaches the task.
+ */
+import { describe, expect, it } from "vitest";
+import { runPipeline, simulatePackageRules } from "../src/index";
+
+const CONFIG = { fileName: "renovate.json", content: '{"labels":["deps"]}' };
+
+describe("engine queue", () => {
+  it("never starts a run whose caller has gone away", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(runPipeline(CONFIG, controller.signal)).rejects.toThrow(/cancelled/);
+  });
+
+  it("…nor a simulation", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      simulatePackageRules({ config: {}, dep: { depName: "react" } }, controller.signal),
+    ).rejects.toThrow(/cancelled/);
+  });
+
+  it("a cancelled task does not take the queue down with it", async () => {
+    const cancelled = new AbortController();
+    cancelled.abort();
+    const [refused, ran] = await Promise.allSettled([
+      runPipeline(CONFIG, cancelled.signal),
+      runPipeline(CONFIG, new AbortController().signal),
+    ]);
+    expect(refused.status).toBe("rejected");
+    expect(ran.status).toBe("fulfilled");
+    expect(ran.status === "fulfilled" && ran.value.finalConfig?.labels).toEqual(["deps"]);
+  });
+
+  it("a signal that is never aborted changes nothing", async () => {
+    const result = await runPipeline(CONFIG, new AbortController().signal);
+    expect(result.finalConfig?.labels).toEqual(["deps"]);
+  });
+});

--- a/packages/engine/test/error-translations.node.test.ts
+++ b/packages/engine/test/error-translations.node.test.ts
@@ -286,6 +286,222 @@ describe("global-only-option translation (008 boundary warning)", () => {
   });
 });
 
+function groupPresetMessage(path: string): ValidationMessage {
+  return {
+    topic: "Configuration Warning",
+    message: `${path}: you should not extend "group:" presets`,
+  };
+}
+
+describe("group-preset-in-package-rule translation (068 — the common WARNING)", () => {
+  const message = groupPresetMessage;
+
+  it("matches the exact upstream message shape, topic-independently", () => {
+    const translation = must(
+      ERROR_TRANSLATIONS.find((t) => t.id === "group-preset-in-package-rule"),
+      "the group-preset-in-package-rule translation",
+    );
+    expect(translation.matches(message("packageRules[0].extends"))).toBe(true);
+    // `explain_message` defaults the topic to "Configuration Error" when a
+    // caller passes only the text — the match must not depend on the topic.
+    expect(
+      translation.matches({
+        topic: "Configuration Error",
+        message: 'packageRules[0].extends: you should not extend "group:" presets',
+      }),
+    ).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains the structural reason: the preset body is a packageRules array", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), null),
+      "a translation for the group-preset message",
+    );
+    expect(translated.explanation).toContain("packageRules[0].extends");
+    expect(translated.explanation).toMatch(/`packageRules` array/);
+    expect(translated.explanation).toMatch(/matchUpdateTypes/);
+    expect(translated.explanation).toMatch(/pin/);
+    expect(translated.docsUrl).toBe("https://docs.renovatebot.com/config-presets/");
+    expect(translated.fix).toBeNull();
+  });
+
+  it("inlines a monorepo group: the underlying monorepo: preset, groupName AND matchUpdateTypes", () => {
+    const config = {
+      packageRules: [{ extends: ["group:jestMonorepo"], automerge: true }],
+    };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the group-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the jestMonorepo case");
+    expect(fix.path).toEqual(["packageRules", 0]);
+    expect(fix.after).toEqual({
+      extends: ["monorepo:jest"],
+      groupName: "jest monorepo",
+      // the group's own pin-excluding update types, restated verbatim
+      matchUpdateTypes: ["digest", "patch", "minor", "major"],
+      automerge: true,
+    });
+    expect(fix.fixedConfig).toEqual({
+      packageRules: [
+        {
+          extends: ["monorepo:jest"],
+          groupName: "jest monorepo",
+          matchUpdateTypes: ["digest", "patch", "minor", "major"],
+          automerge: true,
+        },
+      ],
+    });
+    expect(fix.summary).toContain("group:jestMonorepo");
+    // original untouched
+    expect(config.packageRules[0]?.extends).toEqual(["group:jestMonorepo"]);
+  });
+
+  it("copies a group's plain matchers when it has no underlying preset to extend", () => {
+    const config = { packageRules: [{ extends: ["group:definitelyTyped"] }] };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the definitelyTyped group message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the definitelyTyped case");
+    expect(fix.after).toEqual({
+      groupName: "definitelyTyped",
+      matchPackageNames: ["@types/**"],
+    });
+  });
+
+  it("keeps the rule's other presets and lets the user's own value win a conflict", () => {
+    const config = {
+      packageRules: [
+        {
+          extends: ["group:jestMonorepo", "schedule:weekly"],
+          matchUpdateTypes: ["minor", "patch"],
+        },
+      ],
+    };
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), config),
+      "a translation for the group-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix that keeps the sibling preset");
+    expect(fix.after).toEqual({
+      extends: ["monorepo:jest", "schedule:weekly"],
+      groupName: "jest monorepo",
+      // explicitly set by the user, so it survives the merge
+      matchUpdateTypes: ["minor", "patch"],
+    });
+  });
+
+  it("explains without a fix when the group is a fan-out over other groups (group:monorepos)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:monorepos"] }],
+      }),
+      "a translation for the group:monorepos message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix when the group carries top-level options (group:all)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:all"] }],
+      }),
+      "a translation for the group:all message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix when two group: presets share one rule (ambiguous)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:jestMonorepo", "group:definitelyTyped"] }],
+      }),
+      "a translation for the two-group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("explains without a fix for a group name this Renovate doesn't bundle", () => {
+    const translated = must(
+      translateMessage(message("packageRules[0].extends"), {
+        packageRules: [{ extends: ["group:notARealGroupPreset"] }],
+      }),
+      "a translation for the unknown-group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+
+  it("gives up when the named path isn't in this config (stale message vs. edited config)", () => {
+    const translated = must(
+      translateMessage(message("packageRules[3].extends"), { packageRules: [] as unknown[] }),
+      "a translation for the stale group message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+});
+
+function globalPresetMessage(path: string): ValidationMessage {
+  return {
+    topic: "Configuration Error",
+    message: `${path}: you cannot extend from "global:" presets in a repository config's "extends"`,
+  };
+}
+
+describe("global-preset-in-extends translation", () => {
+  const message = globalPresetMessage;
+
+  it("matches the exact upstream message shape", () => {
+    const translation = must(
+      ERROR_TRANSLATIONS.find((t) => t.id === "global-preset-in-extends"),
+      "the global-preset-in-extends translation",
+    );
+    expect(translation.matches(message("extends"))).toBe(true);
+    expect(translation.matches({ topic: "x", message: "unrelated" })).toBe(false);
+  });
+
+  it("explains that global: presets belong in the self-hosted config", () => {
+    const translated = must(
+      translateMessage(message("extends"), null),
+      "a translation for the global-preset message",
+    );
+    expect(translated.explanation).toMatch(/self-hosted/);
+    expect(translated.docsUrl).toBe("https://docs.renovatebot.com/presets-global/");
+  });
+
+  it("drops only the global: entries, keeping the rest of extends", () => {
+    const translated = must(
+      translateMessage(message("extends"), {
+        extends: ["config:recommended", "global:safeEnv"],
+      }),
+      "a translation for the global-preset message",
+    );
+    const fix = must(translated.fix, "a suggested fix for the global-preset case");
+    expect(fix.path).toEqual(["extends"]);
+    expect(fix.after).toEqual(["config:recommended"]);
+    expect(fix.fixedConfig).toEqual({ extends: ["config:recommended"] });
+  });
+
+  it("removes the key entirely when nothing but global: presets were listed", () => {
+    const translated = must(
+      translateMessage(message("extends"), { extends: ["global:safeEnv"], labels: ["deps"] }),
+      "a translation for the global-only extends message",
+    );
+    const fix = must(translated.fix, "a remove fix for the global-only extends");
+    expect(fix.remove).toBe(true);
+    expect(fix.fixedConfig).toEqual({ labels: ["deps"] });
+  });
+
+  it("gives up when the named path isn't a string array in this config", () => {
+    const translated = must(
+      translateMessage(message("extends"), { extends: "config:recommended" }),
+      "a translation for the non-array extends message",
+    );
+    expect(translated.fix).toBeNull();
+  });
+});
+
 describe("translateMessage", () => {
   it("returns null for a message no curated pattern recognizes", () => {
     expect(

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -207,6 +207,57 @@ describe("compareSimulations", () => {
     });
   });
 
+  /**
+   * Roadmap 068 (2026-07 persona study, 4 of 9 sessions): every consumer was
+   * re-deriving "so did it change?" from six arrays and two booleans. The net
+   * effect is stated here, once, in the order a reader asks it: the changed
+   * keys when there are any, the rules that started or stopped otherwise, and
+   * the identity churn only ever as a parenthetical.
+   */
+  describe("summary", () => {
+    const effect = [{ key: "groupName", after: "frontend" }];
+    const wide = matched(0, [["matchPackageNames", ["react", "vue"]]]);
+    const narrow = matched(0, [["matchPackageNames", ["react"]]]);
+
+    it("names the changed keys when the effective config moved", () => {
+      const a = sim([matched(0, [["matchManagers", ["npm"]]])], { groupName: "old" });
+      const b = sim([matched(0, [["matchManagers", ["npm"]]])], { groupName: "new", labels: [] });
+      expect(compareSimulations(a, b).summary).toBe("differs: groupName, labels");
+    });
+
+    it("counts the rules when the config came out the same", () => {
+      const a = sim([matched(0, [["matchPackageNames", ["lodash"]]])], {});
+      const b = sim([matched(0, [["matchSourceUrls", ["https://x"]]])], {});
+      expect(compareSimulations(a, b).summary).toBe(
+        "differs: 1 rule started matching and 1 rule stopped matching, " +
+          "with no change to the effective config",
+      );
+    });
+
+    it("says identical for a behavior-preserving pattern edit, and why", () => {
+      const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
+      const b = sim([{ ...narrow, merged: effect }], { groupName: "frontend" });
+      expect(compareSimulations(a, b).summary).toBe(
+        "identical: the same effective config results (a rule's pattern text changed)",
+      );
+    });
+
+    it("says identical without the caveat when nothing moved at all", () => {
+      const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
+      expect(compareSimulations(a, a).summary).toBe(
+        "identical: the same rules matched and the same effective config results",
+      );
+    });
+
+    it("stops naming keys once the list would stop being a line", () => {
+      const many = Object.fromEntries(
+        Array.from({ length: 9 }, (_, i) => [`key${i}`, i]),
+      ) as Record<string, unknown>;
+      const cmp = compareSimulations(sim([], {}), sim([], many));
+      expect(cmp.summary).toBe("differs: key0, key1, key2, key3, key4, key5 and 3 more");
+    });
+  });
+
   it("pairs duplicate-signature matched rules as a multiset", () => {
     const clause: [string, unknown][] = [["matchDatasources", ["npm"]]];
     const a = sim([matched(0, clause), matched(1, clause)], {});

--- a/plugins/renovate-config-debugger/skills/debug-renovate-config/SKILL.md
+++ b/plugins/renovate-config-debugger/skills/debug-renovate-config/SKILL.md
@@ -144,13 +144,20 @@ infrastructure error, so it works as a check in CI or a hook without a wrapper.
   concluding an option "is not set".
 - **An oversized answer is elided, not silently cut.** A tool result too big
   to return whole rewrites its largest array in place as
-  `{truncated: true, shown, omitted, items: […]}`, and the whole document
-  gets a top-level `truncated: true` plus a `hint` naming the parameter that
-  narrows the question. Index `rules[0]` on an elided answer and you get
-  `undefined` — the array moved to `.items` inside the wrapper. Follow the
-  hint (fewer rules, one preset node, a smaller depth) rather than re-reading
-  the raw shape; elision keeps both ends of a shrunk array, so a rule your
-  own config appended last is not the one that vanished.
+  `{truncated: true, shown, omitted, omittedFrom, items: […]}` — the gap sits
+  at index `omittedFrom` in `items` — and the whole document gets a top-level
+  `truncated: true` plus a `hint` naming the parameter that narrows the
+  question. Index `rules[0]` on an elided answer and you get `undefined` — the
+  array moved to `.items` inside the wrapper. Follow the hint (fewer rules,
+  one preset node, a smaller depth) rather than re-reading the raw shape;
+  elision keeps both ends of a shrunk array, so a rule your own config
+  appended last is not the one that vanished.
+- **`simulate` answers the question by default.** Its default `detail:
+"verdict"` payload is the matched rules, `flattened` and
+  `finalDependencyConfig`; the ~1 MB step-by-step merge trace (`mergeSteps`,
+  `rawFinalConfig`) only comes with `detail: "full"`, which is over budget by
+  construction and arrives elided. Reach for it only when the per-step merge
+  order itself is the question.
 - This tooling is **experimental**: tool names, flags and output shapes may
   change. If a call fails with an unknown-argument error, list the tools (or
   run `--help`) rather than guessing a variant.

--- a/plugins/renovate-config-debugger/skills/debug-renovate-config/SKILL.md
+++ b/plugins/renovate-config-debugger/skills/debug-renovate-config/SKILL.md
@@ -43,16 +43,17 @@ the whole trace.
 
 ### 3. Drill down — one question, one tool
 
-| question                                        | tool                            |
-| ----------------------------------------------- | ------------------------------- |
-| "what did `extends` pull in?"                   | `get_preset_tree`               |
-| "what did preset X actually contribute?"        | `get_preset_node`               |
-| "who set this option / who overrode whom?"      | `get_provenance` (with a `key`) |
-| "what does this option even mean?"              | `get_option_docs`               |
-| "what does this validator message mean?"        | `explain_message`               |
-| "what would I write without the presets?"       | `get_resolved_config`           |
-| "would this dependency update match the rules?" | `simulate`                      |
-| "did my edit change behavior?"                  | `compare_simulations`           |
+| question                                                | tool                            |
+| ------------------------------------------------------- | ------------------------------- |
+| "what did `extends` pull in?"                           | `get_preset_tree`               |
+| "what did preset X actually contribute?"                | `get_preset_node`               |
+| "who set this option / who overrode whom?"              | `get_provenance` (with a `key`) |
+| "what does this option even mean?"                      | `get_option_docs`               |
+| "what does this validator message mean?"                | `explain_message`               |
+| "what would I write without the presets?"               | `get_resolved_config`           |
+| "what's the whole effective config, defaults included?" | `get_final_config`              |
+| "would this dependency update match the rules?"         | `simulate`                      |
+| "did my edit change behavior?"                          | `compare_simulations`           |
 
 **Preset-node bodies are large — query one node at a time.** `get_preset_tree`
 deliberately returns structure and contribution stats without bodies, and it is
@@ -63,7 +64,26 @@ actual answer.
 
 `get_provenance` is the tool most debugging questions actually want. "Why is
 `minimumReleaseAge` 3 days when I never set it" is a provenance question, not a
-preset-tree question.
+preset-tree question. `get_final_config` is the whole merged document,
+Renovate's defaults included — it is large, and on a `config:recommended` run
+almost never what you actually want; reach for `get_provenance` with a `key`
+instead, and keep `get_final_config` for when you genuinely need the entire
+document.
+
+A `config:best-practices` config resolves to hundreds of rules — scope
+`simulate` to your own rules first rather than reading the whole list.
+`source: "repo"` limits it to the rules your config itself wrote (the answer
+to "my rule is index 713 of 713"); `source: "presets"` is what `extends`
+pulled in. `verdict` narrows by outcome — `matched`, `no-input`, `no-match`,
+or `notable` (matched + unresolved, everything but a plain non-match).
+Reach for `all`/`all` only once you know you need the whole list.
+
+`explain_message` says so plainly when it has no translation for a message —
+`translationKnown: false` plus a note — instead of quietly echoing the raw
+text back at you; treat that as "go read the message yourself", not as an
+answer. When it does know a message, including warnings like the
+`group:`-preset one, it increasingly ships a concrete fix alongside the
+explanation, not just prose.
 
 ### 4. Proposing an edit: prove it
 
@@ -78,8 +98,11 @@ Never hand over a config change on the strength of reading it. The oracle:
 
 `noChange: true` means the edit is behaviorally inert for that dependency —
 which is either the point (a cleanup) or a bug (you meant to change
-something). Say which one it is. When it is not inert, `matchedOnlyInA` /
-`matchedOnlyInB` and `configDelta` are the evidence to quote.
+something). Say which one it is. `compare_simulations` also carries a
+plain-language net-effect summary — quote that one-liner rather than
+paraphrasing the arrays yourself; when you need to go further,
+`behaviorOnlyInA` / `behaviorOnlyInB` and `configDelta` are the evidence
+underneath it.
 
 For `simulate` and `compare_simulations`, set the dependency fields the rules
 actually match on (`depName`, `packageName`, `datasource`, `manager`,
@@ -119,6 +142,15 @@ infrastructure error, so it works as a check in CI or a hook without a wrapper.
 - A preset that cannot be fetched shows up as a failed node, and everything
   under it is missing from the effective config. Check for that before
   concluding an option "is not set".
+- **An oversized answer is elided, not silently cut.** A tool result too big
+  to return whole rewrites its largest array in place as
+  `{truncated: true, shown, omitted, items: […]}`, and the whole document
+  gets a top-level `truncated: true` plus a `hint` naming the parameter that
+  narrows the question. Index `rules[0]` on an elided answer and you get
+  `undefined` — the array moved to `.items` inside the wrapper. Follow the
+  hint (fewer rules, one preset node, a smaller depth) rather than re-reading
+  the raw shape; elision keeps both ends of a shrunk array, so a rule your
+  own config appended last is not the one that vanished.
 - This tooling is **experimental**: tool names, flags and output shapes may
   change. If a call fails with an unknown-argument error, list the tools (or
   run `--help`) rather than guessing a variant.


### PR DESCRIPTION
Round-2 fixes for `rcd mcp`, from a max-depth code review (findings verified empirically) and a second 9-session blinded persona study run against the v2-native server. Stacked on #161. Round 2 scored 9/9 correct diagnoses (round 1: 7 + 2 partial), including the 44529 expert catching the planted `pin`-divergence trap through `compare_simulations` — these fixes target what still hurt.

## Result contract (review H1/M1, the top persona friction)

- `simulate` now answers the question by default: `detail: "verdict"` returns the matched-rule evidence, `flattened` and `finalDependencyConfig`; the ~1 MB merge trace (`mergeSteps`, `rawFinalConfig`) requires `detail: "full"`. Measured on `config:recommended`: rules shown went from **2 of 713** to 76 (unfiltered) — and a `verdict: "matched"` call now fits whole, untruncated.
- The elision budget derives from the host's real cap in code (`25_000 tokens × 3 bytes × 0.87` = 65,250 B) instead of exceeding it, so the host never truncates mid-JSON above our own guarantee.
- Array elision keeps a **head and a tail window** (marker: `{truncated, shown, omitted, omittedFrom, items}`): merged `packageRules` arrays put the repo's own rules last, and those are exactly what used to vanish (`get_resolved_config mode:"full"` dropped the user's rule at index 713; now 141 head + 72 tail survive). The shrink pass also converges instead of handing off to whole-key dropping.
- The default hint names the elided-array shape whenever elision fired.

## Memory (review H2)

`RunStore` held ~165 MB per run — 98% of it `kind:"log"` trace events nothing on the MCP path reads — for ~1.4 GB steady-state at the old limit of 8. Held runs are now stripped of log events and the default limit is 3. Every drill-down tool is test-proven against a stripped run.

## Security (review M3)

`run_config`'s own `endpoint` parameter bypassed the endpoint credential guard (which only inspected `globalConfig`) — over MCP the *model* chooses that parameter. A caller-supplied endpoint now withholds host tokens unless `trustEndpoints: true`, same policy and same style of note as the global-config case, with tests both ways. CLI flags are unchanged (a human typed those).

## Translations, Variant A

- The message-translation library — evaluated for external reuse: it already lives in `packages/engine` and is exported from its public index, so it ships to external consumers with the published engine (roadmap 056); no relocation warranted, a separate package would just re-need the engine.
- New entries: the `group:`-preset warning (fix computed from the group's own bundled body, so the pin-excluding `matchUpdateTypes` is carried by construction, not retyped) and the `global:`-preset error. Entries total 5.
- Every surface now says when it has nothing: `translationKnown: false` plus a note replaces the silent echo three persona sessions called a broken promise, and `fixedTextRewritesDocument` marks a whole-document rewrite that may lose comments.

## Smaller fixes

- `compare_simulations` (and `rcd compare`) lead with a one-line `summary` net-effect verdict — "identical: … (a rule's pattern text changed)" / "differs: <keys>" — the field four sessions asked for.
- MCP `filterNotes` speak parameter names (`source: "repo"`), not CLI flags (review M2).
- Keyed `get_provenance` notes when N packageRules can set the option per-dependency, closing the static-vs-simulation conflation two sessions hit.
- Cancelled tool calls no longer occupy the engine queue (signal checked at entry and at task start).
- Schema rejections: SDK v2 already names fields (`content: Invalid input: expected string, received object`) — regression-pinned with tests; descriptions clarified (`content` is the file text as a JSON string; `endpoint` states its token consequence).
- stderr guarded against a closed pipe; dead `HINTS.optionDocs` wired; the "preset-fetch cache paid once" overclaim corrected (memCache resets per run — only the module graph is amortized).
- Skill + README synced to all of the above.

## Verification

engine 95 golden + 117 shimmed (parity green), app 337 unit/render, cli 139, oauth-worker 33; bundle parity 76/76 against the rebuilt dist; typecheck/oxlint/oxfmt clean. Built-bundle MCP smoke: simulate default shape has no `mergeSteps`/`rawFinalConfig`, `explain_message` returns `translationKnown: true` with the fix for the `group:` warning.

**Follow-up resolved (see the companion PR to `main`):** a suspected engine bug — the simulator "hoisting" nested `packageRules` — was investigated and **disproven**: the flattening is Renovate's own `migrateConfig` behavior, re-applied to the resolved config exactly as upstream does, and the simulator is byte-identical to real `applyPackageRules` on both sides of the construct. The fidelity is now pinned by golden oracle tests in that PR, and the `group:`-warning translation text here was corrected accordingly (the construct behaves scoped by migration side-effect; the warning's real teeth are the unsupported shape and the duplicated rule).
