### PR TITLE
feat(app): Overview card summarizing what the config does

### DIFF
--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -60,7 +60,7 @@ export interface ResultsColumnProps {
   jumpToTab: (tab: ResultsTabId) => void;
   /** Consumed by: pipeline (rewrite-count crosslink), rewrites. */
   migrateSteps: TraceEvent[];
-  /** Consumed by: effective, simulator. */
+  /** Consumed by: overview (069's digest card), effective, simulator. */
   selectPresetNode: (nodeId: string) => void;
   /** Consumed by: simulator, problems. */
   focusEditorRepoIndex: (repoIndex: number) => void;
@@ -250,10 +250,12 @@ export function ResultsColumn({
     return {
       overview: (
         <OverviewTab
+          result={result}
           digest={digest}
           banner={validateHasErrors ? <HypotheticalBanner /> : null}
           onOpen={jumpToTab}
           onWhereFrom={onWhereFrom}
+          onSelectPreset={selectPresetNode}
         />
       ),
       pipeline: (

--- a/packages/app/src/components/DescriptionApprox.tsx
+++ b/packages/app/src/components/DescriptionApprox.tsx
@@ -1,0 +1,46 @@
+import { approximateTitle } from "./description-approx";
+
+/**
+ * Roadmap 069: the shared marks for the engine's *approximate* attribution —
+ * one `≈`, one caveat paragraph, one wording (`description-approx.ts`).
+ *
+ * The engine self-checks its positional replay against Renovate's own resolved
+ * array, and where the two disagree it degrades the subtree to its enclosing
+ * node rather than guessing a leaf (069 PR 1). Every surface that renders an
+ * attribution therefore has to render that caveat too — the Overview's "What
+ * this config does" card here, the Effective config's per-string blame ledger a
+ * layer up (PR 3), the preset tree's inline descriptions after it (PR 4).
+ *
+ * They must say the SAME thing: a reader who learns what `≈` means on one
+ * surface must not meet a differently-worded hedge on the next, and a wording
+ * that drifts in one copy is a wording that lies in the other. Hence one module
+ * both surfaces import, and one `desc-approx-*` CSS family behind it.
+ */
+
+/**
+ * The standalone `≈`, for a row that has no leaf label to prefix.
+ *
+ * Not an optional flourish: {@link DegradedCaveat} promises that every
+ * untraceable sentence is marked, and a row whose attribution is the root node
+ * or one of the tree-less layers has no label to carry the mark — without this
+ * it would read as confidently attributed while being exactly the case the
+ * caveat is about.
+ */
+export function ApproximateMark({ name }: { name?: string }) {
+  return (
+    <span className="desc-approx-mark" title={approximateTitle(name)}>
+      <span aria-hidden="true">≈</span>
+      <span className="visually-hidden">approximate attribution</span>
+    </span>
+  );
+}
+
+/** The paragraph a degraded run carries, wherever attributions are listed. */
+export function DegradedCaveat() {
+  return (
+    <p className="desc-approx-caveat">
+      Some sentences could not be traced to the exact preset that wrote them — those are marked with
+      the enclosing preset and a <code>≈</code>. The wording and the order are still Renovate’s own.
+    </p>
+  );
+}

--- a/packages/app/src/components/DescriptionDigestCard.test.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Roadmap 069 (PR 2): the card end to end, over a real (offline) run — the
+ * grouping logic has its own unit tests, so this covers only what those cannot:
+ * that the engine's attribution reaches the DOM, that a preset extended twice
+ * is called out as redundant instead of repeating itself, that the user's own
+ * `packageRules` description surfaces at all (it has no other home in the app),
+ * and that a leaf label really selects its node in the resolution tree.
+ */
+import { runPipeline } from "@renovate-config-debugger/engine";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { DescriptionDigestCard } from "./DescriptionDigestCard";
+
+afterEach(cleanup);
+
+// Internal presets resolve with no network, so this whole run is offline.
+// `:dependencyDashboard` twice is the redundancy case the card exists to name.
+const CONFIG = {
+  extends: [":dependencyDashboard", ":dependencyDashboard"],
+  description: "My own summary.",
+  packageRules: [
+    {
+      description: "Slow down risky major updates",
+      matchUpdateTypes: ["major"],
+      minimumReleaseAge: "14 days",
+    },
+  ],
+};
+
+it("renders the descriptions grouped by extend, with the user's rules", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(CONFIG),
+  });
+  const onSelectPreset = vi.fn();
+  const view = render(<DescriptionDigestCard result={result} onSelectPreset={onSelectPreset} />);
+
+  // Provenance is loaded through the engine's dynamic import, so nothing is
+  // painted on the first commit.
+  await waitFor(() => expect(view.queryByText("What this config does")).not.toBeNull());
+
+  // The preset's own sentence, attributed to the node that wrote it. By title,
+  // not by name: the group's ProvenanceChip carries the same preset name (and
+  // the same button role) one row above, which is the point of both.
+  const leaf = view.getByTitle(":dependencyDashboard", { exact: false });
+  expect(view.getByText("Enable Renovate Dependency Dashboard creation.")).toBeTruthy();
+  // …and the second extend of the same preset, which bought nothing.
+  expect(view.getByText("redundant — already included above")).toBeTruthy();
+
+  // The repo's own top-level description and its rule description — the latter
+  // reaching a surface for the first time.
+  expect(view.getByText("My own summary.")).toBeTruthy();
+  expect(view.getByText("Slow down risky major updates")).toBeTruthy();
+  expect(view.getByText("packageRules[0] — matchUpdateTypes → minimumReleaseAge")).toBeTruthy();
+
+  // The leaf label is the tree jump, exactly like the effective config's chips.
+  fireEvent.click(leaf);
+  expect(onSelectPreset).toHaveBeenCalledTimes(1);
+});
+
+it("renders nothing when the config has no descriptions at all", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ automerge: true }),
+  });
+  const view = render(<DescriptionDigestCard result={result} />);
+
+  await waitFor(() => expect(view.container.querySelector(".desc-digest-card")).toBeNull());
+  expect(view.container.textContent).toBe("");
+});

--- a/packages/app/src/components/DescriptionDigestCard.test.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.test.tsx
@@ -4,14 +4,65 @@
  * that the engine's attribution reaches the DOM, that a preset extended twice
  * is called out as redundant instead of repeating itself, that the user's own
  * `packageRules` description surfaces at all (it has no other home in the app),
- * and that a leaf label really selects its node in the resolution tree.
+ * that a leaf label really selects its node in the resolution tree, and that a
+ * group stays expanded across a re-run.
  */
-import { runPipeline } from "@renovate-config-debugger/engine";
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+} from "@renovate-config-debugger/engine";
+import { runPipeline, type TraceResult } from "@renovate-config-debugger/engine";
+import type * as DescriptionProvenanceHook from "@/hooks/description-provenance";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { DescriptionDigestCard } from "./DescriptionDigestCard";
+import { ROOT_NODE_ID } from "./preset-tree-stats";
 
-afterEach(cleanup);
+/**
+ * The engine's degraded fallback cannot be provoked from a real config — it
+ * fires only where Renovate's own resolved array contradicts the positional
+ * replay — and neither can a `description` holding a non-string, without
+ * asserting on a validation warning this card knows nothing about. So the hook
+ * is WRAPPED rather than replaced: it always runs (the tests below that want
+ * the real thing get it), and a registered stub overrides what it returned.
+ */
+const stub = vi.hoisted(() => ({
+  active: false,
+  value: undefined as DescriptionProvenance | null | undefined,
+}));
+
+vi.mock("@/hooks/description-provenance", async (importOriginal) => {
+  const actual = await importOriginal<typeof DescriptionProvenanceHook>();
+  return {
+    useDescriptionProvenance: (result: TraceResult | null | undefined) => {
+      const real = actual.useDescriptionProvenance(result);
+      return stub.active ? stub.value : real;
+    },
+  };
+});
+
+/** Renders the card over hand-built provenance, with no run behind it. */
+function renderStubbed(provenance: Partial<DescriptionProvenance>) {
+  const entries = provenance.entries ?? [];
+  const unattributed = provenance.unattributed ?? [];
+  stub.active = true;
+  stub.value = {
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+    finalLength: entries.length + unattributed.length,
+    ...provenance,
+    entries,
+    unattributed,
+  };
+  return render(<DescriptionDigestCard result={{} as TraceResult} />);
+}
+
+afterEach(() => {
+  stub.active = false;
+  stub.value = undefined;
+  cleanup();
+});
 
 // Internal presets resolve with no network, so this whole run is offline.
 // `:dependencyDashboard` twice is the redundancy case the card exists to name.
@@ -73,4 +124,92 @@ it("renders nothing when the config has no descriptions at all", async () => {
 
   await waitFor(() => expect(view.container.querySelector(".desc-digest-card")).toBeNull());
   expect(view.container.textContent).toBe("");
+});
+
+function run(config: object) {
+  return runPipeline({ fileName: "renovate.json", content: JSON.stringify(config) });
+}
+
+/** One entry of the engine's `entries`, in the shape the card consumes. */
+function entry(index: number, value: string, rest: Partial<DescriptionAttribution>) {
+  return { index, value, viaTopLevel: { kind: "repo" }, ...rest } satisfies DescriptionAttribution;
+}
+
+it("marks every approximate sentence, including the ones with no leaf to label", async () => {
+  // The caveat at the foot of the card promises that untraceable sentences are
+  // marked. The `≈` used to live only on the leaf label — so a fallback landing
+  // on the ROOT node (no tree row, hence no label) or on a layer with no preset
+  // tree at all (global/inherited/defaults) read as confidently attributed,
+  // which is the opposite of what the run knows.
+  const view = renderStubbed({
+    degraded: true,
+    entries: [
+      entry(0, "From the bot.", { viaTopLevel: { kind: "global" }, approximate: true }),
+      entry(1, "My own summary.", {
+        node: { nodeId: ROOT_NODE_ID, name: "(input config)" },
+        approximate: true,
+      }),
+      entry(2, "Pin Docker digests.", {
+        viaTopLevel: { kind: "preset", nodeId: "p1", name: "config:best-practices" },
+        node: { nodeId: "p1", name: "config:best-practices" },
+        approximate: true,
+      }),
+    ],
+  });
+
+  await waitFor(() => expect(view.queryByText("What this config does")).not.toBeNull());
+
+  // Two standalone marks — the tree-less layer and the root node — each
+  // carrying the same explanation the leaf label's own `≈` carries.
+  const marks = view.container.querySelectorAll(".desc-approx-mark");
+  expect(marks).toHaveLength(2);
+  for (const mark of marks) {
+    expect(mark.getAttribute("title")).toContain("could not be determined");
+  }
+  // …and the entry that DOES have a leaf keeps carrying the mark on the label.
+  expect(view.getByText("≈ config:best-practices")).toBeTruthy();
+  expect(view.container.querySelector(".desc-approx-caveat")).not.toBeNull();
+});
+
+it("names the array members that are not text instead of dropping them", async () => {
+  // `{"description": ["Keep this.", 42]}` resolves — Renovate warns and keeps
+  // the 42 — so a card titled "What this config does" would otherwise summarize
+  // half an array without saying so.
+  const view = renderStubbed({
+    entries: [entry(0, "Keep this.", { node: { nodeId: ROOT_NODE_ID, name: "(input config)" } })],
+    unattributed: [{ index: 1, value: 42 }],
+  });
+
+  await waitFor(() => expect(view.queryByText("What this config does")).not.toBeNull());
+  expect(
+    view.getByText(
+      "1 member of the description array is not text, so no preset can be credited with it.",
+    ),
+  ).toBeTruthy();
+});
+
+it("keeps a group expanded across a re-run", async () => {
+  // Provenance is loaded asynchronously, so every re-run has a frame with no
+  // digest at all. "Show all" therefore cannot live inside the groups — they
+  // unmount in that gap, and the expansion a reader made before an edit would
+  // be undone by the edit. `config:best-practices` contributes far more than
+  // the collapse threshold, which is what makes the button exist.
+  const first = await run({ extends: ["config:best-practices"] });
+  const view = render(<DescriptionDigestCard result={first} />);
+
+  const showAll = await waitFor(() => view.getByText(/more — show all/));
+  fireEvent.click(showAll);
+  const expandedRows = view.container.querySelectorAll(".desc-digest-row").length;
+  expect(expandedRows).toBeGreaterThan(5);
+  expect(view.queryByText(/more — show all/)).toBeNull();
+
+  // A new run of a config whose descriptions are identical — the next keystroke.
+  const second = await run({ extends: ["config:best-practices"], automerge: true });
+  view.rerender(<DescriptionDigestCard result={second} />);
+
+  // The gap is real — without it this test would prove nothing.
+  expect(view.container.querySelector(".desc-digest-card")).toBeNull();
+  await waitFor(() => expect(view.container.querySelector(".desc-digest-card")).not.toBeNull());
+  expect(view.container.querySelectorAll(".desc-digest-row")).toHaveLength(expandedRows);
+  expect(view.queryByText(/more — show all/)).toBeNull();
 });

--- a/packages/app/src/components/DescriptionDigestCard.test.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.test.tsx
@@ -48,10 +48,16 @@ it("renders the descriptions grouped by extend, with the user's rules", async ()
   expect(view.getByText("redundant — already included above")).toBeTruthy();
 
   // The repo's own top-level description and its rule description — the latter
-  // reaching a surface for the first time.
+  // reaching a surface for the first time. The rule is cited by its index in
+  // the USER's config, which is where the reader can act on it.
   expect(view.getByText("My own summary.")).toBeTruthy();
   expect(view.getByText("Slow down risky major updates")).toBeTruthy();
   expect(view.getByText("packageRules[0] — matchUpdateTypes → minimumReleaseAge")).toBeTruthy();
+
+  // The repo's own sentence is written by the root node, which has no row in
+  // the preset tree — so it gets no leaf label offering to jump there.
+  expect(view.queryByText("(input config)")).toBeNull();
+  expect(view.queryByTitle("(input config)", { exact: false })).toBeNull();
 
   // The leaf label is the tree jump, exactly like the effective config's chips.
   fireEvent.click(leaf);

--- a/packages/app/src/components/DescriptionDigestCard.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/description-digest";
 import { useDescriptionProvenance } from "@/hooks/description-provenance";
 import { CodeText } from "./CodeText";
+import { ROOT_NODE_ID } from "./preset-tree-stats";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { layerClass } from "./provenance-layer";
 
@@ -84,18 +85,19 @@ function DigestEntryRow({
   onSelectPreset?: (nodeId: string) => void;
 }) {
   const duplicate = entry.duplicateOfIndex !== undefined;
+  // The root node is the repo's own config, and the tree has no row for it —
+  // a leaf label there would offer "show it in the preset tree" and select a
+  // node that never renders. The group's own `repo config` chip already says
+  // whose sentence this is, so the row simply carries no label.
+  const leaf = entry.node?.nodeId === ROOT_NODE_ID ? undefined : entry.node;
   return (
     <li className={`desc-digest-row${duplicate ? " duplicate" : ""}`}>
       <span className={`prov-dot ${dotClass}`} aria-hidden="true" />
       <span className="desc-digest-text">
         <CodeText text={entry.value} />
       </span>
-      {entry.node ? (
-        <LeafLabel
-          node={entry.node}
-          approximate={entry.approximate}
-          onSelectPreset={onSelectPreset}
-        />
+      {leaf ? (
+        <LeafLabel node={leaf} approximate={entry.approximate} onSelectPreset={onSelectPreset} />
       ) : null}
     </li>
   );
@@ -125,6 +127,11 @@ function DigestEntryList({
   dotClass: string;
   onSelectPreset?: (nodeId: string) => void;
 }) {
+  // Survives a re-run, and must therefore never end up on a DIFFERENT preset:
+  // the card stays mounted while every keystroke produces a new run, so this
+  // state follows whatever `DigestGroup.key` React reconciles it onto — which
+  // is why that key is name-based rather than node-id-based (the ids are
+  // minted per run).
   const [expanded, setExpanded] = useState(false);
   const hidden = expanded ? 0 : Math.max(0, group.entries.length - COLLAPSE_AFTER);
   const shown = hidden > 0 ? group.entries.slice(0, COLLAPSE_AFTER) : group.entries;

--- a/packages/app/src/components/DescriptionDigestCard.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.tsx
@@ -1,16 +1,20 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { TraceResult } from "@renovate-config-debugger/engine";
 import {
   buildDescriptionDigest,
+  type DescriptionDigest,
   descriptionCountText,
   type DigestEntry,
   type DigestGroup,
   type DigestRule,
   groupContributionText,
   ruleNoteText,
+  unattributedNoteText,
 } from "@/lib/description-digest";
 import { useDescriptionProvenance } from "@/hooks/description-provenance";
 import { CodeText } from "./CodeText";
+import { approximateTitle } from "./description-approx";
+import { ApproximateMark, DegradedCaveat } from "./DescriptionApprox";
 import { ROOT_NODE_ID } from "./preset-tree-stats";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { layerClass } from "./provenance-layer";
@@ -53,7 +57,7 @@ function LeafLabel({
 }) {
   const label = approximate ? `≈ ${node.name}` : node.name;
   const title = approximate
-    ? `Contributed somewhere inside ${node.name} — the exact preset could not be determined`
+    ? approximateTitle(node.name)
     : `Written by ${node.name} — show it in the preset tree`;
   if (!onSelectPreset) {
     return (
@@ -74,6 +78,37 @@ function LeafLabel({
   );
 }
 
+/**
+ * The right-hand end of a row: who wrote the sentence, and how sure we are.
+ *
+ * The two are separable, and must be. `approximate` is rendered by the leaf
+ * label as a `≈` prefix, but a row can be approximate and still have no leaf to
+ * prefix — the engine's fallback lands on the ROOT node whenever the repo
+ * level's own replay disagrees with Renovate, and the defaults/global/inherited
+ * layers carry no node at all. Marking only the labelled rows would leave those
+ * reading as confidently attributed while the card's caveat promises that every
+ * untraceable sentence is marked, so the mark stands alone where it has to.
+ */
+function EntryAttribution({
+  entry,
+  onSelectPreset,
+}: {
+  entry: DigestEntry;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  // The root node is the repo's own config, and the tree has no row for it —
+  // a leaf label there would offer "show it in the preset tree" and select a
+  // node that never renders. The group's own `repo config` chip already says
+  // whose sentence this is, so the row simply carries no label.
+  const leaf = entry.node?.nodeId === ROOT_NODE_ID ? undefined : entry.node;
+  if (leaf) {
+    return (
+      <LeafLabel node={leaf} approximate={entry.approximate} onSelectPreset={onSelectPreset} />
+    );
+  }
+  return entry.approximate ? <ApproximateMark /> : null;
+}
+
 /** One sentence: the layer's dot, the prose, and who wrote it. */
 function DigestEntryRow({
   entry,
@@ -85,20 +120,13 @@ function DigestEntryRow({
   onSelectPreset?: (nodeId: string) => void;
 }) {
   const duplicate = entry.duplicateOfIndex !== undefined;
-  // The root node is the repo's own config, and the tree has no row for it —
-  // a leaf label there would offer "show it in the preset tree" and select a
-  // node that never renders. The group's own `repo config` chip already says
-  // whose sentence this is, so the row simply carries no label.
-  const leaf = entry.node?.nodeId === ROOT_NODE_ID ? undefined : entry.node;
   return (
     <li className={`desc-digest-row${duplicate ? " duplicate" : ""}`}>
       <span className={`prov-dot ${dotClass}`} aria-hidden="true" />
       <span className="desc-digest-text">
         <CodeText text={entry.value} />
       </span>
-      {leaf ? (
-        <LeafLabel node={leaf} approximate={entry.approximate} onSelectPreset={onSelectPreset} />
-      ) : null}
+      <EntryAttribution entry={entry} onSelectPreset={onSelectPreset} />
     </li>
   );
 }
@@ -121,18 +149,17 @@ function DigestRuleRow({ rule, dotClass }: { rule: DigestRule; dotClass: string 
 function DigestEntryList({
   group,
   dotClass,
+  expanded,
+  onExpand,
   onSelectPreset,
 }: {
   group: DigestGroup;
   dotClass: string;
+  /** Owned by the card, not by this list — see {@link DescriptionDigestCard}. */
+  expanded: boolean;
+  onExpand: () => void;
   onSelectPreset?: (nodeId: string) => void;
 }) {
-  // Survives a re-run, and must therefore never end up on a DIFFERENT preset:
-  // the card stays mounted while every keystroke produces a new run, so this
-  // state follows whatever `DigestGroup.key` React reconciles it onto — which
-  // is why that key is name-based rather than node-id-based (the ids are
-  // minted per run).
-  const [expanded, setExpanded] = useState(false);
   const hidden = expanded ? 0 : Math.max(0, group.entries.length - COLLAPSE_AFTER);
   const shown = hidden > 0 ? group.entries.slice(0, COLLAPSE_AFTER) : group.entries;
   return (
@@ -147,7 +174,7 @@ function DigestEntryList({
       ))}
       {hidden > 0 ? (
         <li className="desc-digest-more">
-          <button type="button" className="linklike" onClick={() => setExpanded(true)}>
+          <button type="button" className="linklike" onClick={onExpand}>
             {hidden} more — show all
           </button>
         </li>
@@ -179,9 +206,13 @@ function DigestGroupHead({
 
 function DigestGroupBlock({
   group,
+  expanded,
+  onExpand,
   onSelectPreset,
 }: {
   group: DigestGroup;
+  expanded: boolean;
+  onExpand: (key: string) => void;
   onSelectPreset?: (nodeId: string) => void;
 }) {
   // Same hue the layer wears everywhere else in the app (005/013/054): the dot
@@ -194,7 +225,13 @@ function DigestGroupBlock({
       {/* A redundant group's sentences are all repeats — the chip already said
           so, and printing them again is the noise this card exists to remove. */}
       {group.redundant ? null : (
-        <DigestEntryList group={group} dotClass={dotClass} onSelectPreset={onSelectPreset} />
+        <DigestEntryList
+          group={group}
+          dotClass={dotClass}
+          expanded={expanded}
+          onExpand={() => onExpand(group.key)}
+          onSelectPreset={onSelectPreset}
+        />
       )}
       {group.rules.length > 0 ? (
         <ul className={`desc-digest-list ${dotClass}`}>
@@ -204,6 +241,18 @@ function DigestGroupBlock({
         </ul>
       ) : null}
     </div>
+  );
+}
+
+/** What the groups above could not say: the array members that are not text,
+ *  and the caveat a degraded run carries. */
+function DigestFootnotes({ digest }: { digest: DescriptionDigest }) {
+  const note = unattributedNoteText(digest);
+  return (
+    <>
+      {note ? <p className="desc-digest-aside">{note}</p> : null}
+      {digest.degraded ? <DegradedCaveat /> : null}
+    </>
   );
 }
 
@@ -217,6 +266,18 @@ export function DescriptionDigestCard({
   onSelectPreset?: (nodeId: string) => void;
 }) {
   const provenance = useDescriptionProvenance(result);
+  // "Show all", per group, owned HERE rather than by the list that renders the
+  // button. Provenance for a new run arrives asynchronously, so every re-run
+  // has a frame with no digest at all — the groups (and any state living inside
+  // them) unmount, and an expansion made before an edit would be lost across
+  // every keystroke. This component is the one the parent keeps mounted through
+  // that gap. Keyed by `DigestGroup.key`, which is stable across runs BY
+  // CONSTRUCTION (`stableLayerKey`) precisely so the state cannot reattach to a
+  // different preset when node ids are minted afresh.
+  const [expanded, setExpanded] = useState<ReadonlyMap<string, boolean>>(() => new Map());
+  const expand = useCallback((key: string) => {
+    setExpanded((prev) => new Map(prev).set(key, true));
+  }, []);
   const digest = useMemo(() => {
     if (!provenance) {
       return null;
@@ -240,16 +301,16 @@ export function DescriptionDigestCard({
       </div>
       <div className="desc-digest">
         {digest.groups.map((group) => (
-          <DigestGroupBlock key={group.key} group={group} onSelectPreset={onSelectPreset} />
+          <DigestGroupBlock
+            key={group.key}
+            group={group}
+            expanded={expanded.get(group.key) ?? false}
+            onExpand={expand}
+            onSelectPreset={onSelectPreset}
+          />
         ))}
       </div>
-      {digest.degraded ? (
-        <p className="desc-digest-caveat">
-          Some sentences could not be traced to the exact preset that wrote them — those are marked
-          with the enclosing preset and a <code>≈</code>. The wording and the order are still
-          Renovate’s own.
-        </p>
-      ) : null}
+      <DigestFootnotes digest={digest} />
     </div>
   );
 }

--- a/packages/app/src/components/DescriptionDigestCard.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.tsx
@@ -1,0 +1,248 @@
+import { useMemo, useState } from "react";
+import type { TraceResult } from "@renovate-config-debugger/engine";
+import {
+  buildDescriptionDigest,
+  descriptionCountText,
+  type DigestEntry,
+  type DigestGroup,
+  type DigestRule,
+  groupContributionText,
+  ruleNoteText,
+} from "@/lib/description-digest";
+import { useDescriptionProvenance } from "@/hooks/description-provenance";
+import { CodeText } from "./CodeText";
+import { ProvenanceChip } from "./ProvenanceChip";
+import { layerClass } from "./provenance-layer";
+
+/**
+ * Roadmap 069 (PR 2): "What this config does" — the Overview's second card, and
+ * the flagship surface of the description feature.
+ *
+ * Every preset carries a sentence its author wrote about what it does, and the
+ * resolved config carries all of them concatenated into one anonymous array.
+ * Read end to end they are the best plain-English answer to "what did I just
+ * extend"; grouped by the `extends` entry that pulled each one in, they also
+ * answer "which preset do I remove to stop doing that" — the same question.
+ *
+ * Everything visible here is derived: the grouping and the counts by
+ * `buildDescriptionDigest` (headless, so the CLI can quote it), the attribution
+ * by the engine's `computeDescriptionProvenance`. The card renders it and
+ * nothing else — every chip and leaf label selects its node in the preset tree,
+ * exactly as the effective config's chips do.
+ */
+
+/** Entries shown before a group collapses. Five is the mockup's number, and it
+ *  is the point where the list stops reading as a summary: `config:recommended`
+ *  alone contributes twenty-odd sentences, and twenty sentences pushed the
+ *  question pills — and every other card — below the fold. */
+const COLLAPSE_AFTER = 5;
+
+/** The mono leaf label: the preset that actually wrote this sentence, which is
+ *  rarely the extend it arrived through. Clickable for the same reason the
+ *  chips are — the name is only useful if it takes you to the node. */
+function LeafLabel({
+  node,
+  approximate,
+  onSelectPreset,
+}: {
+  node: { nodeId: string; name: string };
+  /** 069 PR 1's fallback: the enclosing subtree, not a leaf claim. */
+  approximate?: boolean;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const label = approximate ? `≈ ${node.name}` : node.name;
+  const title = approximate
+    ? `Contributed somewhere inside ${node.name} — the exact preset could not be determined`
+    : `Written by ${node.name} — show it in the preset tree`;
+  if (!onSelectPreset) {
+    return (
+      <span className="desc-digest-leaf" title={title}>
+        {label}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className="desc-digest-leaf"
+      title={title}
+      onClick={() => onSelectPreset(node.nodeId)}
+    >
+      {label}
+    </button>
+  );
+}
+
+/** One sentence: the layer's dot, the prose, and who wrote it. */
+function DigestEntryRow({
+  entry,
+  dotClass,
+  onSelectPreset,
+}: {
+  entry: DigestEntry;
+  dotClass: string;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const duplicate = entry.duplicateOfIndex !== undefined;
+  return (
+    <li className={`desc-digest-row${duplicate ? " duplicate" : ""}`}>
+      <span className={`prov-dot ${dotClass}`} aria-hidden="true" />
+      <span className="desc-digest-text">
+        <CodeText text={entry.value} />
+      </span>
+      {entry.node ? (
+        <LeafLabel
+          node={entry.node}
+          approximate={entry.approximate}
+          onSelectPreset={onSelectPreset}
+        />
+      ) : null}
+    </li>
+  );
+}
+
+/** A repo `packageRules` description — prose the user wrote, which until now
+ *  had no surface at all in the app. */
+function DigestRuleRow({ rule, dotClass }: { rule: DigestRule; dotClass: string }) {
+  return (
+    <li className="desc-digest-row">
+      <span className={`prov-dot ${dotClass}`} aria-hidden="true" />
+      <span className="desc-digest-text">
+        <CodeText text={rule.values.join(" ")} />
+      </span>
+      <span className="desc-digest-rule-note">{ruleNoteText(rule)}</span>
+    </li>
+  );
+}
+
+/** The group's sentences, collapsed past {@link COLLAPSE_AFTER}. */
+function DigestEntryList({
+  group,
+  dotClass,
+  onSelectPreset,
+}: {
+  group: DigestGroup;
+  dotClass: string;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hidden = expanded ? 0 : Math.max(0, group.entries.length - COLLAPSE_AFTER);
+  const shown = hidden > 0 ? group.entries.slice(0, COLLAPSE_AFTER) : group.entries;
+  return (
+    <ul className={`desc-digest-list ${dotClass}`}>
+      {shown.map((entry) => (
+        <DigestEntryRow
+          key={entry.index}
+          entry={entry}
+          dotClass={dotClass}
+          onSelectPreset={onSelectPreset}
+        />
+      ))}
+      {hidden > 0 ? (
+        <li className="desc-digest-more">
+          <button type="button" className="linklike" onClick={() => setExpanded(true)}>
+            {hidden} more — show all
+          </button>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+/** The chip line above a group — the extend as the reader wrote it, plus what
+ *  it bought them (or the fact that it bought them nothing). */
+function DigestGroupHead({
+  group,
+  onSelectPreset,
+}: {
+  group: DigestGroup;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const note = groupContributionText(group);
+  return (
+    <div className="desc-digest-group-head">
+      <ProvenanceChip layer={group.layer} onSelectPreset={onSelectPreset} />
+      {group.redundant ? (
+        <span className="badge desc-digest-redundant">redundant — already included above</span>
+      ) : null}
+      {note ? <span className="desc-digest-note">{note}</span> : null}
+    </div>
+  );
+}
+
+function DigestGroupBlock({
+  group,
+  onSelectPreset,
+}: {
+  group: DigestGroup;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  // Same hue the layer wears everywhere else in the app (005/013/054): the dot
+  // IS the chip's colour, so the group and its sentences can never disagree
+  // about where they came from.
+  const dotClass = layerClass(group.layer);
+  return (
+    <div className="desc-digest-group">
+      <DigestGroupHead group={group} onSelectPreset={onSelectPreset} />
+      {/* A redundant group's sentences are all repeats — the chip already said
+          so, and printing them again is the noise this card exists to remove. */}
+      {group.redundant ? null : (
+        <DigestEntryList group={group} dotClass={dotClass} onSelectPreset={onSelectPreset} />
+      )}
+      {group.rules.length > 0 ? (
+        <ul className={`desc-digest-list ${dotClass}`}>
+          {group.rules.map((rule) => (
+            <DigestRuleRow key={rule.ruleIndex} rule={rule} dotClass={dotClass} />
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export function DescriptionDigestCard({
+  result,
+  onSelectPreset,
+}: {
+  result: TraceResult;
+  /** Selects a node in the Preset Resolution Tree — the same callback the
+   *  effective config hands its chips (App's `selectPresetNode`). */
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const provenance = useDescriptionProvenance(result);
+  const digest = useMemo(() => {
+    if (!provenance) {
+      return null;
+    }
+    const rules = result.finalConfig?.packageRules;
+    return buildDescriptionDigest(provenance, Array.isArray(rules) ? rules : null);
+  }, [provenance, result]);
+
+  // No card at all while it is loading, unavailable, or empty: a config with no
+  // author prose has nothing to say here, and an empty card would still promise
+  // that it does.
+  if (!digest) {
+    return null;
+  }
+
+  return (
+    <div className="card desc-digest-card">
+      <div className="card-title">
+        What this config does
+        <span className="desc-digest-count">{descriptionCountText(digest.totals)}</span>
+      </div>
+      <div className="desc-digest">
+        {digest.groups.map((group) => (
+          <DigestGroupBlock key={group.key} group={group} onSelectPreset={onSelectPreset} />
+        ))}
+      </div>
+      {digest.degraded ? (
+        <p className="desc-digest-caveat">
+          Some sentences could not be traced to the exact preset that wrote them — those are marked
+          with the enclosing preset and a <code>≈</code>. The wording and the order are still
+          Renovate’s own.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -21,7 +21,7 @@ import { OptionKey } from "./option-docs";
 import { ConfigJson } from "./ConfigJson";
 import { CopyButton } from "./CopyButton";
 import { ProvenanceChip } from "./ProvenanceChip";
-import { layerId, layerLabel, type LayerId } from "./provenance-layer";
+import { layerId, layerLabel, type LayerId, layerNodeKey } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
 // Roadmap 069 hoisted this out of here: the description digest prints the same
 // one-line matcher summary, and one spelling of it is enough.
@@ -120,14 +120,6 @@ const VERBS: Record<ProvenanceStep["action"], string> = {
  *  produces — a key exists in this view because some layer set it. */
 function winningStep(entry: KeyProvenance): ProvenanceStep | undefined {
   return entry.chain.findLast((s) => !s.noop) ?? entry.chain.at(-1);
-}
-
-/** React key for an override-chain row (roadmap 041). Each layer contributes at
- *  most one step to a key's chain, and preset node ids are unique across the
- *  tree — so this is a genuine identity even when two `extends` entries resolve
- *  to presets with the same NAME (which `layerId` deliberately conflates). */
-function stepKey(step: ProvenanceStep): string {
-  return step.layer.kind === "preset" ? `preset:${step.layer.nodeId}` : step.layer.kind;
 }
 
 /** Non-no-op layers that contributed to a key, for the layer filter. */
@@ -390,8 +382,11 @@ function KeyRow({
           <div className="prov-chain-title">
             Override chain ({visibleSteps.length} step{visibleSteps.length === 1 ? "" : "s"})
           </div>
+          {/* Each layer contributes at most one step to a key's chain, so the
+              layer's NODE identity is a genuine key here (roadmap 041) — and
+              the rows are rebuilt per run, so per-run node ids are fine. */}
           {visibleSteps.map((step) => (
-            <Step key={stepKey(step)} step={step} onSelectPreset={onSelectPreset} />
+            <Step key={layerNodeKey(step.layer)} step={step} onSelectPreset={onSelectPreset} />
           ))}
         </div>
       ) : null}

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -23,6 +23,9 @@ import { CopyButton } from "./CopyButton";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { layerId, layerLabel, type LayerId } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
+// Roadmap 069 hoisted this out of here: the description digest prints the same
+// one-line matcher summary, and one spelling of it is enough.
+import { summarizeRuleSelectors } from "@/lib/rule-selectors";
 import { RuleFramingText } from "./rule-framing";
 
 /**
@@ -222,19 +225,6 @@ function Step({
       </pre>
     </div>
   );
-}
-
-/** First matcher-clause key list, for a one-line rule summary (mirrors the
- *  simulator's ruleLabel — all clauses, no "which one matters" judgment
- *  since this view has no dependency to evaluate against). */
-function summarizeRuleSelectors(rule: unknown): string {
-  if (typeof rule !== "object" || rule === null) {
-    return "(not an object)";
-  }
-  const keys = Object.keys(rule as Record<string, unknown>).filter(
-    (k) => k.startsWith("match") || k.startsWith("exclude"),
-  );
-  return keys.length > 0 ? keys.join(" + ") : "(no match*/exclude* selectors)";
 }
 
 /** Roadmap 013: per-entry provenance for `packageRules` — which layer (repo /

--- a/packages/app/src/components/OverviewTab.tsx
+++ b/packages/app/src/components/OverviewTab.tsx
@@ -1,7 +1,9 @@
 import { memo, type ReactNode } from "react";
+import type { TraceResult } from "@renovate-config-debugger/engine";
 import type { ResultsTabId } from "@/data/results-tabs";
 import type { DigestClause } from "@/lib/run-digest";
 import { CodeText } from "./CodeText";
+import { DescriptionDigestCard } from "./DescriptionDigestCard";
 
 /**
  * Roadmap 029: the run digest — the whole run as one paragraph of prose whose
@@ -75,22 +77,31 @@ function QuestionPills({
 // Roadmap 032: memoized — the digest and its pills change only per run, so
 // the landing tab must not re-render per keystroke with them.
 export const OverviewTab = memo(function OverviewTab({
+  result,
   digest,
   banner,
   onOpen,
   onWhereFrom,
+  onSelectPreset,
 }: {
+  /** Roadmap 069: the run the "What this config does" card reads its
+   *  descriptions off. Per-run identity, so the memo still bails on keystrokes. */
+  result: TraceResult;
   digest: DigestClause[];
   /** The 023 hypothetical-run banner, when validation reported errors. */
   banner?: ReactNode;
   onOpen: (tab: ResultsTabId) => void;
   /** Opens Effective config AND focuses its filter input. */
   onWhereFrom: () => void;
+  /** Selects a preset node in the resolution tree — the digest card's chips
+   *  and leaf labels, wired exactly like the effective config's (013). */
+  onSelectPreset?: (nodeId: string) => void;
 }) {
   return (
     <div className="overview-tab">
       {banner}
       <RunDigest clauses={digest} onOpen={onOpen} />
+      <DescriptionDigestCard result={result} onSelectPreset={onSelectPreset} />
       <QuestionPills
         onWhereFrom={onWhereFrom}
         onDependency={() => onOpen("simulator")}

--- a/packages/app/src/components/description-approx.ts
+++ b/packages/app/src/components/description-approx.ts
@@ -1,0 +1,22 @@
+/**
+ * Roadmap 069: the wording behind the engine's *approximate* attribution.
+ *
+ * Split from the components that render it ({@link DescriptionApprox.tsx}) for
+ * the reason `provenance-layer.ts` is split from `ProvenanceChip.tsx`: a module
+ * that exports both a component and a plain function breaks Fast Refresh
+ * (react/only-export-components), and this text is wanted by callers that
+ * render no component of their own — a title attribute on someone else's label,
+ * a CLI line.
+ */
+
+/**
+ * The hover text behind every `≈`. `name` is the enclosing subtree the engine
+ * fell back to; omitted where naming it would not help the reader — the repo's
+ * own root node, which the preset tree has no row for, and the
+ * defaults/global/inherited layers, which have no preset tree at all.
+ */
+export function approximateTitle(name?: string): string {
+  return name
+    ? `Contributed somewhere inside ${name} — the exact preset could not be determined`
+    : "The exact preset that wrote this sentence could not be determined";
+}

--- a/packages/app/src/components/preset-tree-stats.ts
+++ b/packages/app/src/components/preset-tree-stats.ts
@@ -1,4 +1,17 @@
+import type * as EngineModule from "@renovate-config-debugger/engine";
 import type { PresetNode } from "@renovate-config-debugger/engine";
+
+/**
+ * The root node's id — the input config itself, the one node the tree has no
+ * row for (`flattenTree` starts at the root's CHILDREN). Anything offering
+ * "show this node in the preset tree" must check for it first, or promise a
+ * jump that lands nowhere.
+ *
+ * An app-local copy typed against the engine's `ROOT_NODE_ID` so drift fails
+ * the build, without a static VALUE import that would pull the renovate chunk
+ * into the initial bundle (the same pattern as 033's `STAGE_IDS`).
+ */
+export const ROOT_NODE_ID: typeof EngineModule.ROOT_NODE_ID = "root";
 
 /**
  * The preset tree's derived facts: per-node/per-subtree contribution stats,

--- a/packages/app/src/components/provenance-layer.ts
+++ b/packages/app/src/components/provenance-layer.ts
@@ -34,6 +34,40 @@ export function layerNodeKey(layer: ProvenanceLayer): string {
   return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
 }
 
+/**
+ * Ordinal separator for {@link stableLayerKey}. U+241F (SYMBOL FOR UNIT
+ * SEPARATOR) cannot occur in a preset name — Renovate's `extends` entries are
+ * ASCII package/preset paths — so `preset:foo␟2` can never be produced by a
+ * preset literally called `foo␟2`. A visible `#` would: `{"extends": ["foo",
+ * "foo#2", "foo"]}` gives the second `foo` the key `preset:foo#2`, which is
+ * also the first key of the preset actually named `foo#2`, and React would
+ * reconcile one group's state onto the other. The character is never rendered;
+ * it exists only inside a React key.
+ */
+const KEY_ORDINAL_SEP = "␟";
+
+/**
+ * A React key for a layer that is stable ACROSS RUNS and unique WITHIN a run.
+ *
+ * Node ids (`p1`, `p2`, …) are minted per run, so a node-based key lets a
+ * component's state reattach to a different preset after an edit — but the
+ * name alone is not unique either, because extending the same preset twice is
+ * a case the description surfaces deliberately keep apart (see
+ * {@link layerNodeKey}). So: {@link layerId} as the base, plus an ordinal for
+ * every repeat after the first, counted in the caller's own `seen` map.
+ *
+ * `seen` is mutated — one map per list being keyed, iterated in the order the
+ * keys must be stable in (merge order, in both current callers). Used by the
+ * Overview's description digest, and by the Effective config's per-string
+ * blame ledger a layer up (069 PR 3), which needs the identical key idiom.
+ */
+export function stableLayerKey(layer: ProvenanceLayer, seen: Map<LayerId, number>): string {
+  const base = layerId(layer);
+  const uses = seen.get(base) ?? 0;
+  seen.set(base, uses + 1);
+  return uses === 0 ? base : `${base}${KEY_ORDINAL_SEP}${uses + 1}`;
+}
+
 export function layerLabel(layer: ProvenanceLayer): string {
   if (layer.kind === "defaults") {
     return "default";

--- a/packages/app/src/components/provenance-layer.ts
+++ b/packages/app/src/components/provenance-layer.ts
@@ -11,9 +11,27 @@ import type { GlossaryEntry } from "@/data/glossary-data";
 
 export type LayerId = string;
 
-/** Stable id for a layer, used by dropdown filters + winning-badge classes. */
+/** Stable id for a layer, used by dropdown filters + winning-badge classes.
+ *  NAME-based, so two `extends` entries resolving to the same preset are one
+ *  id — deliberate for a filter ("show me what `config:recommended` did"),
+ *  wrong wherever the two occurrences must stay apart: see {@link layerNodeKey}. */
 export function layerId(layer: ProvenanceLayer): LayerId {
   return layer.kind === "preset" ? `preset:${layer.name}` : layer.kind;
+}
+
+/**
+ * Identity of the layer as a NODE rather than a name: two `extends` entries
+ * resolving to the same preset are two keys, because preset node ids are
+ * unique across the tree. Used wherever conflating them would merge two things
+ * the reader must see as two — the effective config's override-chain rows, the
+ * description digest's per-extend grouping.
+ *
+ * Not a React key and not a persistable id: node ids are regenerated on every
+ * run (`p1`, `p2`, …), so the same string means a different preset after the
+ * next keystroke. `layerId` is the stable-across-runs one.
+ */
+export function layerNodeKey(layer: ProvenanceLayer): string {
+  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
 }
 
 export function layerLabel(layer: ProvenanceLayer): string {

--- a/packages/app/src/hooks/description-provenance.test.tsx
+++ b/packages/app/src/hooks/description-provenance.test.tsx
@@ -1,27 +1,26 @@
 import type { DescriptionProvenance, TraceResult } from "@renovate-config-debugger/engine";
 import { cleanup, render, waitFor } from "@testing-library/react";
-import { afterEach, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { useDescriptionProvenance } from "./description-provenance";
 
 /**
- * Roadmap 069 (PR 2), 2026-08-11 review — the hook's failure path. The engine
- * is reached through a dynamic import and the per-result promise is CACHED, so
- * a throw (a chunk that fails to load, a walk that blows up on an exotic tree)
- * would otherwise be stored as a rejected promise: every consumer of that run
- * gets its own unhandled rejection and hangs on `undefined` — "still loading" —
- * for as long as the result lives. It must settle as `null` (unavailable), for
- * every consumer, exactly like a run that lacks the data.
+ * Roadmap 069 (PR 2), 2026-08-11 review — the two things the hook owns beyond
+ * "call the engine": what it does with a rejection, and what it shows in the
+ * frame between two runs.
  *
- * The engine is mocked here rather than run: this is about what the hook does
- * with a rejection, and mocking is the only way to produce one deterministically
- * (it also keeps the renovate graph out of this file).
+ * The engine is mocked rather than run: both cases are about the hook's own
+ * bookkeeping, mocking is the only way to produce a rejection deterministically,
+ * and it keeps the renovate module graph out of this file.
  */
-
-vi.mock("@renovate-config-debugger/engine", () => ({
-  computeDescriptionProvenance: () => {
-    throw new Error("engine exploded");
-  },
+const engine = vi.hoisted(() => ({
+  computeDescriptionProvenance: vi.fn<(result: TraceResult) => DescriptionProvenance | undefined>(),
 }));
+
+vi.mock("@renovate-config-debugger/engine", () => engine);
+
+beforeEach(() => {
+  engine.computeDescriptionProvenance.mockReset();
+});
 
 afterEach(cleanup);
 
@@ -41,6 +40,13 @@ function Harness({ onState }: { onState: (states: State[]) => void }) {
 }
 
 it("settles as unavailable when the engine throws, for every consumer", async () => {
+  // A chunk that fails to load, or a walk that blows up on an exotic tree. The
+  // per-result promise is CACHED, so a rejection stored there would hand every
+  // consumer of that run its own unhandled rejection and hang them all on
+  // `undefined` — "still loading" — for as long as the result lives.
+  engine.computeDescriptionProvenance.mockImplementation(() => {
+    throw new Error("engine exploded");
+  });
   let states: State[] = [];
   render(
     <Harness
@@ -64,4 +70,42 @@ it("settles as unavailable when the engine throws, for every consumer", async ()
     />,
   );
   await waitFor(() => expect(states).toEqual([null, null]));
+});
+
+it("never pairs a new run with the previous run's provenance", async () => {
+  // The reset has to happen during render. Done in the effect it would land
+  // after the commit, painting one frame in which the NEW result carries the
+  // OLD attribution — whose per-run node ids (`p1`, `p2`, …) resolve against
+  // the new tree, so a sentence flashes attributed to whichever preset
+  // inherited the id.
+  const first = {} as TraceResult;
+  const second = {} as TraceResult;
+  const provenanceOf = (result: TraceResult): DescriptionProvenance =>
+    ({
+      entries: [],
+      unattributed: [],
+      finalLength: 0,
+      dropped: [],
+      ruleDescriptions: [],
+      degraded: result === second,
+    }) satisfies DescriptionProvenance;
+  engine.computeDescriptionProvenance.mockImplementation(provenanceOf);
+
+  const seen: State[] = [];
+  function OneResult({ result }: { result: TraceResult }) {
+    seen.push(useDescriptionProvenance(result));
+    return null;
+  }
+
+  const view = render(<OneResult result={first} />);
+  await waitFor(() => expect(seen.at(-1)).toEqual(provenanceOf(first)));
+
+  const before = seen.length;
+  view.rerender(<OneResult result={second} />);
+
+  // Every render observed since the swap, not just the last one: the gap must
+  // be empty throughout, and the render that performs the reset is one of them.
+  expect(seen.slice(before)).not.toHaveLength(0);
+  expect(seen.slice(before).filter((state) => state !== undefined)).toEqual([]);
+  await waitFor(() => expect(seen.at(-1)).toEqual(provenanceOf(second)));
 });

--- a/packages/app/src/hooks/description-provenance.test.tsx
+++ b/packages/app/src/hooks/description-provenance.test.tsx
@@ -1,0 +1,67 @@
+import type { DescriptionProvenance, TraceResult } from "@renovate-config-debugger/engine";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { useDescriptionProvenance } from "./description-provenance";
+
+/**
+ * Roadmap 069 (PR 2), 2026-08-11 review — the hook's failure path. The engine
+ * is reached through a dynamic import and the per-result promise is CACHED, so
+ * a throw (a chunk that fails to load, a walk that blows up on an exotic tree)
+ * would otherwise be stored as a rejected promise: every consumer of that run
+ * gets its own unhandled rejection and hangs on `undefined` — "still loading" —
+ * for as long as the result lives. It must settle as `null` (unavailable), for
+ * every consumer, exactly like a run that lacks the data.
+ *
+ * The engine is mocked here rather than run: this is about what the hook does
+ * with a rejection, and mocking is the only way to produce one deterministically
+ * (it also keeps the renovate graph out of this file).
+ */
+
+vi.mock("@renovate-config-debugger/engine", () => ({
+  computeDescriptionProvenance: () => {
+    throw new Error("engine exploded");
+  },
+}));
+
+afterEach(cleanup);
+
+// The hook only ever hands the result to the engine (mocked) and uses it as a
+// WeakMap key, so an empty object is the whole fixture this needs.
+const RESULT = {} as TraceResult;
+
+type State = DescriptionProvenance | null | undefined;
+
+/** Renders the hook twice over the SAME result — two consumers sharing the one
+ *  cached promise, which is the case a poisoned cache entry breaks. */
+function Harness({ onState }: { onState: (states: State[]) => void }) {
+  const first = useDescriptionProvenance(RESULT);
+  const second = useDescriptionProvenance(RESULT);
+  onState([first, second]);
+  return null;
+}
+
+it("settles as unavailable when the engine throws, for every consumer", async () => {
+  let states: State[] = [];
+  render(
+    <Harness
+      onState={(next) => {
+        states = next;
+      }}
+    />,
+  );
+
+  expect(states).toEqual([undefined, undefined]);
+  await waitFor(() => expect(states).toEqual([null, null]));
+
+  // …and the cached rejection is not replayed at the next consumer either.
+  cleanup();
+  states = [];
+  render(
+    <Harness
+      onState={(next) => {
+        states = next;
+      }}
+    />,
+  );
+  await waitFor(() => expect(states).toEqual([null, null]));
+});

--- a/packages/app/src/hooks/description-provenance.ts
+++ b/packages/app/src/hooks/description-provenance.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import type { DescriptionProvenance, TraceResult } from "@renovate-config-debugger/engine";
+
+/**
+ * Roadmap 069: per-string `description` provenance, loaded the way every other
+ * post-hoc trace derivation is — through the same dynamic engine import that
+ * keeps the renovate chunk off the critical path, with the per-result promise
+ * cached on the immutable result object so the walk runs ONCE per run however
+ * many consumers ask. Mirrors `rule-provenance.ts` exactly; PR 3's blame ledger
+ * and PR 4's tree annotations are the further consumers this cache is for.
+ */
+const descriptionProvenanceCache = new WeakMap<
+  TraceResult,
+  Promise<DescriptionProvenance | null>
+>();
+
+function descriptionProvenanceFor(result: TraceResult): Promise<DescriptionProvenance | null> {
+  let promise = descriptionProvenanceCache.get(result);
+  if (!promise) {
+    promise = import("@renovate-config-debugger/engine").then(
+      (engine) => engine.computeDescriptionProvenance(result) ?? null,
+    );
+    descriptionProvenanceCache.set(result, promise);
+  }
+  return promise;
+}
+
+/**
+ * `undefined` = loading / no result yet, `null` = unavailable (the run has no
+ * final config, or preset resolution never finished).
+ */
+export function useDescriptionProvenance(
+  result: TraceResult | null | undefined,
+): DescriptionProvenance | null | undefined {
+  const [state, setState] = useState<DescriptionProvenance | null | undefined>(undefined);
+  useEffect(() => {
+    if (!result) {
+      setState(undefined);
+      return;
+    }
+    let live = true;
+    setState(undefined);
+    void (async () => {
+      const provenance = await descriptionProvenanceFor(result);
+      if (live) {
+        setState(provenance);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [result]);
+  return state;
+}

--- a/packages/app/src/hooks/description-provenance.ts
+++ b/packages/app/src/hooks/description-provenance.ts
@@ -35,18 +35,30 @@ function descriptionProvenanceFor(result: TraceResult): Promise<DescriptionProve
 /**
  * `undefined` = loading / no result yet, `null` = unavailable (the run has no
  * final config, or preset resolution never finished).
+ *
+ * The stale state is discarded DURING RENDER, not in the effect. Effects run
+ * after the commit, so a reset made there paints one frame in which the new
+ * `result` is paired with the PREVIOUS run's provenance — and that pairing is
+ * actively wrong rather than merely stale, because preset node ids (`p1`,
+ * `p2`, …) are minted per run: the old attribution's ids resolve against the
+ * new tree, and a sentence flashes attributed to whichever preset inherited
+ * the id. React's "adjust state when a prop changes" idiom re-renders this
+ * component immediately, before anything is committed, so no such frame exists.
  */
 export function useDescriptionProvenance(
   result: TraceResult | null | undefined,
 ): DescriptionProvenance | null | undefined {
   const [state, setState] = useState<DescriptionProvenance | null | undefined>(undefined);
+  const [stateOwner, setStateOwner] = useState(result);
+  if (stateOwner !== result) {
+    setStateOwner(result);
+    setState(undefined);
+  }
   useEffect(() => {
     if (!result) {
-      setState(undefined);
       return;
     }
     let live = true;
-    setState(undefined);
     void (async () => {
       const provenance = await descriptionProvenanceFor(result);
       if (live) {
@@ -57,5 +69,9 @@ export function useDescriptionProvenance(
       live = false;
     };
   }, [result]);
-  return state;
+  // Guarded rather than returned raw: React discards the output of the render
+  // that called `setState` above, but this component's body still RAN with the
+  // pre-reset `state` in hand, and a consumer that reads the return value into
+  // something other than JSX (a ref, a log, a callback) would see it.
+  return stateOwner === result ? state : undefined;
 }

--- a/packages/app/src/hooks/description-provenance.ts
+++ b/packages/app/src/hooks/description-provenance.ts
@@ -6,8 +6,9 @@ import type { DescriptionProvenance, TraceResult } from "@renovate-config-debugg
  * post-hoc trace derivation is — through the same dynamic engine import that
  * keeps the renovate chunk off the critical path, with the per-result promise
  * cached on the immutable result object so the walk runs ONCE per run however
- * many consumers ask. Mirrors `rule-provenance.ts` exactly; PR 3's blame ledger
- * and PR 4's tree annotations are the further consumers this cache is for.
+ * many consumers ask. Shaped like `rule-provenance.ts`, with the failure path
+ * folded into the cached value (see below); PR 3's blame ledger and PR 4's tree
+ * annotations are the further consumers this cache is for.
  */
 const descriptionProvenanceCache = new WeakMap<
   TraceResult,
@@ -17,9 +18,15 @@ const descriptionProvenanceCache = new WeakMap<
 function descriptionProvenanceFor(result: TraceResult): Promise<DescriptionProvenance | null> {
   let promise = descriptionProvenanceCache.get(result);
   if (!promise) {
-    promise = import("@renovate-config-debugger/engine").then(
-      (engine) => engine.computeDescriptionProvenance(result) ?? null,
-    );
+    promise = import("@renovate-config-debugger/engine")
+      .then((engine) => engine.computeDescriptionProvenance(result) ?? null)
+      // A failed chunk load (offline, a stale deploy) or a throw inside the
+      // walk is "unavailable", exactly like a run that lacks the data: the
+      // card renders nothing either way. Caught INSIDE the cached chain so the
+      // cache never holds a rejected promise — every later consumer of this
+      // result would otherwise get its own unhandled rejection and hang on
+      // `undefined` (= still loading) forever.
+      .catch(() => null);
     descriptionProvenanceCache.set(result, promise);
   }
   return promise;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4313,10 +4313,37 @@ button.desc-digest-leaf:focus-visible {
   font-style: italic;
 }
 
+/* A member of the description array that is not a string: Renovate warns and
+   keeps it, no preset can be credited with it, and no group can show it. A
+   quiet footnote rather than a warning — the config is the way it is, and the
+   card's job here is only to not under-report it. */
+.desc-digest-aside {
+  color: var(--muted);
+  font-size: 0.78rem;
+  margin: 0;
+  padding: 0 0.75rem 0.5rem;
+}
+
+/* Roadmap 069: the approximate-attribution family, shared by every surface
+   that renders the engine's per-string attribution — the Overview's digest
+   card here, the Effective config's blame ledger (PR 3), the preset tree's
+   inline descriptions (PR 4). One family, so the `≈` and its caveat cannot
+   drift apart between them; see components/description-approx.tsx. */
+
+/* The standalone mark, for a row with no leaf label to prefix. Same muted
+   weight as the label's own `≈` prefix, so the two read as one mark. */
+.desc-approx-mark {
+  color: var(--muted);
+  cursor: help;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  margin-left: auto;
+}
+
 /* Same warn-notice tint (050 families) and attachment as the resolved
    document's merge-order caveat (051) — a qualification of the thing above it,
    not a problem with the run. */
-.desc-digest-caveat {
+.desc-approx-caveat {
   background: var(--warn-bg);
   border-top: 1px solid var(--warn-border);
   font-size: 0.8rem;

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4183,3 +4183,143 @@ main:has(.app-split.has-results) {
   margin-top: 0.1rem;
   padding: 0.05rem 0.3rem;
 }
+
+/* ---------- 069: the "What this config does" digest card ----------
+   Every preset carries a sentence its author wrote; the resolved config
+   concatenates them all into one anonymous array. This card is that array
+   regrouped by the `extends` entry that pulled each sentence in — so the
+   Overview's first answer to "what does this config do" is the config's own
+   documentation, in its authors' words.
+
+   The palette is not new: a group wears the hue its ProvenanceChip wears
+   (purple preset / blue repo / …), and the dots are the same `.prov-dot` the
+   054 evidence rows use. Only the left rail needs per-layer rules, since it is
+   the one element that carries the hue as a BORDER rather than as `color`. */
+.desc-digest {
+  padding: 0.7rem 0.75rem 0.4rem;
+}
+
+.desc-digest-count {
+  color: var(--muted);
+  font-weight: 400;
+  margin-left: 0.5rem;
+}
+
+.desc-digest-group {
+  margin-bottom: 0.85rem;
+}
+
+.desc-digest-group-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.35rem;
+}
+
+.desc-digest-note {
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
+/* The "this extend added nothing" chip — a fact about redundancy, not a
+   problem, so it stays muted rather than borrowing the warn tint. */
+.badge.desc-digest-redundant {
+  color: var(--muted);
+  font-family: inherit;
+}
+
+.desc-digest-list {
+  border-left: 2px solid color-mix(in srgb, var(--accent-purple) 30%, transparent);
+  display: grid;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0 0 0.35rem;
+  padding: 0.1rem 0 0.1rem 0.85rem;
+}
+
+/* The rail follows the group's layer, matching the dots inside it. */
+.desc-digest-list.prov-repo {
+  border-left-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.desc-digest-list.prov-global {
+  border-left-color: color-mix(in srgb, var(--accent-teal) 30%, transparent);
+}
+
+.desc-digest-list.prov-inherited {
+  border-left-color: color-mix(in srgb, var(--accent-pink) 30%, transparent);
+}
+
+.desc-digest-list.prov-defaults {
+  border-left-color: color-mix(in srgb, var(--muted) 30%, transparent);
+}
+
+.desc-digest-row {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  gap: 0.5rem;
+  line-height: 1.5;
+}
+
+/* A repeat of a sentence contributed above: kept (the array really does say it
+   twice) but visibly demoted. */
+.desc-digest-row.duplicate .desc-digest-text {
+  color: var(--muted);
+}
+
+.desc-digest-row > .prov-dot {
+  position: relative;
+  top: -0.1rem;
+}
+
+.desc-digest-text code {
+  font-size: 0.9em;
+}
+
+/* Who actually wrote the sentence — a quiet mono label, and a button, because
+   the name is only useful if it takes you to the node (013's chip contract). */
+.desc-digest-leaf {
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  margin-left: auto;
+  padding: 0;
+  white-space: nowrap;
+}
+
+button.desc-digest-leaf {
+  cursor: pointer;
+}
+
+button.desc-digest-leaf:hover,
+button.desc-digest-leaf:focus-visible {
+  color: var(--accent);
+}
+
+.desc-digest-rule-note {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  margin-left: auto;
+}
+
+.desc-digest-more {
+  font-size: 0.78rem;
+  font-style: italic;
+}
+
+/* Same warn-notice tint (050 families) and attachment as the resolved
+   document's merge-order caveat (051) — a qualification of the thing above it,
+   not a problem with the run. */
+.desc-digest-caveat {
+  background: var(--warn-bg);
+  border-top: 1px solid var(--warn-border);
+  font-size: 0.8rem;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+}

--- a/packages/app/src/lib/description-digest.test.ts
+++ b/packages/app/src/lib/description-digest.test.ts
@@ -12,7 +12,13 @@ import {
   type DigestRule,
   groupContributionText,
   ruleNoteText,
+  unattributedNoteText,
 } from "./description-digest";
+
+/** The ordinal separator `stableLayerKey` uses (U+241F). Spelled out here
+ *  because a key that silently became `#`-separated again would re-open the
+ *  collision the last test in "grouping" pins down. */
+const SEP = "␟";
 
 /**
  * Roadmap 069 (PR 2): the grouping, the redundancy verdict and the counts, over
@@ -55,7 +61,19 @@ function entries(specs: EntrySpec[]): DescriptionAttribution[] {
 }
 
 function provenance(overrides: Partial<DescriptionProvenance> = {}): DescriptionProvenance {
-  return { entries: [], dropped: [], ruleDescriptions: [], degraded: false, ...overrides };
+  const attributed = overrides.entries ?? [];
+  const nonText = overrides.unattributed ?? [];
+  return {
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+    // The engine guarantees `entries.length + unattributed.length ===
+    // finalLength`; the fixtures keep that invariant unless a test overrides it.
+    finalLength: attributed.length + nonText.length,
+    ...overrides,
+    entries: attributed,
+    unattributed: nonText,
+  };
 }
 
 // The three lookups below throw rather than assert-and-narrow: that fails the
@@ -134,8 +152,29 @@ describe("grouping", () => {
     expect(digest.groups.map((g) => g.redundant)).toEqual([false, true]);
     expect(digest.groups.map((g) => g.key)).toEqual([
       "preset::dependencyDashboard",
-      "preset::dependencyDashboard#2",
+      `preset::dependencyDashboard${SEP}2`,
     ]);
+  });
+
+  test("a preset named like an ordinal does not collide with a repeated extend", () => {
+    // `foo#2` is a legal preset name, and the ordinal used to be spelled `#2` —
+    // so the SECOND `foo` and the preset literally called `foo#2` both keyed on
+    // `preset:foo#2`, and React would have reconciled one group's expansion
+    // state onto the other. The separator is now a character no preset name can
+    // contain.
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "First foo.", via: preset("a", "foo") },
+          { value: "The other preset.", via: preset("b", "foo#2") },
+          { value: "Second foo.", via: preset("c", "foo") },
+        ]),
+      }),
+    );
+
+    const keys = digest.groups.map((g) => g.key);
+    expect(new Set(keys).size).toBe(3);
+    expect(keys).toEqual(["preset:foo", "preset:foo#2", `preset:foo${SEP}2`]);
   });
 
   test("group keys survive a re-run, which mints new node ids", () => {
@@ -360,6 +399,61 @@ describe("totals and empty state", () => {
 
     expect(digest.totals).toEqual({ behaviors: 0, extendsCount: 0, hasUserRules: true });
     expect(descriptionCountText(digest.totals)).toBe("from your rules");
+  });
+
+  test("carries the array members that are not text, and says so", () => {
+    // Renovate WARNS about `{"description": ["Keep this.", 42]}` and keeps the
+    // 42, which occupies index 1 of the final array. No group can show it, so a
+    // card titled "What this config does" has to name it instead of dropping it.
+    const digest = digestOf(
+      provenance({
+        entries: entries([{ value: "Keep this.", via: REPO, node: "root" }]),
+        unattributed: [{ index: 1, value: 42 }],
+      }),
+    );
+
+    expect(digest.unattributed).toBe(1);
+    expect(digest.finalLength).toBe(2);
+    expect(unattributedNoteText(digest)).toBe(
+      "1 member of the description array is not text, so no preset can be credited with it.",
+    );
+    // The behavior count is a count of SENTENCES, and stays one.
+    expect(digest.totals.behaviors).toBe(1);
+    expect(descriptionCountText(digest.totals)).toBe("1 behavior");
+  });
+
+  test("several non-text members read as several", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([{ value: "Keep this.", via: REPO, node: "root" }]),
+        unattributed: [
+          { index: 1, value: 42 },
+          { index: 2, value: null },
+        ],
+      }),
+    );
+
+    expect(digest).toMatchObject({ unattributed: 2, finalLength: 3 });
+    expect(unattributedNoteText(digest)).toBe(
+      "2 members of the description array are not text, so no preset can be credited with them.",
+    );
+  });
+
+  test("a well-formed config has no such note", () => {
+    const digest = digestOf(
+      provenance({ entries: entries([{ value: "Only prose.", via: REPO, node: "root" }]) }),
+    );
+
+    expect(digest).toMatchObject({ unattributed: 0, finalLength: 1 });
+    expect(unattributedNoteText(digest)).toBe("");
+  });
+
+  test("a description array of nothing but non-text is still no card", () => {
+    // There is no prose to summarize, so the card that would carry the note
+    // does not exist — and nothing claims completeness in its absence.
+    expect(
+      buildDescriptionDigest(provenance({ unattributed: [{ index: 0, value: 42 }] })),
+    ).toBeNull();
   });
 
   test("degraded rides through from the engine", () => {

--- a/packages/app/src/lib/description-digest.test.ts
+++ b/packages/app/src/lib/description-digest.test.ts
@@ -1,0 +1,361 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import {
+  buildDescriptionDigest,
+  descriptionCountText,
+  type DescriptionDigest,
+  type DigestGroup,
+  type DigestRule,
+  groupContributionText,
+  ruleNoteText,
+} from "./description-digest";
+
+/**
+ * Roadmap 069 (PR 2): the grouping, the redundancy verdict and the counts, over
+ * hand-built provenance. The engine's own tests prove the ATTRIBUTION is right
+ * (069 PR 1, against the real 1,088-preset tree); everything here is about what
+ * the card makes of it, so nothing needs the real pipeline.
+ */
+
+const REPO: ProvenanceLayer = { kind: "repo" };
+
+function preset(nodeId: string, name = nodeId): ProvenanceLayer {
+  return { kind: "preset", nodeId, name };
+}
+
+interface EntrySpec {
+  value: string;
+  via: ProvenanceLayer;
+  node?: string;
+  approximate?: boolean;
+}
+
+/** Builds `entries` with the indices and duplicate markers the engine would
+ *  assign, from a compact per-entry spec. */
+function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+  const firstByValue = new Map<string, number>();
+  return specs.map((spec, index) => {
+    const duplicateOfIndex = firstByValue.get(spec.value);
+    if (duplicateOfIndex === undefined) {
+      firstByValue.set(spec.value, index);
+    }
+    return {
+      index,
+      value: spec.value,
+      viaTopLevel: spec.via,
+      ...(spec.node ? { node: { nodeId: spec.node, name: spec.node } } : {}),
+      ...(duplicateOfIndex === undefined ? {} : { duplicateOfIndex }),
+      ...(spec.approximate ? { approximate: true } : {}),
+    };
+  });
+}
+
+function provenance(overrides: Partial<DescriptionProvenance> = {}): DescriptionProvenance {
+  return { entries: [], dropped: [], ruleDescriptions: [], degraded: false, ...overrides };
+}
+
+// The three lookups below throw rather than assert-and-narrow: that fails the
+// test with a message naming what WAS there, and keeps the file free of the
+// non-null assertions the lint config bans.
+function digestOf(p: DescriptionProvenance, rules?: readonly unknown[] | null): DescriptionDigest {
+  const digest = buildDescriptionDigest(p, rules);
+  if (!digest) {
+    throw new Error("expected a digest, got null");
+  }
+  return digest;
+}
+
+function groupAt(digest: DescriptionDigest, index: number): DigestGroup {
+  const group = digest.groups[index];
+  if (!group) {
+    throw new Error(`no group #${index} in: ${digest.groups.map((g) => g.key).join(", ")}`);
+  }
+  return group;
+}
+
+function ruleAt(group: DigestGroup, index: number): DigestRule {
+  const rule = group.rules[index];
+  if (!rule) {
+    throw new Error(`group ${group.key} has ${group.rules.length} rules, not ${index + 1}`);
+  }
+  return rule;
+}
+
+const BEST_PRACTICES = preset("n1", "config:best-practices");
+const DASHBOARD = preset("n2", ":dependencyDashboard");
+const MONOREPOS = preset("n3", "group:monorepos");
+
+describe("grouping", () => {
+  test("groups by the top-level layer, in merge order, keeping array order inside", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES, node: ":dependencyDashboard" },
+          { value: "Pin Docker digests.", via: BEST_PRACTICES, node: "docker:pinDigests" },
+          { value: "Group monorepos.", via: MONOREPOS, node: "group:monorepos" },
+          { value: "My own note.", via: REPO, node: "root" },
+        ]),
+      }),
+    );
+
+    expect(digest.groups.map((g) => g.key)).toEqual(["preset:n1", "preset:n3", "repo"]);
+    expect(groupAt(digest, 0).entries.map((e) => e.value)).toEqual([
+      "Dashboard.",
+      "Pin Docker digests.",
+    ]);
+    expect(groupAt(digest, 0).entries[1]?.node).toEqual({
+      nodeId: "docker:pinDigests",
+      name: "docker:pinDigests",
+    });
+  });
+
+  test("the same preset extended twice stays two groups", () => {
+    // The whole point of keying on the NODE: `layerId` would conflate these,
+    // and "you extended it twice" is exactly what the card must be able to say.
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: preset("a", ":dependencyDashboard") },
+          { value: "Dashboard.", via: preset("b", ":dependencyDashboard") },
+        ]),
+      }),
+    );
+
+    expect(digest.groups).toHaveLength(2);
+    expect(digest.groups.map((g) => g.redundant)).toEqual([false, true]);
+  });
+
+  test("entries keep the index, duplicate marker and approximate flag", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Same.", via: BEST_PRACTICES, node: "a" },
+          { value: "Same.", via: BEST_PRACTICES, node: "b", approximate: true },
+        ]),
+      }),
+    );
+
+    expect(groupAt(digest, 0).entries).toEqual([
+      { index: 0, value: "Same.", node: { nodeId: "a", name: "a" } },
+      {
+        index: 1,
+        value: "Same.",
+        node: { nodeId: "b", name: "b" },
+        duplicateOfIndex: 0,
+        approximate: true,
+      },
+    ]);
+  });
+
+  test("the external layers get their own groups", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "From the bot.", via: { kind: "global" } },
+          { value: "From the org.", via: { kind: "inherited" } },
+          { value: "From a preset.", via: BEST_PRACTICES },
+        ]),
+      }),
+    );
+
+    expect(digest.groups.map((g) => g.key)).toEqual(["global", "inherited", "preset:n1"]);
+    // Only real `extends` entries count as extends.
+    expect(digest.totals.extendsCount).toBe(1);
+  });
+});
+
+describe("redundancy", () => {
+  test("a group whose every string repeats an earlier one is redundant", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES },
+          { value: "Group monorepos.", via: BEST_PRACTICES },
+          { value: "Dashboard.", via: DASHBOARD },
+        ]),
+      }),
+    );
+
+    expect(groupAt(digest, 1)).toMatchObject({ key: "preset:n2", redundant: true, behaviors: 0 });
+    expect(groupAt(digest, 0)).toMatchObject({ redundant: false, behaviors: 2 });
+  });
+
+  test("one new sentence is enough to stop a group being redundant", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES },
+          { value: "Dashboard.", via: DASHBOARD },
+          { value: "…and label them.", via: DASHBOARD },
+        ]),
+      }),
+    );
+
+    expect(groupAt(digest, 1)).toMatchObject({ redundant: false, behaviors: 1 });
+  });
+
+  test("a repo group carrying rule descriptions is never redundant", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Shared note.", via: BEST_PRACTICES },
+          { value: "Shared note.", via: REPO, node: "root" },
+        ]),
+        ruleDescriptions: [
+          { ruleIndex: 0, sourceIndex: 0, layer: REPO, values: ["Slow down majors"] },
+        ],
+      }),
+      [{ matchUpdateTypes: ["major"] }],
+    );
+
+    expect(groupAt(digest, 1)).toMatchObject({ key: "repo", redundant: false });
+  });
+});
+
+describe("rule descriptions", () => {
+  const RULES = [
+    {
+      description: ["Slow down risky major updates"],
+      matchUpdateTypes: ["major"],
+      minimumReleaseAge: "14 days",
+    },
+    { description: ["From a preset"], matchManagers: ["npm"] },
+  ];
+
+  function withRule(layer: ProvenanceLayer): DescriptionProvenance {
+    return provenance({
+      ruleDescriptions: [
+        { ruleIndex: 0, sourceIndex: 0, layer, values: ["Slow down risky major updates"] },
+      ],
+    });
+  }
+
+  test("pairs a repo rule with its matcher and write summary", () => {
+    const digest = digestOf(withRule(REPO), RULES);
+
+    expect(digest.groups).toHaveLength(1);
+    expect(groupAt(digest, 0)).toMatchObject({ key: "repo" });
+    expect(ruleAt(groupAt(digest, 0), 0)).toEqual({
+      ruleIndex: 0,
+      values: ["Slow down risky major updates"],
+      selectors: "matchUpdateTypes",
+      writes: ["minimumReleaseAge"],
+    });
+    expect(ruleNoteText(ruleAt(groupAt(digest, 0), 0))).toBe(
+      "packageRules[0] — matchUpdateTypes → minimumReleaseAge",
+    );
+  });
+
+  test("preset rule descriptions are left to the simulator (PR 5)", () => {
+    // `config:best-practices` alone carries hundreds; they would bury the
+    // handful of sentences the card exists to show.
+    expect(buildDescriptionDigest(withRule(BEST_PRACTICES), RULES)).toBeNull();
+  });
+
+  test("survives a rule body the final config no longer has", () => {
+    const digest = digestOf(withRule(REPO), null);
+
+    expect(ruleAt(groupAt(digest, 0), 0)).toMatchObject({
+      selectors: "(not an object)",
+      writes: [],
+    });
+  });
+
+  test("a rule with no selectors says so rather than reading as unconditional", () => {
+    const digest = digestOf(withRule(REPO), [{ description: ["x"], automerge: true }]);
+
+    expect(ruleNoteText(ruleAt(groupAt(digest, 0), 0))).toBe(
+      "packageRules[0] — (no match*/exclude* selectors) → automerge",
+    );
+  });
+});
+
+describe("totals and empty state", () => {
+  test("counts distinct behaviors, contributing extends and user rules", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES },
+          { value: "Pin digests.", via: BEST_PRACTICES },
+          { value: "Dashboard.", via: DASHBOARD },
+          { value: "My note.", via: REPO, node: "root" },
+        ]),
+        ruleDescriptions: [{ ruleIndex: 0, sourceIndex: 0, layer: REPO, values: ["Mine"] }],
+      }),
+      [{ matchUpdateTypes: ["major"] }],
+    );
+
+    // 4 entries, one of them a repeat.
+    expect(digest.totals).toEqual({ behaviors: 3, extendsCount: 2, hasUserRules: true });
+    expect(descriptionCountText(digest.totals)).toBe("3 behaviors · from 2 extends + your rules");
+  });
+
+  test("no descriptions anywhere means no card", () => {
+    expect(buildDescriptionDigest(provenance())).toBeNull();
+  });
+
+  test("rule descriptions alone still produce a digest", () => {
+    const digest = digestOf(
+      provenance({
+        ruleDescriptions: [{ ruleIndex: 0, sourceIndex: 0, layer: REPO, values: ["Mine"] }],
+      }),
+      [{ matchManagers: ["npm"], automerge: true }],
+    );
+
+    expect(digest.totals).toEqual({ behaviors: 0, extendsCount: 0, hasUserRules: true });
+    expect(descriptionCountText(digest.totals)).toBe("from your rules");
+  });
+
+  test("degraded rides through from the engine", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([{ value: "Something.", via: BEST_PRACTICES, approximate: true }]),
+        degraded: true,
+      }),
+    );
+
+    expect(digest.degraded).toBe(true);
+  });
+
+  test("counts read singular where they should", () => {
+    expect(descriptionCountText({ behaviors: 1, extendsCount: 1, hasUserRules: false })).toBe(
+      "1 behavior · from 1 extend",
+    );
+  });
+});
+
+describe("group notes", () => {
+  test("names what a group added, and its described rules", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([{ value: "My note.", via: REPO, node: "root" }]),
+        ruleDescriptions: [
+          { ruleIndex: 0, sourceIndex: 0, layer: REPO, values: ["a"] },
+          { ruleIndex: 1, sourceIndex: 1, layer: REPO, values: ["b"] },
+        ],
+      }),
+      [{}, {}],
+    );
+
+    expect(groupContributionText(groupAt(digest, 0))).toBe(
+      "contributes 1 behavior · 2 described rules",
+    );
+  });
+
+  test("a redundant group has nothing to report", () => {
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES },
+          { value: "Dashboard.", via: DASHBOARD },
+        ]),
+      }),
+    );
+
+    expect(groupContributionText(groupAt(digest, 1))).toBe("");
+  });
+});

--- a/packages/app/src/lib/description-digest.test.ts
+++ b/packages/app/src/lib/description-digest.test.ts
@@ -102,7 +102,11 @@ describe("grouping", () => {
       }),
     );
 
-    expect(digest.groups.map((g) => g.key)).toEqual(["preset:n1", "preset:n3", "repo"]);
+    expect(digest.groups.map((g) => g.key)).toEqual([
+      "preset:config:best-practices",
+      "preset:group:monorepos",
+      "repo",
+    ]);
     expect(groupAt(digest, 0).entries.map((e) => e.value)).toEqual([
       "Dashboard.",
       "Pin Docker digests.",
@@ -114,8 +118,9 @@ describe("grouping", () => {
   });
 
   test("the same preset extended twice stays two groups", () => {
-    // The whole point of keying on the NODE: `layerId` would conflate these,
-    // and "you extended it twice" is exactly what the card must be able to say.
+    // The whole point of GROUPING on the node: a name-keyed grouping would
+    // conflate these, and "you extended it twice" is exactly what the card must
+    // be able to say. The React keys stay distinct via the ordinal.
     const digest = digestOf(
       provenance({
         entries: entries([
@@ -127,6 +132,31 @@ describe("grouping", () => {
 
     expect(digest.groups).toHaveLength(2);
     expect(digest.groups.map((g) => g.redundant)).toEqual([false, true]);
+    expect(digest.groups.map((g) => g.key)).toEqual([
+      "preset::dependencyDashboard",
+      "preset::dependencyDashboard#2",
+    ]);
+  });
+
+  test("group keys survive a re-run, which mints new node ids", () => {
+    // The card stays mounted across runs while `p1`, `p2`, … are handed out
+    // afresh — a node-id key would silently move a group's "show all" state
+    // onto whichever preset inherited the id.
+    const spec: EntrySpec[] = [
+      { value: "Dashboard.", via: preset("p1", ":dependencyDashboard") },
+      { value: "Group monorepos.", via: preset("p2", "group:monorepos") },
+    ];
+    const first = digestOf(provenance({ entries: entries(spec) }));
+    const rerun = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: preset("p7", ":dependencyDashboard") },
+          { value: "Group monorepos.", via: preset("p9", "group:monorepos") },
+        ]),
+      }),
+    );
+
+    expect(rerun.groups.map((g) => g.key)).toEqual(first.groups.map((g) => g.key));
   });
 
   test("entries keep the index, duplicate marker and approximate flag", () => {
@@ -162,7 +192,11 @@ describe("grouping", () => {
       }),
     );
 
-    expect(digest.groups.map((g) => g.key)).toEqual(["global", "inherited", "preset:n1"]);
+    expect(digest.groups.map((g) => g.key)).toEqual([
+      "global",
+      "inherited",
+      "preset:config:best-practices",
+    ]);
     // Only real `extends` entries count as extends.
     expect(digest.totals.extendsCount).toBe(1);
   });
@@ -180,7 +214,11 @@ describe("redundancy", () => {
       }),
     );
 
-    expect(groupAt(digest, 1)).toMatchObject({ key: "preset:n2", redundant: true, behaviors: 0 });
+    expect(groupAt(digest, 1)).toMatchObject({
+      key: "preset::dependencyDashboard",
+      redundant: true,
+      behaviors: 0,
+    });
     expect(groupAt(digest, 0)).toMatchObject({ redundant: false, behaviors: 2 });
   });
 
@@ -226,10 +264,10 @@ describe("rule descriptions", () => {
     { description: ["From a preset"], matchManagers: ["npm"] },
   ];
 
-  function withRule(layer: ProvenanceLayer): DescriptionProvenance {
+  function withRule(layer: ProvenanceLayer, ruleIndex = 0, sourceIndex = 0): DescriptionProvenance {
     return provenance({
       ruleDescriptions: [
-        { ruleIndex: 0, sourceIndex: 0, layer, values: ["Slow down risky major updates"] },
+        { ruleIndex, sourceIndex, layer, values: ["Slow down risky major updates"] },
       ],
     });
   }
@@ -241,10 +279,24 @@ describe("rule descriptions", () => {
     expect(groupAt(digest, 0)).toMatchObject({ key: "repo" });
     expect(ruleAt(groupAt(digest, 0), 0)).toEqual({
       ruleIndex: 0,
+      sourceIndex: 0,
       values: ["Slow down risky major updates"],
       selectors: "matchUpdateTypes",
       writes: ["minimumReleaseAge"],
     });
+    expect(ruleNoteText(ruleAt(groupAt(digest, 0), 0))).toBe(
+      "packageRules[0] — matchUpdateTypes → minimumReleaseAge",
+    );
+  });
+
+  test("cites the rule where the reader can find it, not the merged index", () => {
+    // Presets merge ahead of the repo, so the user's first rule routinely
+    // lands at merged index 297 — a number their editor has no line for. The
+    // body is still read from the merged array.
+    const merged = [...Array.from({ length: 297 }, () => ({})), RULES[0]];
+    const digest = digestOf(withRule(REPO, 297, 0), merged);
+
+    expect(ruleAt(groupAt(digest, 0), 0)).toMatchObject({ ruleIndex: 297, sourceIndex: 0 });
     expect(ruleNoteText(ruleAt(groupAt(digest, 0), 0))).toBe(
       "packageRules[0] — matchUpdateTypes → minimumReleaseAge",
     );

--- a/packages/app/src/lib/description-digest.ts
+++ b/packages/app/src/lib/description-digest.ts
@@ -3,7 +3,7 @@ import type {
   DescriptionSource,
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
-import { layerId, layerNodeKey } from "@/components/provenance-layer";
+import { layerNodeKey, stableLayerKey } from "@/components/provenance-layer";
 import { ruleWrittenKeys, summarizeRuleSelectors } from "./rule-selectors";
 
 /**
@@ -70,8 +70,8 @@ export interface DigestGroup {
    * flag, so the two extends must stay two groups), but node ids are minted per
    * run — and the card stays mounted across runs, so a node-based key would let
    * a group's expansion state reattach to a different preset after an edit.
-   * Hence the name-based `layerId`, plus an ordinal (`…#2`) for the repeated
-   * extend the node grouping deliberately kept separate.
+   * Hence `stableLayerKey`: the name-based `layerId` plus an ordinal for the
+   * repeated extend the node grouping deliberately kept separate.
    */
   key: string;
   layer: ProvenanceLayer;
@@ -98,6 +98,17 @@ export interface DescriptionDigest {
   totals: DescriptionDigestTotals;
   /** At least one string needed the engine's enclosing-node fallback (069 PR 1). */
   degraded: boolean;
+  /**
+   * Members of the final `description` array that are not text. Renovate only
+   * WARNS about `{"description": ["a sentence", 42]}` — the `42` survives into
+   * the array and holds a real index — so no preset can be credited with it and
+   * no group can show it. Counted here so the card can say so rather than let a
+   * summary titled "What this config does" quietly drop a member.
+   */
+  unattributed: number;
+  /** Length of the real final `description` array (069 PR 1's `finalLength`):
+   *  the strings shown across all groups PLUS {@link unattributed}. */
+  finalLength: number;
 }
 
 interface MutableGroup extends Omit<DigestGroup, "behaviors" | "key" | "redundant"> {
@@ -123,7 +134,11 @@ function groupFor(groups: Map<string, MutableGroup>, layer: ProvenanceLayer): Mu
  * descriptions and no user rule descriptions. `null` rather than an empty
  * digest because the card's empty state is *no card*: a config that extends
  * nothing has no author prose to show, and an empty "What this config does"
- * would be a promise the run cannot keep.
+ * would be a promise the run cannot keep. A `description` holding ONLY
+ * non-strings (`{"description": [42]}`) is that same empty state — there is no
+ * prose to summarize, so no card is shown and nothing claims otherwise; the
+ * under-reporting that {@link DescriptionDigest.unattributed} exists to prevent
+ * only arises once a card IS shown.
  *
  * `rules` is the final merged `packageRules` array (`result.finalConfig`), used
  * only to summarize a described rule's matchers.
@@ -180,13 +195,10 @@ export function buildDescriptionDigest(
       extendsCount++;
     }
     hasUserRules ||= group.rules.length > 0;
-    // Name-based key, disambiguated by how many groups of that name came
-    // before it in merge order — stable across runs, unlike the node id.
-    const base = layerId(group.layer);
-    const seen = keyUses.get(base) ?? 0;
-    keyUses.set(base, seen + 1);
     built.push({
-      key: seen === 0 ? base : `${base}#${seen + 1}`,
+      // Name-based key, disambiguated by how many groups of that name came
+      // before it in merge order — stable across runs, unlike the node id.
+      key: stableLayerKey(group.layer, keyUses),
       ...group,
       // A group with rules always has something to show, whatever its strings did.
       redundant: group.entries.length > 0 && group.behaviors === 0 && group.rules.length === 0,
@@ -200,6 +212,8 @@ export function buildDescriptionDigest(
     groups: built,
     totals: { behaviors, extendsCount, hasUserRules },
     degraded: provenance.degraded,
+    unattributed: provenance.unattributed.length,
+    finalLength: provenance.finalLength,
   };
 }
 
@@ -220,6 +234,26 @@ export function descriptionCountText(totals: DescriptionDigestTotals): string {
     parts.push(`from ${sources.join(" + ")}`);
   }
   return parts.join(" · ");
+}
+
+/**
+ * The card's quiet footnote about the members no group can show: `2 members of
+ * the description array are not text, so no preset can be credited with them`.
+ * Empty when there are none — which is every well-formed config.
+ *
+ * Renovate accepts a wrong-typed member with a warning rather than a refusal
+ * (069 PR 1), so this really does happen to real configs; the card summarizes
+ * strings, and a summary that silently omits part of the array it is
+ * summarizing is the thing this line exists to prevent.
+ */
+export function unattributedNoteText(digest: DescriptionDigest): string {
+  const count = digest.unattributed;
+  if (count === 0) {
+    return "";
+  }
+  const members = count === 1 ? "member" : "members";
+  const them = count === 1 ? "it" : "them";
+  return `${nf.format(count)} ${members} of the description array ${count === 1 ? "is" : "are"} not text, so no preset can be credited with ${them}.`;
 }
 
 /** A group header's muted note: what this layer added, in its own right. */

--- a/packages/app/src/lib/description-digest.ts
+++ b/packages/app/src/lib/description-digest.ts
@@ -3,6 +3,7 @@ import type {
   DescriptionSource,
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
+import { layerId, layerNodeKey } from "@/components/provenance-layer";
 import { ruleWrittenKeys, summarizeRuleSelectors } from "./rule-selectors";
 
 /**
@@ -46,8 +47,14 @@ export interface DigestEntry {
 
 /** A description written on one of the repo config's OWN `packageRules`. */
 export interface DigestRule {
-  /** Index into the final merged `packageRules` array, as Renovate cites it. */
+  /** Index into the final merged `packageRules` array — where the rule BODY is
+   *  read from, and the id Renovate's own validator messages cite. */
   ruleIndex: number;
+  /** Index within the repo config's own `packageRules` array — the only one of
+   *  the two the reader can find in their editor, so the one the card cites.
+   *  (Presets extend ahead of the repo, so the merged index of a user rule is
+   *  routinely in the hundreds.) */
+  sourceIndex: number;
   values: string[];
   /** `matchUpdateTypes + matchManagers`, or the honest "no selectors" note. */
   selectors: string;
@@ -57,9 +64,15 @@ export interface DigestRule {
 
 /** Everything one top-level layer contributed. */
 export interface DigestGroup {
-  /** Stable React key. Preset groups key on the NODE, not the name: extending
-   *  the same preset twice is exactly the case this card exists to flag, and
-   *  the two extends must stay two groups. */
+  /**
+   * React key, stable ACROSS RUNS. The grouping itself keys on the preset NODE
+   * (extending the same preset twice is exactly the case this card exists to
+   * flag, so the two extends must stay two groups), but node ids are minted per
+   * run — and the card stays mounted across runs, so a node-based key would let
+   * a group's expansion state reattach to a different preset after an edit.
+   * Hence the name-based `layerId`, plus an ordinal (`…#2`) for the repeated
+   * extend the node grouping deliberately kept separate.
+   */
   key: string;
   layer: ProvenanceLayer;
   entries: DigestEntry[];
@@ -87,23 +100,20 @@ export interface DescriptionDigest {
   degraded: boolean;
 }
 
-/** Groups a preset layer by node id, every other layer by its kind — the same
- *  identity `EffectiveConfig`'s `stepKey` uses, and for the same reason. */
-function layerKey(layer: ProvenanceLayer): string {
-  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
-}
-
-interface MutableGroup extends Omit<DigestGroup, "behaviors" | "redundant"> {
+interface MutableGroup extends Omit<DigestGroup, "behaviors" | "key" | "redundant"> {
   behaviors: number;
 }
 
+/** The group a layer belongs to, created on first sight. Keyed by
+ *  `layerNodeKey` — the node identity, so the same preset extended twice is
+ *  two groups; the React key is derived separately (see {@link DigestGroup}). */
 function groupFor(groups: Map<string, MutableGroup>, layer: ProvenanceLayer): MutableGroup {
-  const key = layerKey(layer);
+  const key = layerNodeKey(layer);
   const existing = groups.get(key);
   if (existing) {
     return existing;
   }
-  const created: MutableGroup = { key, layer, entries: [], rules: [], behaviors: 0 };
+  const created: MutableGroup = { layer, entries: [], rules: [], behaviors: 0 };
   groups.set(key, created);
   return created;
 }
@@ -152,6 +162,7 @@ export function buildDescriptionDigest(
     const body = rules?.[rule.ruleIndex];
     groupFor(groups, rule.layer).rules.push({
       ruleIndex: rule.ruleIndex,
+      sourceIndex: rule.sourceIndex,
       values: rule.values,
       selectors: summarizeRuleSelectors(body),
       writes: ruleWrittenKeys(body),
@@ -159,6 +170,7 @@ export function buildDescriptionDigest(
   }
 
   const built: DigestGroup[] = [];
+  const keyUses = new Map<string, number>();
   let behaviors = 0;
   let extendsCount = 0;
   let hasUserRules = false;
@@ -168,7 +180,13 @@ export function buildDescriptionDigest(
       extendsCount++;
     }
     hasUserRules ||= group.rules.length > 0;
+    // Name-based key, disambiguated by how many groups of that name came
+    // before it in merge order — stable across runs, unlike the node id.
+    const base = layerId(group.layer);
+    const seen = keyUses.get(base) ?? 0;
+    keyUses.set(base, seen + 1);
     built.push({
+      key: seen === 0 ? base : `${base}#${seen + 1}`,
       ...group,
       // A group with rules always has something to show, whatever its strings did.
       redundant: group.entries.length > 0 && group.behaviors === 0 && group.rules.length === 0,
@@ -220,8 +238,18 @@ export function groupContributionText(group: DigestGroup): string {
   return parts.join(" · ");
 }
 
-/** The muted note under a user rule: `packageRules[0] — matchUpdateTypes → minimumReleaseAge`. */
+/**
+ * The muted note under a user rule: `packageRules[0] — matchUpdateTypes →
+ * minimumReleaseAge`.
+ *
+ * Cited by `sourceIndex`, NOT the merged `ruleIndex`: these are the repo's own
+ * rules, and presets merge ahead of the repo — a config extending
+ * `config:best-practices` puts the user's first rule at merged index ~297, a
+ * number that appears nowhere in their editor. The repo-local index is the one
+ * they can act on, and the one the editor cross-links use (App's
+ * `packageRules[repoIndex]` jump).
+ */
 export function ruleNoteText(rule: DigestRule): string {
-  const note = `packageRules[${rule.ruleIndex}] — ${rule.selectors}`;
+  const note = `packageRules[${rule.sourceIndex}] — ${rule.selectors}`;
   return rule.writes.length > 0 ? `${note} → ${rule.writes.join(", ")}` : note;
 }

--- a/packages/app/src/lib/description-digest.ts
+++ b/packages/app/src/lib/description-digest.ts
@@ -1,0 +1,227 @@
+import type {
+  DescriptionProvenance,
+  DescriptionSource,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import { ruleWrittenKeys, summarizeRuleSelectors } from "./rule-selectors";
+
+/**
+ * Roadmap 069 (PR 2): the view-model behind the Overview's "What this config
+ * does" card — the engine's per-string `description` attribution regrouped from
+ * "the final array, in order" into "who contributed what".
+ *
+ * The engine hands back one flat, positionally-correct list (069 PR 1); that
+ * order is the honest one and the Effective config's blame ledger keeps it. The
+ * Overview asks a different question — *what did each `extends` entry buy me* —
+ * so this groups the same strings by the top-level layer they arrived through,
+ * in merge order, without reordering anything inside a group.
+ *
+ * Two things fall out of the grouping that the flat list cannot say:
+ *
+ * - A top-level extend whose every string repeats an earlier one contributed no
+ *   new behavior at all — it is `redundant`, i.e. a preset some other extend
+ *   already pulled in. That is a real and common mistake (adding a preset
+ *   `config:recommended` already contains), and the card names it.
+ * - The repo's own `packageRules` descriptions have no top-level presence
+ *   whatsoever (Renovate never hoists them), so they are carried alongside the
+ *   repo group — the first surface in the app to show them.
+ *
+ * Pure and DOM-free (`lib/`), so `packages/cli` can quote the same digest.
+ */
+
+const nf = new Intl.NumberFormat();
+
+/** One string of the final top-level `description`, as the card renders it. */
+export interface DigestEntry {
+  /** Index into the final `description` array — the canonical id (069 PR 1). */
+  index: number;
+  value: string;
+  /** The preset whose own body wrote it; absent for the defaults/global/inherited layers. */
+  node?: DescriptionSource;
+  /** Set when this string repeats an earlier one, pointing at that first occurrence. */
+  duplicateOfIndex?: number;
+  /** The exact writer is unknown; `node` names the enclosing subtree instead. */
+  approximate?: boolean;
+}
+
+/** A description written on one of the repo config's OWN `packageRules`. */
+export interface DigestRule {
+  /** Index into the final merged `packageRules` array, as Renovate cites it. */
+  ruleIndex: number;
+  values: string[];
+  /** `matchUpdateTypes + matchManagers`, or the honest "no selectors" note. */
+  selectors: string;
+  /** The option keys the rule sets. */
+  writes: string[];
+}
+
+/** Everything one top-level layer contributed. */
+export interface DigestGroup {
+  /** Stable React key. Preset groups key on the NODE, not the name: extending
+   *  the same preset twice is exactly the case this card exists to flag, and
+   *  the two extends must stay two groups. */
+  key: string;
+  layer: ProvenanceLayer;
+  entries: DigestEntry[];
+  /** Repo group only — user-written `packageRules` descriptions. */
+  rules: DigestRule[];
+  /** Entries that are not duplicates of an earlier string: what this layer ADDED. */
+  behaviors: number;
+  /** Every string this layer contributed was already contributed above it. */
+  redundant: boolean;
+}
+
+export interface DescriptionDigestTotals {
+  /** Distinct behaviors — duplicated strings counted once. */
+  behaviors: number;
+  /** Top-level `extends` entries that contributed at least one string. */
+  extendsCount: number;
+  hasUserRules: boolean;
+}
+
+export interface DescriptionDigest {
+  /** Groups in merge order: the external layers, each direct extend, the repo config. */
+  groups: DigestGroup[];
+  totals: DescriptionDigestTotals;
+  /** At least one string needed the engine's enclosing-node fallback (069 PR 1). */
+  degraded: boolean;
+}
+
+/** Groups a preset layer by node id, every other layer by its kind — the same
+ *  identity `EffectiveConfig`'s `stepKey` uses, and for the same reason. */
+function layerKey(layer: ProvenanceLayer): string {
+  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
+}
+
+interface MutableGroup extends Omit<DigestGroup, "behaviors" | "redundant"> {
+  behaviors: number;
+}
+
+function groupFor(groups: Map<string, MutableGroup>, layer: ProvenanceLayer): MutableGroup {
+  const key = layerKey(layer);
+  const existing = groups.get(key);
+  if (existing) {
+    return existing;
+  }
+  const created: MutableGroup = { key, layer, entries: [], rules: [], behaviors: 0 };
+  groups.set(key, created);
+  return created;
+}
+
+/**
+ * Builds the digest, or `null` when this run has nothing to say — no top-level
+ * descriptions and no user rule descriptions. `null` rather than an empty
+ * digest because the card's empty state is *no card*: a config that extends
+ * nothing has no author prose to show, and an empty "What this config does"
+ * would be a promise the run cannot keep.
+ *
+ * `rules` is the final merged `packageRules` array (`result.finalConfig`), used
+ * only to summarize a described rule's matchers.
+ */
+export function buildDescriptionDigest(
+  provenance: DescriptionProvenance,
+  rules?: readonly unknown[] | null,
+): DescriptionDigest | null {
+  const groups = new Map<string, MutableGroup>();
+
+  // Insertion order IS merge order: the engine emits `entries` in final-array
+  // order, and the final array is built layer by layer.
+  for (const entry of provenance.entries) {
+    const group = groupFor(groups, entry.viaTopLevel);
+    group.entries.push({
+      index: entry.index,
+      value: entry.value,
+      ...(entry.node ? { node: entry.node } : {}),
+      ...(entry.duplicateOfIndex === undefined ? {} : { duplicateOfIndex: entry.duplicateOfIndex }),
+      ...(entry.approximate ? { approximate: true } : {}),
+    });
+    if (entry.duplicateOfIndex === undefined) {
+      group.behaviors++;
+    }
+  }
+
+  // Only the REPO's own rules. A preset's rule descriptions are attributed to
+  // the layer, not the writing node (069 PR 1's weaker granularity), and
+  // `config:best-practices` alone carries hundreds of them — they belong to PR
+  // 5's simulator annotation, where a rule is shown because it MATCHED. Here
+  // they would bury the six sentences a reader came for.
+  for (const rule of provenance.ruleDescriptions) {
+    if (rule.layer.kind !== "repo") {
+      continue;
+    }
+    const body = rules?.[rule.ruleIndex];
+    groupFor(groups, rule.layer).rules.push({
+      ruleIndex: rule.ruleIndex,
+      values: rule.values,
+      selectors: summarizeRuleSelectors(body),
+      writes: ruleWrittenKeys(body),
+    });
+  }
+
+  const built: DigestGroup[] = [];
+  let behaviors = 0;
+  let extendsCount = 0;
+  let hasUserRules = false;
+  for (const group of groups.values()) {
+    behaviors += group.behaviors;
+    if (group.layer.kind === "preset" && group.entries.length > 0) {
+      extendsCount++;
+    }
+    hasUserRules ||= group.rules.length > 0;
+    built.push({
+      ...group,
+      // A group with rules always has something to show, whatever its strings did.
+      redundant: group.entries.length > 0 && group.behaviors === 0 && group.rules.length === 0,
+    });
+  }
+
+  if (built.length === 0) {
+    return null;
+  }
+  return {
+    groups: built,
+    totals: { behaviors, extendsCount, hasUserRules },
+    degraded: provenance.degraded,
+  };
+}
+
+/** The card title's muted count: `22 behaviors · from 3 extends + your rules`. */
+export function descriptionCountText(totals: DescriptionDigestTotals): string {
+  const parts: string[] = [];
+  if (totals.behaviors > 0) {
+    parts.push(`${nf.format(totals.behaviors)} behavior${totals.behaviors === 1 ? "" : "s"}`);
+  }
+  const sources: string[] = [];
+  if (totals.extendsCount > 0) {
+    sources.push(`${nf.format(totals.extendsCount)} extend${totals.extendsCount === 1 ? "" : "s"}`);
+  }
+  if (totals.hasUserRules) {
+    sources.push("your rules");
+  }
+  if (sources.length > 0) {
+    parts.push(`from ${sources.join(" + ")}`);
+  }
+  return parts.join(" · ");
+}
+
+/** A group header's muted note: what this layer added, in its own right. */
+export function groupContributionText(group: DigestGroup): string {
+  const parts: string[] = [];
+  if (group.behaviors > 0) {
+    parts.push(
+      `contributes ${nf.format(group.behaviors)} behavior${group.behaviors === 1 ? "" : "s"}`,
+    );
+  }
+  if (group.rules.length > 0) {
+    parts.push(
+      `${nf.format(group.rules.length)} described rule${group.rules.length === 1 ? "" : "s"}`,
+    );
+  }
+  return parts.join(" · ");
+}
+
+/** The muted note under a user rule: `packageRules[0] — matchUpdateTypes → minimumReleaseAge`. */
+export function ruleNoteText(rule: DigestRule): string {
+  const note = `packageRules[${rule.ruleIndex}] — ${rule.selectors}`;
+  return rule.writes.length > 0 ? `${note} → ${rule.writes.join(", ")}` : note;
+}

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -37,6 +37,7 @@ export {
   type DigestRule,
   groupContributionText,
   ruleNoteText,
+  unattributedNoteText,
 } from "./description-digest";
 export {
   effectiveTally,

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -5,8 +5,10 @@
  * The engine answers "what did Renovate do"; these modules answer the handful
  * of questions the app adds on top — the preset-expansion totals, the plain-
  * English run digest, the effective-config tallies, the pollution-checked
- * parse of the 008 config layers, and (roadmap 062) the simulator's rule
- * filters, which `rcd simulate --verdict/--source` is. The CLI must quote the
+ * parse of the 008 config layers, (roadmap 062) the simulator's rule
+ * filters, which `rcd simulate --verdict/--source` is, and (roadmap 069) the
+ * description digest behind the Overview's "What this config does" card — the
+ * grouping and counts, not the attribution, which is the engine's. The CLI must quote the
  * SAME numbers the web
  * app renders, so it imports them rather than restating them; this barrel is
  * the seam that makes that an import instead of a copy.
@@ -25,6 +27,17 @@ export {
   type TreeStats,
   type TreeSummary,
 } from "@/components/preset-tree-stats";
+export {
+  buildDescriptionDigest,
+  descriptionCountText,
+  type DescriptionDigest,
+  type DescriptionDigestTotals,
+  type DigestEntry,
+  type DigestGroup,
+  type DigestRule,
+  groupContributionText,
+  ruleNoteText,
+} from "./description-digest";
 export {
   effectiveTally,
   type EffectiveTally,

--- a/packages/app/src/lib/rule-selectors.ts
+++ b/packages/app/src/lib/rule-selectors.ts
@@ -1,0 +1,47 @@
+/**
+ * One-line summaries of a raw `packageRules` entry — what it selects, and what
+ * it writes — read straight off the merged rule body.
+ *
+ * Hoisted out of `EffectiveConfig.tsx` by roadmap 069: the description digest
+ * needs the same "which matchers does this rule carry" sentence the effective
+ * config's per-rule provenance list already prints, and a second spelling of it
+ * would be a second answer to the same question. Pure and DOM-free, hence
+ * `lib/` — the simulator's `ruleLabel` is the richer variant, but it needs an
+ * evaluated `RuleEvaluation`, which neither of these two callers has.
+ */
+
+function ruleKeys(rule: unknown): string[] | null {
+  if (typeof rule !== "object" || rule === null) {
+    return null;
+  }
+  return Object.keys(rule as Record<string, unknown>);
+}
+
+/** First matcher-clause key list, for a one-line rule summary (mirrors the
+ *  simulator's ruleLabel — all clauses, no "which one matters" judgment
+ *  since neither caller has a dependency to evaluate against). */
+export function summarizeRuleSelectors(rule: unknown): string {
+  const keys = ruleKeys(rule);
+  if (!keys) {
+    return "(not an object)";
+  }
+  const selectors = keys.filter((k) => k.startsWith("match") || k.startsWith("exclude"));
+  return selectors.length > 0 ? selectors.join(" + ") : "(no match*/exclude* selectors)";
+}
+
+/**
+ * The options a rule WRITES: everything that is neither a selector nor the
+ * rule's own prose. Roadmap 069's digest pairs this with the selector summary
+ * so a user rule reads `matchUpdateTypes → minimumReleaseAge` — the mockup's
+ * "major → minimumReleaseAge 14 days" note, without inventing values the
+ * derivation cannot honestly render as one line.
+ */
+export function ruleWrittenKeys(rule: unknown): string[] {
+  const keys = ruleKeys(rule);
+  if (!keys) {
+    return [];
+  }
+  return keys.filter(
+    (k) => k !== "description" && !k.startsWith("match") && !k.startsWith("exclude"),
+  );
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -73,7 +73,7 @@ export {
   type RepoFileRequest,
   type RepoPlatform,
 } from "./shims/repo-config";
-export { STAGE_IDS } from "./trace/model";
+export { ROOT_NODE_ID, STAGE_IDS } from "./trace/model";
 export type {
   LogLevel,
   MigrationStepInfo,

--- a/packages/engine/src/trace/description-provenance.ts
+++ b/packages/engine/src/trace/description-provenance.ts
@@ -52,7 +52,7 @@ import { computeRuleProvenance, type ProvenanceLayer } from "./provenance";
 
 /** The preset-tree node a string (or a drop) is attributed to. */
 export interface DescriptionSource {
-  /** `PresetNode.id`; `"root"` for the repo config itself. */
+  /** `PresetNode.id`; `ROOT_NODE_ID` for the repo config itself. */
   nodeId: string;
   /** Raw preset string as written in `extends`; `"(input config)"` for the root. */
   name: string;

--- a/packages/engine/src/trace/model.ts
+++ b/packages/engine/src/trace/model.ts
@@ -104,7 +104,16 @@ export type PresetNodeState =
   /** Skipped because it already appears in its own ancestor chain */
   | "already-seen";
 
+/**
+ * `PresetNode.id` of the tree's root — the repo's own input config, not a
+ * preset. It is the one node the tree view has no row for (the rows start at
+ * the root's children), so a consumer offering "show this in the preset tree"
+ * must check for it rather than hand it to a node-selection callback.
+ */
+export const ROOT_NODE_ID = "root";
+
 export interface PresetNode {
+  /** `ROOT_NODE_ID` for the tree's root; `p<n>` (per-run, not stable) otherwise. */
   id: string;
   /** Raw preset string as written in `extends`; the root node is the input config */
   name: string;

--- a/packages/engine/src/trace/preset-tree.ts
+++ b/packages/engine/src/trace/preset-tree.ts
@@ -1,10 +1,11 @@
 import { toSerializable } from "./delta";
-import type {
-  PlatformContext,
-  PresetNode,
-  PresetSourceRef,
-  TraceEvent,
-  ValidationMessage,
+import {
+  type PlatformContext,
+  type PresetNode,
+  type PresetSourceRef,
+  ROOT_NODE_ID,
+  type TraceEvent,
+  type ValidationMessage,
 } from "./model";
 
 /**
@@ -154,7 +155,7 @@ export class PresetTreeBuilder {
     const top = this.top();
     if (!top) {
       this.root = {
-        id: "root",
+        id: ROOT_NODE_ID,
         name: "(input config)",
         state: "aborted",
         input: toSerializable(meta.config),


### PR DESCRIPTION
New 'What this config does' card on the Overview tab renders the
author-written preset descriptions as the config's own documentation:
grouped by the top-level extends entry that pulled each one in, leaf
preset labeled and clickable into the resolution tree, redundant
extends collapsed to a single flag, and repo-config packageRules
descriptions surfaced for the first time. Headless digest derivation
exported for CLI reuse. Roadmap 069, PR 2 of 5.