### PR TITLE
feat(app): per-string blame ledger for the description row

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -339,6 +339,9 @@ export function App() {
   // Roadmap 028: bumped to focus the effective config's filter input from the
   // Overview's "Where did a setting come from?" pill.
   const [effectiveFilterNonce, setEffectiveFilterNonce] = useState(0);
+  // Roadmap 069: bumped by the Overview digest card's "show raw order" link to
+  // land on the effective config's `description` row and its blame ledger.
+  const [descriptionLedgerNonce, setDescriptionLedgerNonce] = useState(0);
   // Roadmap 028: the results pane, so a Run on a stacked (narrow) viewport can
   // scroll its consequence into view instead of appearing to do nothing.
   const resultsColRef = useRef<HTMLDivElement>(null);
@@ -468,6 +471,13 @@ export function App() {
   const onWhereFrom = useCallback(() => {
     jumpToTab("effective");
     setEffectiveFilterNonce((n) => n + 1);
+  }, [jumpToTab]);
+
+  /** Roadmap 069: the digest card's "show raw order" link — the same jump, but
+   *  landing on the `description` row rather than on the filter box. */
+  const onShowDescriptionOrder = useCallback(() => {
+    jumpToTab("effective");
+    setDescriptionLedgerNonce((n) => n + 1);
   }, [jumpToTab]);
 
   // Roadmap 028: selecting a preset node from anywhere else (a provenance
@@ -1900,6 +1910,7 @@ export function App() {
               errorLib={errorLib}
               digest={digest}
               onWhereFrom={onWhereFrom}
+              onShowDescriptionOrder={onShowDescriptionOrder}
               selectedStage={selectedStage}
               onSelectStage={setSelectedStage}
               deferredStage={deferredStage}
@@ -1916,6 +1927,7 @@ export function App() {
               onRunAgain={onRunAgain}
               onEffectiveStats={setEffectiveStats}
               effectiveFilterNonce={effectiveFilterNonce}
+              descriptionLedgerNonce={descriptionLedgerNonce}
               pendingRuleFocus={pendingRuleFocus}
               onRuleFocused={onRuleFocused}
               simRequest={simRequest}

--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -70,6 +70,9 @@ export interface ResultsColumnProps {
   // —— overview ——
   digest: DigestClause[];
   onWhereFrom: () => void;
+  /** Roadmap 069: the digest card's "show raw order" link — jumps to Effective
+   *  config and lands on the `description` row's blame ledger. */
+  onShowDescriptionOrder: () => void;
 
   // —— pipeline ——
   selectedStage: StageId;
@@ -96,6 +99,9 @@ export interface ResultsColumnProps {
   // —— effective ——
   onEffectiveStats: (stats: EffectiveStats) => void;
   effectiveFilterNonce: number;
+  /** Roadmap 069: bumped alongside the jump above, so the row is filtered to
+   *  and expanded once the tab is on screen. */
+  descriptionLedgerNonce: number;
 
   // —— simulator ——
   pendingRuleFocus: number | null;
@@ -158,6 +164,7 @@ export function ResultsColumn({
   errorLib,
   digest,
   onWhereFrom,
+  onShowDescriptionOrder,
   selectedStage,
   onSelectStage,
   deferredStage,
@@ -174,6 +181,7 @@ export function ResultsColumn({
   onRunAgain,
   onEffectiveStats,
   effectiveFilterNonce,
+  descriptionLedgerNonce,
   pendingRuleFocus,
   onRuleFocused,
   simRequest,
@@ -256,6 +264,7 @@ export function ResultsColumn({
           onOpen={jumpToTab}
           onWhereFrom={onWhereFrom}
           onSelectPreset={selectPresetNode}
+          onShowRawOrder={onShowDescriptionOrder}
         />
       ),
       pipeline: (
@@ -330,6 +339,7 @@ export function ResultsColumn({
             onSelectPreset={selectPresetNode}
             onStats={onEffectiveStats}
             focusFilterNonce={effectiveFilterNonce}
+            focusDescriptionNonce={descriptionLedgerNonce}
           />
         </>
       ) : (
@@ -380,6 +390,7 @@ export function ResultsColumn({
     errorLib,
     digest,
     onWhereFrom,
+    onShowDescriptionOrder,
     selectedStage,
     onSelectStage,
     deferredStage,
@@ -395,6 +406,7 @@ export function ResultsColumn({
     installUrl,
     onEffectiveStats,
     effectiveFilterNonce,
+    descriptionLedgerNonce,
     pendingRuleFocus,
     onRuleFocused,
     simRequest,

--- a/packages/app/src/components/BlameLedger.test.tsx
+++ b/packages/app/src/components/BlameLedger.test.tsx
@@ -1,0 +1,126 @@
+import type { DescriptionProvenance, ProvenanceLayer } from "@renovate-config-debugger/engine";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { afterEach, expect, test } from "vitest";
+import { buildDescriptionLedger, type DescriptionLedger } from "@/lib/description-ledger";
+import { BlameLedger } from "./BlameLedger";
+
+/**
+ * Roadmap 069 (PR 3): the ledger's honesty marks, over hand-built provenance.
+ *
+ * The wording is unit-tested (`lib/description-ledger.test.ts`,
+ * `lib/drop-reasons.test.ts`) and the row's integration with the Effective
+ * config is covered by that component's own test; what only a render can prove
+ * is that the `≈` reaches the rows that need it — the ones a real run produces
+ * only by degrading, which no fixture config can be relied on to do.
+ */
+
+afterEach(cleanup);
+
+const DASHBOARD: ProvenanceLayer = { kind: "preset", nodeId: "p1", name: ":dependencyDashboard" };
+
+function ledgerOf(provenance: Partial<DescriptionProvenance>): DescriptionLedger {
+  const built = buildDescriptionLedger({
+    entries: [],
+    unattributed: [],
+    finalLength: (provenance.entries?.length ?? 0) + (provenance.unattributed?.length ?? 0),
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+    ...provenance,
+  });
+  if (!built) {
+    throw new Error("expected a ledger, got null");
+  }
+  return built;
+}
+
+test("marks an approximate row, duplicates included", () => {
+  // The duplicate cell renders no chip at all — before 069's review it also
+  // rendered no mark, so an approximate repeat read as a confident accusation
+  // ("repo config repeats it") against a layer the engine had guessed.
+  const ledger = ledgerOf({
+    entries: [
+      {
+        index: 0,
+        value: "Dashboard.",
+        viaTopLevel: DASHBOARD,
+        node: { nodeId: "p1", name: ":dependencyDashboard" },
+      },
+      {
+        index: 1,
+        value: "Dashboard.",
+        viaTopLevel: { kind: "repo" },
+        node: { nodeId: "root", name: "(input config)" },
+        duplicateOfIndex: 0,
+        approximate: true,
+      },
+    ],
+    degraded: true,
+  });
+
+  const view = render(<BlameLedger ledger={ledger} />);
+  const rows = [...view.container.querySelectorAll<HTMLElement>(".desc-ledger-row")];
+  const duplicate = rows[1];
+  if (!duplicate) {
+    throw new Error(`expected two rows, got ${rows.length}`);
+  }
+
+  // The confident row is unmarked…
+  expect(rows[0]?.querySelector(".desc-approx-mark")).toBeNull();
+  // …and the guessed one carries the shared mark plus the hedged wording.
+  expect(duplicate.querySelector(".desc-approx-mark")).not.toBeNull();
+  expect(within(duplicate).getByText("duplicate of #1")).toBeTruthy();
+  expect(duplicate.textContent).toContain("probably repeated by repo config");
+  // …under the shared caveat, not a second wording of it.
+  expect(view.container.querySelector(".desc-approx-caveat")).not.toBeNull();
+  expect(view.container.querySelector(".desc-ledger-caveat")).toBeNull();
+});
+
+test("marks an approximate drop and hedges its reason", () => {
+  const ledger = ledgerOf({
+    entries: [{ index: 0, value: "Kept.", viaTopLevel: { kind: "repo" } }],
+    dropped: [
+      {
+        value: "Group Jest packages.",
+        node: { nodeId: "n5", name: "group:recommended" },
+        reason: "ignore-deps-quirk",
+        droppedBy: { nodeId: "n6", name: "group:jestPlusTypes" },
+        approximate: true,
+      },
+    ],
+  });
+
+  const view = render(<BlameLedger ledger={ledger} />);
+  // The footer is closed by default — it is a footnote.
+  fireEvent.click(view.getByText("Not included: 1 description Renovate dropped"));
+
+  const dropped = view.container.querySelector<HTMLElement>(".desc-ledger-row.dropped");
+  if (!dropped) {
+    throw new Error("the opened footer rendered no dropped row");
+  }
+  expect(dropped.querySelector(".desc-approx-mark")).not.toBeNull();
+  expect(dropped.textContent).toContain("exact preset unknown");
+});
+
+test("gives a non-string member its own line rather than skipping it", () => {
+  const ledger = ledgerOf({
+    entries: [
+      {
+        index: 0,
+        value: "Keep this.",
+        viaTopLevel: { kind: "repo" },
+        node: { nodeId: "root", name: "(input config)" },
+      },
+    ],
+    unattributed: [{ index: 1, value: 42 }],
+  });
+
+  const view = render(<BlameLedger ledger={ledger} />);
+  const rows = [...view.container.querySelectorAll<HTMLElement>(".desc-ledger-row")];
+
+  expect(rows).toHaveLength(2);
+  expect(rows.map((row) => row.querySelector(".desc-ledger-idx")?.textContent)).toEqual(["1", "2"]);
+  expect(rows[1]?.className).toContain("unattributed");
+  expect(rows[1]?.textContent).toContain("42");
+  expect(rows[1]?.textContent).toContain("no preset can be credited");
+});

--- a/packages/app/src/components/BlameLedger.tsx
+++ b/packages/app/src/components/BlameLedger.tsx
@@ -7,19 +7,24 @@ import type {
 import {
   type DescriptionLedger,
   DROPPED_COLLAPSE_AFTER,
-  droppedReasonText,
   droppedSummaryText,
   duplicateNoteText,
   duplicatePillText,
   hiddenCount,
   LEDGER_COLLAPSE_AFTER,
+  ledgerCountText,
   type LedgerGroup,
+  type LedgerRow,
   ledgerWriterText,
   moreDroppedText,
   moreEntriesText,
+  unattributedNoteText,
+  unattributedValueText,
   viaNoteText,
 } from "@/lib/description-ledger";
+import { dropReasonText } from "@/lib/drop-reasons";
 import { CodeText } from "./CodeText";
+import { ApproximateMark, DegradedCaveat } from "./DescriptionApprox";
 import { ROOT_NODE_ID } from "./preset-tree-stats";
 import { layerLabel } from "./provenance-layer";
 import { ProvenanceChip } from "./ProvenanceChip";
@@ -37,9 +42,14 @@ import { ProvenanceChip } from "./ProvenanceChip";
  *
  * The order is the final array's, unaltered — nothing sorted, nothing folded,
  * duplicates struck through rather than removed (DevTools' cascade, not VS
- * Code's hidden precedence). The only imposed structure is the hairline
- * between consecutive runs of the same top-level extend, which is what makes
- * "which line do I delete" readable at a glance.
+ * Code's hidden precedence), and a member that is not text still holding its
+ * own line. The only imposed structure is the hairline between consecutive runs
+ * of the same top-level extend, which is what makes "which line do I delete"
+ * readable at a glance.
+ *
+ * Every hedge here is the shared one (`DescriptionApprox`, `drop-reasons`): a
+ * reader who learned what `≈` means on the Overview's digest card must not meet
+ * a differently-worded caveat on this surface.
  */
 
 /**
@@ -59,19 +69,6 @@ function sourceLayer(entry: DescriptionAttribution): ProvenanceLayer {
   return entry.node && entry.node.nodeId !== ROOT_NODE_ID
     ? { kind: "preset", nodeId: entry.node.nodeId, name: entry.node.name }
     : entry.viaTopLevel;
-}
-
-/** 069 PR 1's honest fallback, in PR 2's marking: the attribution is to an
- *  enclosing subtree, not a leaf, so the chip is prefixed rather than trusted. */
-function ApproximateMark({ name }: { name: string }) {
-  return (
-    <span
-      className="desc-ledger-approx"
-      title={`Contributed somewhere inside ${name} — the exact preset could not be determined`}
-    >
-      ≈
-    </span>
-  );
 }
 
 /** The third cell of a normal row: who wrote it, and which extend carried it. */
@@ -94,19 +91,28 @@ function LedgerSource({
   );
 }
 
-/** …and the same cell for a repeat: no chip, because the sentence adds
- *  nothing — what it needs instead is where it was already said, and which
- *  extend said it a second time. */
+/**
+ * …and the same cell for a repeat: no chip, because the sentence adds
+ * nothing — what it needs instead is where it was already said, and which
+ * extend said it a second time.
+ *
+ * Approximate entries are marked here too. The mark is not decoration: an
+ * approximate repeat's arrival layer is the one the engine's fallback assigned,
+ * so an unmarked "repo config repeats it" would be a confident accusation
+ * against a config that may not have repeated anything (`duplicateNoteText`
+ * hedges the wording to match).
+ */
 function DuplicateSource({ entry }: { entry: DescriptionAttribution }) {
   return (
     <span className="desc-ledger-src">
+      {entry.approximate ? <ApproximateMark name={layerLabel(sourceLayer(entry))} /> : null}
       <span className="desc-ledger-dup">{duplicatePillText(entry)}</span>
       <span className="desc-ledger-via">{duplicateNoteText(entry)}</span>
     </span>
   );
 }
 
-function LedgerRow({
+function LedgerEntryLine({
   entry,
   onSelectPreset,
 }: {
@@ -129,7 +135,38 @@ function LedgerRow({
   );
 }
 
-/** One blame run — consecutive strings from the same top-level extend. */
+/**
+ * A member of the array that is not a string. It has a real index and Renovate
+ * really did keep it (`subType: "string"` is a validation WARNING here), so it
+ * keeps its line in the ledger — the alternative is an array that renders one
+ * member shorter than the "Final value" block above it.
+ */
+function UnattributedLine({ index, value }: { index: number; value: unknown }) {
+  return (
+    <li className="desc-ledger-row unattributed">
+      <span className="desc-ledger-idx">{index + 1}</span>
+      <span className="desc-ledger-text">{unattributedValueText(value)}</span>
+      <span className="desc-ledger-src">
+        <span className="desc-ledger-via">{unattributedNoteText()}</span>
+      </span>
+    </li>
+  );
+}
+
+function LedgerLine({
+  row,
+  onSelectPreset,
+}: {
+  row: LedgerRow;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  if (row.kind === "unattributed") {
+    return <UnattributedLine index={row.index} value={row.value} />;
+  }
+  return <LedgerEntryLine entry={row.entry} onSelectPreset={onSelectPreset} />;
+}
+
+/** One blame run — consecutive rows from the same top-level extend. */
 function LedgerRun({
   group,
   onSelectPreset,
@@ -138,12 +175,12 @@ function LedgerRun({
   onSelectPreset?: (nodeId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
-  const hidden = hiddenCount(group.entries.length, LEDGER_COLLAPSE_AFTER, expanded);
-  const shown = hidden > 0 ? group.entries.slice(0, LEDGER_COLLAPSE_AFTER) : group.entries;
+  const hidden = hiddenCount(group.rows.length, LEDGER_COLLAPSE_AFTER, expanded);
+  const shown = hidden > 0 ? group.rows.slice(0, LEDGER_COLLAPSE_AFTER) : group.rows;
   return (
     <ul className="desc-ledger-list">
-      {shown.map((entry) => (
-        <LedgerRow key={entry.index} entry={entry} onSelectPreset={onSelectPreset} />
+      {shown.map((row) => (
+        <LedgerLine key={row.index} row={row} onSelectPreset={onSelectPreset} />
       ))}
       {hidden > 0 ? (
         <li className="desc-ledger-more">
@@ -157,7 +194,9 @@ function LedgerRun({
 }
 
 /** A dropped description's cell: the preset that authored it, and the rule
- *  that deleted it — the two halves of "why isn't my description showing up". */
+ *  that deleted it — the two halves of "why isn't my description showing up".
+ *  Marked when that preset is the engine's enclosing-subtree guess, exactly as
+ *  an approximate entry's cell is. */
 function DroppedSource({
   drop,
   onSelectPreset,
@@ -167,12 +206,13 @@ function DroppedSource({
 }) {
   return (
     <span className="desc-ledger-src">
+      {drop.approximate ? <ApproximateMark name={drop.node.name} /> : null}
       <ProvenanceChip
         layer={{ kind: "preset", nodeId: drop.node.nodeId, name: drop.node.name }}
         onSelectPreset={onSelectPreset}
       />
       <span className="desc-ledger-via">
-        <CodeText text={droppedReasonText(drop)} />
+        <CodeText text={dropReasonText(drop)} />
       </span>
     </span>
   );
@@ -272,7 +312,10 @@ export function BlameLedger({
   return (
     <div className="desc-ledger">
       <div className="prov-chain-title">
-        Who wrote each line ({ledger.entryCount}
+        {/* The same count the collapsed row shows, from the same function: a
+            title claiming more lines than the list has is the exact
+            under-reporting the unattributed rows exist to prevent. */}
+        Who wrote each line ({ledgerCountText(ledger)}
         {writers ? ` · ${writers}` : null})
       </div>
       {ledger.groups.map((group) => (
@@ -281,13 +324,7 @@ export function BlameLedger({
       {ledger.dropped.length > 0 ? (
         <DroppedSection dropped={ledger.dropped} onSelectPreset={onSelectPreset} />
       ) : null}
-      {ledger.degraded ? (
-        <p className="desc-ledger-caveat">
-          Some sentences could not be traced to the exact preset that wrote them — those are marked
-          with the enclosing preset and a <code>≈</code>. The wording and the order are still
-          Renovate’s own.
-        </p>
-      ) : null}
+      {ledger.degraded ? <DegradedCaveat /> : null}
     </div>
   );
 }

--- a/packages/app/src/components/BlameLedger.tsx
+++ b/packages/app/src/components/BlameLedger.tsx
@@ -1,0 +1,283 @@
+import { useState } from "react";
+import type {
+  DescriptionAttribution,
+  DroppedDescription,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import {
+  type DescriptionLedger,
+  DROPPED_COLLAPSE_AFTER,
+  droppedReasonText,
+  droppedSummaryText,
+  duplicateNoteText,
+  duplicatePillText,
+  hiddenCount,
+  LEDGER_COLLAPSE_AFTER,
+  type LedgerGroup,
+  ledgerWriterText,
+  moreDroppedText,
+  moreEntriesText,
+  viaNoteText,
+} from "@/lib/description-ledger";
+import { CodeText } from "./CodeText";
+import { layerLabel } from "./provenance-layer";
+import { ProvenanceChip } from "./ProvenanceChip";
+
+/**
+ * Roadmap 069 (PR 3): the `description` row of the Effective config, expanded —
+ * the same flat array Renovate produced, with every string attributed to the
+ * preset that wrote it. `git blame` for prose.
+ *
+ * Why this replaces the row's generic override-chain rendering rather than
+ * joining it: for a mergeable array the chain says "extends[0] appends 15,
+ * extends[1] appends 1" and prints the whole array three times over, which is
+ * both bulkier and strictly less informative than naming the author of each
+ * line. Every other key keeps the chain.
+ *
+ * The order is the final array's, unaltered — nothing sorted, nothing folded,
+ * duplicates struck through rather than removed (DevTools' cascade, not VS
+ * Code's hidden precedence). The only imposed structure is the hairline
+ * between consecutive runs of the same top-level extend, which is what makes
+ * "which line do I delete" readable at a glance.
+ */
+
+/** The chip a row wears: the node that WROTE the sentence when there is one
+ *  (that is the answer the reader came for — usually a preset several levels
+ *  below the extend they wrote), falling back to the arrival layer for the
+ *  strings that have no preset tree at all (defaults / global / inherited). */
+function sourceLayer(entry: DescriptionAttribution): ProvenanceLayer {
+  return entry.node
+    ? { kind: "preset", nodeId: entry.node.nodeId, name: entry.node.name }
+    : entry.viaTopLevel;
+}
+
+/** 069 PR 1's honest fallback, in PR 2's marking: the attribution is to an
+ *  enclosing subtree, not a leaf, so the chip is prefixed rather than trusted. */
+function ApproximateMark({ name }: { name: string }) {
+  return (
+    <span
+      className="desc-ledger-approx"
+      title={`Contributed somewhere inside ${name} — the exact preset could not be determined`}
+    >
+      ≈
+    </span>
+  );
+}
+
+/** The third cell of a normal row: who wrote it, and which extend carried it. */
+function LedgerSource({
+  entry,
+  onSelectPreset,
+}: {
+  entry: DescriptionAttribution;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const via = viaNoteText(entry);
+  return (
+    <span className="desc-ledger-src">
+      {entry.approximate ? (
+        <ApproximateMark name={entry.node?.name ?? layerLabel(entry.viaTopLevel)} />
+      ) : null}
+      <ProvenanceChip layer={sourceLayer(entry)} onSelectPreset={onSelectPreset} />
+      {via ? <span className="desc-ledger-via">{via}</span> : null}
+    </span>
+  );
+}
+
+/** …and the same cell for a repeat: no chip, because the sentence adds
+ *  nothing — what it needs instead is where it was already said, and which
+ *  extend said it a second time. */
+function DuplicateSource({ entry }: { entry: DescriptionAttribution }) {
+  return (
+    <span className="desc-ledger-src">
+      <span className="desc-ledger-dup">{duplicatePillText(entry)}</span>
+      <span className="desc-ledger-via">{duplicateNoteText(entry)}</span>
+    </span>
+  );
+}
+
+function LedgerRow({
+  entry,
+  onSelectPreset,
+}: {
+  entry: DescriptionAttribution;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const duplicate = entry.duplicateOfIndex !== undefined;
+  return (
+    <li className={`desc-ledger-row${duplicate ? " duplicate" : ""}`}>
+      <span className="desc-ledger-idx">{entry.index + 1}</span>
+      <span className="desc-ledger-text">
+        <CodeText text={entry.value} />
+      </span>
+      {duplicate ? (
+        <DuplicateSource entry={entry} />
+      ) : (
+        <LedgerSource entry={entry} onSelectPreset={onSelectPreset} />
+      )}
+    </li>
+  );
+}
+
+/** One blame run — consecutive strings from the same top-level extend. */
+function LedgerRun({
+  group,
+  onSelectPreset,
+}: {
+  group: LedgerGroup;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hidden = hiddenCount(group.entries.length, LEDGER_COLLAPSE_AFTER, expanded);
+  const shown = hidden > 0 ? group.entries.slice(0, LEDGER_COLLAPSE_AFTER) : group.entries;
+  return (
+    <ul className="desc-ledger-list">
+      {shown.map((entry) => (
+        <LedgerRow key={entry.index} entry={entry} onSelectPreset={onSelectPreset} />
+      ))}
+      {hidden > 0 ? (
+        <li className="desc-ledger-more">
+          <button type="button" className="linklike" onClick={() => setExpanded(true)}>
+            {moreEntriesText(hidden, group.layer)}
+          </button>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+/** A dropped description's cell: the preset that authored it, and the rule
+ *  that deleted it — the two halves of "why isn't my description showing up". */
+function DroppedSource({
+  drop,
+  onSelectPreset,
+}: {
+  drop: DroppedDescription;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <span className="desc-ledger-src">
+      <ProvenanceChip
+        layer={{ kind: "preset", nodeId: drop.node.nodeId, name: drop.node.name }}
+        onSelectPreset={onSelectPreset}
+      />
+      <span className="desc-ledger-via">
+        <CodeText text={droppedReasonText(drop)} />
+      </span>
+    </span>
+  );
+}
+
+function DroppedRow({
+  drop,
+  onSelectPreset,
+}: {
+  drop: DroppedDescription;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <li className="desc-ledger-row dropped">
+      <span className="desc-ledger-idx" aria-hidden="true">
+        ·
+      </span>
+      <span className="desc-ledger-text">
+        <CodeText text={drop.value} />
+      </span>
+      <DroppedSource drop={drop} onSelectPreset={onSelectPreset} />
+    </li>
+  );
+}
+
+function DroppedList({
+  dropped,
+  onSelectPreset,
+}: {
+  dropped: readonly DroppedDescription[];
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hidden = hiddenCount(dropped.length, DROPPED_COLLAPSE_AFTER, expanded);
+  const shown = hidden > 0 ? dropped.slice(0, DROPPED_COLLAPSE_AFTER) : dropped;
+  return (
+    <ul className="desc-ledger-list">
+      {shown.map((drop, i) => (
+        // Roadmap 041 — index key, deliberately: a dropped description has no
+        // id of its own, and the same preset can drop the same sentence twice
+        // (two `extends` entries reaching it). The list is derived from one
+        // immutable run and never reorders, so position IS the identity.
+        // oxlint-disable-next-line react/no-array-index-key -- see above
+        <DroppedRow key={i} drop={drop} onSelectPreset={onSelectPreset} />
+      ))}
+      {hidden > 0 ? (
+        <li className="desc-ledger-more">
+          <button type="button" className="linklike" onClick={() => setExpanded(true)}>
+            {moreDroppedText(hidden)}
+          </button>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+/**
+ * The quiet footer. Three Renovate quirks delete a description before it can
+ * merge (069 PR 1) — including `config:best-practices`' own one-liner — and
+ * "my preset's description is missing" is otherwise an unanswerable question.
+ * Muted and closed by default: it is a footnote, and on a real config the
+ * `ignoreDeps: []` mute alone drops 135 sentences.
+ */
+function DroppedSection({
+  dropped,
+  onSelectPreset,
+}: {
+  dropped: readonly DroppedDescription[];
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="desc-ledger-dropped">
+      <button
+        type="button"
+        className="linklike"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {droppedSummaryText(dropped)}
+      </button>
+      {open ? <DroppedList dropped={dropped} onSelectPreset={onSelectPreset} /> : null}
+    </div>
+  );
+}
+
+export function BlameLedger({
+  ledger,
+  onSelectPreset,
+}: {
+  ledger: DescriptionLedger;
+  /** Selects the node in the Preset Resolution Tree — the same callback every
+   *  other chip in this view gets (013). */
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const writers = ledgerWriterText(ledger);
+  return (
+    <div className="desc-ledger">
+      <div className="prov-chain-title">
+        Who wrote each line ({ledger.entryCount}
+        {writers ? ` · ${writers}` : null})
+      </div>
+      {ledger.groups.map((group) => (
+        <LedgerRun key={group.key} group={group} onSelectPreset={onSelectPreset} />
+      ))}
+      {ledger.dropped.length > 0 ? (
+        <DroppedSection dropped={ledger.dropped} onSelectPreset={onSelectPreset} />
+      ) : null}
+      {ledger.degraded ? (
+        <p className="desc-ledger-caveat">
+          Some sentences could not be traced to the exact preset that wrote them — those are marked
+          with the enclosing preset and a <code>≈</code>. The wording and the order are still
+          Renovate’s own.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/components/BlameLedger.tsx
+++ b/packages/app/src/components/BlameLedger.tsx
@@ -20,6 +20,7 @@ import {
   viaNoteText,
 } from "@/lib/description-ledger";
 import { CodeText } from "./CodeText";
+import { ROOT_NODE_ID } from "./preset-tree-stats";
 import { layerLabel } from "./provenance-layer";
 import { ProvenanceChip } from "./ProvenanceChip";
 
@@ -41,12 +42,21 @@ import { ProvenanceChip } from "./ProvenanceChip";
  * "which line do I delete" readable at a glance.
  */
 
-/** The chip a row wears: the node that WROTE the sentence when there is one
- *  (that is the answer the reader came for — usually a preset several levels
- *  below the extend they wrote), falling back to the arrival layer for the
- *  strings that have no preset tree at all (defaults / global / inherited). */
+/**
+ * The chip a row wears: the node that WROTE the sentence when there is one
+ * (that is the answer the reader came for — usually a preset several levels
+ * below the extend they wrote), falling back to the arrival layer for the
+ * strings that have no preset tree at all (defaults / global / inherited).
+ *
+ * The root node falls back too, and for a sharper reason: it is the input
+ * config, not a preset, and the tree has no row for it (`flattenTree` starts at
+ * the root's children). Chipped as a preset it would be clickable and select a
+ * node that never renders — a phantom preset in the detail panel. Its arrival
+ * layer is the repo/global/inherited config that actually wrote the sentence,
+ * which is both true and, being non-preset, not a jump.
+ */
 function sourceLayer(entry: DescriptionAttribution): ProvenanceLayer {
-  return entry.node
+  return entry.node && entry.node.nodeId !== ROOT_NODE_ID
     ? { kind: "preset", nodeId: entry.node.nodeId, name: entry.node.name }
     : entry.viaTopLevel;
 }
@@ -75,9 +85,9 @@ function LedgerSource({
   const via = viaNoteText(entry);
   return (
     <span className="desc-ledger-src">
-      {entry.approximate ? (
-        <ApproximateMark name={entry.node?.name ?? layerLabel(entry.viaTopLevel)} />
-      ) : null}
+      {/* Named after the chip beside it, whatever that resolved to — the two
+          must never disagree about which thing was approximated. */}
+      {entry.approximate ? <ApproximateMark name={layerLabel(sourceLayer(entry))} /> : null}
       <ProvenanceChip layer={sourceLayer(entry)} onSelectPreset={onSelectPreset} />
       {via ? <span className="desc-ledger-via">{via}</span> : null}
     </span>

--- a/packages/app/src/components/DescriptionDigestCard.test.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.test.tsx
@@ -13,7 +13,7 @@ import type {
 } from "@renovate-config-debugger/engine";
 import { runPipeline, type TraceResult } from "@renovate-config-debugger/engine";
 import type * as DescriptionProvenanceHook from "@/hooks/description-provenance";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { DescriptionDigestCard } from "./DescriptionDigestCard";
 import { ROOT_NODE_ID } from "./preset-tree-stats";
@@ -113,6 +113,49 @@ it("renders the descriptions grouped by extend, with the user's rules", async ()
   // The leaf label is the tree jump, exactly like the effective config's chips.
   fireEvent.click(leaf);
   expect(onSelectPreset).toHaveBeenCalledTimes(1);
+});
+
+/**
+ * Roadmap 069 (PR 3): the "show raw order" link is a jump to the Effective
+ * config's `description` row — so it may only appear when that row exists.
+ */
+it("offers the raw order only when there is a description row to land on", async () => {
+  const withArray = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(CONFIG),
+  });
+  const onShowRawOrder = vi.fn();
+  const view = render(<DescriptionDigestCard result={withArray} onShowRawOrder={onShowRawOrder} />);
+
+  await waitFor(() => expect(view.queryByText("show raw order")).not.toBeNull());
+  fireEvent.click(view.getByText("show raw order"));
+  expect(onShowRawOrder).toHaveBeenCalledTimes(1);
+
+  // Rules-only: the card still has something to say (the user's own rule prose
+  // has no other home), but Renovate never hoists it into `description`, so the
+  // link would filter the Effective config down to a key that is not there.
+  const rulesOnly = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      packageRules: [
+        {
+          description: "Slow down risky major updates",
+          matchUpdateTypes: ["major"],
+          minimumReleaseAge: "14 days",
+        },
+      ],
+    }),
+  });
+  const second = render(
+    <DescriptionDigestCard result={rulesOnly} onShowRawOrder={onShowRawOrder} />,
+  );
+  // Scoped to the second render's own container: both are mounted in the same
+  // body, and the bound queries would find the first card's link.
+  const card = within(second.container);
+
+  await waitFor(() => expect(card.getByText("Slow down risky major updates")).toBeTruthy());
+  expect(card.queryByText("show raw order")).toBeNull();
+  expect(onShowRawOrder).toHaveBeenCalledTimes(1);
 });
 
 it("renders nothing when the config has no descriptions at all", async () => {

--- a/packages/app/src/components/DescriptionDigestCard.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.tsx
@@ -8,6 +8,7 @@ import {
   type DigestGroup,
   type DigestRule,
   groupContributionText,
+  hasTopLevelDescriptions,
   ruleNoteText,
   unattributedNoteText,
 } from "@/lib/description-digest";
@@ -303,7 +304,11 @@ export function DescriptionDigestCard({
       <div className="card-title">
         What this config does
         <span className="desc-digest-count">{descriptionCountText(digest.totals)}</span>
-        {onShowRawOrder ? (
+        {/* Only when there IS a `description` row to land on: a digest built
+            purely from the repo's own `packageRules` prose has no top-level
+            array, so the link would filter the Effective config down to a key
+            that isn't there and land on "No keys match". */}
+        {onShowRawOrder && hasTopLevelDescriptions(digest) ? (
           <button
             type="button"
             className="linklike desc-digest-raw"

--- a/packages/app/src/components/DescriptionDigestCard.tsx
+++ b/packages/app/src/components/DescriptionDigestCard.tsx
@@ -259,11 +259,16 @@ function DigestFootnotes({ digest }: { digest: DescriptionDigest }) {
 export function DescriptionDigestCard({
   result,
   onSelectPreset,
+  onShowRawOrder,
 }: {
   result: TraceResult;
   /** Selects a node in the Preset Resolution Tree — the same callback the
    *  effective config hands its chips (App's `selectPresetNode`). */
   onSelectPreset?: (nodeId: string) => void;
+  /** Roadmap 069 (PR 3): opens the Effective config's `description` row, whose
+   *  blame ledger keeps the final array's own order — the fact this card
+   *  deliberately trades away by grouping. The link is the way back to it. */
+  onShowRawOrder?: () => void;
 }) {
   const provenance = useDescriptionProvenance(result);
   // "Show all", per group, owned HERE rather than by the list that renders the
@@ -298,6 +303,16 @@ export function DescriptionDigestCard({
       <div className="card-title">
         What this config does
         <span className="desc-digest-count">{descriptionCountText(digest.totals)}</span>
+        {onShowRawOrder ? (
+          <button
+            type="button"
+            className="linklike desc-digest-raw"
+            title="Open the description row in the Effective config — every sentence in Renovate's own array order, with the preset that wrote it"
+            onClick={onShowRawOrder}
+          >
+            show raw order
+          </button>
+        ) : null}
       </div>
       <div className="desc-digest">
         {digest.groups.map((group) => (

--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -7,11 +7,25 @@
  * numbers exist, and the first report already carries them.
  */
 import { runPipeline } from "@renovate-config-debugger/engine";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { afterEach, expect, it, vi } from "vitest";
 import { EffectiveConfig } from "./EffectiveConfig";
 
 afterEach(cleanup);
+
+/** The `description` row's head button, whatever else the run produced. */
+function descriptionRow(container: HTMLElement): HTMLElement {
+  const rows = [...container.querySelectorAll<HTMLElement>(".prov-row-head")];
+  const row = rows.find((head) =>
+    head.querySelector(".prov-key-name")?.textContent?.includes("description"),
+  );
+  if (!row) {
+    throw new Error(
+      `no description row among: ${rows.map((head) => head.querySelector(".prov-key-name")?.textContent).join(", ")}`,
+    );
+  }
+  return row;
+}
 
 it("reports stats only once provenance has resolved, never a loading-time zero", async () => {
   // No `extends`, so the run resolves offline; several non-default options so
@@ -35,4 +49,60 @@ it("reports stats only once provenance has resolved, never a loading-time zero",
   await waitFor(() => expect(onStats).toHaveBeenCalled());
   const first = onStats.mock.calls[0]?.[0] as { keys: number } | undefined;
   expect(first?.keys).toBeGreaterThan(0);
+});
+
+/**
+ * Roadmap 069 (PR 3): the `description` row stops being an anonymous string
+ * array. The grouping and the wording have their own unit tests
+ * (lib/description-ledger.test.ts); this covers what those cannot — that the
+ * engine's per-string attribution reaches the DOM through the row's own
+ * expansion, that a re-extended preset's repeated sentence is called out
+ * instead of silently listed twice, and that a source chip really selects its
+ * node in the resolution tree.
+ */
+it("expands the description row into a per-string blame ledger", async () => {
+  // Internal presets resolve with no network. `:dependencyDashboard` twice is
+  // the duplicate case: Renovate concatenates its sentence a second time.
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      extends: [":dependencyDashboard", ":dependencyDashboard"],
+      description: "My own summary.",
+    }),
+  });
+
+  const onSelectPreset = vi.fn();
+  const view = render(<EffectiveConfig result={result} onSelectPreset={onSelectPreset} />);
+
+  // The collapsed row already says what the array holds — the generic preview
+  // would have said `[ 3 items ]`.
+  await waitFor(() => expect(descriptionRow(view.container).textContent).toContain("3 entries"));
+  // …and how many presets had a hand in it, which no layer chip can express —
+  // one, since both extends entries resolve the same preset.
+  expect(descriptionRow(view.container).textContent).toContain("1 preset");
+
+  fireEvent.click(descriptionRow(view.container));
+  const ledger = view.container.querySelector<HTMLElement>(".desc-ledger");
+  if (!ledger) {
+    throw new Error("the expanded description row rendered no ledger");
+  }
+
+  // Every string, in the final array's order, with the preset that wrote it.
+  const rows = [...ledger.querySelectorAll(".desc-ledger-row")];
+  expect(rows).toHaveLength(3);
+  expect(rows.map((row) => row.querySelector(".desc-ledger-idx")?.textContent)).toEqual([
+    "1",
+    "2",
+    "3",
+  ]);
+  // …and the second extend's copy struck through, pointing at the first.
+  expect(within(ledger).getByText("duplicate of #1")).toBeTruthy();
+  expect(rows[1]?.className).toContain("duplicate");
+
+  // The chain rendering belongs to every OTHER key now.
+  expect(view.container.textContent).not.toContain("Override chain");
+
+  // The source chip is the tree jump, exactly like the row's own origin chip.
+  fireEvent.click(within(ledger).getByText(":dependencyDashboard"));
+  expect(onSelectPreset).toHaveBeenCalledTimes(1);
 });

--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -119,10 +119,12 @@ it("expands the description row into a per-string blame ledger", async () => {
 /**
  * Roadmap 069 (PR 3): `description` is `type: array, subType: string` to
  * Renovate — a non-string member is a validation warning, not a refusal, and
- * still merges. The engine's walk only attributes strings, so the ledger would
- * silently omit it; the row has to notice and hand back to the generic chain.
+ * still merges, holding a real index in the final array. The engine reports it
+ * (`unattributed`) and the ledger gives it a line of its own, so the row keeps
+ * the blame rendering instead of falling back: what it must never do is print
+ * a ledger one member shorter than the array it claims to be.
  */
-it("keeps the generic rendering when the ledger cannot account for the whole array", async () => {
+it("gives a non-string member of the description array its own ledger line", async () => {
   const result = await runPipeline({
     fileName: "renovate.json",
     content: JSON.stringify({ description: ["Keep this.", 42] }),
@@ -132,14 +134,54 @@ it("keeps the generic rendering when the ledger cannot account for the whole arr
 
   await waitFor(() => expect(view.container.querySelector(".prov-row")).not.toBeNull());
   const head = descriptionRow(view.container);
-  // The ledger's "2 entries — …" would be a lie: it has one line for a
-  // two-member array.
-  expect(head.textContent).toContain("[ 2 items ]");
-  expect(head.textContent).not.toContain("entries");
+  // Counted apart rather than summed: "2 entries" would credit prose the array
+  // does not contain, and the generic preview said only `[ 2 items ]`.
+  await waitFor(() =>
+    expect(descriptionRow(view.container).textContent).toContain("1 sentence + 1 other member"),
+  );
+  expect(head.textContent).not.toContain("[ 2 items ]");
 
-  fireEvent.click(head);
-  expect(view.container.querySelector(".desc-ledger")).toBeNull();
+  fireEvent.click(descriptionRow(view.container));
+  const ledger = view.container.querySelector<HTMLElement>(".desc-ledger");
+  if (!ledger) {
+    throw new Error("the expanded description row rendered no ledger");
+  }
+  const rows = [...ledger.querySelectorAll<HTMLElement>(".desc-ledger-row")];
+  expect(rows).toHaveLength(2);
+  expect(rows[1]?.className).toContain("unattributed");
+  expect(rows[1]?.textContent).toContain("42");
+  expect(rows[1]?.textContent).toContain("no preset can be credited");
+});
+
+/**
+ * …and the guard behind that is still a guard: a ledger that cannot reproduce
+ * the row's final value hands back to the generic chain. Provoked here through
+ * the row a run cannot produce on demand — `packageRules`, whose value is an
+ * array of objects and which has no ledger at all — so the assertion is that
+ * the blame rendering is confined to `description`.
+ */
+it("keeps the chain on every other key", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      description: "My own summary.",
+      packageRules: [{ matchManagers: ["npm"], automerge: true }],
+    }),
+  });
+
+  const view = render(<EffectiveConfig result={result} />);
+  await waitFor(() => expect(view.container.querySelector(".prov-row")).not.toBeNull());
+
+  const rows = [...view.container.querySelectorAll<HTMLElement>(".prov-row-head")];
+  const rules = rows.find((head) =>
+    head.querySelector(".prov-key-name")?.textContent?.includes("packageRules"),
+  );
+  if (!rules) {
+    throw new Error("no packageRules row");
+  }
+  fireEvent.click(rules);
   expect(view.container.textContent).toContain("Override chain");
+  expect(view.container.querySelector(".desc-ledger")).toBeNull();
 });
 
 /**

--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -102,7 +102,77 @@ it("expands the description row into a per-string blame ledger", async () => {
   // The chain rendering belongs to every OTHER key now.
   expect(view.container.textContent).not.toContain("Override chain");
 
+  // The repo's own sentence is written by the ROOT node — the input config,
+  // which is not a preset and has no row in the resolution tree. It wears the
+  // repo-config chip, so there is no jump to promise and none to break.
+  const repoChip = within(ledger).getByText("repo config");
+  expect(repoChip.getAttribute("role")).toBeNull();
+  expect(within(ledger).queryByText("(input config)")).toBeNull();
+  fireEvent.click(repoChip);
+  expect(onSelectPreset).not.toHaveBeenCalled();
+
   // The source chip is the tree jump, exactly like the row's own origin chip.
   fireEvent.click(within(ledger).getByText(":dependencyDashboard"));
   expect(onSelectPreset).toHaveBeenCalledTimes(1);
+});
+
+/**
+ * Roadmap 069 (PR 3): `description` is `type: array, subType: string` to
+ * Renovate — a non-string member is a validation warning, not a refusal, and
+ * still merges. The engine's walk only attributes strings, so the ledger would
+ * silently omit it; the row has to notice and hand back to the generic chain.
+ */
+it("keeps the generic rendering when the ledger cannot account for the whole array", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ description: ["Keep this.", 42] }),
+  });
+
+  const view = render(<EffectiveConfig result={result} />);
+
+  await waitFor(() => expect(view.container.querySelector(".prov-row")).not.toBeNull());
+  const head = descriptionRow(view.container);
+  // The ledger's "2 entries — …" would be a lie: it has one line for a
+  // two-member array.
+  expect(head.textContent).toContain("[ 2 items ]");
+  expect(head.textContent).not.toContain("entries");
+
+  fireEvent.click(head);
+  expect(view.container.querySelector(".desc-ledger")).toBeNull();
+  expect(view.container.textContent).toContain("Override chain");
+});
+
+/**
+ * Roadmap 069 (PR 3): the digest card's "show raw order" link promises the
+ * description row. Landing has to CLEAR the filters, not just set the query —
+ * a layer filter or "only overridden" left from earlier reading would hide the
+ * one row the link exists to show. (`show default-only` is left alone:
+ * `description` has no Renovate default, so it is never a default-only row.)
+ */
+it("clears the other filters when the digest card lands on the description row", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      extends: [":dependencyDashboard"],
+      description: "My own summary.",
+    }),
+  });
+
+  const view = render(<EffectiveConfig result={result} />);
+  await waitFor(() => expect(view.container.querySelector(".prov-row")).not.toBeNull());
+
+  // Reading state a user can easily be in: "only what the defaults set", plus
+  // "only overridden". Neither can ever show the description row.
+  const layerSelect = view.getByLabelText("Filter keys by layer");
+  fireEvent.change(layerSelect, { target: { value: "defaults" } });
+  const onlyOverridden = view.getByLabelText("only overridden");
+  fireEvent.click(onlyOverridden);
+  expect(view.container.querySelector(".desc-ledger")).toBeNull();
+
+  view.rerender(<EffectiveConfig result={result} focusDescriptionNonce={1} />);
+
+  await waitFor(() => expect(view.container.querySelector(".desc-ledger")).not.toBeNull());
+  expect(descriptionRow(view.container).textContent).toContain("entries");
+  expect((layerSelect as HTMLSelectElement).value).toBe("all");
+  expect((onlyOverridden as HTMLInputElement).checked).toBe(false);
 });

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -28,6 +28,7 @@ import { useDescriptionProvenance } from "@/hooks/description-provenance";
 import {
   buildDescriptionLedger,
   type DescriptionLedger,
+  ledgerMatchesFinalValue,
   ledgerPreviewText,
   ledgerWriterText,
 } from "@/lib/description-ledger";
@@ -50,6 +51,23 @@ type Provenance = Map<string, KeyProvenance>;
 /** Roadmap 069: the one key whose expanded body is a per-string blame ledger
  *  rather than an override chain — see `BlameLedger`. */
 const DESCRIPTION_KEY = "description";
+
+/**
+ * The ledger a row renders with: only the `description` row has one at all
+ * (`undefined` everywhere else), and only when it accounts for that row's final
+ * value string for string. A `description` array carrying a non-string member
+ * — legal enough for Renovate to merge — has no line in the ledger, so the row
+ * keeps the generic preview and chain rather than quietly under-reporting it.
+ */
+function ledgerForRow(
+  entry: KeyProvenance,
+  ledger: DescriptionLedger | null,
+): DescriptionLedger | null | undefined {
+  if (entry.key !== DESCRIPTION_KEY) {
+    return undefined;
+  }
+  return ledger && ledgerMatchesFinalValue(ledger, entry.finalValue) ? ledger : null;
+}
 
 // `LayerId` IS `string`, so `| "all"` is formally redundant — it stays as
 // documentation that "all" is the sentinel this filter uses for "no layer
@@ -823,10 +841,18 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   // Roadmap 069: the digest card's "show raw order" link lands on the blame
   // ledger — the row is one of ~90, so arriving at the tab is not arriving at
   // the answer. Filter, expand, no focus steal: the reader is here to read.
+  // …which means clearing every OTHER filter too, not just setting the query:
+  // a layer filter or "only overridden" left over from earlier reading would
+  // hide the very row the link promised, and the reader would land on "No keys
+  // match". `showDefaults` is deliberately left alone — `description` has no
+  // Renovate default, so the row can never be default-only and that checkbox
+  // cannot hide it.
   useEffect(() => {
     if (focusDescriptionNonce) {
       setView("keys");
       setQuery(DESCRIPTION_KEY);
+      setLayerFilter("all");
+      setOnlyOverridden(false);
       setExpanded(new Set([DESCRIPTION_KEY]));
     }
   }, [focusDescriptionNonce]);
@@ -907,7 +933,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
                   key={entry.key}
                   entry={entry}
                   ruleAttribution={entry.key === "packageRules" ? ruleAttribution : undefined}
-                  ledger={entry.key === DESCRIPTION_KEY ? ledger : undefined}
+                  ledger={ledgerForRow(entry, ledger)}
                   expanded={expanded.has(entry.key)}
                   onToggle={() =>
                     setExpanded((prev) => {

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -18,11 +18,19 @@ import {
   multiContribBadgeKind,
 } from "@/lib/effective-tally";
 import { OptionKey } from "./option-docs";
+import { BlameLedger } from "./BlameLedger";
 import { ConfigJson } from "./ConfigJson";
 import { CopyButton } from "./CopyButton";
 import { ProvenanceChip } from "./ProvenanceChip";
 import { layerId, layerLabel, type LayerId, layerNodeKey } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
+import { useDescriptionProvenance } from "@/hooks/description-provenance";
+import {
+  buildDescriptionLedger,
+  type DescriptionLedger,
+  ledgerPreviewText,
+  ledgerWriterText,
+} from "@/lib/description-ledger";
 // Roadmap 069 hoisted this out of here: the description digest prints the same
 // one-line matcher summary, and one spelling of it is enough.
 import { summarizeRuleSelectors } from "@/lib/rule-selectors";
@@ -38,6 +46,10 @@ import { RuleFramingText } from "./rule-framing";
  */
 
 type Provenance = Map<string, KeyProvenance>;
+
+/** Roadmap 069: the one key whose expanded body is a per-string blame ledger
+ *  rather than an override chain — see `BlameLedger`. */
+const DESCRIPTION_KEY = "description";
 
 // `LayerId` IS `string`, so `| "all"` is formally redundant — it stays as
 // documentation that "all" is the sentinel this filter uses for "no layer
@@ -290,28 +302,35 @@ function KeyRowKey({ name, expanded }: { name: string; expanded: boolean }) {
   );
 }
 
-/** The value cell: what the merged config ends up with — or, for the one row
- *  whose value is a list of rules, how many of them came from where. */
+/** The value cell: what the merged config ends up with — or, for the two rows
+ *  whose value is a list, what that list is made of: how many rules came from
+ *  where, or (069) how many description strings and how they start. */
 function KeyRowPreview({
   entry,
   rules,
   ruleAttribution,
+  ledger,
 }: {
   entry: KeyProvenance;
   rules: unknown[] | null;
   ruleAttribution?: RuleAttribution[] | null;
+  /** Only meaningful for the `description` row. */
+  ledger?: DescriptionLedger | null;
 }) {
-  return (
-    <span className="prov-key-preview">
-      {rules ? (
+  if (rules) {
+    return (
+      <span className="prov-key-preview">
         <RuleFramingText
           total={rules.length}
           attribution={ruleAttribution ?? null}
           variant="full"
         />
-      ) : (
-        preview(entry.finalValue)
-      )}
+      </span>
+    );
+  }
+  return (
+    <span className="prov-key-preview">
+      {ledger ? ledgerPreviewText(ledger) : preview(entry.finalValue)}
     </span>
   );
 }
@@ -323,16 +342,70 @@ function KeyRowOrigin({
   entry,
   winner,
   onSelectPreset,
+  ledger,
 }: {
   entry: KeyProvenance;
   winner?: ProvenanceStep;
   onSelectPreset?: (nodeId: string) => void;
+  /** 069: the `description` row's own count of contributors, which the layer
+   *  chips cannot express — for a concatenated array the "winning" layer is
+   *  just the last of twenty-odd presets that each wrote a line, not the one
+   *  that decided the value. */
+  ledger?: DescriptionLedger | null;
 }) {
+  const writers = ledger ? ledgerWriterText(ledger) : null;
   return (
     <span className="prov-row-origin">
       <MultiContribBadgeChip entry={entry} />
+      {writers ? (
+        <span
+          className="badge prov-layer prov-preset"
+          title="Presets that wrote at least one of these sentences — expand the row for the per-line ledger"
+        >
+          {writers}
+        </span>
+      ) : null}
       {winner ? <ProvenanceChip layer={winner.layer} onSelectPreset={onSelectPreset} /> : null}
     </span>
+  );
+}
+
+/** The expanded row's default body: the final value, the per-rule table on the
+ *  one row that has one, and the override chain. Its own component since 069
+ *  gave the `description` row a different body — and the depth ratchet counts
+ *  the two alternatives inside `KeyRow` as one expression. */
+function KeyRowChain({
+  entry,
+  rules,
+  ruleAttribution,
+  onSelectPreset,
+}: {
+  entry: KeyProvenance;
+  rules: unknown[] | null;
+  ruleAttribution?: RuleAttribution[] | null;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const visibleSteps = entry.chain.filter((s) => !s.noop);
+  return (
+    <>
+      <FinalValueBlock value={entry.finalValue} />
+      {rules && rules.length > 0 && ruleAttribution && ruleAttribution.length === rules.length ? (
+        <PackageRulesProvenance
+          rules={rules}
+          attribution={ruleAttribution}
+          onSelectPreset={onSelectPreset}
+        />
+      ) : null}
+      <div className="prov-chain-title">
+        Override chain ({visibleSteps.length} step{visibleSteps.length === 1 ? "" : "s"})
+      </div>
+      {/* Each layer contributes at most one step to a key's chain, so the
+          layer's NODE identity is a genuine key here (roadmap 041) — and
+          the rows are rebuilt per run, so per-run node ids are fine. */}
+      {visibleSteps.map((step) => (
+        <Step key={layerNodeKey(step.layer)} step={step} onSelectPreset={onSelectPreset} />
+      ))}
+    </>
   );
 }
 
@@ -342,6 +415,7 @@ function KeyRow({
   onToggle,
   onSelectPreset,
   ruleAttribution,
+  ledger,
 }: {
   entry: KeyProvenance;
   expanded: boolean;
@@ -349,9 +423,11 @@ function KeyRow({
   onSelectPreset?: (nodeId: string) => void;
   /** Only meaningful for the `packageRules` row; undefined/unavailable elsewhere. */
   ruleAttribution?: RuleAttribution[] | null;
+  /** Roadmap 069: only for the `description` row — null when the attribution
+   *  is unavailable, in which case the row renders exactly as it always did. */
+  ledger?: DescriptionLedger | null;
 }) {
   const winner = winningStep(entry);
-  const visibleSteps = entry.chain.filter((s) => !s.noop);
   const rules =
     entry.key === "packageRules" && Array.isArray(entry.finalValue) ? entry.finalValue : null;
   return (
@@ -363,31 +439,31 @@ function KeyRow({
         aria-expanded={expanded}
       >
         <KeyRowKey name={entry.key} expanded={expanded} />
-        <KeyRowPreview entry={entry} rules={rules} ruleAttribution={ruleAttribution} />
-        <KeyRowOrigin entry={entry} winner={winner} onSelectPreset={onSelectPreset} />
+        <KeyRowPreview
+          entry={entry}
+          rules={rules}
+          ruleAttribution={ruleAttribution}
+          ledger={ledger}
+        />
+        <KeyRowOrigin
+          entry={entry}
+          winner={winner}
+          onSelectPreset={onSelectPreset}
+          ledger={ledger}
+        />
       </button>
       {expanded ? (
         <div className="prov-detail">
-          <FinalValueBlock value={entry.finalValue} />
-          {rules &&
-          rules.length > 0 &&
-          ruleAttribution &&
-          ruleAttribution.length === rules.length ? (
-            <PackageRulesProvenance
+          {ledger ? (
+            <BlameLedger ledger={ledger} onSelectPreset={onSelectPreset} />
+          ) : (
+            <KeyRowChain
+              entry={entry}
               rules={rules}
-              attribution={ruleAttribution}
+              ruleAttribution={ruleAttribution}
               onSelectPreset={onSelectPreset}
             />
-          ) : null}
-          <div className="prov-chain-title">
-            Override chain ({visibleSteps.length} step{visibleSteps.length === 1 ? "" : "s"})
-          </div>
-          {/* Each layer contributes at most one step to a key's chain, so the
-              layer's NODE identity is a genuine key here (roadmap 041) — and
-              the rows are rebuilt per run, so per-run node ids are fine. */}
-          {visibleSteps.map((step) => (
-            <Step key={layerNodeKey(step.layer)} step={step} onSelectPreset={onSelectPreset} />
-          ))}
+          )}
         </div>
       ) : null}
     </div>
@@ -627,6 +703,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   onSelectPreset,
   onStats,
   focusFilterNonce,
+  focusDescriptionNonce,
 }: {
   result: TraceResult;
   onSelectPreset?: (nodeId: string) => void;
@@ -637,9 +714,20 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   /** Roadmap 028: bumped by the Overview's "Where did a setting come from?"
    *  pill to focus the filter input after switching to this tab. */
   focusFilterNonce?: number;
+  /** Roadmap 069: bumped by the Overview digest card's "show raw order" link —
+   *  the same nonce idiom, landing on the `description` row instead of the
+   *  filter box: filter prefilled, row expanded, ledger on screen. */
+  focusDescriptionNonce?: number;
 }) {
   const provenance = useProvenance(result);
   const ruleAttribution = useRuleProvenance(result);
+  // Roadmap 069: the per-string `description` attribution. Cached per result by
+  // the hook, so the Overview's digest card and this row share one walk.
+  const descriptionProvenance = useDescriptionProvenance(result);
+  const ledger = useMemo(
+    () => (descriptionProvenance ? buildDescriptionLedger(descriptionProvenance) : null),
+    [descriptionProvenance],
+  );
   const filterInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [layerFilter, setLayerFilter] = useState<LayerFilterValue>("all");
@@ -732,6 +820,17 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     }
   }, [focusFilterNonce]);
 
+  // Roadmap 069: the digest card's "show raw order" link lands on the blame
+  // ledger — the row is one of ~90, so arriving at the tab is not arriving at
+  // the answer. Filter, expand, no focus steal: the reader is here to read.
+  useEffect(() => {
+    if (focusDescriptionNonce) {
+      setView("keys");
+      setQuery(DESCRIPTION_KEY);
+      setExpanded(new Set([DESCRIPTION_KEY]));
+    }
+  }, [focusDescriptionNonce]);
+
   if (!result.finalConfig) {
     return null;
   }
@@ -808,6 +907,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
                   key={entry.key}
                   entry={entry}
                   ruleAttribution={entry.key === "packageRules" ? ruleAttribution : undefined}
+                  ledger={entry.key === DESCRIPTION_KEY ? ledger : undefined}
                   expanded={expanded.has(entry.key)}
                   onToggle={() =>
                     setExpanded((prev) => {

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -35,6 +35,7 @@ import {
 // Roadmap 069 hoisted this out of here: the description digest prints the same
 // one-line matcher summary, and one spelling of it is enough.
 import { summarizeRuleSelectors } from "@/lib/rule-selectors";
+import { truncate } from "@/lib/truncate";
 import { RuleFramingText } from "./rule-framing";
 
 /**
@@ -55,8 +56,9 @@ const DESCRIPTION_KEY = "description";
 /**
  * The ledger a row renders with: only the `description` row has one at all
  * (`undefined` everywhere else), and only when it accounts for that row's final
- * value string for string. A `description` array carrying a non-string member
- * — legal enough for Renovate to merge — has no line in the ledger, so the row
+ * value member for member — including the non-string members Renovate merges
+ * with a warning, which the ledger carries as authorless rows of their own. A
+ * ledger that cannot reproduce the row's final value is not shown: the row
  * keeps the generic preview and chain rather than quietly under-reporting it.
  */
 function ledgerForRow(
@@ -195,10 +197,6 @@ function MultiContribBadgeChip({ entry }: { entry: KeyProvenance }) {
  * rather than a copy of it; the name the shell knows it by stays.
  */
 export type EffectiveStats = EffectiveTally;
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
-}
 
 function preview(value: unknown): string {
   if (value === null) {

--- a/packages/app/src/components/OverviewTab.tsx
+++ b/packages/app/src/components/OverviewTab.tsx
@@ -83,6 +83,7 @@ export const OverviewTab = memo(function OverviewTab({
   onOpen,
   onWhereFrom,
   onSelectPreset,
+  onShowRawOrder,
 }: {
   /** Roadmap 069: the run the "What this config does" card reads its
    *  descriptions off. Per-run identity, so the memo still bails on keystrokes. */
@@ -96,12 +97,19 @@ export const OverviewTab = memo(function OverviewTab({
   /** Selects a preset node in the resolution tree — the digest card's chips
    *  and leaf labels, wired exactly like the effective config's (013). */
   onSelectPreset?: (nodeId: string) => void;
+  /** Roadmap 069 (PR 3): opens Effective config on the `description` row's
+   *  blame ledger — the same "jump and land" mechanism as `onWhereFrom`. */
+  onShowRawOrder?: () => void;
 }) {
   return (
     <div className="overview-tab">
       {banner}
       <RunDigest clauses={digest} onOpen={onOpen} />
-      <DescriptionDigestCard result={result} onSelectPreset={onSelectPreset} />
+      <DescriptionDigestCard
+        result={result}
+        onSelectPreset={onSelectPreset}
+        onShowRawOrder={onShowRawOrder}
+      />
       <QuestionPills
         onWhereFrom={onWhereFrom}
         onDependency={() => onOpen("simulator")}

--- a/packages/app/src/components/option-docs.tsx
+++ b/packages/app/src/components/option-docs.tsx
@@ -3,6 +3,7 @@ import type { OptionDoc, OptionIndex } from "@renovate-config-debugger/engine";
 import { useMoveGatedHover } from "@/hooks/hover-gate";
 import { OptionDocsContext, useOptionDocs } from "@/hooks/option-docs-hooks";
 import { type AnchorRect, anchoredCardStyle } from "@/lib/anchored-card";
+import { truncate } from "@/lib/truncate";
 
 /**
  * Inline documentation for renovate options (roadmap 003): a context carrying
@@ -148,10 +149,6 @@ function OptionCard({
       )}
     </div>
   );
-}
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
 }
 
 interface OptionKeyProps {

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4350,3 +4350,148 @@ button.desc-digest-leaf:focus-visible {
   margin: 0;
   padding: 0.5rem 0.75rem;
 }
+
+/* ---------- 069 PR 3: the description row's blame ledger ----------
+
+   The Effective config's `description` row, expanded: every string of the
+   final array in the order Renovate built it, each attributed to the preset
+   that wrote it. A three-column grid (index / prose / source) repeated across
+   every run, so the columns line up down the whole ledger even though each run
+   is its own `<ul>` — the runs are separate lists precisely so a hairline and
+   a collapse toggle can belong to one of them. */
+.desc-ledger {
+  padding-top: 0.2rem;
+}
+
+.desc-ledger-list {
+  list-style: none;
+  margin: 0;
+  padding: 0.15rem 0 0.35rem;
+}
+
+/* The blame grouping: a hairline wherever the top-level extend changes. The
+   first run needs none — the row's own head is its separator. */
+.desc-ledger-list + .desc-ledger-list,
+.desc-ledger-dropped {
+  border-top: 1px solid var(--border);
+  margin-top: 0.3rem;
+  padding-top: 0.45rem;
+}
+
+.desc-ledger-row {
+  align-items: baseline;
+  column-gap: 0.75rem;
+  display: grid;
+  grid-template-columns: 2.2rem minmax(12rem, 1fr) minmax(11rem, 17rem);
+  padding: 0.2rem 0.2rem 0.2rem 0;
+}
+
+.desc-ledger-row:hover {
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.desc-ledger-idx {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-align: right;
+}
+
+.desc-ledger-text {
+  font-size: 0.85rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.desc-ledger-text code {
+  font-size: 0.9em;
+}
+
+/* A sentence the array really does carry twice: kept in place (the order is
+   the point) but demoted — DevTools' struck-through overridden declaration,
+   not VS Code's silently hidden one. */
+.desc-ledger-row.duplicate .desc-ledger-text {
+  color: var(--muted);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
+}
+
+.desc-ledger-src {
+  align-items: baseline;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+/* Which extend carried the sentence in, when that is not the preset that wrote
+   it — the line to delete, next to the line that wrote it. */
+.desc-ledger-via {
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1.4;
+}
+
+/* 069 PR 1's enclosing-node fallback, marked where PR 2 marks it: on the name,
+   so a subtree attribution can never read as a leaf claim. */
+.desc-ledger-approx {
+  color: var(--muted);
+  cursor: help;
+  font-size: 0.75rem;
+}
+
+/* The repeat's pill. Warn-tinted rather than muted: unlike the digest card's
+   "redundant" note this one is per-line and actionable — an extends entry is
+   paying for a sentence twice. */
+.desc-ledger-dup {
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 999px;
+  color: var(--warn);
+  font-size: 0.68rem;
+  padding: 0.1em 0.5em;
+  white-space: nowrap;
+}
+
+.desc-ledger-more {
+  font-size: 0.78rem;
+  font-style: italic;
+  padding: 0.2rem 0 0 3rem;
+}
+
+/* The footer answering "where did my preset's description go" — a footnote,
+   and typed like one: quiet, closed, and never competing with the ledger. */
+.desc-ledger-dropped {
+  font-size: 0.78rem;
+}
+
+.desc-ledger-dropped .desc-ledger-text {
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+.desc-ledger-caveat {
+  background: var(--warn-bg);
+  border-top: 1px solid var(--warn-border);
+  font-size: 0.8rem;
+  margin: 0.5rem 0 0;
+  padding: 0.5rem 0.75rem;
+}
+
+/* The digest card's way back to the ledger above (069 PR 3) — a card-title
+   action, so it sits with the count rather than inside the prose. The title
+   becomes a row for it, the way the effective config's already is. */
+.desc-digest-card > .card-title {
+  align-items: baseline;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.desc-digest-card > .card-title .desc-digest-count {
+  margin-left: 0;
+}
+
+.desc-digest-raw {
+  font-size: 0.75rem;
+  font-weight: 400;
+  margin-left: auto;
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4331,12 +4331,18 @@ button.desc-digest-leaf:focus-visible {
    drift apart between them; see components/description-approx.tsx. */
 
 /* The standalone mark, for a row with no leaf label to prefix. Same muted
-   weight as the label's own `≈` prefix, so the two read as one mark. */
+   weight as the label's own `≈` prefix, so the two read as one mark.
+   Placement is the caller's: the digest card pushes it to the row's right edge
+   where the leaf label would sit, while the ledger keeps it inline, immediately
+   before the chip it qualifies. */
 .desc-approx-mark {
   color: var(--muted);
   cursor: help;
   font-family: var(--font-mono);
   font-size: 0.7rem;
+}
+
+.desc-digest-row > .desc-approx-mark {
   margin-left: auto;
 }
 
@@ -4416,6 +4422,16 @@ button.desc-digest-leaf:focus-visible {
   text-decoration-color: color-mix(in srgb, var(--muted) 60%, transparent);
 }
 
+/* A member of the array that is not text (Renovate warns and keeps it, so it
+   holds a real index). Mono and muted: it is shown to be identified, not read —
+   the point of the row is that it is not prose, and it must not compete with
+   the sentences around it. */
+.desc-ledger-row.unattributed .desc-ledger-text {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
 .desc-ledger-src {
   align-items: baseline;
   display: flex;
@@ -4429,14 +4445,6 @@ button.desc-digest-leaf:focus-visible {
   color: var(--muted);
   font-size: 0.7rem;
   line-height: 1.4;
-}
-
-/* 069 PR 1's enclosing-node fallback, marked where PR 2 marks it: on the name,
-   so a subtree attribution can never read as a leaf claim. */
-.desc-ledger-approx {
-  color: var(--muted);
-  cursor: help;
-  font-size: 0.75rem;
 }
 
 /* The repeat's pill. Warn-tinted rather than muted: unlike the digest card's
@@ -4469,12 +4477,11 @@ button.desc-digest-leaf:focus-visible {
   font-size: 0.8rem;
 }
 
-.desc-ledger-caveat {
-  background: var(--warn-bg);
-  border-top: 1px solid var(--warn-border);
-  font-size: 0.8rem;
-  margin: 0.5rem 0 0;
-  padding: 0.5rem 0.75rem;
+/* The shared degraded caveat (`.desc-approx-caveat`) sits at the end of the
+   ledger rather than at a card edge, so it needs the gap the digest card's copy
+   gets from the card padding — the wording and the tint stay shared. */
+.desc-ledger > .desc-approx-caveat {
+  margin-top: 0.5rem;
 }
 
 /* The digest card's way back to the ledger above (069 PR 3) — a card-title

--- a/packages/app/src/lib/description-digest.test.ts
+++ b/packages/app/src/lib/description-digest.test.ts
@@ -11,6 +11,7 @@ import {
   type DigestGroup,
   type DigestRule,
   groupContributionText,
+  hasTopLevelDescriptions,
   ruleNoteText,
   unattributedNoteText,
 } from "./description-digest";
@@ -383,6 +384,23 @@ describe("totals and empty state", () => {
     // 4 entries, one of them a repeat.
     expect(digest.totals).toEqual({ behaviors: 3, extendsCount: 2, hasUserRules: true });
     expect(descriptionCountText(digest.totals)).toBe("3 behaviors · from 2 extends + your rules");
+    expect(hasTopLevelDescriptions(digest)).toBe(true);
+  });
+
+  test("a digest whose every entry is a repeat still has a description row", () => {
+    // `behaviors: 0` says the strings added nothing NEW — the final
+    // `description` array still holds them, so the row exists.
+    const digest = digestOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES },
+          { value: "Dashboard.", via: DASHBOARD },
+        ]),
+      }),
+    );
+
+    expect(digest.totals.behaviors).toBe(1);
+    expect(hasTopLevelDescriptions(digest)).toBe(true);
   });
 
   test("no descriptions anywhere means no card", () => {
@@ -399,6 +417,9 @@ describe("totals and empty state", () => {
 
     expect(digest.totals).toEqual({ behaviors: 0, extendsCount: 0, hasUserRules: true });
     expect(descriptionCountText(digest.totals)).toBe("from your rules");
+    // …but no top-level `description` key at all: Renovate never hoists a
+    // rule's prose, so there is no Effective config row to send a reader to.
+    expect(hasTopLevelDescriptions(digest)).toBe(false);
   });
 
   test("carries the array members that are not text, and says so", () => {

--- a/packages/app/src/lib/description-digest.ts
+++ b/packages/app/src/lib/description-digest.ts
@@ -217,6 +217,19 @@ export function buildDescriptionDigest(
   };
 }
 
+/**
+ * Does this digest have anything in the final top-level `description` array?
+ *
+ * A config whose only prose sits on its own `packageRules` still produces a
+ * digest — those rule descriptions have no other home in the app — but it
+ * produces no `description` key, so anything offering "see these in the
+ * Effective config's description row" has to ask first, or promise a row that
+ * does not exist.
+ */
+export function hasTopLevelDescriptions(digest: DescriptionDigest): boolean {
+  return digest.groups.some((group) => group.entries.length > 0);
+}
+
 /** The card title's muted count: `22 behaviors · from 3 extends + your rules`. */
 export function descriptionCountText(totals: DescriptionDigestTotals): string {
   const parts: string[] = [];

--- a/packages/app/src/lib/description-ledger.test.ts
+++ b/packages/app/src/lib/description-ledger.test.ts
@@ -4,12 +4,12 @@ import type {
   DescriptionProvenance,
   DroppedDescription,
   ProvenanceLayer,
+  UnattributedDescription,
 } from "@renovate-config-debugger/engine";
 import {
   buildDescriptionLedger,
   type DescriptionLedger,
   DROPPED_COLLAPSE_AFTER,
-  droppedReasonText,
   droppedSummaryText,
   duplicateNoteText,
   duplicatePillText,
@@ -18,9 +18,12 @@ import {
   type LedgerGroup,
   ledgerMatchesFinalValue,
   ledgerPreviewText,
+  type LedgerRow,
   ledgerWriterText,
   moreDroppedText,
   moreEntriesText,
+  unattributedNoteText,
+  unattributedValueText,
   viaNoteText,
 } from "./description-ledger";
 
@@ -51,10 +54,13 @@ interface EntrySpec {
   approximate?: boolean;
 }
 
-/** Builds `entries` with the indices and duplicate markers the engine assigns. */
-function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+/** Builds `entries` with the indices and duplicate markers the engine assigns.
+ *  `startAt` shifts the first index, for the arrays whose earlier positions are
+ *  held by non-string members. */
+function entries(specs: EntrySpec[], startAt = 0): DescriptionAttribution[] {
   const firstByValue = new Map<string, number>();
-  return specs.map((spec, index) => {
+  return specs.map((spec, offset) => {
+    const index = startAt + offset;
     const duplicateOfIndex = firstByValue.get(spec.value);
     if (duplicateOfIndex === undefined) {
       firstByValue.set(spec.value, index);
@@ -71,7 +77,20 @@ function entries(specs: EntrySpec[]): DescriptionAttribution[] {
 }
 
 function provenance(overrides: Partial<DescriptionProvenance> = {}): DescriptionProvenance {
-  return { entries: [], dropped: [], ruleDescriptions: [], degraded: false, ...overrides };
+  const merged: DescriptionProvenance = {
+    entries: [],
+    unattributed: [],
+    finalLength: 0,
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+    ...overrides,
+  };
+  // The engine's own invariant (069 PR 1), so no test can build a provenance
+  // that could not have come out of a run.
+  return overrides.finalLength === undefined
+    ? { ...merged, finalLength: merged.entries.length + merged.unattributed.length }
+    : merged;
 }
 
 // Throws rather than assert-and-narrow: the failure names what WAS there, and
@@ -100,9 +119,19 @@ function entryAt(list: DescriptionAttribution[], index: number): DescriptionAttr
   return entry;
 }
 
+/** Every row of every run, in the order the ledger renders them. */
+function allRows(ledger: DescriptionLedger): LedgerRow[] {
+  return ledger.groups.flatMap((group) => group.rows);
+}
+
 describe("buildDescriptionLedger", () => {
-  test("is null when the run has no descriptions at all", () => {
+  test("is null when the run has no attributed string at all", () => {
     expect(buildDescriptionLedger(provenance())).toBeNull();
+    // `{"description": [42]}` is that same empty state: there is no prose to
+    // blame anyone for, so the row keeps the generic chain.
+    expect(
+      buildDescriptionLedger(provenance({ unattributed: [{ index: 0, value: 42 }] })),
+    ).toBeNull();
   });
 
   test("keeps the final array's order and groups consecutive runs by top-level layer", () => {
@@ -117,10 +146,11 @@ describe("buildDescriptionLedger", () => {
       }),
     );
 
-    expect(ledger.groups.map((group) => group.entries.length)).toEqual([2, 1, 1]);
+    expect(ledger.groups.map((group) => group.rows.length)).toEqual([2, 1, 1]);
     expect(ledger.entryCount).toBe(4);
+    expect(ledger.finalLength).toBe(4);
     // Indices are the engine's — the canonical position in the final array.
-    expect(groupAt(ledger, 0).entries.map((entry) => entry.index)).toEqual([0, 1]);
+    expect(groupAt(ledger, 0).rows.map((row) => row.index)).toEqual([0, 1]);
     expect(groupAt(ledger, 2).layer).toEqual(REPO);
   });
 
@@ -140,11 +170,12 @@ describe("buildDescriptionLedger", () => {
 
     expect(ledger.groups).toHaveLength(3);
     // The runs break on the NODE, but the keys are named after the layer, with
-    // an ordinal for the second run of the same name.
+    // an ordinal for the second run of the same name (`stableLayerKey`, whose
+    // separator is U+241F — a character no preset name can contain).
     expect(ledger.groups.map((group) => group.key)).toEqual([
       "preset:config:best-practices",
       "preset::dependencyDashboard",
-      "preset:config:best-practices#2",
+      "preset:config:best-practices␟2",
     ]);
   });
 
@@ -188,7 +219,7 @@ describe("buildDescriptionLedger", () => {
 
     expect(ledger.groups.map((group) => group.key)).toEqual([
       "preset::dependencyDashboard",
-      "preset::dependencyDashboard#2",
+      "preset::dependencyDashboard␟2",
     ]);
   });
 
@@ -233,6 +264,83 @@ describe("buildDescriptionLedger", () => {
   });
 });
 
+/**
+ * `description` is `type: array, subType: string`, but a wrong-typed member is
+ * a validation WARNING: `{"description": ["keep", 42]}` merges and the `42`
+ * holds index 1. The ledger claims to be the final array with the authorship
+ * put back, so it has to carry a line for that member too — the alternative is
+ * an array rendered one member shorter than the "Final value" above it.
+ */
+describe("members that are not text", () => {
+  const mixed = provenance({
+    entries: entries(
+      [
+        { value: "Keep this.", via: REPO, node: "root" },
+        { value: "And this.", via: REPO, node: "root" },
+      ],
+      1,
+    ),
+    unattributed: [
+      { index: 0, value: 42 },
+      { index: 3, value: { nested: true } },
+    ],
+    finalLength: 4,
+  });
+
+  test("every index of the final array gets exactly one row, in order", () => {
+    const rows = allRows(ledgerOf(mixed));
+
+    expect(rows.map((row) => row.index)).toEqual([0, 1, 2, 3]);
+    expect(rows.map((row) => row.kind)).toEqual(["unattributed", "entry", "entry", "unattributed"]);
+  });
+
+  test("they sit inline in the surrounding run rather than in a section of their own", () => {
+    // The run is a visual grouping and nothing more — every row carries its own
+    // source cell — so index order is worth more here than a hairline that
+    // would have to mean "no layer", which is not a thing a run can say.
+    const ledger = ledgerOf(mixed);
+
+    expect(ledger.groups).toHaveLength(1);
+    expect(groupAt(ledger, 0).layer).toEqual(REPO);
+  });
+
+  test("the counts keep the two kinds apart instead of summing them", () => {
+    const ledger = ledgerOf(mixed);
+
+    expect(ledger.entryCount).toBe(2);
+    expect(ledger.unattributedCount).toBe(2);
+    expect(ledger.finalLength).toBe(4);
+    // "4 entries" would credit prose the array does not contain.
+    expect(ledgerPreviewText(ledger)).toBe(
+      '2 sentences + 2 other members — "Keep this.", "And this."',
+    );
+  });
+
+  test("one of each is worded in the singular", () => {
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([{ value: "Keep this.", via: REPO, node: "root" }]),
+        unattributed: [{ index: 1, value: 42 }],
+      }),
+    );
+
+    expect(ledgerPreviewText(ledger)).toBe('1 sentence + 1 other member — "Keep this."');
+  });
+
+  test("the row shows compact JSON and says plainly that nobody wrote it", () => {
+    expect(unattributedValueText(42)).toBe("42");
+    expect(unattributedValueText({ a: 1 })).toBe('{"a":1}');
+    expect(unattributedValueText(null)).toBe("null");
+    // `undefined` has no JSON form at all — printed rather than dropped.
+    expect(unattributedValueText(undefined)).toBe("undefined");
+    // …and truncated, so a 4 KB object cannot become the ledger.
+    expect(unattributedValueText({ long: "x".repeat(200) }).length).toBeLessThan(70);
+    expect(unattributedNoteText()).toBe(
+      "not text — Renovate accepted it, but no preset can be credited",
+    );
+  });
+});
+
 describe("ledgerMatchesFinalValue", () => {
   const three = provenance({
     entries: entries([
@@ -246,17 +354,22 @@ describe("ledgerMatchesFinalValue", () => {
     expect(ledgerMatchesFinalValue(ledgerOf(three), ["a", "b", "c"])).toBe(true);
   });
 
-  test("rejects a non-string member the walk never saw", () => {
-    // `{"description": ["keep", 42]}` is merged by Renovate (type: array,
-    // subType: string — a warning, not a refusal), but only the string is
-    // attributed. Rendering the ledger would report "1 entry" over a
-    // two-member array and make the 42 invisible.
+  test("accepts a mixed array, non-string member included", () => {
+    const member: UnattributedDescription = { index: 1, value: { keep: true } };
     const ledger = ledgerOf(
-      provenance({ entries: entries([{ value: "keep", via: REPO, node: "root" }]) }),
+      provenance({
+        entries: entries([{ value: "keep", via: REPO, node: "root" }]),
+        unattributed: [member],
+      }),
     );
 
-    expect(ledgerMatchesFinalValue(ledger, ["keep", 42])).toBe(false);
-    expect(ledgerMatchesFinalValue(ledger, [42, "keep"])).toBe(false);
+    // The member is compared by identity — it IS the object the engine took out
+    // of this array…
+    expect(ledgerMatchesFinalValue(ledger, ["keep", member.value])).toBe(true);
+    // …so a structurally equal stand-in is not the same array.
+    expect(ledgerMatchesFinalValue(ledger, ["keep", { keep: true }])).toBe(false);
+    // …and a member that moved is a different array too.
+    expect(ledgerMatchesFinalValue(ledger, [member.value, "keep"])).toBe(false);
   });
 
   test("rejects a length mismatch, a reordering and a non-array value", () => {
@@ -267,6 +380,16 @@ describe("ledgerMatchesFinalValue", () => {
     expect(ledgerMatchesFinalValue(ledger, ["c", "b", "a"])).toBe(false);
     expect(ledgerMatchesFinalValue(ledger, "a b c")).toBe(false);
     expect(ledgerMatchesFinalValue(ledger, undefined)).toBe(false);
+  });
+
+  test("rejects a ledger whose rows do not cover the array", () => {
+    // The genuine-mismatch fallback the `description` row still needs: a ledger
+    // claiming a length it has no rows for accounts for the array only in the
+    // header, and the row hands back to the generic chain rather than print it.
+    const ledger = ledgerOf(three);
+    const overclaiming: DescriptionLedger = { ...ledger, finalLength: 4 };
+
+    expect(ledgerMatchesFinalValue(overclaiming, ["a", "b", "c", "d"])).toBe(false);
   });
 });
 
@@ -287,26 +410,20 @@ describe("the collapsed row's cells", () => {
       true,
     );
     // Truncated, so the cell never becomes the wall of text the row is meant
-    // to summarise.
+    // to summarise — and truncated safely (see `truncate.test.ts`).
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(100);
-  });
-
-  test("the truncation cuts on a character, never through one", () => {
-    // A surrogate pair straddling the 80-unit cut would leave half an emoji in
-    // the cell, which renders as U+FFFD.
-    const split = ledgerOf(
-      provenance({ entries: entries([{ value: `${"a".repeat(78)}😀tail`, via: REPO }]) }),
-    );
-    const whole = ledgerOf(
-      provenance({ entries: entries([{ value: `${"a".repeat(77)}😀tail`, via: REPO }]) }),
-    );
-
-    // Dropped rather than halved…
-    expect(ledgerPreviewText(split)).toBe(`1 entry — "${"a".repeat(78)}…`);
-    expect(/[\uD800-\uDFFF]/.test(ledgerPreviewText(split))).toBe(false);
-    // …and kept whole when it fits, so the back-off never eats a full one.
-    expect(ledgerPreviewText(whole)).toBe(`1 entry — "${"a".repeat(77)}😀…`);
+    expect(
+      /[\uD800-\uDFFF]/.test(
+        ledgerPreviewText(
+          ledgerOf(
+            provenance({
+              entries: entries([{ value: `${"a".repeat(78)}😀tail`, via: REPO }]),
+            }),
+          ),
+        ),
+      ),
+    ).toBe(false);
   });
 
   test("one string is one entry", () => {
@@ -378,6 +495,23 @@ describe("the per-row notes", () => {
 
     expect(duplicateNoteText(entryAt(repoDuplicates, 1))).toBe("repo config repeats it");
   });
+
+  test("an approximate duplicate hedges instead of accusing a layer", () => {
+    // The engine reached these through its enclosing-node fallback, so the
+    // arrival layer is assigned rather than verified — and for a whole-run
+    // fallback it is the fabricated `repo` layer, which would otherwise have
+    // the reader's own config blamed for a repeat a preset caused.
+    const hedged = entries([
+      { value: "a", via: BEST_PRACTICES, node: "p1" },
+      { value: "a", via: DASHBOARD, node: "p2", approximate: true },
+      { value: "a", via: REPO, node: "root", approximate: true },
+    ]);
+
+    expect(duplicateNoteText(entryAt(hedged, 1))).toBe(
+      "probably resolved again by :dependencyDashboard",
+    );
+    expect(duplicateNoteText(entryAt(hedged, 2))).toBe("probably repeated by repo config");
+  });
 });
 
 describe("collapsing", () => {
@@ -398,43 +532,17 @@ describe("collapsing", () => {
 });
 
 describe("the dropped footer", () => {
-  const wrapper: DroppedDescription = {
-    value: "Use best practices.",
-    node: { nodeId: "n1", name: "config:best-practices" },
-    reason: "wrapper-preset",
-  };
-  const packageList: DroppedDescription = {
-    value: "AWS SDK packages.",
-    node: { nodeId: "n4", name: "packages:awsSdk" },
-    reason: "package-list-preset",
-  };
-  const muted: DroppedDescription = {
-    value: "Group Jest packages.",
-    node: { nodeId: "n5", name: "group:jestPlusTypes" },
-    reason: "ignore-deps-quirk",
-    droppedBy: { nodeId: "n6", name: "group:recommended" },
-  };
-
+  // The wording of each drop rule lives in `lib/drop-reasons.ts` (shared with
+  // the preset tree's own note) and is tested there; this is the ledger's own
+  // summary line.
   test("summarises the count", () => {
-    expect(droppedSummaryText([wrapper, muted])).toBe(
-      "Not included: 2 descriptions Renovate dropped",
-    );
-    expect(droppedSummaryText([wrapper])).toBe("Not included: 1 description Renovate dropped");
-  });
+    const drop: DroppedDescription = {
+      value: "Use best practices.",
+      node: { nodeId: "n1", name: "config:best-practices" },
+      reason: "wrapper-preset",
+    };
 
-  test("gives each drop rule its own human reason", () => {
-    expect(droppedReasonText(wrapper)).toContain("wrapper preset");
-    expect(droppedReasonText(packageList)).toContain("`matchPackageNames`");
-    // The mute names the extending config, because that is the config the
-    // reader can change.
-    expect(droppedReasonText(muted)).toBe(
-      "muted by `group:recommended` — its empty `ignoreDeps` deletes every description it extends",
-    );
-  });
-
-  test("the mute is still explained when the extending node is unknown", () => {
-    expect(droppedReasonText({ ...muted, droppedBy: undefined })).toContain(
-      "muted by the extending config",
-    );
+    expect(droppedSummaryText([drop, drop])).toBe("Not included: 2 descriptions Renovate dropped");
+    expect(droppedSummaryText([drop])).toBe("Not included: 1 description Renovate dropped");
   });
 });

--- a/packages/app/src/lib/description-ledger.test.ts
+++ b/packages/app/src/lib/description-ledger.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+  DroppedDescription,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import {
+  buildDescriptionLedger,
+  type DescriptionLedger,
+  DROPPED_COLLAPSE_AFTER,
+  droppedReasonText,
+  droppedSummaryText,
+  duplicateNoteText,
+  duplicatePillText,
+  hiddenCount,
+  LEDGER_COLLAPSE_AFTER,
+  type LedgerGroup,
+  ledgerPreviewText,
+  ledgerWriterText,
+  moreDroppedText,
+  moreEntriesText,
+  viaNoteText,
+} from "./description-ledger";
+
+/**
+ * Roadmap 069 (PR 3): the blame ledger's view-model — the run grouping, the
+ * collapse arithmetic and the wording of every note, over hand-built
+ * provenance. The engine's own tests prove the ATTRIBUTION is right (PR 1,
+ * against the real 1,088-preset tree); nothing here needs the pipeline.
+ */
+
+const REPO: ProvenanceLayer = { kind: "repo" };
+
+function preset(nodeId: string, name = nodeId): ProvenanceLayer {
+  return { kind: "preset", nodeId, name };
+}
+
+const BEST_PRACTICES = preset("n1", "config:best-practices");
+const DASHBOARD = preset("n2", ":dependencyDashboard");
+const MONOREPOS = preset("n3", "group:monorepos");
+
+interface EntrySpec {
+  value: string;
+  via: ProvenanceLayer;
+  /** The writing node's id; its name defaults to the id unless `nodeName`
+   *  says otherwise (which matters wherever the id is compared to a layer's). */
+  node?: string;
+  nodeName?: string;
+  approximate?: boolean;
+}
+
+/** Builds `entries` with the indices and duplicate markers the engine assigns. */
+function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+  const firstByValue = new Map<string, number>();
+  return specs.map((spec, index) => {
+    const duplicateOfIndex = firstByValue.get(spec.value);
+    if (duplicateOfIndex === undefined) {
+      firstByValue.set(spec.value, index);
+    }
+    return {
+      index,
+      value: spec.value,
+      viaTopLevel: spec.via,
+      ...(spec.node ? { node: { nodeId: spec.node, name: spec.nodeName ?? spec.node } } : {}),
+      ...(duplicateOfIndex === undefined ? {} : { duplicateOfIndex }),
+      ...(spec.approximate ? { approximate: true } : {}),
+    };
+  });
+}
+
+function provenance(overrides: Partial<DescriptionProvenance> = {}): DescriptionProvenance {
+  return { entries: [], dropped: [], ruleDescriptions: [], degraded: false, ...overrides };
+}
+
+// Throws rather than assert-and-narrow: the failure names what WAS there, and
+// the file stays free of the non-null assertions the lint config bans.
+function ledgerOf(p: DescriptionProvenance): DescriptionLedger {
+  const ledger = buildDescriptionLedger(p);
+  if (!ledger) {
+    throw new Error("expected a ledger, got null");
+  }
+  return ledger;
+}
+
+function groupAt(ledger: DescriptionLedger, index: number): LedgerGroup {
+  const group = ledger.groups[index];
+  if (!group) {
+    throw new Error(`no run #${index} in: ${ledger.groups.map((g) => g.key).join(", ")}`);
+  }
+  return group;
+}
+
+function entryAt(list: DescriptionAttribution[], index: number): DescriptionAttribution {
+  const entry = list[index];
+  if (!entry) {
+    throw new Error(`no entry #${index} among ${list.length}`);
+  }
+  return entry;
+}
+
+describe("buildDescriptionLedger", () => {
+  test("is null when the run has no descriptions at all", () => {
+    expect(buildDescriptionLedger(provenance())).toBeNull();
+  });
+
+  test("keeps the final array's order and groups consecutive runs by top-level layer", () => {
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "Dashboard.", via: BEST_PRACTICES, node: ":dependencyDashboard" },
+          { value: "Pin digests.", via: BEST_PRACTICES, node: "docker:pinDigests" },
+          { value: "Monorepos.", via: MONOREPOS, node: "group:monorepos" },
+          { value: "My own summary.", via: REPO, node: "root" },
+        ]),
+      }),
+    );
+
+    expect(ledger.groups.map((group) => group.entries.length)).toEqual([2, 1, 1]);
+    expect(ledger.entryCount).toBe(4);
+    // Indices are the engine's — the canonical position in the final array.
+    expect(groupAt(ledger, 0).entries.map((entry) => entry.index)).toEqual([0, 1]);
+    expect(groupAt(ledger, 2).layer).toEqual(REPO);
+  });
+
+  test("a layer that contributes twice stays two runs", () => {
+    // The interleaving is what a re-extend looks like: the duplicate arrives
+    // through its own top-level entry, after the subtree that first pulled it
+    // in — folding the two together would erase exactly that story.
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "a", via: BEST_PRACTICES, node: "x" },
+          { value: "b", via: DASHBOARD, node: "y" },
+          { value: "c", via: BEST_PRACTICES, node: "z" },
+        ]),
+      }),
+    );
+
+    expect(ledger.groups).toHaveLength(3);
+    expect(ledger.groups.map((group) => group.key)).toEqual([
+      "preset:n1@0",
+      "preset:n2@1",
+      "preset:n1@2",
+    ]);
+  });
+
+  test("counts distinct writing presets, not strings", () => {
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "a", via: BEST_PRACTICES, node: "docker:pinDigests" },
+          { value: "b", via: BEST_PRACTICES, node: "docker:pinDigests" },
+          { value: "c", via: BEST_PRACTICES, node: ":semanticCommits" },
+          // A defaults/global/inherited string has no preset node at all…
+          { value: "d", via: { kind: "defaults" } },
+          // …and the repo's own sentence is written by the root config, which
+          // is not a preset however much it looks like a node.
+          { value: "e", via: REPO, node: "root" },
+        ]),
+      }),
+    );
+
+    expect(ledger.entryCount).toBe(5);
+    expect(ledger.writerCount).toBe(2);
+  });
+
+  test("carries the drops and the degraded flag straight through", () => {
+    const dropped: DroppedDescription[] = [
+      {
+        value: "Use best practices.",
+        node: { nodeId: "n1", name: "config:best-practices" },
+        reason: "wrapper-preset",
+      },
+    ];
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([{ value: "a", via: REPO, node: "root" }]),
+        dropped,
+        degraded: true,
+      }),
+    );
+
+    expect(ledger.dropped).toEqual(dropped);
+    expect(ledger.degraded).toBe(true);
+  });
+});
+
+describe("the collapsed row's cells", () => {
+  test("the preview counts the strings and quotes as many as fit", () => {
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "Enable Renovate Dependency Dashboard creation.", via: REPO, node: "root" },
+          { value: "Pin Docker digests.", via: REPO, node: "root" },
+          { value: "Ignore node_modules and various test directories.", via: REPO, node: "root" },
+        ]),
+      }),
+    );
+    const text = ledgerPreviewText(ledger);
+
+    expect(text.startsWith('3 entries — "Enable Renovate Dependency Dashboard creation."')).toBe(
+      true,
+    );
+    // Truncated, so the cell never becomes the wall of text the row is meant
+    // to summarise.
+    expect(text.endsWith("…")).toBe(true);
+    expect(text.length).toBeLessThan(100);
+  });
+
+  test("one string is one entry", () => {
+    const ledger = ledgerOf(
+      provenance({ entries: entries([{ value: "Just this.", via: REPO, node: "root" }]) }),
+    );
+
+    expect(ledgerPreviewText(ledger)).toBe('1 entry — "Just this."');
+  });
+
+  test("the origin cell counts contributing presets, and says nothing without one", () => {
+    const withPresets = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "a", via: BEST_PRACTICES, node: "p1" },
+          { value: "b", via: BEST_PRACTICES, node: "p2" },
+        ]),
+      }),
+    );
+    const single = ledgerOf(
+      provenance({ entries: entries([{ value: "a", via: BEST_PRACTICES, node: "p1" }]) }),
+    );
+    const none = ledgerOf(
+      provenance({ entries: entries([{ value: "a", via: { kind: "defaults" } }]) }),
+    );
+
+    expect(ledgerWriterText(withPresets)).toBe("2 presets");
+    expect(ledgerWriterText(single)).toBe("1 preset");
+    expect(ledgerWriterText(none)).toBeNull();
+  });
+});
+
+describe("the per-row notes", () => {
+  const list = entries([
+    { value: "Pin Docker digests.", via: BEST_PRACTICES, node: "docker:pinDigests" },
+    {
+      value: "Group known monorepo packages together.",
+      via: MONOREPOS,
+      node: "n3",
+      nodeName: "group:monorepos",
+    },
+    { value: "My own summary.", via: REPO, node: "root" },
+    { value: "Pin Docker digests.", via: DASHBOARD, node: "docker:pinDigests" },
+  ]);
+
+  test("names the top-level extend only when it is not the writer itself", () => {
+    // Nested: written four levels down, arrived through the extend the reader
+    // actually wrote — which is the line they would delete.
+    expect(viaNoteText(entryAt(list, 0))).toBe("via config:best-practices");
+    // The top-level extend IS the writer: repeating its name would be noise.
+    expect(viaNoteText(entryAt(list, 1))).toBeUndefined();
+    // Not a preset layer at all — the chip already says "repo config".
+    expect(viaNoteText(entryAt(list, 2))).toBeUndefined();
+  });
+
+  test("a duplicate points at the occurrence that already said it, 1-based", () => {
+    const duplicate = entryAt(list, 3);
+
+    expect(duplicate.duplicateOfIndex).toBe(0);
+    expect(duplicatePillText(duplicate)).toBe("duplicate of #1");
+    expect(duplicateNoteText(duplicate)).toBe(":dependencyDashboard resolves it again");
+  });
+
+  test("a duplicate from a non-preset layer is worded for that layer", () => {
+    const repoDuplicates = entries([
+      { value: "a", via: BEST_PRACTICES, node: "p1" },
+      { value: "a", via: REPO, node: "root" },
+    ]);
+
+    expect(duplicateNoteText(entryAt(repoDuplicates, 1))).toBe("repo config repeats it");
+  });
+});
+
+describe("collapsing", () => {
+  test("hides nothing until the threshold is passed, and nothing once expanded", () => {
+    expect(hiddenCount(LEDGER_COLLAPSE_AFTER, LEDGER_COLLAPSE_AFTER, false)).toBe(0);
+    expect(hiddenCount(LEDGER_COLLAPSE_AFTER + 3, LEDGER_COLLAPSE_AFTER, false)).toBe(3);
+    expect(hiddenCount(LEDGER_COLLAPSE_AFTER + 3, LEDGER_COLLAPSE_AFTER, true)).toBe(0);
+    expect(hiddenCount(2, DROPPED_COLLAPSE_AFTER, false)).toBe(0);
+  });
+
+  test("the toggle names the layer whose run it belongs to", () => {
+    expect(moreEntriesText(11, BEST_PRACTICES)).toBe(
+      "11 more from config:best-practices — show all",
+    );
+    expect(moreEntriesText(2, REPO)).toBe("2 more from repo config — show all");
+    expect(moreDroppedText(129)).toBe("129 more — show all");
+  });
+});
+
+describe("the dropped footer", () => {
+  const wrapper: DroppedDescription = {
+    value: "Use best practices.",
+    node: { nodeId: "n1", name: "config:best-practices" },
+    reason: "wrapper-preset",
+  };
+  const packageList: DroppedDescription = {
+    value: "AWS SDK packages.",
+    node: { nodeId: "n4", name: "packages:awsSdk" },
+    reason: "package-list-preset",
+  };
+  const muted: DroppedDescription = {
+    value: "Group Jest packages.",
+    node: { nodeId: "n5", name: "group:jestPlusTypes" },
+    reason: "ignore-deps-quirk",
+    droppedBy: { nodeId: "n6", name: "group:recommended" },
+  };
+
+  test("summarises the count", () => {
+    expect(droppedSummaryText([wrapper, muted])).toBe(
+      "Not included: 2 descriptions Renovate dropped",
+    );
+    expect(droppedSummaryText([wrapper])).toBe("Not included: 1 description Renovate dropped");
+  });
+
+  test("gives each drop rule its own human reason", () => {
+    expect(droppedReasonText(wrapper)).toContain("wrapper preset");
+    expect(droppedReasonText(packageList)).toContain("`matchPackageNames`");
+    // The mute names the extending config, because that is the config the
+    // reader can change.
+    expect(droppedReasonText(muted)).toBe(
+      "muted by `group:recommended` — its empty `ignoreDeps` deletes every description it extends",
+    );
+  });
+
+  test("the mute is still explained when the extending node is unknown", () => {
+    expect(droppedReasonText({ ...muted, droppedBy: undefined })).toContain(
+      "muted by the extending config",
+    );
+  });
+});

--- a/packages/app/src/lib/description-ledger.test.ts
+++ b/packages/app/src/lib/description-ledger.test.ts
@@ -16,6 +16,7 @@ import {
   hiddenCount,
   LEDGER_COLLAPSE_AFTER,
   type LedgerGroup,
+  ledgerMatchesFinalValue,
   ledgerPreviewText,
   ledgerWriterText,
   moreDroppedText,
@@ -138,10 +139,56 @@ describe("buildDescriptionLedger", () => {
     );
 
     expect(ledger.groups).toHaveLength(3);
+    // The runs break on the NODE, but the keys are named after the layer, with
+    // an ordinal for the second run of the same name.
     expect(ledger.groups.map((group) => group.key)).toEqual([
-      "preset:n1@0",
-      "preset:n2@1",
-      "preset:n1@2",
+      "preset:config:best-practices",
+      "preset::dependencyDashboard",
+      "preset:config:best-practices#2",
+    ]);
+  });
+
+  test("run keys survive a re-run, which mints new node ids", () => {
+    // The panel stays mounted while every keystroke produces a new run and
+    // hands out `p1`, `p2`, … afresh — a node-id key would silently move a
+    // run's "show all" state onto whichever preset inherited the id.
+    const spec: EntrySpec[] = [
+      { value: "a", via: preset("p1", "config:best-practices") },
+      { value: "b", via: preset("p2", "group:monorepos") },
+      { value: "c", via: preset("p3", "config:best-practices") },
+    ];
+    const first = ledgerOf(provenance({ entries: entries(spec) }));
+    const rerun = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "a", via: preset("p7", "config:best-practices") },
+          { value: "b", via: preset("p8", "group:monorepos") },
+          { value: "c", via: preset("p9", "config:best-practices") },
+        ]),
+      }),
+    );
+
+    expect(rerun.groups.map((group) => group.key)).toEqual(first.groups.map((group) => group.key));
+    // …and still three runs: the repeat is the story, and the key only has to
+    // be stable, not unique per node.
+    expect(rerun.groups).toHaveLength(3);
+  });
+
+  test("two adjacent nodes of the same preset stay two runs", () => {
+    // Name-keyed grouping would fold these into one run and erase the fact
+    // that the preset was extended twice.
+    const ledger = ledgerOf(
+      provenance({
+        entries: entries([
+          { value: "a", via: preset("p1", ":dependencyDashboard") },
+          { value: "a", via: preset("p2", ":dependencyDashboard") },
+        ]),
+      }),
+    );
+
+    expect(ledger.groups.map((group) => group.key)).toEqual([
+      "preset::dependencyDashboard",
+      "preset::dependencyDashboard#2",
     ]);
   });
 
@@ -186,6 +233,43 @@ describe("buildDescriptionLedger", () => {
   });
 });
 
+describe("ledgerMatchesFinalValue", () => {
+  const three = provenance({
+    entries: entries([
+      { value: "a", via: REPO, node: "root" },
+      { value: "b", via: BEST_PRACTICES, node: "p1" },
+      { value: "c", via: BEST_PRACTICES, node: "p1" },
+    ]),
+  });
+
+  test("accepts the array the entries were attributed from", () => {
+    expect(ledgerMatchesFinalValue(ledgerOf(three), ["a", "b", "c"])).toBe(true);
+  });
+
+  test("rejects a non-string member the walk never saw", () => {
+    // `{"description": ["keep", 42]}` is merged by Renovate (type: array,
+    // subType: string — a warning, not a refusal), but only the string is
+    // attributed. Rendering the ledger would report "1 entry" over a
+    // two-member array and make the 42 invisible.
+    const ledger = ledgerOf(
+      provenance({ entries: entries([{ value: "keep", via: REPO, node: "root" }]) }),
+    );
+
+    expect(ledgerMatchesFinalValue(ledger, ["keep", 42])).toBe(false);
+    expect(ledgerMatchesFinalValue(ledger, [42, "keep"])).toBe(false);
+  });
+
+  test("rejects a length mismatch, a reordering and a non-array value", () => {
+    const ledger = ledgerOf(three);
+
+    expect(ledgerMatchesFinalValue(ledger, ["a", "b"])).toBe(false);
+    expect(ledgerMatchesFinalValue(ledger, ["a", "b", "c", "d"])).toBe(false);
+    expect(ledgerMatchesFinalValue(ledger, ["c", "b", "a"])).toBe(false);
+    expect(ledgerMatchesFinalValue(ledger, "a b c")).toBe(false);
+    expect(ledgerMatchesFinalValue(ledger, undefined)).toBe(false);
+  });
+});
+
 describe("the collapsed row's cells", () => {
   test("the preview counts the strings and quotes as many as fit", () => {
     const ledger = ledgerOf(
@@ -206,6 +290,23 @@ describe("the collapsed row's cells", () => {
     // to summarise.
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(100);
+  });
+
+  test("the truncation cuts on a character, never through one", () => {
+    // A surrogate pair straddling the 80-unit cut would leave half an emoji in
+    // the cell, which renders as U+FFFD.
+    const split = ledgerOf(
+      provenance({ entries: entries([{ value: `${"a".repeat(78)}😀tail`, via: REPO }]) }),
+    );
+    const whole = ledgerOf(
+      provenance({ entries: entries([{ value: `${"a".repeat(77)}😀tail`, via: REPO }]) }),
+    );
+
+    // Dropped rather than halved…
+    expect(ledgerPreviewText(split)).toBe(`1 entry — "${"a".repeat(78)}…`);
+    expect(/[\uD800-\uDFFF]/.test(ledgerPreviewText(split))).toBe(false);
+    // …and kept whole when it fits, so the back-off never eats a full one.
+    expect(ledgerPreviewText(whole)).toBe(`1 entry — "${"a".repeat(77)}😀…`);
   });
 
   test("one string is one entry", () => {

--- a/packages/app/src/lib/description-ledger.ts
+++ b/packages/app/src/lib/description-ledger.ts
@@ -3,8 +3,10 @@ import type {
   DescriptionProvenance,
   DroppedDescription,
   ProvenanceLayer,
+  UnattributedDescription,
 } from "@renovate-config-debugger/engine";
-import { layerId, layerLabel, layerNodeKey } from "@/components/provenance-layer";
+import { layerLabel, layerNodeKey, stableLayerKey } from "@/components/provenance-layer";
+import { truncate } from "./truncate";
 
 /**
  * Roadmap 069 (PR 3): the view-model behind the Effective config's blame
@@ -17,6 +19,13 @@ import { layerId, layerLabel, layerNodeKey } from "@/components/provenance-layer
  * the authorship put back — nothing reordered, nothing folded away, duplicates
  * still in place (struck through, not removed, the way DevTools shows an
  * overridden CSS declaration).
+ *
+ * "The same array" is meant literally, which is why a row exists for every
+ * member and not only for the attributed ones: `description` is `type: array,
+ * subType: string` to Renovate, so `{"description": ["keep", 42]}` merges with a
+ * warning and the `42` holds index 1 (069 PR 1's `unattributed`/`finalLength`).
+ * A ledger that silently skipped it would print an array one member short of the
+ * one above it — so it gets a line of its own saying that nobody wrote it.
  *
  * The only structure imposed on top is blame-style grouping: CONSECUTIVE runs
  * of entries that arrived through the same top-level layer get a hairline
@@ -31,7 +40,25 @@ import { layerId, layerLabel, layerNodeKey } from "@/components/provenance-layer
 
 const nf = new Intl.NumberFormat();
 
-/** A consecutive run of entries that arrived through one top-level layer. */
+/** An attributed string: one line of prose and the preset that wrote it. */
+export interface LedgerEntryRow {
+  kind: "entry";
+  /** Position in the final `description` array — the engine's own index. */
+  index: number;
+  entry: DescriptionAttribution;
+}
+
+/** A member of that array that is not a string, and therefore has no author to
+ *  name (069 PR 1's `unattributed`). */
+export interface LedgerUnattributedRow {
+  kind: "unattributed";
+  index: number;
+  value: unknown;
+}
+
+export type LedgerRow = LedgerEntryRow | LedgerUnattributedRow;
+
+/** A consecutive run of rows that arrived through one top-level layer. */
 export interface LedgerGroup {
   /**
    * React key, stable ACROSS RUNS. The runs themselves break on the layer's
@@ -39,19 +66,23 @@ export interface LedgerGroup {
    * that repeat is the story this row tells), but node ids are minted per run
    * (`p1`, `p2`, …) and the panel stays mounted across edits, so a node-based
    * key would let a run's "show all" state reattach to a different preset after
-   * the next keystroke. Hence the name-based `layerId`, plus an ordinal
-   * (`…#2`) for each further run of the same name — the same shape the
-   * Overview digest's group keys use.
+   * the next keystroke. Hence `stableLayerKey`, the same name-plus-ordinal key
+   * the Overview digest's groups use.
    */
   key: string;
   layer: ProvenanceLayer;
-  entries: DescriptionAttribution[];
+  rows: LedgerRow[];
 }
 
 export interface DescriptionLedger {
   groups: LedgerGroup[];
-  /** Strings in the final `description` array — duplicates included. */
+  /** Attributed strings in the final `description` array — duplicates included. */
   entryCount: number;
+  /** Members of that array that are not text, so no preset can be credited. */
+  unattributedCount: number;
+  /** Members of the final array all told: `entryCount + unattributedCount`, and
+   *  the number of rows the ledger renders. */
+  finalLength: number;
   /** Distinct presets that wrote at least one of them, counted by NAME: two
    *  tree nodes of the same preset are one preset, and the repo config's own
    *  sentences are not a preset at all. */
@@ -74,23 +105,34 @@ export const LEDGER_COLLAPSE_AFTER = 8;
  *  run — a footnote must not become the page. */
 export const DROPPED_COLLAPSE_AFTER = 8;
 
-/** Cuts on a code point, never through one: a UTF-16 slice at `max` can land
- *  between the halves of a surrogate pair and render the emoji it split as
- *  U+FFFD. Checking the last kept unit is enough — only a trailing HIGH
- *  surrogate can be an orphan — and costs nothing on a string of any size. */
-function truncate(text: string, max: number): string {
-  if (text.length <= max) {
-    return text;
-  }
-  const last = text.charCodeAt(max - 1);
-  const end = last >= 0xd800 && last <= 0xdbff ? max - 1 : max;
-  return `${text.slice(0, end)}…`;
+/**
+ * The array's members in index order, strings and non-strings interleaved.
+ * Both engine lists are already ascending and disjoint (`entries.length +
+ * unattributed.length === finalLength`), so one merge pass reconstructs the
+ * real array's shape without trusting either list to be complete on its own.
+ */
+function rowsInOrder(
+  entries: readonly DescriptionAttribution[],
+  unattributed: readonly UnattributedDescription[],
+): LedgerRow[] {
+  const rows: LedgerRow[] = [
+    ...entries.map((entry): LedgerRow => ({ kind: "entry", index: entry.index, entry })),
+    ...unattributed.map((member): LedgerRow => ({
+      kind: "unattributed",
+      index: member.index,
+      value: member.value,
+    })),
+  ];
+  rows.sort((a, b) => a.index - b.index);
+  return rows;
 }
 
 /**
- * Builds the ledger, or `null` when the run's final `description` is empty —
- * in which case the row falls back to the generic override-chain rendering,
- * because a ledger with no lines would say less than the chain does.
+ * Builds the ledger, or `null` when the run's final `description` holds no
+ * attributed string at all — in which case the row falls back to the generic
+ * override-chain rendering, because a ledger of nothing but "nobody wrote this"
+ * lines would say less than the chain does. (Same empty state the Overview's
+ * digest card takes for `{"description": [42]}`.)
  */
 export function buildDescriptionLedger(
   provenance: DescriptionProvenance,
@@ -101,7 +143,27 @@ export function buildDescriptionLedger(
   const groups: LedgerGroup[] = [];
   const writers = new Set<string>();
   const keyUses = new Map<string, number>();
-  for (const entry of provenance.entries) {
+  // Non-strings before the first attributed string: they belong to the ledger
+  // (they hold a real index) but cannot open a run, since no layer is known to
+  // have carried them. Held until the first run exists and prepended to it, so
+  // index order survives — see the placement note in the loop.
+  const leading: LedgerRow[] = [];
+
+  for (const row of rowsInOrder(provenance.entries, provenance.unattributed)) {
+    if (row.kind === "unattributed") {
+      // Placed INSIDE the surrounding run rather than breaking one: the run is
+      // a visual grouping only (each row carries its own source cell, and this
+      // row's says plainly that nobody can be credited), so keeping the index
+      // order intact is worth more than a hairline nobody could interpret.
+      const open = groups.at(-1);
+      if (open) {
+        open.rows.push(row);
+      } else {
+        leading.push(row);
+      }
+      continue;
+    }
+    const { entry } = row;
     // Only strings that arrived through a preset — the repo's own sentences are
     // written by the root node, which is a config, not a preset — and counted
     // by name, because a preset reached twice is still one preset. (The runs
@@ -110,26 +172,24 @@ export function buildDescriptionLedger(
     if (entry.node && entry.viaTopLevel.kind === "preset") {
       writers.add(entry.node.name);
     }
-    const nodeKey = layerNodeKey(entry.viaTopLevel);
     const open = groups.at(-1);
-    if (open && layerNodeKey(open.layer) === nodeKey) {
-      open.entries.push(entry);
+    if (open && layerNodeKey(open.layer) === layerNodeKey(entry.viaTopLevel)) {
+      open.rows.push(row);
       continue;
     }
-    // A new run: named after the layer, disambiguated by how many runs of that
-    // name opened before it — the per-run node id must not reach the key.
-    const base = layerId(entry.viaTopLevel);
-    const seen = keyUses.get(base) ?? 0;
-    keyUses.set(base, seen + 1);
     groups.push({
-      key: seen === 0 ? base : `${base}#${seen + 1}`,
+      key: stableLayerKey(entry.viaTopLevel, keyUses),
       layer: entry.viaTopLevel,
-      entries: [entry],
+      rows: [...leading, row],
     });
+    leading.length = 0;
   }
+
   return {
     groups,
     entryCount: provenance.entries.length,
+    unattributedCount: provenance.unattributed.length,
+    finalLength: provenance.finalLength,
     writerCount: writers.size,
     dropped: provenance.dropped,
     degraded: provenance.degraded,
@@ -137,33 +197,39 @@ export function buildDescriptionLedger(
 }
 
 /**
- * Is this ledger the row's ACTUAL final value, string for string?
+ * Is this ledger the row's ACTUAL final value, member for member?
  *
- * The engine's walk only ever attributes strings, but `description` is merely
- * `type: array, subType: string` to Renovate — `{"description": ["keep", 42]}`
- * validates with a warning and still merges, so the final array can hold
- * members the ledger has no line for. Rendering it anyway would print "1 entry"
- * over a two-member array and make the `42` invisible, which is strictly worse
- * than the generic override chain the row used to show.
+ * The ledger claims to BE the final array with the authorship put back, and the
+ * row prints it in place of the generic chain — so the claim is checked before
+ * it is made, positionally: same length, every attributed index holding exactly
+ * the string the ledger credits, every unattributed index holding exactly the
+ * member it lists. On `false` the row falls back to the chain; the ledger is an
+ * enrichment, never a replacement for the truth.
  *
- * So the row asks this first, positionally: same length, and every member
- * strictly equal to the string attributed at that index (strict equality
- * against a string also rejects any non-string member). On `false` the row
- * falls back to the chain — the ledger is an enrichment, never a replacement
- * for the truth.
+ * Unattributed members are compared with `Object.is` rather than structurally.
+ * They are `unknown` and the engine took them straight out of this same array,
+ * so reference identity is what "the ledger is that array" means — a deep
+ * compare would additionally accept a different-but-equal member, which is a
+ * weaker claim than the one being made (and `Object.is` gets `NaN` right, which
+ * `===` does not).
  */
 export function ledgerMatchesFinalValue(ledger: DescriptionLedger, finalValue: unknown): boolean {
-  if (!Array.isArray(finalValue) || finalValue.length !== ledger.entryCount) {
+  if (!Array.isArray(finalValue) || finalValue.length !== ledger.finalLength) {
     return false;
   }
+  let rows = 0;
   for (const group of ledger.groups) {
-    for (const entry of group.entries) {
-      if (finalValue[entry.index] !== entry.value) {
+    for (const row of group.rows) {
+      rows++;
+      const member = finalValue[row.index];
+      if (row.kind === "entry" ? member !== row.entry.value : !Object.is(member, row.value)) {
         return false;
       }
     }
   }
-  return true;
+  // One row per index, so a ledger missing a member (or claiming one twice)
+  // cannot pass by having every row it does carry line up.
+  return rows === ledger.finalLength;
 }
 
 /** How much of the array fits in a collapsed row's preview cell. The generic
@@ -171,15 +237,36 @@ export function ledgerMatchesFinalValue(ledger: DescriptionLedger, finalValue: u
  *  useful sentence in the view. */
 const PREVIEW_CHARS = 80;
 
+/** How much of a non-string member fits in its own row's value cell. Short: it
+ *  is there to be identified, not read — the row's point is that it is not
+ *  prose. */
+const UNATTRIBUTED_PREVIEW_CHARS = 60;
+
+/** The head of the collapsed row's value cell — and the ledger's own count of
+ *  what the array holds. Plain `24 entries` while every member is a sentence;
+ *  once one is not, the two kinds are counted apart rather than summed, because
+ *  "3 entries" over two sentences and a number is the under-reporting the
+ *  unattributed rows exist to prevent. */
+export function ledgerCountText(ledger: DescriptionLedger): string {
+  if (ledger.unattributedCount === 0) {
+    return `${nf.format(ledger.finalLength)} ${ledger.finalLength === 1 ? "entry" : "entries"}`;
+  }
+  const sentences = `${nf.format(ledger.entryCount)} sentence${ledger.entryCount === 1 ? "" : "s"}`;
+  const others = `${nf.format(ledger.unattributedCount)} other member${ledger.unattributedCount === 1 ? "" : "s"}`;
+  return `${sentences} + ${others}`;
+}
+
 /** The collapsed row's value cell: `24 entries — "Pin Docker digests.", "Use…`. */
 export function ledgerPreviewText(ledger: DescriptionLedger): string {
-  const count = ledger.entryCount;
-  const head = `${nf.format(count)} ${count === 1 ? "entry" : "entries"}`;
+  const head = ledgerCountText(ledger);
   // Runs per keystroke via KeyRowPreview — stop quoting once the cell is full.
   let quoted = "";
   for (const group of ledger.groups) {
-    for (const entry of group.entries) {
-      quoted += quoted.length > 0 ? `, "${entry.value}"` : `"${entry.value}"`;
+    for (const row of group.rows) {
+      if (row.kind !== "entry") {
+        continue;
+      }
+      quoted += quoted.length > 0 ? `, "${row.entry.value}"` : `"${row.entry.value}"`;
       if (quoted.length > PREVIEW_CHARS) {
         return `${head} — ${truncate(quoted, PREVIEW_CHARS)}`;
       }
@@ -224,10 +311,39 @@ export function duplicatePillText(entry: DescriptionAttribution): string {
  * second time. Renovate never deduplicates `description`, so this is the whole
  * explanation — and the actionable one, since the named layer is the line to
  * remove.
+ *
+ * Hedged for an `approximate` entry, where naming a layer confidently would be
+ * the one thing this view must not do: the engine reached that entry through
+ * its enclosing-node fallback, so `viaTopLevel` is the layer the fallback
+ * assigned rather than one it verified — and for a whole-run fallback it is the
+ * fabricated `repo` layer, which would otherwise have the repo config
+ * confidently blamed for a repeat a preset caused. The row carries the shared
+ * `≈` next to it (069 PR 2's mark), so the hedge and the mark say one thing.
  */
 export function duplicateNoteText(entry: DescriptionAttribution): string {
   const via = entry.viaTopLevel;
+  if (entry.approximate) {
+    return via.kind === "preset"
+      ? `probably resolved again by ${via.name}`
+      : `probably repeated by ${layerLabel(via)}`;
+  }
   return via.kind === "preset" ? `${via.name} resolves it again` : `${layerLabel(via)} repeats it`;
+}
+
+/** A non-string member's value cell — compact JSON, so `{"a":1}` and `"1"` are
+ *  distinguishable from `1` at a glance. */
+export function unattributedValueText(value: unknown): string {
+  return truncate(JSON.stringify(value) ?? String(value), UNATTRIBUTED_PREVIEW_CHARS);
+}
+
+/**
+ * …and its source cell. The same fact the digest card footnotes (069 PR 2's
+ * `unattributedNoteText`), said per row because here the row IS the member:
+ * Renovate warns about a wrong-typed member and keeps it, so it is genuinely
+ * part of the config and genuinely authorless.
+ */
+export function unattributedNoteText(): string {
+  return "not text — Renovate accepted it, but no preset can be credited";
 }
 
 /** The collapse toggle inside one run. */
@@ -244,25 +360,6 @@ export function moreDroppedText(hidden: number): string {
 export function droppedSummaryText(dropped: readonly DroppedDescription[]): string {
   const count = dropped.length;
   return `Not included: ${nf.format(count)} description${count === 1 ? "" : "s"} Renovate dropped`;
-}
-
-const DROP_REASONS: Record<"wrapper-preset" | "package-list-preset", string> = {
-  // Both are `getPreset` deletions, so they are facts about the preset's SHAPE
-  // — worth saying, because the two headline presets are the shape.
-  "wrapper-preset":
-    "wrapper preset — Renovate drops the description of a preset whose body is only `description` + `extends`",
-  "package-list-preset":
-    "package-name list — Renovate drops the description of a preset that only lists `matchPackageNames`",
-};
-
-/** Backtick-marked (the `CodeText` convention), so option names stay mono. */
-export function droppedReasonText(drop: DroppedDescription): string {
-  const reason = drop.reason;
-  if (reason === "ignore-deps-quirk") {
-    const by = drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config";
-    return `muted by ${by} — its empty \`ignoreDeps\` deletes every description it extends`;
-  }
-  return DROP_REASONS[reason];
 }
 
 /** Rows hidden by a collapsed list — shared by the runs and the dropped

--- a/packages/app/src/lib/description-ledger.ts
+++ b/packages/app/src/lib/description-ledger.ts
@@ -4,7 +4,7 @@ import type {
   DroppedDescription,
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
-import { layerLabel } from "@/components/provenance-layer";
+import { layerId, layerLabel, layerNodeKey } from "@/components/provenance-layer";
 
 /**
  * Roadmap 069 (PR 3): the view-model behind the Effective config's blame
@@ -33,8 +33,16 @@ const nf = new Intl.NumberFormat();
 
 /** A consecutive run of entries that arrived through one top-level layer. */
 export interface LedgerGroup {
-  /** Stable React key: the layer identity plus where the run starts, since the
-   *  same layer can open more than one run. */
+  /**
+   * React key, stable ACROSS RUNS. The runs themselves break on the layer's
+   * NODE (a preset reached through two `extends` entries must stay two runs —
+   * that repeat is the story this row tells), but node ids are minted per run
+   * (`p1`, `p2`, …) and the panel stays mounted across edits, so a node-based
+   * key would let a run's "show all" state reattach to a different preset after
+   * the next keystroke. Hence the name-based `layerId`, plus an ordinal
+   * (`…#2`) for each further run of the same name — the same shape the
+   * Overview digest's group keys use.
+   */
   key: string;
   layer: ProvenanceLayer;
   entries: DescriptionAttribution[];
@@ -66,12 +74,17 @@ export const LEDGER_COLLAPSE_AFTER = 8;
  *  run — a footnote must not become the page. */
 export const DROPPED_COLLAPSE_AFTER = 8;
 
-function layerKey(layer: ProvenanceLayer): string {
-  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
-}
-
+/** Cuts on a code point, never through one: a UTF-16 slice at `max` can land
+ *  between the halves of a surrogate pair and render the emoji it split as
+ *  U+FFFD. Checking the last kept unit is enough — only a trailing HIGH
+ *  surrogate can be an orphan — and costs nothing on a string of any size. */
 function truncate(text: string, max: number): string {
-  return text.length > max ? `${text.slice(0, max)}…` : text;
+  if (text.length <= max) {
+    return text;
+  }
+  const last = text.charCodeAt(max - 1);
+  const end = last >= 0xd800 && last <= 0xdbff ? max - 1 : max;
+  return `${text.slice(0, end)}…`;
 }
 
 /**
@@ -87,22 +100,32 @@ export function buildDescriptionLedger(
   }
   const groups: LedgerGroup[] = [];
   const writers = new Set<string>();
+  const keyUses = new Map<string, number>();
   for (const entry of provenance.entries) {
     // Only strings that arrived through a preset — the repo's own sentences are
     // written by the root node, which is a config, not a preset — and counted
     // by name, because a preset reached twice is still one preset. (The runs
-    // below key on the NODE, deliberately: there the second arrival is the
+    // below BREAK on the node, deliberately: there the second arrival is the
     // whole story.)
     if (entry.node && entry.viaTopLevel.kind === "preset") {
       writers.add(entry.node.name);
     }
-    const key = layerKey(entry.viaTopLevel);
+    const nodeKey = layerNodeKey(entry.viaTopLevel);
     const open = groups.at(-1);
-    if (open && layerKey(open.layer) === key) {
+    if (open && layerNodeKey(open.layer) === nodeKey) {
       open.entries.push(entry);
-    } else {
-      groups.push({ key: `${key}@${entry.index}`, layer: entry.viaTopLevel, entries: [entry] });
+      continue;
     }
+    // A new run: named after the layer, disambiguated by how many runs of that
+    // name opened before it — the per-run node id must not reach the key.
+    const base = layerId(entry.viaTopLevel);
+    const seen = keyUses.get(base) ?? 0;
+    keyUses.set(base, seen + 1);
+    groups.push({
+      key: seen === 0 ? base : `${base}#${seen + 1}`,
+      layer: entry.viaTopLevel,
+      entries: [entry],
+    });
   }
   return {
     groups,
@@ -111,6 +134,36 @@ export function buildDescriptionLedger(
     dropped: provenance.dropped,
     degraded: provenance.degraded,
   };
+}
+
+/**
+ * Is this ledger the row's ACTUAL final value, string for string?
+ *
+ * The engine's walk only ever attributes strings, but `description` is merely
+ * `type: array, subType: string` to Renovate — `{"description": ["keep", 42]}`
+ * validates with a warning and still merges, so the final array can hold
+ * members the ledger has no line for. Rendering it anyway would print "1 entry"
+ * over a two-member array and make the `42` invisible, which is strictly worse
+ * than the generic override chain the row used to show.
+ *
+ * So the row asks this first, positionally: same length, and every member
+ * strictly equal to the string attributed at that index (strict equality
+ * against a string also rejects any non-string member). On `false` the row
+ * falls back to the chain — the ledger is an enrichment, never a replacement
+ * for the truth.
+ */
+export function ledgerMatchesFinalValue(ledger: DescriptionLedger, finalValue: unknown): boolean {
+  if (!Array.isArray(finalValue) || finalValue.length !== ledger.entryCount) {
+    return false;
+  }
+  for (const group of ledger.groups) {
+    for (const entry of group.entries) {
+      if (finalValue[entry.index] !== entry.value) {
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 /** How much of the array fits in a collapsed row's preview cell. The generic

--- a/packages/app/src/lib/description-ledger.ts
+++ b/packages/app/src/lib/description-ledger.ts
@@ -1,0 +1,213 @@
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+  DroppedDescription,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import { layerLabel } from "@/components/provenance-layer";
+
+/**
+ * Roadmap 069 (PR 3): the view-model behind the Effective config's blame
+ * ledger — the `description` row's answer to "who wrote this sentence".
+ *
+ * Where the Overview's digest (PR 2) REGROUPS the strings by what each
+ * `extends` entry bought, this keeps the one order that is a fact: the final
+ * array's. That is the order Renovate produced and the order the row's own
+ * "Final value" would print, so the ledger can claim to be the same array with
+ * the authorship put back — nothing reordered, nothing folded away, duplicates
+ * still in place (struck through, not removed, the way DevTools shows an
+ * overridden CSS declaration).
+ *
+ * The only structure imposed on top is blame-style grouping: CONSECUTIVE runs
+ * of entries that arrived through the same top-level layer get a hairline
+ * between them, exactly as `git blame` groups consecutive lines by commit.
+ * Runs, not a keyed grouping — a layer that appears twice in the array must
+ * stay two runs, because the second appearance is the duplicate story this
+ * row exists to tell.
+ *
+ * Pure and DOM-free, so the wording of every note is unit-testable and the
+ * component below it only decides where things sit.
+ */
+
+const nf = new Intl.NumberFormat();
+
+/** A consecutive run of entries that arrived through one top-level layer. */
+export interface LedgerGroup {
+  /** Stable React key: the layer identity plus where the run starts, since the
+   *  same layer can open more than one run. */
+  key: string;
+  layer: ProvenanceLayer;
+  entries: DescriptionAttribution[];
+}
+
+export interface DescriptionLedger {
+  groups: LedgerGroup[];
+  /** Strings in the final `description` array — duplicates included. */
+  entryCount: number;
+  /** Distinct presets that wrote at least one of them, counted by NAME: two
+   *  tree nodes of the same preset are one preset, and the repo config's own
+   *  sentences are not a preset at all. */
+  writerCount: number;
+  /** Descriptions Renovate deleted before they could merge (069 PR 1). */
+  dropped: readonly DroppedDescription[];
+  /** At least one string needed the engine's enclosing-node fallback. */
+  degraded: boolean;
+}
+
+/** Entries shown before a run collapses. Larger than the Overview card's five:
+ *  this list IS the detail view, and the run it most often applies to —
+ *  `config:best-practices` with twenty-odd sentences — is what the reader
+ *  expanded the row to read. It only has to stop one extend from burying the
+ *  ones after it. */
+export const LEDGER_COLLAPSE_AFTER = 8;
+
+/** Dropped descriptions shown before the footer's own list collapses. The
+ *  `ignoreDeps: []` mute alone drops 135 sentences on a `config:best-practices`
+ *  run — a footnote must not become the page. */
+export const DROPPED_COLLAPSE_AFTER = 8;
+
+function layerKey(layer: ProvenanceLayer): string {
+  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+}
+
+/**
+ * Builds the ledger, or `null` when the run's final `description` is empty —
+ * in which case the row falls back to the generic override-chain rendering,
+ * because a ledger with no lines would say less than the chain does.
+ */
+export function buildDescriptionLedger(
+  provenance: DescriptionProvenance,
+): DescriptionLedger | null {
+  if (provenance.entries.length === 0) {
+    return null;
+  }
+  const groups: LedgerGroup[] = [];
+  const writers = new Set<string>();
+  for (const entry of provenance.entries) {
+    // Only strings that arrived through a preset — the repo's own sentences are
+    // written by the root node, which is a config, not a preset — and counted
+    // by name, because a preset reached twice is still one preset. (The runs
+    // below key on the NODE, deliberately: there the second arrival is the
+    // whole story.)
+    if (entry.node && entry.viaTopLevel.kind === "preset") {
+      writers.add(entry.node.name);
+    }
+    const key = layerKey(entry.viaTopLevel);
+    const open = groups.at(-1);
+    if (open && layerKey(open.layer) === key) {
+      open.entries.push(entry);
+    } else {
+      groups.push({ key: `${key}@${entry.index}`, layer: entry.viaTopLevel, entries: [entry] });
+    }
+  }
+  return {
+    groups,
+    entryCount: provenance.entries.length,
+    writerCount: writers.size,
+    dropped: provenance.dropped,
+    degraded: provenance.degraded,
+  };
+}
+
+/** How much of the array fits in a collapsed row's preview cell. The generic
+ *  `preview()` would print `[ 24 items ]` here — true, and the single least
+ *  useful sentence in the view. */
+const PREVIEW_CHARS = 80;
+
+/** The collapsed row's value cell: `24 entries — "Pin Docker digests.", "Use…`. */
+export function ledgerPreviewText(ledger: DescriptionLedger): string {
+  const count = ledger.entryCount;
+  const head = `${nf.format(count)} ${count === 1 ? "entry" : "entries"}`;
+  const quoted = ledger.groups
+    .flatMap((group) => group.entries)
+    .map((entry) => `"${entry.value}"`)
+    .join(", ");
+  return quoted.length > 0 ? `${head} — ${truncate(quoted, PREVIEW_CHARS)}` : head;
+}
+
+/** The origin cell's compact summary of how many presets had a hand in this
+ *  one key — `null` when nothing in the array came from a preset (a repo-only
+ *  description, where the winning-layer chip already says everything). */
+export function ledgerWriterText(ledger: DescriptionLedger): string | null {
+  if (ledger.writerCount === 0) {
+    return null;
+  }
+  return `${nf.format(ledger.writerCount)} preset${ledger.writerCount === 1 ? "" : "s"}`;
+}
+
+/**
+ * The muted note after a source chip: the top-level `extends` entry the string
+ * ARRIVED through, when that is not the preset that wrote it. Nested presets
+ * are the common case — `docker:pinDigests` writes the sentence, but
+ * `config:best-practices` is the line you delete to stop it.
+ */
+export function viaNoteText(entry: DescriptionAttribution): string | undefined {
+  const via = entry.viaTopLevel;
+  if (via.kind !== "preset" || entry.node?.nodeId === via.nodeId) {
+    return undefined;
+  }
+  return `via ${via.name}`;
+}
+
+/** The warn-tinted pill on a repeated sentence, pointing at the occurrence
+ *  that already said it (1-based, like every index this view prints). */
+export function duplicatePillText(entry: DescriptionAttribution): string {
+  return `duplicate of #${(entry.duplicateOfIndex ?? 0) + 1}`;
+}
+
+/**
+ * Why the repeat happened, named after the layer that caused it: extending a
+ * preset some other extend already pulled in concatenates its sentence a
+ * second time. Renovate never deduplicates `description`, so this is the whole
+ * explanation — and the actionable one, since the named layer is the line to
+ * remove.
+ */
+export function duplicateNoteText(entry: DescriptionAttribution): string {
+  const via = entry.viaTopLevel;
+  return via.kind === "preset" ? `${via.name} resolves it again` : `${layerLabel(via)} repeats it`;
+}
+
+/** The collapse toggle inside one run. */
+export function moreEntriesText(hidden: number, layer: ProvenanceLayer): string {
+  return `${nf.format(hidden)} more from ${layerLabel(layer)} — show all`;
+}
+
+/** …and the dropped footer's, which has no single layer to name. */
+export function moreDroppedText(hidden: number): string {
+  return `${nf.format(hidden)} more — show all`;
+}
+
+/** The quiet footer's own line — "where did my preset's description go". */
+export function droppedSummaryText(dropped: readonly DroppedDescription[]): string {
+  const count = dropped.length;
+  return `Not included: ${nf.format(count)} description${count === 1 ? "" : "s"} Renovate dropped`;
+}
+
+const DROP_REASONS: Record<"wrapper-preset" | "package-list-preset", string> = {
+  // Both are `getPreset` deletions, so they are facts about the preset's SHAPE
+  // — worth saying, because the two headline presets are the shape.
+  "wrapper-preset":
+    "wrapper preset — Renovate drops the description of a preset whose body is only `description` + `extends`",
+  "package-list-preset":
+    "package-name list — Renovate drops the description of a preset that only lists `matchPackageNames`",
+};
+
+/** Backtick-marked (the `CodeText` convention), so option names stay mono. */
+export function droppedReasonText(drop: DroppedDescription): string {
+  const reason = drop.reason;
+  if (reason === "ignore-deps-quirk") {
+    const by = drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config";
+    return `muted by ${by} — its empty \`ignoreDeps\` deletes every description it extends`;
+  }
+  return DROP_REASONS[reason];
+}
+
+/** Rows hidden by a collapsed list — shared by the runs and the dropped
+ *  footer, which collapse the same way at different thresholds. */
+export function hiddenCount(total: number, after: number, expanded: boolean): number {
+  return expanded ? 0 : Math.max(0, total - after);
+}

--- a/packages/app/src/lib/description-ledger.ts
+++ b/packages/app/src/lib/description-ledger.ts
@@ -122,11 +122,17 @@ const PREVIEW_CHARS = 80;
 export function ledgerPreviewText(ledger: DescriptionLedger): string {
   const count = ledger.entryCount;
   const head = `${nf.format(count)} ${count === 1 ? "entry" : "entries"}`;
-  const quoted = ledger.groups
-    .flatMap((group) => group.entries)
-    .map((entry) => `"${entry.value}"`)
-    .join(", ");
-  return quoted.length > 0 ? `${head} — ${truncate(quoted, PREVIEW_CHARS)}` : head;
+  // Runs per keystroke via KeyRowPreview — stop quoting once the cell is full.
+  let quoted = "";
+  for (const group of ledger.groups) {
+    for (const entry of group.entries) {
+      quoted += quoted.length > 0 ? `, "${entry.value}"` : `"${entry.value}"`;
+      if (quoted.length > PREVIEW_CHARS) {
+        return `${head} — ${truncate(quoted, PREVIEW_CHARS)}`;
+      }
+    }
+  }
+  return quoted.length > 0 ? `${head} — ${quoted}` : head;
 }
 
 /** The origin cell's compact summary of how many presets had a hand in this

--- a/packages/app/src/lib/drop-reasons.test.ts
+++ b/packages/app/src/lib/drop-reasons.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DroppedDescription,
+  DroppedDescriptionReason,
+} from "@renovate-config-debugger/engine";
+import { DROP_REASONS, dropReasonLabel, dropReasonText } from "./drop-reasons";
+
+/**
+ * Roadmap 069: the wording of the three rules that delete a description before
+ * it can merge. Shared by the Effective config's blame ledger footer (PR 3) and
+ * the preset tree's per-node note (PR 4), so it is tested once, here.
+ */
+
+const wrapper: DroppedDescription = {
+  value: "Use best practices.",
+  node: { nodeId: "n1", name: "config:best-practices" },
+  reason: "wrapper-preset",
+};
+const packageList: DroppedDescription = {
+  value: "AWS SDK packages.",
+  node: { nodeId: "n4", name: "packages:awsSdk" },
+  reason: "package-list-preset",
+};
+const muted: DroppedDescription = {
+  value: "Group Jest packages.",
+  node: { nodeId: "n5", name: "group:jestPlusTypes" },
+  reason: "ignore-deps-quirk",
+  droppedBy: { nodeId: "n6", name: "group:recommended" },
+};
+
+describe("dropReasonText", () => {
+  test("gives each drop rule its own human reason", () => {
+    expect(dropReasonText(wrapper)).toContain("wrapper preset");
+    expect(dropReasonText(packageList)).toContain("`matchPackageNames`");
+    // The mute names the extending config, because that is the config the
+    // reader can change.
+    expect(dropReasonText(muted)).toBe(
+      "muted by `group:recommended` — its empty `ignoreDeps` deletes every description it extends",
+    );
+  });
+
+  test("the mute is still explained when the extending node is unknown", () => {
+    expect(dropReasonText({ ...muted, droppedBy: undefined })).toContain(
+      "muted by the extending config",
+    );
+  });
+
+  test("an approximate drop hedges the preset, never the rule", () => {
+    // The drop came out of a subtree that had already degraded to its enclosing
+    // node (069 PR 1): what Renovate did is certain, who wrote the sentence is
+    // not — so the rule stays intact and the hedge is appended, matching the
+    // `≈` the row puts beside the chip.
+    expect(dropReasonText({ ...wrapper, approximate: true })).toBe(
+      `${dropReasonText(wrapper)}; exact preset unknown`,
+    );
+  });
+});
+
+describe("dropReasonLabel", () => {
+  test("is the rule alone — the compact form a node marker has room for", () => {
+    expect(dropReasonLabel(wrapper)).toBe("wrapper preset");
+    expect(dropReasonLabel(packageList)).toBe("package-name list");
+    expect(dropReasonLabel(muted)).toBe("muted by `group:recommended`");
+  });
+});
+
+test("every reason the engine can report has wording", () => {
+  // The `Record<DroppedDescriptionReason, …>` makes this exhaustive at compile
+  // time; this catches the runtime half — a table key that is not a reason, and
+  // an empty clause that would render as a dangling em dash.
+  const reasons: DroppedDescriptionReason[] = [
+    "wrapper-preset",
+    "package-list-preset",
+    "ignore-deps-quirk",
+  ];
+
+  expect(Object.keys(DROP_REASONS).toSorted()).toEqual(reasons.toSorted());
+  for (const reason of reasons) {
+    const text = dropReasonText({ ...wrapper, reason });
+    expect(text).toContain(" — ");
+    expect(text.endsWith("—")).toBe(false);
+  }
+});

--- a/packages/app/src/lib/drop-reasons.ts
+++ b/packages/app/src/lib/drop-reasons.ts
@@ -1,0 +1,77 @@
+import type {
+  DroppedDescription,
+  DroppedDescriptionReason,
+} from "@renovate-config-debugger/engine";
+
+/**
+ * Roadmap 069: one wording table for the three rules that delete a description
+ * before it can merge (069 PR 1's `dropped`).
+ *
+ * Two surfaces answer "where did my preset's description go" and they must
+ * answer it identically: the Effective config's blame ledger footer (PR 3),
+ * which lists every drop with its reason, and the preset tree's per-node note
+ * (PR 4), which says it on the node whose sentence went missing. A wording that
+ * drifts in one copy is a wording that lies in the other — the same argument
+ * `description-approx.ts` makes for the `≈`.
+ *
+ * The table is split into a LABEL and a WHY rather than one sentence, because
+ * the two surfaces need different amounts of it: a node marker has room for
+ * "muted by `group:recommended`" and nothing more, while the ledger's footer
+ * cell can carry the whole rule. {@link dropReasonText} is the two joined.
+ *
+ * Pure and DOM-free (`lib/`), and exhaustive by construction: a new
+ * `DroppedDescriptionReason` in the engine fails to typecheck here rather than
+ * rendering as `undefined` in a footnote nobody reads.
+ */
+
+interface DropReasonWording {
+  /**
+   * The rule, as short as it goes. Takes the drop because one of the three
+   * names the config that caused it — which is the only actionable half of
+   * that sentence, since it is the config the reader can edit.
+   */
+  label: (drop: DroppedDescription) => string;
+  /** What Renovate did, following the label after an em dash. */
+  why: string;
+}
+
+/** Backtick-marked (the `CodeText` convention), so option and preset names stay
+ *  mono wherever the wording is rendered. */
+export const DROP_REASONS: Record<DroppedDescriptionReason, DropReasonWording> = {
+  // The first two are `getPreset` deletions, so they are facts about the
+  // preset's SHAPE — worth saying, because the two headline presets are the
+  // shape.
+  "wrapper-preset": {
+    label: () => "wrapper preset",
+    why: "Renovate drops the description of a preset whose body is only `description` + `extends`",
+  },
+  "package-list-preset": {
+    label: () => "package-name list",
+    why: "Renovate drops the description of a preset that only lists `matchPackageNames`",
+  },
+  "ignore-deps-quirk": {
+    label: (drop) =>
+      `muted by ${drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config"}`,
+    why: "its empty `ignoreDeps` deletes every description it extends",
+  },
+};
+
+/** The compact form: the rule alone, naming the muting config where there is
+ *  one. For a marker beside the node whose description went missing. */
+export function dropReasonLabel(drop: DroppedDescription): string {
+  return DROP_REASONS[drop.reason].label(drop);
+}
+
+/**
+ * The full form: the rule and what it did.
+ *
+ * An `approximate` drop came out of a subtree that had already degraded to its
+ * enclosing node (069 PR 1), so the preset the row credits is a guess while the
+ * rule itself is not — the hedge is appended rather than allowed to soften the
+ * rule, and the row carries the shared `≈` beside the chip it qualifies.
+ */
+export function dropReasonText(drop: DroppedDescription): string {
+  const wording = DROP_REASONS[drop.reason];
+  const text = `${wording.label(drop)} — ${wording.why}`;
+  return drop.approximate ? `${text}; exact preset unknown` : text;
+}

--- a/packages/app/src/lib/truncate.test.ts
+++ b/packages/app/src/lib/truncate.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { truncate } from "./truncate";
+
+/** Moved here from `description-ledger.test.ts` when the ledger's private copy
+ *  became the app's one truncation (069 PR 3): the surrogate case is a property
+ *  of the helper, not of the cell that happens to call it. */
+
+test("leaves a string that fits untouched, ellipsis included", () => {
+  expect(truncate("short", 10)).toBe("short");
+  expect(truncate("exactly-10", 10)).toBe("exactly-10");
+  expect(truncate("eleven chars", 10)).toBe("eleven cha…");
+});
+
+test("cuts on a code point, never through one", () => {
+  // The cut lands between the halves of the pair: dropped whole rather than
+  // halved, because half a surrogate renders as U+FFFD.
+  const split = `${"a".repeat(9)}😀tail`;
+  expect(truncate(split, 10)).toBe(`${"a".repeat(9)}…`);
+  expect(/[\uD800-\uDFFF]/.test(truncate(split, 10))).toBe(false);
+
+  // …and kept whole when both halves fit, so the back-off never eats a full
+  // character it had room for.
+  const whole = `${"a".repeat(8)}😀tail`;
+  expect(truncate(whole, 10)).toBe(`${"a".repeat(8)}😀…`);
+});
+
+test("a trailing LOW surrogate is not an orphan and is kept", () => {
+  // Only a HIGH surrogate can be left dangling: if the last kept unit is the
+  // LOW half, its partner is inside the slice too.
+  expect(truncate("😀abcdefghij", 2)).toBe("😀…");
+});

--- a/packages/app/src/lib/truncate.ts
+++ b/packages/app/src/lib/truncate.ts
@@ -1,0 +1,25 @@
+/**
+ * One truncation for the whole app, and a surrogate-safe one.
+ *
+ * A plain `slice(0, max)` cuts UTF-16 code UNITS, so a cut that lands between
+ * the halves of a surrogate pair leaves an orphan half in the string — rendered
+ * as U+FFFD, i.e. an emoji turned into a replacement glyph by the very code
+ * meant to make the cell readable. Checking the last kept unit is enough (only
+ * a trailing HIGH surrogate can be an orphan) and costs nothing on a string of
+ * any size, which is why every caller can afford the safe version: the blame
+ * ledger's preview (069), the effective config's value cells, the option-docs
+ * hover card's default/manager lines.
+ *
+ * Combining marks and ZWJ sequences are deliberately NOT handled: cutting a
+ * grapheme cluster produces a different (still valid) glyph, whereas cutting a
+ * surrogate pair produces a broken one — and `Intl.Segmenter` over every cell of
+ * a ~90-row table on every keystroke is not a trade this view can make.
+ */
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) {
+    return text;
+  }
+  const last = text.charCodeAt(max - 1);
+  const end = last >= 0xd800 && last <= 0xdbff ? max - 1 : max;
+  return `${text.slice(0, end)}…`;
+}


### PR DESCRIPTION
Expanding the description key in Effective Config now shows every
accumulated string in final-array order: index, text, clickable chip
for the preset that wrote it, 'via <extend>' notes, blame-style run
separators, struck-through duplicates naming the extend that re-added
them, and a quiet footer listing descriptions Renovate silently
dropped. Overview digest card links here via 'show raw order'.
Roadmap 069, PR 3 of 5.