### PR TITLE
test(engine): pin nested-packageRules simulator fidelity against real applyPackageRules

### DIFF
--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -34,6 +34,18 @@ import type { ValidationMessage } from "./trace/model";
  * token and upstream THROWS without one, so rules containing it are reported
  * as "not-simulated" instead of being decided — mirroring that a real run
  * would abort rather than silently match or skip.
+ *
+ * A rule carrying a NESTED `packageRules` array (what `extends: ["group:…"]`
+ * inside a rule resolves to) is treated exactly as `applyPackageRules` treats
+ * it: the nested array is inert — it is neither descended into for matching nor
+ * hoisted into the outer rule — and a rule with no top-level `match*` clause
+ * matches every dependency, because upstream `matchesRule` skips every matcher
+ * that returns null and then returns true. The hoisting a resolved config
+ * usually shows is Renovate's OWN, applied earlier: `migrateConfig`'s flatten
+ * block, which `pipeline.ts` runs on the resolved config in the same position
+ * upstream `mergeRenovateConfig` does. Do not replicate it here — that would
+ * double-apply it. See the `group:`-preset block in
+ * test/simulate-package-rules.node.test.ts.
  */
 
 /** Everything the 18 matchers can read about a hypothetical dependency update. */

--- a/packages/engine/test/simulate-package-rules.node.test.ts
+++ b/packages/engine/test/simulate-package-rules.node.test.ts
@@ -8,7 +8,8 @@ import { mergeChildConfig } from "renovate/dist/config/utils.js";
 import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
 import { describe, expect, it } from "vitest";
 import type { DependencyDescriptor } from "../src/index";
-import { simulatePackageRules } from "../src/index";
+import { runPipeline, simulatePackageRules } from "../src/index";
+import { must } from "./helpers";
 
 const UPDATE_TYPE_KEYS = [
   "major",
@@ -125,5 +126,148 @@ describe("simulatePackageRules (golden)", () => {
     expect(simulated.rawFinalConfig).toEqual(oracle);
     expect(simulated.rules.map((r) => r.verdict)).toEqual(["no-match", "matched", "matched"]);
     expect(oracle.automerge).toBe(true);
+  });
+});
+
+/**
+ * `extends: ["group:…"]` INSIDE a packageRules entry — the construct Renovate's
+ * validator warns about (`you should not extend "group:" presets`). Preset
+ * resolution leaves the rule shaped `{ packageRules: [innerGroupRule],
+ * <userOptions> }`, i.e. a rule whose only matcher-carrying content sits one
+ * level down, and it has been claimed that the visualizer "hoists" that inner
+ * body where a real run would ignore it. It does not — the flattening is
+ * Renovate's own, and these tests pin both halves of why with real
+ * `applyPackageRules` as the oracle:
+ *
+ * 1. A real repo run never reaches `applyPackageRules` with the nested shape.
+ *    Upstream `mergeRenovateConfig` re-migrates the RESOLVED config ("Resolved
+ *    config needs migrating"), and `migrateConfig`'s own flatten block
+ *    (`mergeChildConfig(packageRule, subrule)` + `delete
+ *    combinedRule.packageRules`) merges every nested rule into its parent.
+ *    `pipeline.ts` runs that same second migration in the same position, so the
+ *    effective config the simulator is handed is already flattened — by
+ *    Renovate's code, not by the simulator's.
+ * 2. Should such a rule reach the simulator anyway (an effective config that
+ *    never went through migration), the simulator still reproduces upstream
+ *    exactly: with no top-level `match*` clause `matchesRule` returns true for
+ *    EVERY dependency (every matcher returns null and is skipped), only the
+ *    rule's own top-level options merge, and the nested `packageRules` array is
+ *    inert for matching — `applyPackageRules` iterates the snapshot it was
+ *    handed and never descends into it.
+ */
+describe("simulatePackageRules with a `group:` preset extended inside a rule (golden)", () => {
+  const brokenConfig = JSON.stringify({
+    $schema: "https://docs.renovatebot.com/renovate-schema.json",
+    extends: ["config:recommended"],
+    packageRules: [{ extends: ["group:jacksonMonorepo"], minimumGroupSize: 5 }],
+  });
+
+  /** In the extended group. */
+  const jacksonDep: DependencyDescriptor = {
+    manager: "gradle",
+    datasource: "maven",
+    packageName: "com.fasterxml.jackson.core:jackson-databind",
+    sourceUrl: "https://github.com/FasterXML/jackson-databind",
+    currentValue: "2.15.0",
+    newValue: "2.16.0",
+    updateType: "minor",
+  };
+  /** Not in the extended group — the misconfiguration's blast radius, if any. */
+  const reactDep: DependencyDescriptor = {
+    manager: "npm",
+    datasource: "npm",
+    packageName: "react",
+    sourceUrl: "https://github.com/facebook/react",
+    currentValue: "17.0.0",
+    newValue: "18.0.0",
+    updateType: "major",
+  };
+
+  async function resolveBroken(): Promise<Record<string, unknown>> {
+    const run = await runPipeline({ fileName: "renovate.json", content: brokenConfig });
+    expect(run.stageStatus.preset).toBe("ok");
+    return must(run.finalConfig, "a resolved effective config");
+  }
+
+  it("resolves to a FLATTENED rule — upstream's post-preset re-migration, plus the validator's warning", async () => {
+    const run = await runPipeline({ fileName: "renovate.json", content: brokenConfig });
+    expect(run.warnings).toContainEqual({
+      topic: "Configuration Warning",
+      message: 'packageRules[0].extends: you should not extend "group:" presets',
+    });
+    const config = must(run.finalConfig, "a resolved effective config");
+    const rules = config.packageRules;
+    if (!Array.isArray(rules)) {
+      throw new Error("expected the resolved config to carry packageRules");
+    }
+    const objectRules = rules.filter(
+      (rule): rule is Record<string, unknown> =>
+        typeof rule === "object" && rule !== null && !Array.isArray(rule),
+    );
+    // Nothing survives nested: migrateConfig's flatten block ran on the
+    // resolved config, exactly as mergeRenovateConfig does upstream.
+    expect(objectRules.some((rule) => "packageRules" in rule)).toBe(false);
+    const authored = objectRules.filter((rule) => rule.minimumGroupSize === 5);
+    expect(authored).toHaveLength(1);
+    const flattened = must(authored[0], "the flattened jackson rule");
+    // The group preset's body is IN the rule now — matchers and groupName both.
+    expect(flattened.groupName).toBe("jackson monorepo");
+    expect(flattened.matchSourceUrls).toContain("https://github.com/FasterXML/jackson-databind");
+  });
+
+  it("agrees with real applyPackageRules for an in-group and an unrelated dependency", async () => {
+    const config = await resolveBroken();
+    for (const dep of [jacksonDep, reactDep]) {
+      const oracle = await applyPackageRules({ ...config, ...dep, depName: dep.packageName });
+      const simulated = await simulatePackageRules({ config, dep });
+      expect(simulated.rawFinalConfig).toEqual(oracle);
+    }
+    // The scoping is real, not a simulator artifact: only the jackson dep picks
+    // up the rule's option, so the misconfiguration has no global blast radius.
+    const jacksonOracle = await applyPackageRules({
+      ...config,
+      ...jacksonDep,
+      depName: jacksonDep.packageName,
+    });
+    const reactOracle = await applyPackageRules({
+      ...config,
+      ...reactDep,
+      depName: reactDep.packageName,
+    });
+    expect(jacksonOracle.minimumGroupSize).toBe(5);
+    expect(reactOracle.minimumGroupSize).not.toBe(5);
+  });
+
+  it("stays oracle-faithful when a nested rule reaches it un-migrated: match-all, nested array inert", async () => {
+    const config = {
+      groupSlug: "pre-existing",
+      packageRules: [
+        {
+          minimumGroupSize: 5,
+          packageRules: [
+            {
+              matchSourceUrls: ["https://github.com/FasterXML/jackson-databind"],
+              groupName: "jackson monorepo",
+            },
+          ],
+        },
+      ],
+    };
+    for (const dep of [jacksonDep, reactDep]) {
+      const oracle = await applyPackageRules({ ...config, ...dep, depName: dep.packageName });
+      const simulated = await simulatePackageRules({ config, dep });
+      expect(simulated.rawFinalConfig).toEqual(oracle);
+      const rule = must(simulated.rules[0], "the nested rule's evaluation");
+      // No top-level match* clause at all — so nothing to report, and upstream
+      // matches every dependency.
+      expect(rule.clauses).toEqual([]);
+      expect(rule.verdict).toBe("matched");
+      // The nested body is NOT hoisted by either side: the outer option applies
+      // and the inner rule's groupName never lands.
+      expect(oracle.minimumGroupSize).toBe(5);
+      expect(oracle.groupName).toBeUndefined();
+      expect(simulated.finalDependencyConfig.minimumGroupSize).toBe(5);
+      expect(simulated.finalDependencyConfig.groupName).toBeUndefined();
+    }
   });
 });

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -508,4 +508,34 @@ describe("simulatePackageRules", () => {
     expect(nothingMatched.rules[0]?.verdict).toBe("no-match");
     expect(nothingMatched.mergeSteps).toEqual([]);
   });
+
+  /**
+   * Shimmed twin of the `group:`-preset block in the golden test. A rule left
+   * shaped `{ packageRules: [inner], <options> }` — what `extends: ["group:…"]`
+   * inside a rule resolves to before Renovate's own migration flattens it — is
+   * treated by `applyPackageRules` as a matcher-less rule: it matches EVERY
+   * dependency, contributes only its top-level options, and the nested array is
+   * never descended into. The simulator neither hoists the inner body nor
+   * descends into it, so it stays oracle-identical here too.
+   */
+  it("treats a rule's nested packageRules as inert, like applyPackageRules (oracle parity)", async () => {
+    const config = {
+      groupSlug: "pre-existing",
+      packageRules: [
+        {
+          minimumGroupSize: 5,
+          packageRules: [{ matchPackageNames: ["react"], groupName: "react monorepo" }],
+        },
+      ],
+    };
+    // npmDep is `lodash` — the nested rule's matcher would exclude it if the
+    // simulator hoisted, and upstream matches it anyway.
+    const simulated = await simulatePackageRules({ config, dep: npmDep });
+    const oracle = await applyPackageRules(oracleInput(config, npmDep));
+    expect(simulated.rawFinalConfig).toEqual(oracle);
+    expect(simulated.rules[0]?.verdict).toBe("matched");
+    expect(simulated.rules[0]?.clauses).toEqual([]);
+    expect(simulated.finalDependencyConfig.minimumGroupSize).toBe(5);
+    expect(simulated.finalDependencyConfig.groupName).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Pins the simulator's fidelity for the nested-`packageRules` construct with golden oracle tests — and documents that a reported "hoisting bug" here is **not** a bug.

## The report, and what investigation found

Two blinded persona studies plus a translation-authoring pass produced the claim: "the simulator hoists nested `packageRules` into the outer rule, so `compare` reports no behavioral change between a broken `group:`-in-a-rule config and its proper fix, while real Renovate diverges (the matcher-less rule matches everything)."

Mechanical re-verification against the pinned Renovate 44.7.4 disproves it:

- The flattening is **Renovate's own** `migrateConfig` (`dist/config/migration.js:81-92` — "Flattening nested packageRules": each inner rule merged over the outer, nested key deleted).
- Upstream **re-migrates the resolved config** after preset resolution (`workers/repository/init/merge.js:196`), and `packages/engine/src/pipeline.ts` performs the same second migration in the same position — so in a real repo run the construct behaves *scoped and group-named*, not matcher-less.
- Oracle comparison — full pipeline on the repro config, ground truth from real `applyPackageRules` deep-imported in the golden project: **byte-identical** simulator output for both the in-group dep (`minimumGroupSize: 5`, `groupName: "jackson monorepo"`) and an unrelated dep (`minimumGroupSize: 1` from `config:recommended` — the user's 5 does *not* leak globally).
- The un-migrated nested shape (the one the report reasoned about) is *also* oracle-faithful: match-all, zero clauses, nested array inert — on both sides.

The earlier "divergence" came from running `applyPackageRules` on a config resolved **without** the post-preset re-migration — two different inputs compared.

## What this PR adds

- `test/simulate-package-rules.node.test.ts` — golden block deriving ground truth from real `applyPackageRules` (not hand-written): the repro config flattens with no surviving nested key + the validator warning; simulator == oracle for in-group and unrelated deps, with the global-blast-radius asserted **absent**; the un-migrated shape stays oracle-faithful.
- `test/simulate-package-rules.shimmed.test.ts` — shimmed twin pinning the browser module graph.
- A docblock in `simulate-package-rules.ts` stating the flatten belongs to `migrateConfig` and must not be replicated in the simulator ("that would double-apply it") — the anti-regression note for the next person handed this same bug report.

No behavior changes; no snapshots touched (golden↔shimmed byte-identity unaffected).

## Verification

engine golden 70 (was 67) + shimmed 115 (was 114), app unit 334, typecheck/oxlint/oxfmt clean.
