### PR TITLE
feat(engine): attribute description strings to preset-tree nodes

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -43,6 +43,7 @@ export {
   type DroppedDescription,
   type DroppedDescriptionReason,
   type RuleDescriptionAttribution,
+  type UnattributedDescription,
 } from "./trace/description-provenance";
 export {
   computeProvenance,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -36,6 +36,15 @@ export {
 } from "./error-translations";
 export { applyFixToText, type AppliedTextFix } from "./error-fix-text";
 export {
+  computeDescriptionProvenance,
+  type DescriptionAttribution,
+  type DescriptionProvenance,
+  type DescriptionSource,
+  type DroppedDescription,
+  type DroppedDescriptionReason,
+  type RuleDescriptionAttribution,
+} from "./trace/description-provenance";
+export {
   computeProvenance,
   computeRuleProvenance,
   type KeyProvenance,

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -18,7 +18,12 @@ export { parsePreset } from "renovate/dist/config/presets/parse.js";
 // `presets/index.js` — roadmap 014's `group:`-preset translation reads the
 // flagged group's OWN body rather than restating it, so the suggested rule
 // can't drift from the pinned Renovate.
-export { getPreset as getInternalPreset } from "renovate/dist/config/presets/internal/index.js";
+// `groups` is the raw table those bodies live in — the SAME objects renovate
+// hands out, which `getPreset` mutates (see trace/description-provenance.ts).
+export {
+  getPreset as getInternalPreset,
+  groups as internalPresetGroups,
+} from "renovate/dist/config/presets/internal/index.js";
 export { mergeChildConfig } from "renovate/dist/config/utils.js";
 export { getConfig as getDefaultConfig } from "renovate/dist/config/defaults.js";
 export { GlobalConfig } from "renovate/dist/config/global.js";

--- a/packages/engine/src/trace/description-provenance.ts
+++ b/packages/engine/src/trace/description-provenance.ts
@@ -41,6 +41,13 @@ import { computeRuleProvenance, type ProvenanceLayer } from "./provenance";
  * guessing a leaf. An honest "contributed by subtree X" beats a confident wrong
  * leaf, and because the fallback re-seeds from ground truth, one bad subtree
  * cannot desynchronise its parent's indices.
+ *
+ * A `description` array may also hold non-strings: Renovate only WARNS about
+ * `{"description": ["a", 42]}`, so the `42` survives into the final array and
+ * occupies a real index. The replay pairs string members only, but every
+ * `index` reported here is the member's position in the REAL final array, and
+ * the non-strings are listed separately in `unattributed` — no preset wrote
+ * them, and skipping them silently would shift every position after them.
  */
 
 /** The preset-tree node a string (or a drop) is attributed to. */
@@ -83,6 +90,24 @@ export interface DroppedDescription {
   reason: DroppedDescriptionReason;
   /** `ignore-deps-quirk` only: the extending node whose `ignoreDeps: []` deleted it. */
   droppedBy?: DescriptionSource;
+  /**
+   * The authoring node is a guess: the drop came out of a subtree that had
+   * already degraded to its enclosing node (see the fallback semantics above),
+   * so `node` names that subtree rather than the exact writer. Never set on the
+   * two `getPreset` drops, which are read off a pristine body.
+   */
+  approximate?: boolean;
+}
+
+/**
+ * A member of the final top-level `description` array that is not a string.
+ * Renovate warns about these but keeps them, so they hold a real index; no
+ * preset attribution exists for them, hence the separate list.
+ */
+export interface UnattributedDescription {
+  /** 0-based index into the final top-level `description` array. */
+  index: number;
+  value: unknown;
 }
 
 /**
@@ -102,6 +127,13 @@ export interface RuleDescriptionAttribution {
 export interface DescriptionProvenance {
   /** Every string of the final top-level `description`, in order. */
   entries: DescriptionAttribution[];
+  /** Non-string members of that same array, which carry no attribution. */
+  unattributed: UnattributedDescription[];
+  /**
+   * Length of the real final `description` array — `entries.length +
+   * unattributed.length` — so "position N of M" needs no re-derivation.
+   */
+  finalLength: number;
   /** Descriptions Renovate deleted before they could merge. */
   dropped: DroppedDescription[];
   /** Descriptions living on merged `packageRules` entries. */
@@ -117,14 +149,13 @@ function isPlainObject(value: unknown): value is Obj {
 }
 
 /**
- * The description strings of a config body. `input`/`resolved` are already
- * massaged (so `allowString` has coerced `"x"` to `["x"]`), but raw `fetched`
- * bodies are not — and a hand-injected preset may be anything, so the string
- * form and non-string array members are handled defensively. Dropping a
- * non-string member is deliberate: it desynchronises the replay, which the
- * per-node alignment check turns into an honest `approximate` attribution.
+ * A config body's `description` as the array Renovate holds. `input`/`resolved`
+ * are already massaged (so `allowString` has coerced `"x"` to `["x"]`), but raw
+ * `fetched` bodies are not — and a hand-injected preset may be anything — so
+ * the string form is still coerced here. Members are returned untouched,
+ * non-strings included: they are real positions in the array.
  */
-function descriptionsOf(body: unknown): string[] {
+function descriptionMembersOf(body: unknown): unknown[] {
   if (!isPlainObject(body)) {
     return [];
   }
@@ -132,10 +163,17 @@ function descriptionsOf(body: unknown): string[] {
   if (typeof value === "string") {
     return [value];
   }
-  if (Array.isArray(value)) {
-    return value.filter((item): item is string => typeof item === "string");
-  }
-  return [];
+  return Array.isArray(value) ? value : [];
+}
+
+/**
+ * The description STRINGS of a config body — the only members a preset can be
+ * held responsible for, and the sequence the positional replay works in.
+ * Non-strings are excluded here and accounted for separately against the final
+ * array (`unattributed`), so excluding them never shifts a reported index.
+ */
+function descriptionsOf(body: unknown): string[] {
+  return descriptionMembersOf(body).filter((item): item is string => typeof item === "string");
 }
 
 function sourceOf(node: PresetNode): DescriptionSource {
@@ -277,6 +315,37 @@ function valuesMatch(contributions: Contribution[], truth: string[]): boolean {
 }
 
 /**
+ * Everything one merging child of `parent` contributes: its own `getPreset`
+ * drop, its subtree, and — when `quirk` says the parent carries
+ * `ignoreDeps: []` — the diversion of that whole subtree into `dropped`,
+ * leaving nothing to merge. Shared by `walk` and the root level, which differ
+ * only in what they do with the returned contributions.
+ */
+function processChild(
+  parent: PresetNode,
+  child: PresetNode,
+  quirk: boolean,
+  dropped: DroppedDescription[],
+): WalkResult {
+  recordOwnDrop(child, dropped);
+  const sub = walk(child, dropped);
+  if (!quirk) {
+    return sub;
+  }
+  for (const contribution of sub.contributions) {
+    dropped.push({
+      value: contribution.value,
+      node: contribution.node ?? sourceOf(child),
+      reason: "ignore-deps-quirk",
+      droppedBy: sourceOf(parent),
+      // a guessed author stays labelled as a guess once it is a drop
+      ...(contribution.approximate ? { approximate: true } : {}),
+    });
+  }
+  return { contributions: [], degraded: sub.degraded };
+}
+
+/**
  * Replays one `resolveConfigPresets` invocation: every merging child in
  * `extends` order (each already flattened), then the node's own body last —
  * then checks the result against the node's ground-truth `resolved`.
@@ -287,21 +356,9 @@ function walk(node: PresetNode, dropped: DroppedDescription[]): WalkResult {
   const quirk = dropsChildDescriptions(node);
 
   for (const child of mergingChildren(node)) {
-    recordOwnDrop(child, dropped);
-    const sub = walk(child, dropped);
+    const sub = processChild(node, child, quirk, dropped);
     degraded ||= sub.degraded;
-    if (quirk) {
-      for (const contribution of sub.contributions) {
-        dropped.push({
-          value: contribution.value,
-          node: contribution.node ?? sourceOf(child),
-          reason: "ignore-deps-quirk",
-          droppedBy: sourceOf(node),
-        });
-      }
-    } else {
-      contributions.push(...sub.contributions);
-    }
+    contributions.push(...sub.contributions);
   }
 
   for (const value of descriptionsOf(node.input)) {
@@ -320,6 +377,19 @@ function walk(node: PresetNode, dropped: DroppedDescription[]): WalkResult {
     contributions: truth.map((value) => ({ value, node: sourceOf(node), approximate: true })),
     degraded: true,
   };
+}
+
+/**
+ * The `defaults` layer's descriptions (none, in every Renovate to date, but
+ * read rather than assumed). `getDefaultConfig()` rebuilds the whole option
+ * table on every call, so — like `INTERNAL_DROPS` — it is paid for once and
+ * cached at module level; the defaults cannot change within a process.
+ */
+let cachedDefaultDescriptions: string[] | undefined;
+
+function defaultDescriptions(): string[] {
+  cachedDefaultDescriptions ??= descriptionsOf(getDefaultConfig());
+  return cachedDefaultDescriptions;
 }
 
 /** A top-level layer's contribution, before indices are assigned. */
@@ -374,13 +444,12 @@ export function computeDescriptionProvenance(
   // Layers merging ahead of the repo's own resolution (008). Neither has a
   // preset tree of its own here, so their strings carry no node.
   const layered: LayerContribution[] = [];
-  const prefix: [ProvenanceLayer, unknown][] = [
-    [{ kind: "defaults" }, getDefaultConfig()],
-    [{ kind: "global" }, result.layerConfigs?.globalResolved],
-    [{ kind: "inherited" }, result.layerConfigs?.inheritedResolved],
+  const prefix: [ProvenanceLayer, string[]][] = [
+    [{ kind: "defaults" }, defaultDescriptions()],
+    [{ kind: "global" }, descriptionsOf(result.layerConfigs?.globalResolved)],
+    [{ kind: "inherited" }, descriptionsOf(result.layerConfigs?.inheritedResolved)],
   ];
-  for (const [layer, config] of prefix) {
-    const values = descriptionsOf(config);
+  for (const [layer, values] of prefix) {
     if (values.length > 0) {
       layered.push({ layer, contributions: values.map((value) => ({ value })) });
     }
@@ -392,18 +461,9 @@ export function computeDescriptionProvenance(
   const rootQuirk = dropsChildDescriptions(root);
   const rootContributions: Contribution[] = [];
   for (const child of mergingChildren(root)) {
-    recordOwnDrop(child, dropped);
-    const sub = walk(child, dropped);
+    const sub = processChild(root, child, rootQuirk, dropped);
     degraded ||= sub.degraded;
     if (rootQuirk) {
-      for (const contribution of sub.contributions) {
-        dropped.push({
-          value: contribution.value,
-          node: contribution.node ?? sourceOf(child),
-          reason: "ignore-deps-quirk",
-          droppedBy: sourceOf(root),
-        });
-      }
       continue;
     }
     layered.push({
@@ -444,32 +504,49 @@ export function computeDescriptionProvenance(
 
   // Ground truth for the whole run. Post-resolution re-migration (052) and the
   // 008 layers both act between `root.resolved` and `finalConfig`, so the final
-  // array — not the replay — decides how many entries there are.
-  const finalValues = descriptionsOf(finalConfig);
+  // array — not the replay — decides how many members there are. Its non-string
+  // members (Renovate warns, but keeps them) take no part in the replay yet
+  // still hold their index, so the replay is consumed by a separate cursor and
+  // every reported index is the member's REAL position.
+  const finalMembers = descriptionMembersOf(finalConfig);
   const entries: DescriptionAttribution[] = [];
+  const unattributed: UnattributedDescription[] = [];
   const firstIndexByValue = new Map<string, number>();
-  for (const [index, value] of finalValues.entries()) {
-    const aligned = flat[index];
-    const matched = aligned?.contribution.value === value ? aligned : undefined;
+  let replayCursor = 0;
+  for (const [index, member] of finalMembers.entries()) {
+    if (typeof member !== "string") {
+      unattributed.push({ index, value: member });
+      continue;
+    }
+    const aligned = flat[replayCursor];
+    replayCursor += 1;
+    const matched = aligned?.contribution.value === member ? aligned : undefined;
     if (!matched) {
       degraded = true;
     }
     const contribution = matched?.contribution;
     const approximate = contribution?.approximate ?? !matched;
     const node = contribution?.node;
-    const firstIndex = firstIndexByValue.get(value);
+    const firstIndex = firstIndexByValue.get(member);
     entries.push({
       index,
-      value,
+      value: member,
       ...(node ? { node } : {}),
       viaTopLevel: matched?.layer ?? { kind: "repo" },
       ...(approximate ? { approximate: true } : {}),
       ...(firstIndex === undefined ? {} : { duplicateOfIndex: firstIndex }),
     });
     if (firstIndex === undefined) {
-      firstIndexByValue.set(value, index);
+      firstIndexByValue.set(member, index);
     }
   }
 
-  return { entries, dropped, ruleDescriptions: ruleDescriptions(result), degraded };
+  return {
+    entries,
+    unattributed,
+    finalLength: finalMembers.length,
+    dropped,
+    ruleDescriptions: ruleDescriptions(result),
+    degraded,
+  };
 }

--- a/packages/engine/src/trace/description-provenance.ts
+++ b/packages/engine/src/trace/description-provenance.ts
@@ -1,0 +1,475 @@
+import { getDefaultConfig, internalPresetGroups } from "../renovate-adapter";
+import type { PresetNode, TraceResult } from "./model";
+import { computeRuleProvenance, type ProvenanceLayer } from "./provenance";
+
+/**
+ * Roadmap 069: per-string `description` provenance.
+ *
+ * `description` is an ordinary mergeable array option (`type: "array"`,
+ * `subType: "string"`, `allowString: true`), so every preset's author-written
+ * sentence is concatenated — never deduplicated — into one flat top-level
+ * array. The link back to the preset that wrote each sentence is lost the
+ * moment the merge happens. This module restores it.
+ *
+ * The reconstruction is POSITIONAL, not value-matching: `resolveConfigPresets`
+ * resolves each entry of `extends` in order (each subtree already flattened)
+ * and merges the node's OWN body LAST, and `mergeChildConfig` concatenates
+ * arrays in encounter order. Replaying that depth-first order over the preset
+ * tree therefore reproduces the exact index of every string, so two nodes that
+ * happen to write the same sentence still attribute to their own node.
+ *
+ * Three Renovate quirks silently delete descriptions before they ever reach
+ * the merge — all three are reported in `dropped` rather than left unexplained:
+ *
+ * - **wrapper-preset** — `getPreset` deletes the description of a preset whose
+ *   keys are exactly `{description, extends}` (e.g. `config:best-practices`).
+ * - **package-list-preset** — same, for a preset whose keys are a subset of
+ *   `{description, matchPackageNames}`.
+ * - **ignore-deps-quirk** — a config carrying `ignoreDeps: []` (length zero)
+ *   makes `resolveConfigPresets` delete the WHOLE resolved description of every
+ *   preset it extends.
+ *
+ * The first two happen inside `getPreset`, i.e. before the node's `input` is
+ * captured, so they are detected from the node's raw pre-migration body — not
+ * predicted. Which body that is takes some care, because Renovate mutates its
+ * own preset table; see `INTERNAL_DROPS` below.
+ *
+ * Correctness is self-checked: at every node the replayed sequence is compared
+ * against that node's ground-truth `resolved.description`. Where they disagree
+ * the subtree degrades to the enclosing node — every string of the ground truth
+ * is attributed to that node with `approximate: true` — rather than throwing or
+ * guessing a leaf. An honest "contributed by subtree X" beats a confident wrong
+ * leaf, and because the fallback re-seeds from ground truth, one bad subtree
+ * cannot desynchronise its parent's indices.
+ */
+
+/** The preset-tree node a string (or a drop) is attributed to. */
+export interface DescriptionSource {
+  /** `PresetNode.id`; `"root"` for the repo config itself. */
+  nodeId: string;
+  /** Raw preset string as written in `extends`; `"(input config)"` for the root. */
+  name: string;
+}
+
+export interface DescriptionAttribution {
+  /** 0-based index into the final top-level `description` array (the canonical index). */
+  index: number;
+  value: string;
+  /**
+   * The node whose OWN body wrote this string. Absent for strings contributed
+   * by layers that have no preset tree (defaults / global / inherited).
+   */
+  node?: DescriptionSource;
+  /** The top-level layer this string arrived through (same identity `computeProvenance` uses). */
+  viaTopLevel: ProvenanceLayer;
+  /** Index of the first value-equal entry, when this entry repeats an earlier one. */
+  duplicateOfIndex?: number;
+  /**
+   * The exact writing node could not be determined; `node` names the nearest
+   * enclosing subtree instead (see the fallback semantics above).
+   */
+  approximate?: boolean;
+}
+
+export type DroppedDescriptionReason =
+  | "wrapper-preset"
+  | "package-list-preset"
+  | "ignore-deps-quirk";
+
+export interface DroppedDescription {
+  value: string;
+  /** The node that authored the string. */
+  node: DescriptionSource;
+  reason: DroppedDescriptionReason;
+  /** `ignore-deps-quirk` only: the extending node whose `ignoreDeps: []` deleted it. */
+  droppedBy?: DescriptionSource;
+}
+
+/**
+ * `packageRules[n].description` is never hoisted to the top level, so it is
+ * attributed separately — and only to the LAYER that contributed the rule
+ * (which is all `computeRuleProvenance` knows), not to the exact node.
+ */
+export interface RuleDescriptionAttribution {
+  /** 0-based index into the final merged `packageRules` array. */
+  ruleIndex: number;
+  /** 0-based index within the contributing layer's own `packageRules` array. */
+  sourceIndex: number;
+  layer: ProvenanceLayer;
+  values: string[];
+}
+
+export interface DescriptionProvenance {
+  /** Every string of the final top-level `description`, in order. */
+  entries: DescriptionAttribution[];
+  /** Descriptions Renovate deleted before they could merge. */
+  dropped: DroppedDescription[];
+  /** Descriptions living on merged `packageRules` entries. */
+  ruleDescriptions: RuleDescriptionAttribution[];
+  /** At least one entry needed the enclosing-node fallback. */
+  degraded: boolean;
+}
+
+type Obj = Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is Obj {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * The description strings of a config body. `input`/`resolved` are already
+ * massaged (so `allowString` has coerced `"x"` to `["x"]`), but raw `fetched`
+ * bodies are not — and a hand-injected preset may be anything, so the string
+ * form and non-string array members are handled defensively. Dropping a
+ * non-string member is deliberate: it desynchronises the replay, which the
+ * per-node alignment check turns into an honest `approximate` attribution.
+ */
+function descriptionsOf(body: unknown): string[] {
+  if (!isPlainObject(body)) {
+    return [];
+  }
+  const value = body.description;
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === "string");
+  }
+  return [];
+}
+
+function sourceOf(node: PresetNode): DescriptionSource {
+  return { nodeId: node.id, name: node.name };
+}
+
+/** Same participant filter `buildLayers` uses: nested nodes merge inside their
+ *  parent's value, and unresolved ones never merged at all. */
+function mergingChildren(node: PresetNode): PresetNode[] {
+  return node.children.filter(
+    (child) => !child.nested && child.state === "resolved" && child.resolved !== undefined,
+  );
+}
+
+/** Renovate's `inputConfig?.ignoreDeps?.length === 0` guard, on a node's own body. */
+function dropsChildDescriptions(node: PresetNode): boolean {
+  const input = node.input;
+  return isPlainObject(input) && Array.isArray(input.ignoreDeps) && input.ignoreDeps.length === 0;
+}
+
+/**
+ * Renovate's two `getPreset` deletions, evaluated on the same keys Renovate
+ * evaluates them on: the fetched body after parameter substitution, before
+ * migration. Returns the reason, or undefined when the body keeps its
+ * description.
+ */
+function getPresetDropReason(raw: unknown): DroppedDescriptionReason | undefined {
+  if (!isPlainObject(raw)) {
+    return undefined;
+  }
+  const keys = Object.keys(raw);
+  if (!keys.includes("description")) {
+    return undefined;
+  }
+  if (keys.length === 2 && keys.includes("extends")) {
+    return "wrapper-preset";
+  }
+  if (keys.every((key) => key === "description" || key === "matchPackageNames")) {
+    return "package-list-preset";
+  }
+  return undefined;
+}
+
+interface DropInfo {
+  reason: DroppedDescriptionReason;
+  values: string[];
+}
+
+/**
+ * Renovate's internal preset table hands out its module-level objects BY
+ * REFERENCE (`internal/index.js`'s `getPreset` is a two-level lookup, no
+ * clone), so `getPreset`'s `delete presetConfig.description` permanently
+ * removes the description from the table. Renovate resolves a config once per
+ * process and never notices; this app resolves one on every keystroke, so from
+ * the second run on the deleted description is simply gone — including from
+ * the `fetched` body the trace records.
+ *
+ * Hence this index, built ONCE at module load (i.e. when the engine chunk is
+ * imported, always before a run) from the pristine table: the authoritative
+ * answer to "which internal preset lost its own description, and what did it
+ * say". Nothing is mutated — Renovate's behavior is left exactly as it is.
+ *
+ * Presets reached with parameters are not in here and do not need to be:
+ * `replaceArgs` clones before the delete, so their `afterParams` body is
+ * pristine on every run.
+ */
+const INTERNAL_DROPS: ReadonlyMap<string, DropInfo> = buildInternalDropIndex();
+
+function buildInternalDropIndex(): Map<string, DropInfo> {
+  const index = new Map<string, DropInfo>();
+  for (const [group, presets] of Object.entries(internalPresetGroups)) {
+    for (const [name, body] of Object.entries(presets)) {
+      const reason = getPresetDropReason(body);
+      if (!reason) {
+        continue;
+      }
+      const info: DropInfo = { reason, values: descriptionsOf(body) };
+      // `default:` presets are written both ways in `extends`.
+      for (const alias of group === "default"
+        ? [`:${name}`, `default:${name}`]
+        : [`${group}:${name}`]) {
+        index.set(alias, info);
+      }
+    }
+  }
+  return index;
+}
+
+/**
+ * The description `getPreset` deleted from a node's own body, if any. Sources,
+ * in order of trustworthiness: a node that still HAS a description lost
+ * nothing; `afterParams` is a pristine clone; the internal index survives
+ * re-runs; a hosted preset's `fetched` body is pristine because the preset
+ * cache is re-initialised per run.
+ */
+function droppedOwnDescription(node: PresetNode): DropInfo | undefined {
+  if (descriptionsOf(node.input).length > 0) {
+    return undefined;
+  }
+  if (node.afterParams === undefined) {
+    const internal = INTERNAL_DROPS.get(node.name);
+    if (internal) {
+      return internal;
+    }
+  }
+  const raw = node.afterParams ?? node.fetched;
+  const reason = getPresetDropReason(raw);
+  return reason ? { reason, values: descriptionsOf(raw) } : undefined;
+}
+
+/** One string contributed by one node, before it is placed in the final array.
+ *  `node` is absent only for the defaults/global/inherited layers, which have
+ *  no preset tree of their own. */
+interface Contribution {
+  value: string;
+  node?: DescriptionSource;
+  approximate?: boolean;
+}
+
+interface WalkResult {
+  contributions: Contribution[];
+  degraded: boolean;
+}
+
+function recordOwnDrop(node: PresetNode, dropped: DroppedDescription[]): void {
+  const info = droppedOwnDescription(node);
+  if (!info) {
+    return;
+  }
+  for (const value of info.values) {
+    dropped.push({ value, node: sourceOf(node), reason: info.reason });
+  }
+}
+
+function valuesMatch(contributions: Contribution[], truth: string[]): boolean {
+  return (
+    contributions.length === truth.length && contributions.every((c, i) => c.value === truth[i])
+  );
+}
+
+/**
+ * Replays one `resolveConfigPresets` invocation: every merging child in
+ * `extends` order (each already flattened), then the node's own body last —
+ * then checks the result against the node's ground-truth `resolved`.
+ */
+function walk(node: PresetNode, dropped: DroppedDescription[]): WalkResult {
+  const contributions: Contribution[] = [];
+  let degraded = false;
+  const quirk = dropsChildDescriptions(node);
+
+  for (const child of mergingChildren(node)) {
+    recordOwnDrop(child, dropped);
+    const sub = walk(child, dropped);
+    degraded ||= sub.degraded;
+    if (quirk) {
+      for (const contribution of sub.contributions) {
+        dropped.push({
+          value: contribution.value,
+          node: contribution.node ?? sourceOf(child),
+          reason: "ignore-deps-quirk",
+          droppedBy: sourceOf(node),
+        });
+      }
+    } else {
+      contributions.push(...sub.contributions);
+    }
+  }
+
+  for (const value of descriptionsOf(node.input)) {
+    contributions.push({ value, node: sourceOf(node) });
+  }
+
+  if (node.resolved === undefined) {
+    return { contributions, degraded };
+  }
+  const truth = descriptionsOf(node.resolved);
+  if (valuesMatch(contributions, truth)) {
+    return { contributions, degraded };
+  }
+  // Re-seed from ground truth so the parent's indices stay aligned.
+  return {
+    contributions: truth.map((value) => ({ value, node: sourceOf(node), approximate: true })),
+    degraded: true,
+  };
+}
+
+/** A top-level layer's contribution, before indices are assigned. */
+interface LayerContribution {
+  layer: ProvenanceLayer;
+  contributions: Contribution[];
+}
+
+function ruleDescriptions(result: TraceResult): RuleDescriptionAttribution[] {
+  const attribution = computeRuleProvenance(result);
+  if (!attribution) {
+    return [];
+  }
+  const rules = result.finalConfig?.packageRules;
+  if (!Array.isArray(rules)) {
+    return [];
+  }
+  const out: RuleDescriptionAttribution[] = [];
+  for (const { index, layer, sourceIndex } of attribution) {
+    const values = descriptionsOf(rules[index]);
+    if (values.length > 0) {
+      out.push({ ruleIndex: index, sourceIndex, layer, values });
+    }
+  }
+  return out;
+}
+
+/**
+ * Attributes every string of a completed run's final top-level `description`
+ * array to the preset-tree node that wrote it, or `undefined` when the run
+ * lacks the data it needs (mirrors `computeProvenance`'s availability: no final
+ * config, or preset resolution did not finish so the root has no
+ * `resolved`/`input`).
+ *
+ * Unlike `computeRuleProvenance` this never returns `undefined` for a
+ * misaligned replay — a description is prose, so a conservative
+ * "contributed by subtree X" is still useful; `degraded` (and per-entry
+ * `approximate`) say when that happened.
+ */
+export function computeDescriptionProvenance(
+  result: TraceResult,
+): DescriptionProvenance | undefined {
+  const { finalConfig } = result;
+  const root = result.presetTree;
+  if (!finalConfig || !root || root.resolved === undefined || root.input === undefined) {
+    return undefined;
+  }
+
+  const dropped: DroppedDescription[] = [];
+  let degraded = false;
+
+  // Layers merging ahead of the repo's own resolution (008). Neither has a
+  // preset tree of its own here, so their strings carry no node.
+  const layered: LayerContribution[] = [];
+  const prefix: [ProvenanceLayer, unknown][] = [
+    [{ kind: "defaults" }, getDefaultConfig()],
+    [{ kind: "global" }, result.layerConfigs?.globalResolved],
+    [{ kind: "inherited" }, result.layerConfigs?.inheritedResolved],
+  ];
+  for (const [layer, config] of prefix) {
+    const values = descriptionsOf(config);
+    if (values.length > 0) {
+      layered.push({ layer, contributions: values.map((value) => ({ value })) });
+    }
+  }
+  const externalLayerCount = layered.length;
+
+  // The root level is walked here rather than through `walk` so that each
+  // string keeps the direct-extend layer it arrived through.
+  const rootQuirk = dropsChildDescriptions(root);
+  const rootContributions: Contribution[] = [];
+  for (const child of mergingChildren(root)) {
+    recordOwnDrop(child, dropped);
+    const sub = walk(child, dropped);
+    degraded ||= sub.degraded;
+    if (rootQuirk) {
+      for (const contribution of sub.contributions) {
+        dropped.push({
+          value: contribution.value,
+          node: contribution.node ?? sourceOf(child),
+          reason: "ignore-deps-quirk",
+          droppedBy: sourceOf(root),
+        });
+      }
+      continue;
+    }
+    layered.push({
+      layer: { kind: "preset", nodeId: child.id, name: child.name },
+      contributions: sub.contributions,
+    });
+    rootContributions.push(...sub.contributions);
+  }
+  const ownContributions: Contribution[] = descriptionsOf(root.input).map((value) => ({
+    value,
+    node: sourceOf(root),
+  }));
+  rootContributions.push(...ownContributions);
+  layered.push({ layer: { kind: "repo" }, contributions: ownContributions });
+
+  // Ground truth for the repo's own resolution: if the per-preset split does
+  // not reproduce it, collapse the whole repo level onto the root node.
+  const rootTruth = descriptionsOf(root.resolved);
+  if (!valuesMatch(rootContributions, rootTruth)) {
+    degraded = true;
+    layered.length = externalLayerCount;
+    layered.push({
+      layer: { kind: "repo" },
+      contributions: rootTruth.map((value) => ({
+        value,
+        node: sourceOf(root),
+        approximate: true,
+      })),
+    });
+  }
+
+  const flat: { layer: ProvenanceLayer; contribution: Contribution }[] = [];
+  for (const { layer, contributions } of layered) {
+    for (const contribution of contributions) {
+      flat.push({ layer, contribution });
+    }
+  }
+
+  // Ground truth for the whole run. Post-resolution re-migration (052) and the
+  // 008 layers both act between `root.resolved` and `finalConfig`, so the final
+  // array — not the replay — decides how many entries there are.
+  const finalValues = descriptionsOf(finalConfig);
+  const entries: DescriptionAttribution[] = [];
+  const firstIndexByValue = new Map<string, number>();
+  for (const [index, value] of finalValues.entries()) {
+    const aligned = flat[index];
+    const matched = aligned?.contribution.value === value ? aligned : undefined;
+    if (!matched) {
+      degraded = true;
+    }
+    const contribution = matched?.contribution;
+    const approximate = contribution?.approximate ?? !matched;
+    const node = contribution?.node;
+    const firstIndex = firstIndexByValue.get(value);
+    entries.push({
+      index,
+      value,
+      ...(node ? { node } : {}),
+      viaTopLevel: matched?.layer ?? { kind: "repo" },
+      ...(approximate ? { approximate: true } : {}),
+      ...(firstIndex === undefined ? {} : { duplicateOfIndex: firstIndex }),
+    });
+    if (firstIndex === undefined) {
+      firstIndexByValue.set(value, index);
+    }
+  }
+
+  return { entries, dropped, ruleDescriptions: ruleDescriptions(result), degraded };
+}

--- a/packages/engine/src/types/renovate-dist.d.ts
+++ b/packages/engine/src/types/renovate-dist.d.ts
@@ -107,6 +107,11 @@ declare module "renovate/dist/config/presets/internal/index.js" {
     repo?: string;
     presetName?: string;
   }): RenovateConfig | undefined;
+  /** The table those presets live in, keyed by group then preset name. These
+   *  are the very objects `getPreset` hands out — `config/presets/index.js`
+   *  MUTATES them (see trace/description-provenance.ts), so treat as read-only
+   *  and never assume a body is still what its author wrote. */
+  export const groups: Record<string, Record<string, RenovateConfig>>;
 }
 
 declare module "renovate/dist/config/presets/util.js" {

--- a/packages/engine/test/description-provenance.node.test.ts
+++ b/packages/engine/test/description-provenance.node.test.ts
@@ -58,13 +58,16 @@ function build(spec: NodeSpec, id: string): PresetNode {
   };
 }
 
-function traceResult(spec: NodeSpec): TraceResult {
+/** `finalDescription` overrides the array the run ended with — the only way to
+ *  state a final array the replay cannot derive, e.g. one holding a non-string
+ *  member (Renovate warns about those but keeps them). */
+function traceResult(spec: NodeSpec, finalDescription?: unknown[]): TraceResult {
   counter = 0;
   const root = build(spec, "root");
   const resolved = root.resolved as Record<string, unknown>;
   return {
     events: [],
-    finalConfig: { description: descriptionsOf(resolved) },
+    finalConfig: { description: finalDescription ?? descriptionsOf(resolved) },
     errors: [],
     warnings: [],
     renovateVersion: "test",
@@ -175,6 +178,29 @@ describe("computeDescriptionProvenance: the positional walk", () => {
     expect(prov.degraded).toBe(true);
     // only the contradicting subtree is degraded; `b` keeps its exact attribution
     expect(prov.entries.map((e) => e.approximate)).toEqual([true, true, undefined]);
+  });
+
+  it("indexes against the REAL final array, listing its non-string members apart", () => {
+    // Renovate only warns about `{"description": ["a", 42]}`, so the 42 reaches
+    // the final array and holds index 1 — everything after it must say 2, not 1.
+    const result = traceResult(
+      {
+        name: "(input config)",
+        input: { description: ["mine", 42] },
+        children: [{ name: "a", input: { description: ["a-own"] } }],
+      },
+      ["a-own", 42, "mine"],
+    );
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    expect(prov.entries.map((e) => [e.index, e.value, e.node?.name])).toEqual([
+      [0, "a-own", "a"],
+      [2, "mine", "(input config)"],
+    ]);
+    expect(prov.unattributed).toEqual([{ index: 1, value: 42 }]);
+    expect(prov.finalLength).toBe(3);
+    // the strings still replay exactly, so nothing is approximate
+    expect(prov.degraded).toBe(false);
+    expect(prov.entries.some((e) => e.approximate)).toBe(false);
   });
 
   it("skips nested and unresolved children, which never merged", () => {
@@ -298,6 +324,40 @@ describe("computeDescriptionProvenance: the drop rules", () => {
     expect(prov.degraded).toBe(false);
   });
 
+  it("keeps a muted subtree's guessed author labelled as a guess", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "quirky",
+          input: { ignoreDeps: [] },
+          children: [
+            {
+              name: "a",
+              input: { description: ["a-own"] },
+              // contradicts the replay, so `a`'s subtree degrades to `a` …
+              resolved: { description: ["surprise"] },
+              children: [{ name: "a-child", input: { description: ["a-child-own"] } }],
+            },
+          ],
+        },
+      ],
+    });
+    // … and the quirk then diverts that guess into `dropped`, still labelled
+    expect(prov.dropped).toEqual([
+      {
+        value: "surprise",
+        node: { nodeId: "p2", name: "a" },
+        reason: "ignore-deps-quirk",
+        droppedBy: { nodeId: "p1", name: "quirky" },
+        approximate: true,
+      },
+    ]);
+    expect(prov.entries).toEqual([]);
+    expect(prov.degraded).toBe(true);
+  });
+
   it("applies the `ignoreDeps: []` quirk at the repo level too", () => {
     const prov = provenance({
       name: "(input config)",
@@ -318,6 +378,13 @@ describe("computeDescriptionProvenance: availability", () => {
 
   it("returns an empty attribution when nothing describes anything", () => {
     const prov = provenance({ name: "(input config)", input: { automerge: true } });
-    expect(prov).toEqual({ entries: [], dropped: [], ruleDescriptions: [], degraded: false });
+    expect(prov).toEqual({
+      entries: [],
+      unattributed: [],
+      finalLength: 0,
+      dropped: [],
+      ruleDescriptions: [],
+      degraded: false,
+    });
   });
 });

--- a/packages/engine/test/description-provenance.node.test.ts
+++ b/packages/engine/test/description-provenance.node.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for roadmap 069's positional walk, over hand-built preset trees.
+ *
+ * The shimmed suite proves the walk against Renovate's real presets; this one
+ * isolates the individual rules — own-body-last ordering, two nodes writing
+ * the identical sentence, the raw-string body, the drop rules, and the
+ * enclosing-node fallback when a subtree's replay does not reproduce its own
+ * ground-truth `resolved`. Everything here is pure data, so it runs in the
+ * `golden` (unshimmed) project.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeDescriptionProvenance,
+  type DescriptionProvenance,
+  type PresetNode,
+  type TraceResult,
+} from "../src/index";
+import { must } from "./helpers";
+
+interface NodeSpec {
+  name: string;
+  input: Record<string, unknown>;
+  /** Own body + subtree, i.e. what merges into the parent. Defaults to a
+   *  faithful replay of `children` then `input`, so a test only states it when
+   *  it wants the ground truth to disagree with the replay. */
+  resolved?: Record<string, unknown>;
+  fetched?: Record<string, unknown>;
+  children?: NodeSpec[];
+}
+
+let counter = 0;
+
+function descriptionsOf(body: Record<string, unknown> | undefined): string[] {
+  const value = body?.description;
+  if (typeof value === "string") {
+    return [value];
+  }
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function build(spec: NodeSpec, id: string): PresetNode {
+  const children = (spec.children ?? []).map((child) => build(child, `p${++counter}`));
+  const quirk = Array.isArray(spec.input.ignoreDeps) && spec.input.ignoreDeps.length === 0;
+  const replayed = [
+    ...(quirk
+      ? []
+      : children.flatMap((c) => descriptionsOf(c.resolved as Record<string, unknown>))),
+    ...descriptionsOf(spec.input),
+  ];
+  return {
+    id,
+    name: spec.name,
+    state: "resolved",
+    input: spec.input,
+    resolved: spec.resolved ?? { description: replayed },
+    ...(spec.fetched ? { fetched: spec.fetched } : {}),
+    children,
+  };
+}
+
+function traceResult(spec: NodeSpec): TraceResult {
+  counter = 0;
+  const root = build(spec, "root");
+  const resolved = root.resolved as Record<string, unknown>;
+  return {
+    events: [],
+    finalConfig: { description: descriptionsOf(resolved) },
+    errors: [],
+    warnings: [],
+    renovateVersion: "test",
+    stageStatus: {
+      global: "skipped",
+      inherit: "skipped",
+      parse: "ok",
+      migrate: "ok",
+      massage: "ok",
+      validate: "ok",
+      preset: "ok",
+      merge: "ok",
+    },
+    visitedPresets: { merged: [], unmerged: [] },
+    presetTree: root,
+    platformContext: { platform: "github", endpoint: "https://api.github.com/" },
+    usedInjections: [],
+  };
+}
+
+function provenance(spec: NodeSpec): DescriptionProvenance {
+  return must(computeDescriptionProvenance(traceResult(spec)), "the description provenance");
+}
+
+/** `[value, nodeName, topLevelLayer]` per entry — the whole attribution, terse. */
+function shape(prov: DescriptionProvenance): [string, string | undefined, string][] {
+  return prov.entries.map((entry) => [
+    entry.value,
+    entry.node?.name,
+    entry.viaTopLevel.kind === "preset" ? entry.viaTopLevel.name : entry.viaTopLevel.kind,
+  ]);
+}
+
+describe("computeDescriptionProvenance: the positional walk", () => {
+  it("merges children in extends order and the node's own body last, at every depth", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: { description: ["mine"] },
+      children: [
+        {
+          name: "a",
+          input: { description: ["a-own"] },
+          children: [{ name: "a-child", input: { description: ["a-child-own"] } }],
+        },
+        { name: "b", input: { description: ["b-own"] } },
+      ],
+    });
+    expect(shape(prov)).toEqual([
+      ["a-child-own", "a-child", "a"],
+      ["a-own", "a", "a"],
+      ["b-own", "b", "b"],
+      ["mine", "(input config)", "repo"],
+    ]);
+    expect(prov.degraded).toBe(false);
+  });
+
+  it("attributes identical strings to their own nodes, not to the first match", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        { name: "a", input: { description: ["same"] } },
+        { name: "b", input: { description: ["same"] } },
+      ],
+    });
+    expect(shape(prov)).toEqual([
+      ["same", "a", "a"],
+      ["same", "b", "b"],
+    ]);
+    expect(prov.entries[0]?.duplicateOfIndex).toBeUndefined();
+    expect(prov.entries[1]?.duplicateOfIndex).toBe(0);
+  });
+
+  it("accepts a raw string description (allowString) as a one-element array", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: { description: "own string" },
+      children: [{ name: "a", input: { description: "child string" } }],
+    });
+    expect(shape(prov)).toEqual([
+      ["child string", "a", "a"],
+      ["own string", "(input config)", "repo"],
+    ]);
+    expect(prov.degraded).toBe(false);
+  });
+
+  it("falls back to the enclosing node when a subtree's replay contradicts its resolved body", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "a",
+          input: { description: ["a-own"] },
+          // ground truth disagrees with the replay (a hypothetical unmodelled
+          // drop/reorder inside `a`) — attribute the subtree, not a leaf
+          resolved: { description: ["surprise", "a-own"] },
+          children: [{ name: "a-child", input: { description: ["a-child-own"] } }],
+        },
+        { name: "b", input: { description: ["b-own"] } },
+      ],
+    });
+    expect(shape(prov)).toEqual([
+      ["surprise", "a", "a"],
+      ["a-own", "a", "a"],
+      ["b-own", "b", "b"],
+    ]);
+    expect(prov.degraded).toBe(true);
+    // only the contradicting subtree is degraded; `b` keeps its exact attribution
+    expect(prov.entries.map((e) => e.approximate)).toEqual([true, true, undefined]);
+  });
+
+  it("skips nested and unresolved children, which never merged", () => {
+    const spec: NodeSpec = {
+      name: "(input config)",
+      input: {},
+      children: [{ name: "a", input: { description: ["a-own"] } }],
+    };
+    const result = traceResult(spec);
+    const root = must(result.presetTree, "the preset tree");
+    root.children.push(
+      {
+        id: "n1",
+        name: "nested",
+        state: "resolved",
+        nested: true,
+        resolved: { description: ["x"] },
+        input: { description: ["x"] },
+        children: [],
+      },
+      { id: "n2", name: "broken", state: "error", children: [] },
+    );
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    expect(prov.entries.map((e) => e.value)).toEqual(["a-own"]);
+    expect(prov.degraded).toBe(false);
+  });
+});
+
+describe("computeDescriptionProvenance: the drop rules", () => {
+  it("reports a `{description, extends}` wrapper preset's own deleted description", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "org/wrapper",
+          fetched: { description: "Our org standard.", extends: ["a"] },
+          input: { extends: ["a"] },
+          children: [{ name: "a", input: { description: ["a-own"] } }],
+        },
+      ],
+    });
+    expect(prov.entries.map((e) => e.value)).toEqual(["a-own"]);
+    expect(prov.dropped).toEqual([
+      {
+        value: "Our org standard.",
+        node: { nodeId: "p1", name: "org/wrapper" },
+        reason: "wrapper-preset",
+      },
+    ]);
+  });
+
+  it("reports a `{description, matchPackageNames}` package-list preset's deleted description", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "org/list",
+          fetched: { description: "Just a list.", matchPackageNames: ["left-pad"] },
+          input: { matchPackageNames: ["left-pad"] },
+        },
+      ],
+    });
+    expect(prov.entries).toEqual([]);
+    expect(prov.dropped.map((d) => [d.value, d.reason])).toEqual([
+      ["Just a list.", "package-list-preset"],
+    ]);
+  });
+
+  it("leaves a preset that kept its description alone, whatever its fetched shape", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "org/kept",
+          fetched: { description: "Kept.", extends: ["a"], automerge: true },
+          input: { description: ["Kept."], extends: ["a"], automerge: true },
+        },
+      ],
+    });
+    expect(prov.entries.map((e) => e.value)).toEqual(["Kept."]);
+    expect(prov.dropped).toEqual([]);
+  });
+
+  it("reports every description an extending `ignoreDeps: []` deleted, per authoring node", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "quirky",
+          input: { description: ["quirky-own"], ignoreDeps: [] },
+          children: [
+            {
+              name: "a",
+              input: { description: ["a-own"] },
+              children: [{ name: "a-child", input: { description: ["a-child-own"] } }],
+            },
+          ],
+        },
+      ],
+    });
+    // only the extending node's OWN description survives
+    expect(shape(prov)).toEqual([["quirky-own", "quirky", "quirky"]]);
+    expect(prov.dropped).toEqual([
+      {
+        value: "a-child-own",
+        node: { nodeId: "p3", name: "a-child" },
+        reason: "ignore-deps-quirk",
+        droppedBy: { nodeId: "p1", name: "quirky" },
+      },
+      {
+        value: "a-own",
+        node: { nodeId: "p2", name: "a" },
+        reason: "ignore-deps-quirk",
+        droppedBy: { nodeId: "p1", name: "quirky" },
+      },
+    ]);
+    expect(prov.degraded).toBe(false);
+  });
+
+  it("applies the `ignoreDeps: []` quirk at the repo level too", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: { description: ["mine"], ignoreDeps: [] },
+      children: [{ name: "a", input: { description: ["a-own"] } }],
+    });
+    expect(shape(prov)).toEqual([["mine", "(input config)", "repo"]]);
+    expect(prov.dropped.map((d) => [d.value, d.droppedBy?.nodeId])).toEqual([["a-own", "root"]]);
+  });
+});
+
+describe("computeDescriptionProvenance: availability", () => {
+  it("returns undefined without a preset tree", () => {
+    const result = traceResult({ name: "(input config)", input: {} });
+    expect(computeDescriptionProvenance({ ...result, presetTree: undefined })).toBeUndefined();
+    expect(computeDescriptionProvenance({ ...result, finalConfig: undefined })).toBeUndefined();
+  });
+
+  it("returns an empty attribution when nothing describes anything", () => {
+    const prov = provenance({ name: "(input config)", input: { automerge: true } });
+    expect(prov).toEqual({ entries: [], dropped: [], ruleDescriptions: [], degraded: false });
+  });
+});

--- a/packages/engine/test/description-provenance.shimmed.test.ts
+++ b/packages/engine/test/description-provenance.shimmed.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Shimmed-project tests for roadmap 069 per-string `description` provenance.
+ *
+ * Runs against Renovate's own INTERNAL presets (no network, no injection): the
+ * point of this suite is that the positional replay survives a real, deep
+ * preset tree — `config:best-practices` alone expands to a four-level chain
+ * whose top-level `description` ends up 20+ strings long — and that the
+ * hand-derived facts about it (leaf attributions, duplicates from re-extending
+ * an already-merged preset, wrapper-preset drops) come out exactly.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  computeDescriptionProvenance,
+  type DescriptionAttribution,
+  type DescriptionProvenance,
+  runPipeline,
+  type TraceResult,
+} from "../src/index";
+import { must } from "./helpers";
+
+const repoConfig = JSON.stringify({
+  extends: ["config:best-practices", ":dependencyDashboard", "group:monorepos"],
+});
+
+const DEPENDENCY_DASHBOARD = "Enable Renovate Dependency Dashboard creation.";
+const MONOREPOS = "Group known monorepo packages together.";
+const PIN_DOCKER = "Pin Docker digests.";
+const SEMANTIC_COMMITS =
+  "Use semantic commit type `fix` for dependencies and `chore` for all others if semantic commits are in use.";
+
+async function runResult(content: string): Promise<TraceResult> {
+  const result = await runPipeline({ fileName: "renovate.json", content });
+  expect(result.stageStatus.preset).toBe("ok");
+  return result;
+}
+
+async function attribution(): Promise<{ result: TraceResult; prov: DescriptionProvenance }> {
+  const result = await runResult(repoConfig);
+  const prov = must(computeDescriptionProvenance(result), "the description provenance");
+  return { result, prov };
+}
+
+/** Terse label for an entry's top-level layer, mirroring the provenance tests. */
+function via(entry: DescriptionAttribution): string {
+  return entry.viaTopLevel.kind === "preset" ? entry.viaTopLevel.name : entry.viaTopLevel.kind;
+}
+
+describe("computeDescriptionProvenance (069)", () => {
+  it("attributes every string of the final description array, in order", async () => {
+    const { result, prov } = await attribution();
+    const final = result.finalConfig?.description as string[];
+    expect(final.length).toBeGreaterThan(20);
+    expect(prov.entries.map((e) => e.value)).toEqual(final);
+    expect(prov.entries.map((e) => e.index)).toEqual(final.map((_, i) => i));
+    // the real tree replays exactly — no enclosing-node fallback needed
+    expect(prov.degraded).toBe(false);
+    expect(prov.entries.every((e) => e.node !== undefined)).toBe(true);
+    expect(prov.entries.some((e) => e.approximate)).toBe(false);
+  });
+
+  it("attributes leaf strings to the preset that actually wrote them", async () => {
+    const { prov } = await attribution();
+    const docker = must(
+      prov.entries.find((e) => e.value === PIN_DOCKER),
+      `the "${PIN_DOCKER}" entry`,
+    );
+    expect(docker.node?.name).toBe("docker:pinDigests");
+    // it arrived through the first top-level extend, four levels down
+    expect(via(docker)).toBe("config:best-practices");
+
+    const semantic = must(
+      prov.entries.find((e) => e.value === SEMANTIC_COMMITS),
+      "the semantic-commit entry",
+    );
+    expect(semantic.node?.name).toBe(":semanticPrefixFixDepsChoreOthers");
+    expect(via(semantic)).toBe("config:best-practices");
+  });
+
+  it("marks the two re-extended presets as duplicates of their first occurrence", async () => {
+    const { prov } = await attribution();
+    const dashboard = prov.entries.filter((e) => e.value === DEPENDENCY_DASHBOARD);
+    expect(dashboard).toHaveLength(2);
+    expect(dashboard[0]?.duplicateOfIndex).toBeUndefined();
+    expect(via(must(dashboard[0], "the first dashboard entry"))).toBe("config:best-practices");
+    const dashboardRepeat = must(dashboard[1], "the repeated dashboard entry");
+    expect(dashboardRepeat.duplicateOfIndex).toBe(dashboard[0]?.index);
+    expect(via(dashboardRepeat)).toBe(":dependencyDashboard");
+    expect(dashboardRepeat.node?.name).toBe(":dependencyDashboard");
+
+    const monorepos = prov.entries.filter((e) => e.value === MONOREPOS);
+    expect(monorepos).toHaveLength(2);
+    expect(via(must(monorepos[0], "the first monorepos entry"))).toBe("config:best-practices");
+    const monoreposRepeat = must(monorepos[1], "the repeated monorepos entry");
+    expect(monoreposRepeat.duplicateOfIndex).toBe(monorepos[0]?.index);
+    expect(via(monoreposRepeat)).toBe("group:monorepos");
+    // the repeats are the last two entries: they arrive through the 2nd and 3rd extend
+    expect([dashboardRepeat.index, monoreposRepeat.index]).toEqual([
+      prov.entries.length - 2,
+      prov.entries.length - 1,
+    ]);
+  });
+
+  it("reports the wrapper presets whose own description Renovate deleted", async () => {
+    const { prov } = await attribution();
+    const wrapper = must(
+      prov.dropped.find((d) => d.node.name === "config:best-practices"),
+      "the config:best-practices drop",
+    );
+    expect(wrapper.reason).toBe("wrapper-preset");
+    expect(wrapper.value).toContain("best practices from the Renovate maintainers");
+    expect(wrapper.droppedBy).toBeUndefined();
+    // and its own `{description, extends}` wrapper child too
+    expect(
+      prov.dropped.filter((d) => d.reason === "wrapper-preset").map((d) => d.node.name),
+    ).toContain("config:recommended");
+    // nothing dropped ever reaches the final array
+    const values = new Set(prov.entries.map((e) => e.value));
+    expect(prov.dropped.some((d) => values.has(d.value))).toBe(false);
+  });
+
+  it("reports the descriptions group:recommended's `ignoreDeps: []` silently deletes", async () => {
+    const { prov } = await attribution();
+    const quirk = prov.dropped.filter((d) => d.reason === "ignore-deps-quirk");
+    // group:recommended carries `ignoreDeps: []`, which deletes the resolved
+    // description of every one of its ~130 sub-groups — and it is not alone:
+    // `replacements:all` and `workarounds:all` use the same trick to keep
+    // their hundreds of member presets out of the top-level description.
+    expect(quirk.length).toBeGreaterThan(100);
+    expect(new Set(quirk.map((d) => d.droppedBy?.name))).toEqual(
+      new Set(["group:recommended", "replacements:all", "workarounds:all"]),
+    );
+    const nodeJs = must(
+      quirk.find((d) => d.node.name === "group:nodeJs"),
+      "the group:nodeJs drop",
+    );
+    expect(nodeJs.value).toContain("Node.js");
+  });
+
+  it("finds the same drops on a repeated run, despite Renovate mutating its own preset table", async () => {
+    // `internal/index.js` hands out the module-level preset objects by
+    // reference, so `getPreset`'s `delete presetConfig.description` strips
+    // `config:best-practices` for the rest of the process — every run after
+    // the first sees a `fetched` body that never had a description.
+    const first = must(computeDescriptionProvenance(await runResult(repoConfig)), "run 1");
+    const second = must(computeDescriptionProvenance(await runResult(repoConfig)), "run 2");
+    expect(second.dropped.map((d) => [d.node.name, d.reason, d.value])).toEqual(
+      first.dropped.map((d) => [d.node.name, d.reason, d.value]),
+    );
+    expect(second.entries).toEqual(first.entries);
+  });
+
+  it("attributes packageRules descriptions to their contributing layer", async () => {
+    const { result, prov } = await attribution();
+    const rules = result.finalConfig?.packageRules as Record<string, unknown>[];
+    expect(prov.ruleDescriptions.length).toBeGreaterThan(0);
+    for (const entry of prov.ruleDescriptions) {
+      expect(rules[entry.ruleIndex]?.description).toBeDefined();
+      expect(entry.values.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns an empty attribution for a config with no descriptions anywhere", async () => {
+    const result = await runResult(JSON.stringify({ automerge: true }));
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    expect(prov.entries).toEqual([]);
+    expect(prov.dropped).toEqual([]);
+    expect(prov.degraded).toBe(false);
+  });
+
+  it("attributes a repo config's own description to the root node", async () => {
+    const result = await runResult(
+      JSON.stringify({ description: "Our house rules.", extends: [":dependencyDashboard"] }),
+    );
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    // preset first, own body last — Renovate's merge order
+    expect(prov.entries.map((e) => [e.value, via(e)])).toEqual([
+      [DEPENDENCY_DASHBOARD, ":dependencyDashboard"],
+      ["Our house rules.", "repo"],
+    ]);
+    expect(prov.entries[1]?.node?.nodeId).toBe("root");
+  });
+
+  it("returns undefined when preset resolution did not complete", async () => {
+    const result = await runPipeline({
+      fileName: "renovate.json",
+      content: JSON.stringify({ extends: ["github>test-org/does-not-resolve"] }),
+    });
+    expect(result.stageStatus.preset).toBe("error");
+    expect(computeDescriptionProvenance(result)).toBeUndefined();
+  });
+});

--- a/packages/engine/test/description-provenance.shimmed.test.ts
+++ b/packages/engine/test/description-provenance.shimmed.test.ts
@@ -52,6 +52,8 @@ describe("computeDescriptionProvenance (069)", () => {
     expect(final.length).toBeGreaterThan(20);
     expect(prov.entries.map((e) => e.value)).toEqual(final);
     expect(prov.entries.map((e) => e.index)).toEqual(final.map((_, i) => i));
+    expect(prov.finalLength).toBe(final.length);
+    expect(prov.unattributed).toEqual([]);
     // the real tree replays exactly — no enclosing-node fallback needed
     expect(prov.degraded).toBe(false);
     expect(prov.entries.every((e) => e.node !== undefined)).toBe(true);
@@ -178,6 +180,33 @@ describe("computeDescriptionProvenance (069)", () => {
       ["Our house rules.", "repo"],
     ]);
     expect(prov.entries[1]?.node?.nodeId).toBe("root");
+  });
+
+  it("indexes against a final array Renovate let a non-string into", async () => {
+    // `description` is `subType: "string"`, but a wrong-typed member is a
+    // validation WARNING, not a refusal: the number survives into the final
+    // array and holds a real index, which everything after it is offset by.
+    const result = await runResult(
+      JSON.stringify({
+        extends: [":dependencyDashboard"],
+        description: ["Our house rules.", 42, "And another."],
+      }),
+    );
+    const final = result.finalConfig?.description as unknown[];
+    expect(final).toEqual([DEPENDENCY_DASHBOARD, "Our house rules.", 42, "And another."]);
+
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    expect(prov.finalLength).toBe(4);
+    expect(prov.entries.map((e) => [e.index, e.value, via(e)])).toEqual([
+      [0, DEPENDENCY_DASHBOARD, ":dependencyDashboard"],
+      [1, "Our house rules.", "repo"],
+      [3, "And another.", "repo"],
+    ]);
+    expect(prov.unattributed).toEqual([{ index: 2, value: 42 }]);
+    // the string members still replay exactly — a stray non-string is not a
+    // reason to stop trusting the attribution
+    expect(prov.degraded).toBe(false);
+    expect(prov.entries.some((e) => e.approximate)).toBe(false);
   });
 
   it("returns undefined when preset resolution did not complete", async () => {

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
           // renovate's preset data modules — 4-6s on 2-core CI runners
           testTimeout: 30_000,
           include: [
+            "test/description-provenance.shimmed.test.ts",
             "test/global-inherit.shimmed.test.ts",
             "test/pipeline.shimmed.test.ts",
             "test/preset-fetchers.test.ts",

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -72,6 +72,27 @@ direct-extend layer it arrived through (the same `ProvenanceLayer` identity the
 expressible too), and `duplicateOfIndex` points a repeated sentence at its first
 occurrence.
 
+### `index` is a position in the real array
+
+`description` is `subType: "string"`, but a wrong-typed member is a validation
+**warning**, not a refusal: `{"description": ["a sentence", 42]}` resolves, and
+the `42` reaches the final array and occupies index 1. So the result reports
+three things about the final array rather than one:
+
+- `entries` — the string members, each `index` being the member's position in
+  the **real** array. Only strings can have an author, so only strings take part
+  in the positional replay; they are paired with it through a cursor of their
+  own, which is what keeps an entry after a non-string from claiming the index
+  the non-string holds.
+- `unattributed` — `{ index, value }` for every non-string member: accepted by
+  Renovate, written by nobody the walk can name.
+- `finalLength` — the real array's length, so a consumer can say "position N of
+  M" without re-deriving it from two lists.
+
+The per-node and whole-run alignment checks still compare string members only,
+so a stray non-string is not by itself a reason to degrade; `entries.length +
+unattributed.length === finalLength` always.
+
 ### Fallback semantics
 
 Correctness is self-checked rather than assumed: at every node the replayed
@@ -92,9 +113,13 @@ desynchronise the indices of everything after it. The UI is expected to render
 ## The drop rules
 
 Three places delete a description before it can merge. All three are reported in
-`dropped` (`{ value, node, reason, droppedBy? }`) rather than left as an
-unexplained absence, because "why isn't my preset's description showing up" is
-one of the questions this feature exists to answer.
+`dropped` (`{ value, node, reason, droppedBy?, approximate? }`) rather than left
+as an unexplained absence, because "why isn't my preset's description showing
+up" is one of the questions this feature exists to answer. `approximate` carries
+the same meaning it has on an entry, and for the same reason: a subtree that had
+already degraded to its enclosing node can then be muted by the quirk below, and
+the guessed author must stay labelled as a guess once it becomes a drop. The two
+`getPreset` drops are read off a pristine body and are never approximate.
 
 - **`wrapper-preset`** — `getPreset` deletes the description of any preset whose
   keys are exactly `{description, extends}`. `config:best-practices` and
@@ -196,12 +221,14 @@ offline (internal presets need no network):
   full-array attribution and ordering, the two known leaf attributions, both
   duplicates with their `viaTopLevel` and `duplicateOfIndex`, the wrapper-preset
   drops, the `ignoreDeps: []` drops with their three `droppedBy` presets, a
-  repo-config's own description landing last on the root node, and — the
-  regression guard for the mutation above — a second run producing byte-identical
-  `entries` and `dropped`.
+  repo-config's own description landing last on the root node, a config whose
+  `description` holds a number (Renovate warns and keeps it) proving the reported
+  indices are positions in the real array, and — the regression guard for the
+  mutation above — a second run producing byte-identical `entries` and `dropped`.
 - `test/description-provenance.node.test.ts` — the walk in isolation over
   hand-built trees: own-body-last ordering at depth, identical strings from two
-  nodes, the raw-string (`allowString`) body, nested/unresolved children
-  excluded, each drop rule, and the enclosing-node fallback proving that a
-  contradicting subtree degrades alone while its siblings keep exact
-  attribution.
+  nodes, the raw-string (`allowString`) body, a mixed-type final array with its
+  `unattributed` member and `finalLength`, nested/unresolved children excluded,
+  each drop rule, the enclosing-node fallback proving that a contradicting
+  subtree degrades alone while its siblings keep exact attribution, and that
+  fallback's `approximate` surviving into a drop when the quirk mutes it.

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -1,0 +1,207 @@
+# 069 — Per-string `description` provenance: who said what about this config
+
+Milestone: M19 · Status: in progress (PR 1 of 5 landed)
+
+Mockups: [mockups/069/](mockups/069/)
+
+## Summary
+
+Every Renovate preset carries a `description` its author wrote — "Pin Docker
+digests.", "Use semantic commit type `fix` for dependencies and `chore` for all
+others if semantic commits are in use." — and the resolved config carries all
+of them, concatenated into one flat array with no indication of who wrote
+which. `{"extends": ["config:best-practices"]}` produces 22 of these sentences.
+Read end to end they are the single best plain-English answer to "what does
+this config actually do", and the app currently renders them as an anonymous
+string array in the Effective config, one row among ninety.
+
+The information is not lost, only unlinked: array concatenation is positional,
+and the app already holds the preset tree that produced the array. 069 restores
+the link — every string attributed to the exact preset-tree node that wrote it
+— and then spends it across the UI. This document covers the whole feature; the
+first PR is the engine primitive alone.
+
+## User story
+
+As someone reading a config I did not write (mine from six months ago, or the
+one my platform team ships), I want each sentence of that wall of descriptions
+to name the preset that contributed it, so that "what does this config do" and
+"which preset do I remove to stop doing that" are the same question.
+
+## The merge mechanics
+
+`description` is an ordinary option — `type: "array"`, `subType: "string"`,
+`allowString: true`, `mergeable: true` (`dist/config/options/index.js`). Three
+consequences, all confirmed against the pinned Renovate 44.7.4:
+
+- `massageConfig` coerces `"a string"` to `["a string"]` for `allowString`
+  options, on every preset body and on the top-level config. By the time the
+  trace records a node's `input`, the description is always an array.
+- `mergeChildConfig` (`dist/config/utils.js`) concatenates when both sides have
+  the key and the option is a mergeable array: `parent.concat(child)`, in
+  encounter order, **never deduplicated**. Extend the same preset twice and its
+  sentence appears twice.
+- `resolveConfigPresets` (`dist/config/presets/index.js`) resolves each entry of
+  `extends` in order — recursively, so each subtree arrives already flattened —
+  and merges the node's OWN body **last**. So the order is: children in
+  `extends` order (depth-first), then the node's own sentence.
+
+`packageRules[n].description` is a different thing entirely: nested bodies are
+resolved separately and never hoisted to the top level.
+
+## The attribution algorithm
+
+`computeDescriptionProvenance(result)` in
+`packages/engine/src/trace/description-provenance.ts` — the per-string
+counterpart to `computeProvenance` (per key) and `computeRuleProvenance` (per
+`packageRules` entry), built from the same trace data, with the same
+availability guard (`finalConfig` present, root `input`/`resolved` present).
+
+It is a **positional replay**, not value matching. Value matching would be
+easier and wrong: two presets that write the same sentence must attribute to
+their own nodes, and the fixture below contains exactly that case twice. The
+walk mirrors one `resolveConfigPresets` invocation per node — merging children
+in `extends` order, own `input.description` last — using the same participant
+filter `computeProvenance`'s `buildLayers` uses (non-nested, resolved children
+only; `already-seen` and `ignored` nodes never merged and contribute nothing).
+
+Each string comes back as `{ index, value, node, viaTopLevel, duplicateOfIndex?,
+approximate? }`: `node` is the exact preset that wrote it, `viaTopLevel` is the
+direct-extend layer it arrived through (the same `ProvenanceLayer` identity the
+005/013 provenance uses, so `defaults`/`global`/`inherited`/`repo` are
+expressible too), and `duplicateOfIndex` points a repeated sentence at its first
+occurrence.
+
+### Fallback semantics
+
+Correctness is self-checked rather than assumed: at every node the replayed
+sequence is compared against that node's ground-truth `resolved.description`,
+and the whole run against `finalConfig.description`. Where they disagree — an
+unmodelled drop, a reorder, a future Renovate change — the subtree **degrades to
+its enclosing node**: every string of the ground truth is attributed to that
+node with `approximate: true`, and `degraded` is set on the result.
+
+Two reasons this beats `undefined` (the choice `computeRuleProvenance` makes for
+a misaligned `packageRules` replay) and beats throwing: a description is prose,
+so "contributed by the `config:best-practices` subtree" is still a useful
+answer, whereas a confidently wrong leaf is worse than none; and because the
+fallback re-seeds from ground truth, one contradicting subtree cannot
+desynchronise the indices of everything after it. The UI is expected to render
+`approximate` entries with the subtree name and no leaf claim.
+
+## The drop rules
+
+Three places delete a description before it can merge. All three are reported in
+`dropped` (`{ value, node, reason, droppedBy? }`) rather than left as an
+unexplained absence, because "why isn't my preset's description showing up" is
+one of the questions this feature exists to answer.
+
+- **`wrapper-preset`** — `getPreset` deletes the description of any preset whose
+  keys are exactly `{description, extends}`. `config:best-practices` and
+  `config:recommended` are both this shape, so the two headline presets'
+  own one-line summaries never reach the config that extends them.
+- **`package-list-preset`** — same, for a preset whose keys are a subset of
+  `{description, matchPackageNames}`. This is most of the `packages:` group.
+- **`ignore-deps-quirk`** — `resolveConfigPresets` deletes the ENTIRE resolved
+  description of a preset when the extending config carries `ignoreDeps: []`
+  (length zero). Three internal presets use this deliberately, as a mute button:
+  `group:recommended`, `replacements:all` and `workarounds:all` would otherwise
+  each contribute a hundred-plus sentences. `droppedBy` names the extending
+  node; the `node` on each entry is still the preset that authored the sentence,
+  because the walk attributes the subtree first and diverts it afterwards.
+
+The first two happen inside `getPreset`, i.e. **before** the body the trace
+records as `input`, so they are detected — not predicted — by comparing the raw
+fetched body against the migrated one.
+
+### Renovate mutates its own internal preset table
+
+Detecting the first two from `fetched` alone is a trap, and the engine works
+around it. `dist/config/presets/internal/index.js` returns its module-level
+preset objects **by reference**, so `getPreset`'s `delete presetConfig.description`
+permanently strips the description from Renovate's own table. Renovate resolves
+one config per process and never notices. This app resolves one on every
+keystroke: from the second run on, `config:best-practices`'s fetched body simply
+has no description, and a `fetched`-based detector reports the drop once and
+then goes quiet.
+
+So `description-provenance.ts` builds a small index of "which internal preset
+loses its own description, and what did it say" **once at module load**, from
+the pristine table, and consults it for internal presets. Nothing is mutated and
+no Renovate behavior changes — the resolved config is identical either way,
+since the description is deleted on every run regardless. Parameterised presets
+need no index entry: `replaceArgs` clones before the delete, so their
+`afterParams` body is pristine on every run. Hosted presets need none either:
+the preset cache is re-initialised per run, so their `fetched` body is fresh.
+
+The same mutation is a latent cosmetic bug in the Preset tree's "fetched" body
+view (`PresetDetail.tsx` shows a body that quietly loses its description after
+the first run). Out of scope here; noted for whoever picks it up.
+
+## `packageRules` descriptions
+
+`ruleDescriptions` rides along on the same result: `computeRuleProvenance`
+already attributes every merged `packageRules` index to a contributing layer, so
+reading `description` off the rule body costs nothing. The granularity is
+weaker than the top-level attribution — the contributing **layer** (which
+direct extend), not the exact node — which is enough for PR 5's simulator
+annotation and no more. Per-node attribution of nested bodies would need the
+nested `resolveConfigPresets` invocations threaded through the tree; if PR 5
+wants it, that is its own piece of work.
+
+## What the real tree does
+
+Verified against `{"extends": ["config:best-practices", ":dependencyDashboard",
+"group:monorepos"]}` — 1,088 resolved presets, four levels deep, entirely
+offline (internal presets need no network):
+
+- 24 strings in the final `description`, **all 24 attributed exactly**;
+  `degraded` is `false` and no entry is `approximate`. The positional replay
+  reproduces Renovate's array byte for byte, at every depth.
+- Leaves land where they should: "Pin Docker digests." → `docker:pinDigests`,
+  four levels down, arriving through `config:best-practices`; the semantic-commit
+  sentence → `:semanticPrefixFixDepsChoreOthers`.
+- The last two entries are duplicates — `:dependencyDashboard` and
+  `group:monorepos` were already pulled in by `config:best-practices`, and
+  re-extending them concatenates their sentence a second time. Both carry
+  `duplicateOfIndex` pointing at index 0 and 3, and both attribute to the
+  top-level extend that repeated them, not to the first occurrence. This is the
+  case value matching would get wrong, and it is not exotic: it is what happens
+  whenever someone adds a preset that `config:recommended` already contains.
+- 2 wrapper-preset drops (`config:best-practices`, `config:recommended`) and
+  135 `ignore-deps-quirk` drops from the three mute-button presets.
+
+## The 5-PR plan
+
+1. **Engine** (this PR) — `computeDescriptionProvenance`, exported from
+   `packages/engine/src/index.ts` alongside the other provenance entry points.
+   No UI.
+2. **Overview: "What this config does"** — a digest card built from `entries`,
+   the sentences in order with their contributing preset, so the first thing a
+   run shows is the config in English.
+3. **Effective config: the per-string blame ledger** — the `description` row
+   stops being an anonymous string array and becomes a per-string ledger with
+   the writing preset, duplicates folded, and the `dropped` list as the answer
+   to "where did my description go".
+4. **Preset tree: inline descriptions** — each node shows its own sentence, with
+   a position marker for where it landed in the final array (and a struck-through
+   marker for a dropped one).
+5. **Hover attribution + simulator rule descriptions** — hovering a sentence
+   anywhere highlights its node in the tree; the simulator's rule ledger picks up
+   `ruleDescriptions` so a matched rule can say what it is for.
+
+## Verification (PR 1)
+
+- `test/description-provenance.shimmed.test.ts` — the real fixture above:
+  full-array attribution and ordering, the two known leaf attributions, both
+  duplicates with their `viaTopLevel` and `duplicateOfIndex`, the wrapper-preset
+  drops, the `ignoreDeps: []` drops with their three `droppedBy` presets, a
+  repo-config's own description landing last on the root node, and — the
+  regression guard for the mutation above — a second run producing byte-identical
+  `entries` and `dropped`.
+- `test/description-provenance.node.test.ts` — the walk in isolation over
+  hand-built trees: own-body-last ordering at depth, identical strings from two
+  nodes, the raw-string (`allowString`) body, nested/unresolved children
+  excluded, each drop rule, and the enclosing-node fallback proving that a
+  contradicting subtree degrades alone while its siblings keep exact
+  attribution.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -3,76 +3,77 @@
 Planned features for the Renovate Config Visualizer, in intended build order.
 Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 
-| #                                                       | Feature                                                           | Milestone            | Status   |
-| ------------------------------------------------------- | ----------------------------------------------------------------- | -------------------- | -------- |
-| [001](001-engine-and-config-input.md)                   | Trace engine + config input                                       | M0/M1                | done     |
-| [002](002-preset-resolution-tree.md)                    | Preset resolution tree                                            | M1 (MVP centerpiece) | done     |
-| [003](003-inline-option-docs.md)                        | Inline option documentation                                       | M1                   | done     |
-| [004](004-migration-step-through.md)                    | Migration step-through                                            | M2                   | done     |
-| [005](005-merge-provenance-view.md)                     | Merge provenance view                                             | M2                   | done     |
-| [006](006-package-rules-simulator.md)                   | packageRules simulator                                            | M3                   | done     |
-| [007](007-shareable-links-and-repo-fetch.md)            | Shareable links + fetch config from repo                          | M4                   | done     |
-| [008](008-global-and-inherited-config.md)               | Global + inherited config layers                                  | M3                   | done     |
-| [009](009-github-oauth-sign-in.md)                      | "Sign in with GitHub" (replace PAT field)                         | M4                   | done     |
-| [010](010-preset-hosting-coverage.md)                   | Preset hosting coverage + `local>`                                | M2                   | done     |
-| [011](011-preset-tree-legibility-at-scale.md)           | Preset tree legibility at scale                                   | M2                   | done     |
-| [012](012-simulator-verdict-first-results.md)           | Simulator: verdict-first results + update-type flattening         | M5                   | done     |
-| [013](013-rule-identity-and-provenance.md)              | Rule identity: numbering, provenance, cross-links                 | M5                   | done     |
-| [014](014-validation-translations-and-quick-fixes.md)   | Validation error translations + suggested fixes                   | M5                   | done     |
-| [015](015-simulator-input-ergonomics.md)                | Simulator input ergonomics                                        | M5                   | done     |
-| [016](016-scale-framing-and-page-ergonomics.md)         | Scale framing, badge glossary, page & editor ergonomics           | M5                   | done     |
-| [017](017-share-links-in-a-running-app.md)              | Share links opened in a running app (hashchange)                  | M5                   | done     |
-| [018](018-evidence-export-and-expert-precision.md)      | Evidence export + expert-grade precision                          | M6                   | done     |
-| [019](019-persona-replay-skill.md)                      | Persona usability-test replay skill                               | M6                   | done     |
-| [020](020-browser-e2e-tests.md)                         | Browser end-to-end test suite                                     | M6                   | done     |
-| [021](021-simulator-input-hardening.md)                 | Simulator input hardening + A/B comparison integrity              | M7                   | done     |
-| [022](022-verdict-copy-precision.md)                    | Verdict & translation copy precision                              | M7                   | done     |
-| [023](023-post-action-focus-and-guidance.md)            | Post-action focus, honest error states, rule filters              | M7                   | done     |
-| [024](024-stage-chips-signal-outcomes.md)               | Stage chips signal what each stage did                            | M7                   | done     |
-| [025](025-hover-card-overflow.md)                       | Hover card text overflows its box                                 | M7                   | done     |
-| [026](026-schema-first-class-option.md)                 | Treat `$schema` as a first-class option                           | M7                   | done     |
-| [027](027-share-link-failure-diagnostics.md)            | Share-link failure diagnostics                                    | M7                   | done     |
-| [028](028-tabbed-results-shell.md)                      | Tabbed results shell (post-run progressive disclosure)            | M8                   | done     |
-| [029](029-run-digest.md)                                | Run digest (plain-English overview)                               | M8                   | done     |
-| [030](030-input-validation-zod.md)                      | Input validation at every boundary (zod/mini)                     | M8                   | done     |
-| [031](031-critical-path-loading.md)                     | Critical-path loading performance                                 | M9                   | done     |
-| [032](032-keystroke-render-performance.md)              | Keystroke render performance                                      | M9                   | done     |
-| [033](033-app-decomposition-and-boundaries.md)          | App decomposition + single-source boundaries                      | M9                   | done     |
-| [034](034-lint-hardening.md)                            | Lint hardening (oxlint)                                           | M9                   | done     |
-| [035](035-layout-polish.md)                             | Layout polish + regression tests                                  | M10                  | done     |
-| [036](036-unified-chrome.md)                            | Unified chrome: filled badges, copy button, diff toolbar          | M10                  | done     |
-| [037](037-theme-switcher.md)                            | Light / dark theme switcher                                       | M10                  | done     |
-| [038](038-lint-audit-follow-up.md)                      | Lint audit follow-up: quick wins + 034 corrections                | M10                  | done     |
-| [039](039-editor-column-polish.md)                      | Editor column polish: theme, one Button, repo-load                | M10                  | done     |
-| [040](040-jsx-depth-decomposition.md)                   | JSX-depth ratchet: decompose the monoliths to depth 4             | M10                  | done     |
-| [041](041-warn-tier-to-error.md)                        | Promote the warn tier to error                                    | M10                  | done     |
-| [042](042-rewrites-inset-and-pipeline-arrows.md)        | Rewrites inset + Pipeline order arrows                            | M10                  | done     |
-| [043](043-docker-self-host.md)                          | Docker self-host distribution                                     | M11                  | done     |
-| [044](044-simulator-merge-step-through.md)              | Simulator: step through rule merges one at a time                 | M12                  | done     |
-| [045](045-auto-load-inherited-config.md)                | Auto-load the inherited config for a loaded repository            | M12                  | done     |
-| [046](046-simulator-verdict-card-and-merge-timeline.md) | Simulator: verdict card + merge timeline                          | M12                  | done     |
-| [047](047-simulator-progressive-disclosure.md)          | Simulator: progressive disclosure                                 | M12                  | done     |
-| [048](048-app-decomposition-and-depth-ratchet.md)       | App decomposition + depth ratchet to 3                            | M13                  | done     |
-| [049](049-feature-layer-expansion.md)                   | Feature-layer expansion: editor, presets                          | M13                  | done     |
-| [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement              | M13                  | done     |
-| [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document          | M14                  | done     |
-| [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity)        | M14                  | done     |
-| [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost        | M14                  | done     |
-| [054](054-simulator-results-readability.md)             | Simulator: results readability — the ledger is the trace          | M14                  | done     |
-| [055](055-header-project-links.md)                      | Header links to the source and the issue tracker                  | M14                  | done     |
-| [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`          | M15                  | proposed |
-| [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                           | M15                  | proposed |
-| [058](058-rcd-debugger-cli.md)                          | `rcd`: the debugger CLI on the shimmed engine (experimental)      | M16                  | done     |
-| [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli` (experimental) | M16                  | done     |
-| [060](060-mcp-server-and-agent-discovery.md)            | `rcd mcp` + pointing agents at the headless interface             | M16                  | proposed |
-| [061](061-claude-plugin-marketplace.md)                 | Claude plugin marketplace for the debugger                        | M16                  | proposed |
-| [062](062-results-tab-taxonomy.md)                      | Results tabs: `Simulator` → `packageRules`, + `Extraction`        | M17                  | proposed |
-| [063](063-custom-manager-extraction.md)                 | Custom-manager extraction simulator                               | M17                  | proposed |
-| [064](064-extraction-fidelity-and-mismatch.md)          | Extraction fidelity: RE2 gap + unmatched comments                 | M17                  | proposed |
-| [065](065-persistent-sign-in.md)                        | Persistent sign-in: HttpOnly refresh-token cookie                 | M14                  | done     |
-| [066](066-header-account-menu.md)                       | Header session menu: account, theme and links in one corner       | M14                  | done     |
-| [067](067-semantic-release.md)                          | semantic-release: one version for every public package            | M16                  | done     |
-| [068](068-keyboard-ux.md)                               | Keyboard UX: ⌘⏎ to run, a bare-key jump layer, one Escape ladder  | M18                  | done     |
+| #                                                       | Feature                                                              | Milestone            | Status      |
+| ------------------------------------------------------- | -------------------------------------------------------------------- | -------------------- | ----------- |
+| [001](001-engine-and-config-input.md)                   | Trace engine + config input                                          | M0/M1                | done        |
+| [002](002-preset-resolution-tree.md)                    | Preset resolution tree                                               | M1 (MVP centerpiece) | done        |
+| [003](003-inline-option-docs.md)                        | Inline option documentation                                          | M1                   | done        |
+| [004](004-migration-step-through.md)                    | Migration step-through                                               | M2                   | done        |
+| [005](005-merge-provenance-view.md)                     | Merge provenance view                                                | M2                   | done        |
+| [006](006-package-rules-simulator.md)                   | packageRules simulator                                               | M3                   | done        |
+| [007](007-shareable-links-and-repo-fetch.md)            | Shareable links + fetch config from repo                             | M4                   | done        |
+| [008](008-global-and-inherited-config.md)               | Global + inherited config layers                                     | M3                   | done        |
+| [009](009-github-oauth-sign-in.md)                      | "Sign in with GitHub" (replace PAT field)                            | M4                   | done        |
+| [010](010-preset-hosting-coverage.md)                   | Preset hosting coverage + `local>`                                   | M2                   | done        |
+| [011](011-preset-tree-legibility-at-scale.md)           | Preset tree legibility at scale                                      | M2                   | done        |
+| [012](012-simulator-verdict-first-results.md)           | Simulator: verdict-first results + update-type flattening            | M5                   | done        |
+| [013](013-rule-identity-and-provenance.md)              | Rule identity: numbering, provenance, cross-links                    | M5                   | done        |
+| [014](014-validation-translations-and-quick-fixes.md)   | Validation error translations + suggested fixes                      | M5                   | done        |
+| [015](015-simulator-input-ergonomics.md)                | Simulator input ergonomics                                           | M5                   | done        |
+| [016](016-scale-framing-and-page-ergonomics.md)         | Scale framing, badge glossary, page & editor ergonomics              | M5                   | done        |
+| [017](017-share-links-in-a-running-app.md)              | Share links opened in a running app (hashchange)                     | M5                   | done        |
+| [018](018-evidence-export-and-expert-precision.md)      | Evidence export + expert-grade precision                             | M6                   | done        |
+| [019](019-persona-replay-skill.md)                      | Persona usability-test replay skill                                  | M6                   | done        |
+| [020](020-browser-e2e-tests.md)                         | Browser end-to-end test suite                                        | M6                   | done        |
+| [021](021-simulator-input-hardening.md)                 | Simulator input hardening + A/B comparison integrity                 | M7                   | done        |
+| [022](022-verdict-copy-precision.md)                    | Verdict & translation copy precision                                 | M7                   | done        |
+| [023](023-post-action-focus-and-guidance.md)            | Post-action focus, honest error states, rule filters                 | M7                   | done        |
+| [024](024-stage-chips-signal-outcomes.md)               | Stage chips signal what each stage did                               | M7                   | done        |
+| [025](025-hover-card-overflow.md)                       | Hover card text overflows its box                                    | M7                   | done        |
+| [026](026-schema-first-class-option.md)                 | Treat `$schema` as a first-class option                              | M7                   | done        |
+| [027](027-share-link-failure-diagnostics.md)            | Share-link failure diagnostics                                       | M7                   | done        |
+| [028](028-tabbed-results-shell.md)                      | Tabbed results shell (post-run progressive disclosure)               | M8                   | done        |
+| [029](029-run-digest.md)                                | Run digest (plain-English overview)                                  | M8                   | done        |
+| [030](030-input-validation-zod.md)                      | Input validation at every boundary (zod/mini)                        | M8                   | done        |
+| [031](031-critical-path-loading.md)                     | Critical-path loading performance                                    | M9                   | done        |
+| [032](032-keystroke-render-performance.md)              | Keystroke render performance                                         | M9                   | done        |
+| [033](033-app-decomposition-and-boundaries.md)          | App decomposition + single-source boundaries                         | M9                   | done        |
+| [034](034-lint-hardening.md)                            | Lint hardening (oxlint)                                              | M9                   | done        |
+| [035](035-layout-polish.md)                             | Layout polish + regression tests                                     | M10                  | done        |
+| [036](036-unified-chrome.md)                            | Unified chrome: filled badges, copy button, diff toolbar             | M10                  | done        |
+| [037](037-theme-switcher.md)                            | Light / dark theme switcher                                          | M10                  | done        |
+| [038](038-lint-audit-follow-up.md)                      | Lint audit follow-up: quick wins + 034 corrections                   | M10                  | done        |
+| [039](039-editor-column-polish.md)                      | Editor column polish: theme, one Button, repo-load                   | M10                  | done        |
+| [040](040-jsx-depth-decomposition.md)                   | JSX-depth ratchet: decompose the monoliths to depth 4                | M10                  | done        |
+| [041](041-warn-tier-to-error.md)                        | Promote the warn tier to error                                       | M10                  | done        |
+| [042](042-rewrites-inset-and-pipeline-arrows.md)        | Rewrites inset + Pipeline order arrows                               | M10                  | done        |
+| [043](043-docker-self-host.md)                          | Docker self-host distribution                                        | M11                  | done        |
+| [044](044-simulator-merge-step-through.md)              | Simulator: step through rule merges one at a time                    | M12                  | done        |
+| [045](045-auto-load-inherited-config.md)                | Auto-load the inherited config for a loaded repository               | M12                  | done        |
+| [046](046-simulator-verdict-card-and-merge-timeline.md) | Simulator: verdict card + merge timeline                             | M12                  | done        |
+| [047](047-simulator-progressive-disclosure.md)          | Simulator: progressive disclosure                                    | M12                  | done        |
+| [048](048-app-decomposition-and-depth-ratchet.md)       | App decomposition + depth ratchet to 3                               | M13                  | done        |
+| [049](049-feature-layer-expansion.md)                   | Feature-layer expansion: editor, presets                             | M13                  | done        |
+| [050](050-css-design-tokens.md)                         | CSS design tokens: dedup, consolidation, enforcement                 | M13                  | done        |
+| [051](051-resolved-config-output.md)                    | Effective config: resolved config as a copyable document             | M14                  | done        |
+| [052](052-post-resolution-remigration.md)               | Fidelity: re-migrate the resolved config (upstream parity)           | M14                  | done        |
+| [053](053-analytics-localhost-exclusion.md)             | Analytics: CI is not an audience, not tracked on localhost           | M14                  | done        |
+| [054](054-simulator-results-readability.md)             | Simulator: results readability — the ledger is the trace             | M14                  | done        |
+| [055](055-header-project-links.md)                      | Header links to the source and the issue tracker                     | M14                  | done        |
+| [056](056-publish-engine-package.md)                    | Publish the engine as `@renovate-config-debugger/engine`             | M15                  | proposed    |
+| [057](057-fork-codemirror-json-schema.md)               | Fork + publish `codemirror-json-schema`                              | M15                  | proposed    |
+| [058](058-rcd-debugger-cli.md)                          | `rcd`: the debugger CLI on the shimmed engine (experimental)         | M16                  | done        |
+| [059](059-publish-cli-package.md)                       | Publish the CLI as `@renovate-config-debugger/cli` (experimental)    | M16                  | done        |
+| [060](060-mcp-server-and-agent-discovery.md)            | `rcd mcp` + pointing agents at the headless interface                | M16                  | proposed    |
+| [061](061-claude-plugin-marketplace.md)                 | Claude plugin marketplace for the debugger                           | M16                  | proposed    |
+| [062](062-results-tab-taxonomy.md)                      | Results tabs: `Simulator` → `packageRules`, + `Extraction`           | M17                  | proposed    |
+| [063](063-custom-manager-extraction.md)                 | Custom-manager extraction simulator                                  | M17                  | proposed    |
+| [064](064-extraction-fidelity-and-mismatch.md)          | Extraction fidelity: RE2 gap + unmatched comments                    | M17                  | proposed    |
+| [065](065-persistent-sign-in.md)                        | Persistent sign-in: HttpOnly refresh-token cookie                    | M14                  | done        |
+| [066](066-header-account-menu.md)                       | Header session menu: account, theme and links in one corner          | M14                  | done        |
+| [067](067-semantic-release.md)                          | semantic-release: one version for every public package               | M16                  | done        |
+| [068](068-keyboard-ux.md)                               | Keyboard UX: ⌘⏎ to run, a bare-key jump layer, one Escape ladder     | M18                  | done        |
+| [069](069-description-provenance.md)                    | Per-string `description` provenance: who said what about this config | M19                  | in progress |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live
@@ -234,3 +235,13 @@ follow-up pass added the jump layer the two-pane shape asks for — bare `e` /
 `r` / `1`–`7` and `⌘⇧⏎` to run and read — plus the `?` sheet
 that eleven bindings made compulsory, and Enter opening a native `<select>`,
 which nobody noticed was missing until Tab stopped being trapped.
+
+M19 — **Descriptions** — is 069, and it starts from something the app already
+renders and nobody can read: the resolved `description` array, twenty-plus
+author-written sentences with no indication of who wrote which. The link is
+recoverable — array concatenation is positional and the preset tree is already
+in hand — so the milestone is one engine primitive (every string attributed to
+the node that wrote it, plus the three rules under which Renovate silently
+deletes one) and four UI passes that spend it: the config in English on the
+Overview, a per-string blame ledger in the Effective config, inline
+descriptions in the preset tree, and hover attribution across the two.

--- a/roadmap/mockups/069/description-provenance-variants.html
+++ b/roadmap/mockups/069/description-provenance-variants.html
@@ -1,0 +1,1292 @@
+<title>Description provenance — 4 presentation variants</title>
+<style>
+  /* ── Frame + app token system (mirrors packages/app/src/index.css palette) ── */
+  :root {
+    color-scheme: light dark;
+    /* app tokens, light */
+    --canvas: #ffffff;
+    --surface: #f6f8fa;
+    --surface-raised: #ffffff;
+    --ink: #1f2328;
+    --muted: #59626b;
+    --border: #d1d9e0;
+    --accent: #0969da;
+    --accent-fill: #0757ba;
+    --on-accent: #ffffff;
+    --accent-purple: #8250df;
+    --accent-teal: #136f77;
+    --accent-pink: #bf3989;
+    --ok: #1a7f37;
+    --warn: #9a6700;
+    --error: #d1242f;
+    /* doc-frame tokens (slightly cool-tinted so mockups pop as "the content") */
+    --frame-bg: #eef0f3;
+    --frame-ink: #23282e;
+    --frame-muted: #5d6670;
+    --frame-border: #d6dade;
+    --shadow-popover: 0 8px 24px rgba(31, 35, 40, 0.16);
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --canvas: #0d1117;
+      --surface: #161b22;
+      --surface-raised: #1c2129;
+      --ink: #e6edf3;
+      --muted: #909aa5;
+      --border: #30363d;
+      --accent: #4493f8;
+      --accent-fill: #1f6feb;
+      --accent-purple: #a371f7;
+      --accent-teal: #4ac6d2;
+      --accent-pink: #f778ba;
+      --ok: #3fb950;
+      --warn: #d29922;
+      --error: #f85149;
+      --frame-bg: #090c10;
+      --frame-ink: #dfe6ed;
+      --frame-muted: #8b949e;
+      --frame-border: #21262d;
+      --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.55);
+    }
+  }
+  :root[data-theme="dark"] {
+    --canvas: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2129;
+    --ink: #e6edf3;
+    --muted: #909aa5;
+    --border: #30363d;
+    --accent: #4493f8;
+    --accent-fill: #1f6feb;
+    --accent-purple: #a371f7;
+    --accent-teal: #4ac6d2;
+    --accent-pink: #f778ba;
+    --ok: #3fb950;
+    --warn: #d29922;
+    --error: #f85149;
+    --frame-bg: #090c10;
+    --frame-ink: #dfe6ed;
+    --frame-muted: #8b949e;
+    --frame-border: #21262d;
+    --shadow-popover: 0 8px 24px rgba(0, 0, 0, 0.55);
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+  body {
+    margin: 0;
+    background: var(--frame-bg);
+    color: var(--frame-ink);
+    font:
+      16px/1.55 system-ui,
+      -apple-system,
+      "Segoe UI",
+      sans-serif;
+  }
+  .wrap {
+    max-width: 1020px;
+    margin: 0 auto;
+    padding: 3rem 1.25rem 5rem;
+  }
+
+  /* ── Doc frame typography ── */
+  header.doc h1 {
+    font-size: 1.6rem;
+    line-height: 1.25;
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.01em;
+    text-wrap: balance;
+  }
+  header.doc .sub {
+    color: var(--frame-muted);
+    max-width: 62ch;
+    margin: 0;
+  }
+  .eyebrow {
+    font-size: 0.7rem;
+    font-weight: 650;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: var(--frame-muted);
+    margin: 0 0 0.35rem;
+  }
+  section.variant {
+    margin-top: 4rem;
+  }
+  section.variant > h2 {
+    font-size: 1.25rem;
+    margin: 0 0 0.4rem;
+    letter-spacing: -0.01em;
+  }
+  section.variant > .concept {
+    color: var(--frame-muted);
+    max-width: 68ch;
+    margin: 0 0 1.25rem;
+  }
+  section.variant > .concept strong {
+    color: var(--frame-ink);
+    font-weight: 600;
+  }
+
+  .facts {
+    margin-top: 3rem;
+    display: grid;
+    gap: 0.75rem;
+  }
+  .fact {
+    border-left: 3px solid var(--frame-border);
+    padding: 0.1rem 0 0.1rem 0.9rem;
+    max-width: 74ch;
+    font-size: 0.95rem;
+  }
+  .fact b {
+    font-weight: 600;
+  }
+  .fact code,
+  .notes code,
+  .concept code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: color-mix(in srgb, var(--frame-ink) 7%, transparent);
+    padding: 0.05em 0.3em;
+    border-radius: 4px;
+  }
+
+  /* ── Mockup shell: an "app window" ── */
+  .shell {
+    background: var(--canvas);
+    color: var(--ink);
+    border: 1px solid var(--frame-border);
+    border-radius: 10px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(15, 20, 25, 0.08);
+    font-size: 0.85rem;
+  }
+  .shell-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 0.45rem 0.8rem;
+    color: var(--muted);
+    font-size: 0.72rem;
+  }
+  .shell-bar .dots {
+    display: flex;
+    gap: 5px;
+  }
+  .shell-bar .dots i {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--border);
+  }
+  .shell-body {
+    padding: 0;
+  }
+  .overflow {
+    overflow-x: auto;
+  }
+
+  /* app card chrome */
+  .card-title {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.55rem 0.8rem;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+  }
+  .card-title .count {
+    color: var(--muted);
+    font-weight: 400;
+  }
+
+  /* segmented control (app .seg) */
+  .seg {
+    display: inline-flex;
+    margin-left: auto;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    overflow: hidden;
+    font-size: 0.72rem;
+    font-weight: 500;
+  }
+  .seg span {
+    padding: 0.2rem 0.6rem;
+    color: var(--muted);
+    background: var(--canvas);
+  }
+  .seg span.on {
+    background: var(--accent-fill);
+    color: var(--on-accent);
+  }
+
+  /* provenance chips (app .badge / ProvenanceChip) */
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3em;
+    font-size: 0.68rem;
+    font-weight: 550;
+    line-height: 1;
+    font-family: var(--font-mono);
+    padding: 0.22em 0.55em;
+    border-radius: 999px;
+    background: color-mix(in srgb, currentColor 10%, transparent);
+    border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+    white-space: nowrap;
+  }
+  .chip.preset {
+    color: var(--accent-purple);
+  }
+  .chip.repo {
+    color: var(--accent);
+  }
+  .chip.meta {
+    color: var(--muted);
+    font-family: inherit;
+  }
+  .chip.clickable {
+    cursor: pointer;
+  }
+  .dotchip {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: currentColor;
+    flex: none;
+  }
+  .verb {
+    color: var(--muted);
+    font-size: 0.72rem;
+  }
+
+  /* kv ledger row (app .kv-row) */
+  .kv-head {
+    display: grid;
+    grid-template-columns: minmax(150px, 0.9fr) 1.6fr auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.5rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    background: var(--canvas);
+  }
+  .kv-key {
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  .kv-key .caret {
+    color: var(--muted);
+    font-size: 0.65rem;
+  }
+  .kv-prev {
+    color: var(--muted);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .kv-origin {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  /* blame list (variant A) */
+  .blame {
+    list-style: none;
+    margin: 0;
+    padding: 0.35rem 0 0.6rem;
+    background: var(--canvas);
+  }
+  .blame li {
+    display: grid;
+    grid-template-columns: 2.4rem minmax(220px, 1fr) minmax(180px, 15rem);
+    gap: 0.75rem;
+    align-items: baseline;
+    padding: 0.28rem 0.8rem;
+  }
+  .blame li:hover {
+    background: color-mix(in srgb, var(--accent) 5%, transparent);
+  }
+  .blame .idx {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--muted);
+    text-align: right;
+  }
+  .blame .txt {
+    font-size: 0.8rem;
+    line-height: 1.45;
+  }
+  .blame .txt code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: color-mix(in srgb, var(--ink) 6%, transparent);
+    padding: 0 0.25em;
+    border-radius: 3px;
+  }
+  .blame .src {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    justify-self: start;
+  }
+  .blame .via {
+    color: var(--muted);
+    font-size: 0.66rem;
+    white-space: nowrap;
+  }
+  .blame li.groupfirst {
+    border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+    margin-top: 0.15rem;
+    padding-top: 0.4rem;
+  }
+  .blame li.dup .txt {
+    color: var(--muted);
+    text-decoration: line-through;
+    text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
+  }
+  .blame .dupnote {
+    font-size: 0.66rem;
+    color: var(--warn);
+    white-space: nowrap;
+    background: color-mix(in srgb, var(--warn) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--warn) 30%, transparent);
+    border-radius: 999px;
+    padding: 0.1em 0.5em;
+  }
+  .blame li.ellipsis {
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-style: italic;
+  }
+
+  /* variant B digest */
+  .digest {
+    padding: 0.8rem 1rem 1rem;
+    background: var(--canvas);
+  }
+  .digest-group {
+    margin-bottom: 0.9rem;
+  }
+  .digest-group > .gh {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.3rem;
+  }
+  .digest-group > .gh .n {
+    color: var(--muted);
+    font-size: 0.7rem;
+  }
+  .digest ul {
+    list-style: none;
+    margin: 0;
+    padding: 0 0 0 1rem;
+    border-left: 2px solid color-mix(in srgb, var(--accent-purple) 30%, transparent);
+    display: grid;
+    gap: 0.22rem;
+  }
+  .digest li {
+    font-size: 0.8rem;
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+  }
+  .digest li .dotchip {
+    position: relative;
+    top: -1px;
+    color: var(--accent-purple);
+  }
+  .digest li .leaf {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    color: var(--muted);
+    white-space: nowrap;
+  }
+  .digest li.more {
+    color: var(--muted);
+    font-style: italic;
+    font-size: 0.72rem;
+  }
+  .digest li.userrule .dotchip {
+    color: var(--accent);
+  }
+  .digest .rulenote {
+    color: var(--muted);
+    font-size: 0.68rem;
+  }
+
+  /* variant C tree */
+  .tree {
+    font-size: 0.8rem;
+    padding: 0.6rem 0.9rem 0.9rem;
+    background: var(--canvas);
+    display: grid;
+    gap: 0.05rem;
+  }
+  .tnode {
+    padding: 0.22rem 0.4rem;
+    border-radius: 6px;
+  }
+  .tnode:hover {
+    background: color-mix(in srgb, var(--accent) 6%, transparent);
+  }
+  .tnode.sel {
+    background: color-mix(in srgb, var(--accent) 10%, transparent);
+    outline: 1px solid color-mix(in srgb, var(--accent) 40%, transparent);
+  }
+  .tnode .row1 {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+  }
+  .tnode .name {
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    font-weight: 550;
+  }
+  .tnode .meta {
+    color: var(--muted);
+    font-size: 0.66rem;
+  }
+  .tnode .desc {
+    color: var(--muted);
+    font-size: 0.72rem;
+    line-height: 1.4;
+    margin: 0.1rem 0 0 1.05rem;
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+  .tnode .desc::before {
+    content: "❝";
+    color: color-mix(in srgb, var(--accent-purple) 55%, transparent);
+    font-size: 0.8rem;
+    flex: none;
+  }
+  .d1 {
+    margin-left: 1.1rem;
+  }
+  .d2 {
+    margin-left: 2.2rem;
+  }
+  .d3 {
+    margin-left: 3.3rem;
+  }
+
+  /* variant D json + hover card */
+  .jsonpane {
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    line-height: 1.6;
+    padding: 0.8rem 1rem;
+    background: var(--canvas);
+    position: relative;
+  }
+  .jk {
+    color: var(--accent);
+  }
+  .js {
+    color: var(--accent-teal);
+  }
+  .jp {
+    color: var(--muted);
+  }
+  .js.hovered {
+    background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+    outline: 1px solid color-mix(in srgb, var(--accent-purple) 45%, transparent);
+    border-radius: 3px;
+    position: relative;
+  }
+  .option-card {
+    position: absolute;
+    z-index: 30;
+    max-width: 330px;
+    background: var(--surface-raised);
+    color: var(--ink);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: var(--shadow-popover);
+    padding: 0.65rem 0.8rem;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+    font-size: 0.75rem;
+    line-height: 1.45;
+  }
+  .option-card .oc-head {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-bottom: 0.35rem;
+  }
+  .option-card .oc-name {
+    font-weight: 600;
+    font-size: 0.8rem;
+  }
+  .option-card .oc-row {
+    color: var(--muted);
+    font-size: 0.7rem;
+    margin-top: 0.3rem;
+  }
+  .option-card .oc-path {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    color: var(--muted);
+    margin-top: 0.35rem;
+  }
+  .option-card .oc-path b {
+    color: var(--ink);
+    font-weight: 550;
+  }
+  .option-card .oc-link {
+    color: var(--accent);
+    font-size: 0.72rem;
+    margin-top: 0.45rem;
+    display: inline-block;
+  }
+  .callout-tag {
+    position: absolute;
+    z-index: 31;
+    font-size: 0.62rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--frame-bg);
+    background: var(--accent-pink);
+    padding: 0.15em 0.55em;
+    border-radius: 999px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  }
+
+  /* simulator verdict row (variant D lower half) */
+  .verdict {
+    padding: 0.7rem 0.9rem 0.9rem;
+    background: var(--canvas);
+    display: grid;
+    gap: 0.55rem;
+  }
+  .vrow {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.55rem 0.75rem;
+    display: grid;
+    gap: 0.3rem;
+  }
+  .vrow .vhead {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .vrow .match {
+    font-size: 0.66rem;
+    font-weight: 650;
+    color: var(--ok);
+    background: color-mix(in srgb, var(--ok) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--ok) 30%, transparent);
+    padding: 0.14em 0.5em;
+    border-radius: 999px;
+  }
+  .vrow .rname {
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+  }
+  .vrow .why {
+    font-size: 0.78rem;
+    line-height: 1.45;
+    padding-left: 0.7rem;
+    border-left: 3px solid color-mix(in srgb, var(--accent-purple) 45%, transparent);
+    color: var(--ink);
+  }
+  .vrow .why .attr {
+    color: var(--muted);
+    font-size: 0.68rem;
+  }
+  .vrow .setline {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--muted);
+  }
+
+  /* notes under each mockup */
+  .notes {
+    margin-top: 1rem;
+    display: grid;
+    gap: 0.4rem;
+    font-size: 0.88rem;
+    max-width: 76ch;
+  }
+  .notes .n {
+    display: grid;
+    grid-template-columns: 5.2rem 1fr;
+    gap: 0.7rem;
+    align-items: baseline;
+  }
+  .notes .tag {
+    font-size: 0.66rem;
+    font-weight: 650;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    text-align: right;
+  }
+  .notes .tag.pro {
+    color: var(--ok);
+  }
+  .notes .tag.con {
+    color: var(--error);
+  }
+  .notes .tag.data {
+    color: var(--frame-muted);
+  }
+
+  /* comparison table */
+  .cmp-wrap {
+    overflow-x: auto;
+    margin-top: 1.25rem;
+    border: 1px solid var(--frame-border);
+    border-radius: 10px;
+  }
+  table.cmp {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 640px;
+    font-size: 0.82rem;
+    background: var(--canvas);
+    color: var(--ink);
+  }
+  .cmp th,
+  .cmp td {
+    text-align: left;
+    padding: 0.55rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: top;
+  }
+  .cmp th {
+    background: var(--surface);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+  .cmp tr:last-child td {
+    border-bottom: none;
+  }
+  .cmp td:first-child {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .reco {
+    margin-top: 2rem;
+    border-left: 3px solid var(--accent);
+    padding: 0.2rem 0 0.2rem 1rem;
+    max-width: 74ch;
+  }
+  .reco p {
+    margin: 0.4rem 0;
+    font-size: 0.95rem;
+  }
+</style>
+
+<div class="wrap">
+  <header class="doc">
+    <p class="eyebrow">Renovate Config Debugger · design exploration</p>
+    <h1>Where did this description come from? — four presentation variants</h1>
+    <p class="sub">
+      Preset authors write <code>description</code> strings to explain what their rules do. Renovate
+      concatenates them all into one flat array — losing the connection to the preset that wrote
+      each one. The trace already captures enough to restore it. All mockups below use the real
+      output of
+      <code>{"extends": ["config:best-practices", ":dependencyDashboard", "group:monorepos"]}</code
+      >: 24 accumulated strings, including two duplicates.
+    </p>
+
+    <div class="facts">
+      <p class="eyebrow" style="margin-top: 1.5rem">What the investigation established</p>
+      <div class="fact">
+        <b>Mechanics:</b> <code>description</code> is an ordinary <code>mergeable</code> array
+        option. Each preset resolves depth-first, children's strings land first, the node's own
+        string last; strings are never deduplicated. Wrapper presets (<code
+          >{description, extends}</code
+        >) get theirs silently dropped.
+      </div>
+      <div class="fact">
+        <b>Data availability:</b> every preset-tree node already carries its own literal body
+        (<code>input</code>) and its fully-merged result (<code>resolved</code>). Per-string
+        attribution is a recursive positional walk — same technique as the existing
+        <code>computeRuleProvenance</code>. No new trace collection needed.
+      </div>
+      <div class="fact">
+        <b>Today's UI:</b> descriptions are actively filtered out — <code>META_KEYS</code> excludes
+        them from "sets real options", and the provenance view attributes the whole array to
+        top-level extends entries only. <code>packageRules[n].description</code> never surfaces at
+        all.
+      </div>
+      <div class="fact">
+        <b>Prior art:</b> GitHub blame (group consecutive same-source entries), DevTools cascade
+        (show suppressed values struck-through, not hidden), ESLint config-inspector (merged ⇄
+        per-source toggle), Nix (source vs. import-path split). Renovate upstream punted on exactly
+        this feature (discussion #38024).
+      </div>
+    </div>
+  </header>
+
+  <!-- ═══════════════════ VARIANT A ═══════════════════ -->
+  <section class="variant">
+    <p class="eyebrow">Variant A · Effective Config tab</p>
+    <h2>The blame ledger</h2>
+    <p class="concept">
+      The existing <code>description</code> row in <strong>Effective config → By key</strong> stops
+      being a truncated wall of text. Expanding it shows every string in final array order,
+      blame-style: each entry carries a preset chip (click → selects the node in the preset tree),
+      consecutive entries from the same top-level extend are grouped under a hairline, and
+      duplicates are struck through with an explanation instead of silently kept.
+    </p>
+
+    <div class="shell">
+      <div class="shell-bar">
+        <span class="dots"><i></i><i></i><i></i></span> Effective config — By key
+      </div>
+      <div class="card-title">
+        Effective config <span class="count">9 keys · 1 overridden</span>
+        <span class="seg"><span class="on">By key</span><span>As JSON</span></span>
+      </div>
+      <div class="overflow">
+        <div class="kv-head">
+          <span class="kv-key"><span class="caret">▾</span> description</span>
+          <span class="kv-prev"
+            >24 entries — "Enable Renovate Dependency Dashboard creation.", "Use semantic commit
+            type…</span
+          >
+          <span class="kv-origin"
+            ><span class="chip meta">appended ×3</span
+            ><span class="chip preset clickable"
+              ><span class="dotchip"></span>18 presets</span
+            ></span
+          >
+        </div>
+        <ul class="blame">
+          <li class="groupfirst">
+            <span class="idx">1</span>
+            <span class="txt">Enable Renovate Dependency Dashboard creation.</span>
+            <span class="src"
+              ><span class="chip preset clickable">:dependencyDashboard</span
+              ><span class="via">via config:best-practices</span></span
+            >
+          </li>
+          <li>
+            <span class="idx">2</span>
+            <span class="txt"
+              >Use semantic commit type <code>fix</code> for dependencies and <code>chore</code> for
+              all others if semantic commits are in use.</span
+            >
+            <span class="src"
+              ><span class="chip preset clickable">:semanticPrefixFixDepsChoreOthers</span></span
+            >
+          </li>
+          <li>
+            <span class="idx">3</span>
+            <span class="txt"
+              >Ignore <code>node_modules</code>, <code>bower_components</code>,
+              <code>vendor</code> and various test/tests directories.</span
+            >
+            <span class="src"
+              ><span class="chip preset clickable">:ignoreModulesAndTests</span></span
+            >
+          </li>
+          <li>
+            <span class="idx">4</span>
+            <span class="txt">Group known monorepo packages together.</span>
+            <span class="src"><span class="chip preset clickable">group:monorepos</span></span>
+          </li>
+          <li class="ellipsis">
+            <span class="idx">…</span><span class="txt">11 more from config:best-practices</span
+            ><span></span>
+          </li>
+          <li>
+            <span class="idx">16</span>
+            <span class="txt">Pin Docker digests.</span>
+            <span class="src"><span class="chip preset clickable">docker:pinDigests</span></span>
+          </li>
+          <li>
+            <span class="idx">21</span>
+            <span class="txt"
+              >Wait until the npm package is three days old before raising the update…</span
+            >
+            <span class="src"
+              ><span class="chip preset clickable">security:minimumReleaseAgeNpm</span></span
+            >
+          </li>
+          <li class="groupfirst dup">
+            <span class="idx">23</span>
+            <span class="txt">Enable Renovate Dependency Dashboard.</span>
+            <span class="src"
+              ><span class="dupnote">duplicate of #1</span
+              ><span class="via">extends[1] resolves it again</span></span
+            >
+          </li>
+          <li class="dup">
+            <span class="idx">24</span>
+            <span class="txt">Group known monorepo packages together.</span>
+            <span class="src"
+              ><span class="dupnote">duplicate of #4</span
+              ><span class="via">extends[2] resolves it again</span></span
+            >
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="notes">
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Zero new surface — it deepens the row users already open to ask this question; final
+          array order stays honest (VS Code's hidden-precedence mistake avoided).</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Duplicates become a teaching moment ("extending <code>:dependencyDashboard</code> twice
+          is redundant") instead of silent noise.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag con">Con</span
+        ><span
+          >Lives behind the Effective Config tab + one expand; users who'd benefit most may never
+          look there.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag data">Data</span
+        ><span
+          >Needs the new recursive per-string attribution walk (positional, to handle duplicates),
+          plus duplicate detection.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ VARIANT B ═══════════════════ -->
+  <section class="variant">
+    <p class="eyebrow">Variant B · Overview tab</p>
+    <h2>"What this config does" — descriptions as the config's own documentation</h2>
+    <p class="concept">
+      Reframe: the accumulated descriptions
+      <strong>are the author-written summary of the config's behavior</strong> — the same list
+      Renovate itself pastes into onboarding PRs. A new Overview card presents them as a readable
+      digest, grouped by the top-level <code>extends</code> entry that pulled each one in,
+      deduplicated (with a count), each line attributed to its leaf preset via a quiet mono label.
+      User-written <code>packageRules</code>
+      descriptions join at the bottom — surfacing for the first time.
+    </p>
+
+    <div class="shell">
+      <div class="shell-bar">
+        <span class="dots"><i></i><i></i><i></i></span> Overview
+      </div>
+      <div class="card-title">
+        What this config does <span class="count">22 behaviors · from 3 extends + your rules</span>
+      </div>
+      <div class="digest">
+        <div class="digest-group">
+          <div class="gh">
+            <span class="chip preset clickable">config:best-practices</span
+            ><span class="n">contributes 22 behaviors</span>
+          </div>
+          <ul>
+            <li>
+              <span class="dotchip"></span
+              ><span>Enable Renovate Dependency Dashboard creation.</span
+              ><span class="leaf">:dependencyDashboard</span>
+            </li>
+            <li>
+              <span class="dotchip"></span><span>Pin Docker digests.</span
+              ><span class="leaf">docker:pinDigests</span>
+            </li>
+            <li>
+              <span class="dotchip"></span><span>Pin <code>github-action</code> digests.</span
+              ><span class="leaf">helpers:pinGitHubActionDigests</span>
+            </li>
+            <li>
+              <span class="dotchip"></span
+              ><span>Wait until the npm package is three days old before raising the update.</span
+              ><span class="leaf">security:minimumReleaseAgeNpm</span>
+            </li>
+            <li>
+              <span class="dotchip"></span
+              ><span>Run lock file maintenance (updates) early Monday mornings.</span
+              ><span class="leaf">:maintainLockFilesWeekly</span>
+            </li>
+            <li class="more">17 more — show all</li>
+          </ul>
+        </div>
+        <div class="digest-group">
+          <div class="gh">
+            <span class="chip preset clickable">:dependencyDashboard</span>
+            <span class="chip meta">redundant — already included above</span>
+          </div>
+        </div>
+        <div class="digest-group">
+          <div class="gh">
+            <span class="chip preset clickable">group:monorepos</span>
+            <span class="chip meta">redundant — already included above</span>
+          </div>
+        </div>
+        <div class="digest-group">
+          <div class="gh">
+            <span class="chip repo">repo config</span><span class="n">your own rules</span>
+          </div>
+          <ul style="border-left-color: color-mix(in srgb, var(--accent) 30%, transparent)">
+            <li class="userrule">
+              <span class="dotchip"></span><span>Slow down risky major updates</span
+              ><span class="rulenote">packageRules[0] — major → minimumReleaseAge 14 days</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="notes">
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Highest user value per pixel: answers "what did I just extend?" — the question preset
+          descriptions were written for. Mirrors what Renovate prints in onboarding PRs, so it feels
+          canonical.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >The only variant that surfaces <code>packageRules</code> descriptions and flags redundant
+          extends at the top level.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag con">Con</span
+        ><span
+          >An interpretation, not a raw view — grouping + dedup mean it no longer matches the
+          literal resolved array (needs a "show raw order" escape hatch, e.g. linking to Variant
+          A).</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag data">Data</span
+        ><span
+          >Same attribution walk as A, plus grouping by top-level extend and value-level dedup with
+          provenance kept per copy.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ VARIANT C ═══════════════════ -->
+  <section class="variant">
+    <p class="eyebrow">Variant C · Presets tab</p>
+    <h2>Descriptions live in the tree</h2>
+    <p class="concept">
+      Attribution by placement instead of by label: each node in the Preset Resolution Tree shows
+      its
+      <strong>own</strong> description as a quote line beneath its name — the text appears exactly
+      where it was written, so no chips are needed. Nodes whose description was silently dropped by
+      Renovate (wrapper presets, the <code>ignoreDeps</code> quirk) say so, making the two invisible
+      drop rules visible for the first time.
+    </p>
+
+    <div class="shell">
+      <div class="shell-bar">
+        <span class="dots"><i></i><i></i><i></i></span> Presets — Resolution tree
+      </div>
+      <div class="card-title">
+        Preset resolution <span class="count">1,088 presets · 18 contribute descriptions</span>
+        <span class="seg"><span>compact</span><span class="on">describe</span></span>
+      </div>
+      <div class="overflow">
+        <div class="tree">
+          <div class="tnode">
+            <div class="row1">
+              <span class="name">(input config)</span><span class="meta">1 rule</span>
+            </div>
+          </div>
+          <div class="tnode d1">
+            <div class="row1">
+              <span class="name">config:best-practices</span><span class="meta">+1087 below</span>
+            </div>
+            <div class="desc">no own description — wrapper preset (Renovate drops it on merge)</div>
+          </div>
+          <div class="tnode d2">
+            <div class="row1">
+              <span class="name">config:recommended</span><span class="meta">+1077 below</span>
+            </div>
+          </div>
+          <div class="tnode d3 sel">
+            <div class="row1">
+              <span class="name">:dependencyDashboard</span><span class="meta">→ #1 of 24</span>
+            </div>
+            <div class="desc">Enable Renovate Dependency Dashboard creation.</div>
+          </div>
+          <div class="tnode d3">
+            <div class="row1">
+              <span class="name">:semanticPrefixFixDepsChoreOthers</span
+              ><span class="meta">→ #2 of 24</span>
+            </div>
+            <div class="desc">
+              Use semantic commit type <code>fix</code> for dependencies and <code>chore</code> for
+              all others…
+            </div>
+          </div>
+          <div class="tnode d3">
+            <div class="row1">
+              <span class="name">group:monorepos</span
+              ><span class="meta">→ #4 of 24 · +924 below</span>
+            </div>
+            <div class="desc">Group known monorepo packages together.</div>
+          </div>
+          <div class="tnode d2">
+            <div class="row1">
+              <span class="name">docker:pinDigests</span
+              ><span class="meta">→ #16 of 24 · 2 rules</span>
+            </div>
+            <div class="desc">Pin Docker digests.</div>
+          </div>
+          <div class="tnode d2">
+            <div class="row1">
+              <span class="name">security:minimumReleaseAgeNpm</span
+              ><span class="meta">→ #21 of 24 · 5 rules</span>
+            </div>
+            <div class="desc">
+              Wait until the npm package is three days old before raising the update…
+            </div>
+          </div>
+          <div class="tnode d1">
+            <div class="row1">
+              <span class="name">:dependencyDashboard</span
+              ><span class="meta">duplicate · → #23 of 24</span>
+            </div>
+            <div class="desc">Enable Renovate Dependency Dashboard creation.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="notes">
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Makes the tree self-documenting — 1,088 cryptic preset names become skimmable prose; the
+          <code>→ #16 of 24</code> marker ties each node to its slot in the final array (and links
+          back to Variant A's row).</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Only variant that can show the <em>dropped</em> descriptions at the node where the drop
+          happened.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag con">Con</span
+        ><span
+          >Answers "what does this node say?", not the reverse lookup "who wrote this string?" —
+          needs the array→tree jump from A/B to complete the loop. Adds vertical bulk to an already
+          huge tree (hence the describe/compact toggle).</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag data">Data</span
+        ><span
+          >Cheapest: node's own description is already in <code>input</code>; only the position
+          marker and drop detection need the attribution walk.</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ VARIANT D ═══════════════════ -->
+  <section class="variant">
+    <p class="eyebrow">Variant D · everywhere descriptions appear</p>
+    <h2>Attribution at point of contact — hover cards &amp; simulator verdicts</h2>
+    <p class="concept">
+      No new panel at all. Wherever a description string is already visible — the resolved JSON
+      document, a preset body, a simulator verdict — it becomes an attributed object: hovering any
+      string pops the app's standard hover card naming the contributing preset, its import path, and
+      its array position. In the simulator, a matched rule's author description is promoted to the
+      verdict itself: <strong>the rule explains why it exists</strong>.
+    </p>
+
+    <div class="shell" style="margin-bottom: 1rem">
+      <div class="shell-bar">
+        <span class="dots"><i></i><i></i><i></i></span> Effective config — As JSON
+      </div>
+      <div class="jsonpane">
+        <span class="jp">{</span><br />
+        &nbsp;&nbsp;<span class="jk">"description"</span><span class="jp">: [</span><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="js"
+          >"Enable Renovate Dependency Dashboard creation."</span
+        ><span class="jp">,</span><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="js hovered">"Pin Docker digests."</span
+        ><span class="jp">,</span><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="js">"Pin `github-action` digests."</span
+        ><span class="jp">,</span><br />
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="jp">…</span><br />
+        &nbsp;&nbsp;<span class="jp">],</span><br />
+        &nbsp;&nbsp;<span class="jk">"dependencyDashboard"</span><span class="jp">: true,</span
+        ><br />
+        <span class="jp">}</span>
+        <div class="option-card" style="right: 1.5rem; top: 2.2rem">
+          <div class="oc-head">
+            <span class="chip preset clickable">docker:pinDigests</span
+            ><span class="oc-name">wrote this description</span>
+          </div>
+          <div class="oc-path">
+            (input) › <b>config:best-practices</b> › <b>docker:pinDigests</b>
+          </div>
+          <div class="oc-row">Position 16 of 24 · also sets 2 packageRules</div>
+          <a class="oc-link">Show in preset tree →</a>
+        </div>
+        <span class="callout-tag" style="right: 0.6rem; top: 0.6rem">hover card</span>
+      </div>
+    </div>
+
+    <div class="shell">
+      <div class="shell-bar">
+        <span class="dots"><i></i><i></i><i></i></span> Simulator — react 17.0.0 → 19.0.0
+      </div>
+      <div class="verdict">
+        <div class="vrow">
+          <div class="vhead">
+            <span class="match">MATCHED</span><span class="rname">packageRules[312]</span
+            ><span class="chip preset clickable">security:minimumReleaseAgeNpm</span>
+          </div>
+          <div class="why">
+            “Wait until the npm package is three days old before raising the update. This introduces
+            a short delay to allow malware researchers and scanners to detect malicious
+            behaviour…”<br /><span class="attr">— author's description of this rule</span>
+          </div>
+          <div class="setline">sets minimumReleaseAge: "3 days"</div>
+        </div>
+        <div class="vrow">
+          <div class="vhead">
+            <span class="match">MATCHED</span><span class="rname">packageRules[726]</span
+            ><span class="chip repo">repo config</span>
+          </div>
+          <div class="why">
+            “Slow down risky major updates”<br /><span class="attr"
+              >— your description, packageRules[0] in renovate.json</span
+            >
+          </div>
+          <div class="setline">
+            sets minimumReleaseAge: "14 days"
+            <span style="color: var(--warn)">(overrides "3 days")</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="notes">
+      <div class="n">
+        <span class="tag pro">Pro</span
+        ><span
+          >Meets users where they already are; builds on the existing
+          <code>Explained</code>/option-card and chip→tree wiring, so it's mostly composition. The
+          simulator half turns descriptions into <em>answers</em> ("why is my update delayed 14
+          days?").</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag con">Con</span
+        ><span
+          >Hover-only provenance is invisible until discovered, and unavailable on touch; no single
+          place to read all descriptions at once.</span
+        >
+      </div>
+      <div class="n">
+        <span class="tag data">Data</span
+        ><span
+          >Same attribution walk; simulator half additionally joins rule provenance (already exists)
+          with each rule's own description (already in the rule body).</span
+        >
+      </div>
+    </div>
+  </section>
+
+  <!-- ═══════════════════ COMPARISON ═══════════════════ -->
+  <section class="variant">
+    <p class="eyebrow">Synthesis</p>
+    <h2>Comparison &amp; recommendation</h2>
+    <div class="cmp-wrap">
+      <table class="cmp">
+        <tr>
+          <th>Variant</th>
+          <th>Question it answers</th>
+          <th>Where</th>
+          <th>Build cost</th>
+          <th>Discoverability</th>
+        </tr>
+        <tr>
+          <td>A · Blame ledger</td>
+          <td>"Who wrote string #N, and why is it duplicated?"</td>
+          <td>Effective config → By key</td>
+          <td>Medium — new attribution walk + one expanded-row renderer</td>
+          <td>Medium (behind expand)</td>
+        </tr>
+        <tr>
+          <td>B · Behavior digest</td>
+          <td>"What does this config actually do?"</td>
+          <td>Overview (new card)</td>
+          <td>Medium — walk + grouping/dedup</td>
+          <td>High (front page)</td>
+        </tr>
+        <tr>
+          <td>C · Tree inline</td>
+          <td>"What does this preset say about itself?"</td>
+          <td>Preset tree (toggle)</td>
+          <td>Low — data already per-node</td>
+          <td>Medium</td>
+        </tr>
+        <tr>
+          <td>D · Point of contact</td>
+          <td>"Why does this string / this rule exist?"</td>
+          <td>JSON views + simulator</td>
+          <td>Low–medium — composes existing hover &amp; chip primitives</td>
+          <td>Low (hover) / High (simulator)</td>
+        </tr>
+      </table>
+    </div>
+    <div class="reco">
+      <p>
+        <b>Recommendation:</b> the variants share one engine primitive — the recursive per-string
+        attribution walk — and are otherwise independent surfaces. Build the walk once, then ship
+        <b>B as the flagship</b> (largest user value: it converts author intent into the config's
+        own documentation and exposes redundant extends), with
+        <b>A as its "show raw order" escape hatch</b> in the Effective Config row. C's quote-lines
+        and D's simulator verdicts are cheap follow-ups on the same data; D's hover card falls out
+        of the chip wiring A introduces.
+      </p>
+      <p style="color: var(--frame-muted); font-size: 0.85rem">
+        Every element above reuses existing app primitives: ProvenanceChip (purple = preset, blue =
+        repo config), the .kv ledger grid, the option-card hover, and the seg control — no new
+        visual vocabulary required.
+      </p>
+    </div>
+  </section>
+</div>


### PR DESCRIPTION
Recursive positional replay of Renovate's preset merge order turns the
flat resolved description array into per-string attributions: which
preset node wrote each entry, which top-level extend pulled it in,
duplicate marking, and the silently-dropped descriptions (wrapper
presets, package-list presets, ignoreDeps mute). Guards against
Renovate's in-process mutation of its internal preset table so results
are stable across runs. Roadmap 069, PR 1 of 5.