### PR TITLE
feat(app): preset descriptions as name hover cards and a detail-panel entry

### DIFF
--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -71,7 +71,9 @@ export interface ResultsColumnProps {
   digest: DigestClause[];
   onWhereFrom: () => void;
   /** Roadmap 069: the digest card's "show raw order" link — jumps to Effective
-   *  config and lands on the `description` row's blame ledger. */
+   *  config and lands on the `description` row's blame ledger. Shared with the
+   *  preset tree (PR 4), whose `→ #16 of 24` position markers are the same
+   *  jump from the other end. */
   onShowDescriptionOrder: () => void;
 
   // —— pipeline ——
@@ -325,6 +327,7 @@ export function ResultsColumn({
           authState={authState}
           onSignIn={onSignIn}
           installUrl={installUrl}
+          onShowDescriptionOrder={onShowDescriptionOrder}
         />
       ) : (
         <EmptyNote>

--- a/packages/app/src/components/glossary.tsx
+++ b/packages/app/src/components/glossary.tsx
@@ -1,151 +1,18 @@
-import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import type { ReactNode } from "react";
 import { GLOSSARY, type GlossaryEntry, type TermId } from "@/data/glossary-data";
-import { useMoveGatedHover } from "@/hooks/hover-gate";
-import { type AnchorRect, anchoredCardStyle, anchorRectOf } from "@/lib/anchored-card";
-import { overlayKeyboardOwned } from "@/lib/escape-stack";
+import { HoverCardAnchor, type HoverCardHandlers } from "./hover-card";
 
 /**
  * The hover/focus card UI for the glossary. The entries themselves live in
- * glossary-data.ts.
+ * glossary-data.ts; the interaction (the one-card-at-a-time singleton, the
+ * grace period, the Escape ruling) lives in `hooks/hover-card.ts`, which
+ * roadmap 069 PR 5 hoisted out of here so the description attribution card
+ * could inherit it rather than grow a second tooltip of its own.
  */
 
-interface CardState {
-  entry: GlossaryEntry;
-  pos: AnchorRect;
-}
-
-/** Module-level singleton so only one glossary card is ever open. */
-let activeHide: (() => void) | null = null;
-
-/**
- * Shared hover/focus behavior for an element that explains itself with a
- * floating card. Same interaction contract as the option hover docs: a grace
- * period lets the pointer travel into the card to click the docs link.
- */
-function useHoverCard(entry: GlossaryEntry) {
-  const [card, setCard] = useState<CardState | null>(null);
-  const hideTimer = useRef<number | undefined>(undefined);
-
-  const hideNow = useCallback(() => {
-    window.clearTimeout(hideTimer.current);
-    setCard(null);
-  }, []);
-
-  const show = useCallback(
-    (el: Element) => {
-      if (activeHide && activeHide !== hideNow) {
-        activeHide();
-      }
-      activeHide = hideNow;
-      window.clearTimeout(hideTimer.current);
-      setCard({ entry, pos: anchorRectOf(el) });
-    },
-    [entry, hideNow],
-  );
-
-  const hide = useCallback(() => {
-    window.clearTimeout(hideTimer.current);
-    hideTimer.current = window.setTimeout(() => setCard(null), 250);
-  }, []);
-
-  const cancelHide = useCallback(() => {
-    window.clearTimeout(hideTimer.current);
-  }, []);
-
-  // Roadmap 068: an element-scoped Escape that ACTS must claim the key from the
-  // ladder, or one press hides this card AND pops the topmost ladder layer —
-  // typically the simulator's return pill, which the reader cannot even see from
-  // here. With no card up there is nothing to claim, and the key belongs to the
-  // ladder.
-  //
-  // `preventDefault`, NOT `stopPropagation`, and the difference is the whole
-  // rule. Both stop the ladder (its document listener bails on
-  // `defaultPrevented`), but React's `stopPropagation` also ends the native
-  // event's journey at the root container, so it takes the press away from every
-  // ANCESTOR element handler too — and this card can be inside one. A `Term`
-  // renders in the repo-load panel, whose `<form>` closes the panel on Escape;
-  // focusing that term always opens a card, so claiming by propagation left the
-  // user pressing Escape twice to cancel a panel they had asked to cancel once.
-  // Preventing the default claims exactly the listener that reads it and leaves
-  // the ancestor free to act on the same press, which is the contract the editor
-  // already keeps (see `lib/escape-stack.ts`).
-  //
-  // The other half, which the review after it found: a card the user did not
-  // open cannot outrank a layer they did. This card opens on FOCUS, so Tabbing
-  // onto a `ProvenanceChip` inside an open rule-evidence popover ALWAYS has one
-  // up — claiming there made the popover undismissable by keyboard, every press
-  // stopping at the tooltip. So the rule is not "act whenever there is a card"
-  // but "act only when this card is the topmost thing between the reader and the
-  // page": `overlayKeyboardOwned()` reports exactly when it is not (a popover or
-  // a menu is over the page), and there the press goes to the ladder, which
-  // dismisses the layer the user chose to open — and usually the anchor with it.
-  //
-  // The RANK is the right question here, and the ninth review pushed back on it:
-  // `ambient` is excluded, so with the simulator return pill up a reader walking
-  // a thread — who has a focus-opened tooltip at most stops — needs two presses
-  // to dismiss the pill. That cost is real and it is the lesser one. Widening
-  // this to "any layer at all" was tried and reverted: it means a press aimed at
-  // the tooltip the reader is looking at instead destroys a pill they cannot see
-  // from here, leaving the tooltip up — an invisible destructive action, which is
-  // exactly what the sixth review fixed. A wasted keystroke is recoverable; a
-  // silently destroyed way back is not. The two tests below pin both directions.
-  // That is the same ranking the ladder itself applies, asked rather than
-  // joined: registering this card as a layer would make it a stack entry that
-  // pushes and releases on every hover, and Escape would then dismiss a card the
-  // pointer merely rested on instead of the pill the user is looking at.
-  //
-  // Lives in the shared hook rather than on one anchor: `Term` had it and
-  // `Explained` did not, which made Escape on a preset-source badge's card
-  // destroy the return pill instead of the card the user was looking at.
-  const onKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key !== "Escape" || !card || overlayKeyboardOwned()) {
-        return;
-      }
-      e.preventDefault();
-      hideNow();
-    },
-    [card, hideNow],
-  );
-
-  // Scrolling moves the anchor out from under the fixed-position card; hide
-  // rather than float a card pointing at nothing.
-  useEffect(() => {
-    if (!card) {
-      return;
-    }
-    window.addEventListener("scroll", hideNow, { passive: true });
-    return () => window.removeEventListener("scroll", hideNow);
-  }, [card, hideNow]);
-
-  return { card, show, hide, hideNow, cancelHide, onKeyDown };
-}
-
-function GlossaryCard({
-  card,
-  onEnter,
-  onLeave,
-}: {
-  card: CardState;
-  onEnter: () => void;
-  onLeave: () => void;
-}) {
-  const { entry, pos } = card;
-  const style = anchoredCardStyle(pos, 320, 200);
-  // Roadmap 035: portalled to <body>. The coordinates above are viewport
-  // coordinates, which only hold while no ancestor is a containing block for
-  // fixed-position descendants — and CSS containment creates exactly that, so
-  // the moment any ancestor gains `container-type` (035 gave the preset-tree
-  // card one) an in-place card would silently re-anchor to it. The portal
-  // makes the viewport-relative math structurally true instead of incidental.
-  return createPortal(
-    <div
-      className="option-card glossary-card"
-      style={style}
-      onMouseEnter={onEnter}
-      onMouseLeave={onLeave}
-    >
+function GlossaryCard({ entry }: { entry: GlossaryEntry }) {
+  return (
+    <>
       <div className="option-card-head">
         <code className="option-card-name">{entry.name}</code>
       </div>
@@ -157,8 +24,7 @@ function GlossaryCard({
           </a>
         </p>
       ) : null}
-    </div>,
-    document.body,
+    </>
   );
 }
 
@@ -175,48 +41,21 @@ interface TermProps {
  */
 export function Term({ id, children }: TermProps) {
   const entry = GLOSSARY[id];
-  const { card, show, hide, cancelHide, onKeyDown } = useHoverCard(entry);
-  const moveGate = useMoveGatedHover<HTMLSpanElement>(show);
   return (
-    <>
-      <span
-        className="term"
-        tabIndex={0}
-        onMouseEnter={moveGate.onMouseEnter}
-        onMouseMove={moveGate.onMouseMove}
-        onMouseLeave={() => {
-          moveGate.onMouseLeave();
-          hide();
-        }}
-        onFocus={(e) => show(e.currentTarget)}
-        onBlur={hide}
-        onKeyDown={onKeyDown}
-      >
-        {children ?? entry.name}
-      </span>
-      {card ? <GlossaryCard card={card} onEnter={cancelHide} onLeave={hide} /> : null}
-    </>
+    <Explained entry={entry}>
+      {(handlers) => (
+        <span className="term" tabIndex={0} {...handlers}>
+          {children ?? entry.name}
+        </span>
+      )}
+    </Explained>
   );
 }
 
 interface ExplainedProps {
   entry: GlossaryEntry;
   /** Renders the anchor element; receives the hover/focus handlers to spread. */
-  children: (handlers: {
-    onMouseEnter: () => void;
-    onMouseMove: (e: React.MouseEvent) => void;
-    onMouseLeave: () => void;
-    onFocus: (e: React.FocusEvent) => void;
-    onBlur: () => void;
-    /**
-     * Escape dismisses the card while this card is the topmost thing over the
-     * page — see `useHoverCard` for what it stands aside for. An anchor with a
-     * keydown handler of its own must COMPOSE this one rather than let a later
-     * spread decide which survives — `ProvenanceChip` is the clickable case,
-     * and it would otherwise trade its Enter/Space for this or this for it.
-     */
-    onKeyDown: (e: React.KeyboardEvent) => void;
-  }) => ReactNode;
+  children: (handlers: HoverCardHandlers) => ReactNode;
 }
 
 /**
@@ -224,22 +63,9 @@ interface ExplainedProps {
  * already a button). The child render-prop spreads the handlers on its anchor.
  */
 export function Explained({ entry, children }: ExplainedProps) {
-  const { card, show, hide, cancelHide, onKeyDown } = useHoverCard(entry);
-  const moveGate = useMoveGatedHover(show);
   return (
-    <>
-      {children({
-        onMouseEnter: moveGate.onMouseEnter,
-        onMouseMove: moveGate.onMouseMove,
-        onMouseLeave: () => {
-          moveGate.onMouseLeave();
-          hide();
-        },
-        onFocus: (e) => show(e.currentTarget),
-        onBlur: hide,
-        onKeyDown,
-      })}
-      {card ? <GlossaryCard card={card} onEnter={cancelHide} onLeave={hide} /> : null}
-    </>
+    <HoverCardAnchor className="glossary-card" card={<GlossaryCard entry={entry} />}>
+      {children}
+    </HoverCardAnchor>
   );
 }

--- a/packages/app/src/components/hover-card.tsx
+++ b/packages/app/src/components/hover-card.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { HoverCardCloseProvider, useHoverCard } from "@/hooks/hover-card";
+import { useMoveGatedHover } from "@/hooks/hover-gate";
+import { anchoredCardStyle } from "@/lib/anchored-card";
+
+/**
+ * The app's one hover-card affordance, as a primitive: an anchor that spreads
+ * hover/focus handlers onto whatever element the caller renders, plus the card
+ * itself on the shared `.option-card` plane, portalled to `<body>`.
+ *
+ * Roadmap 035: portalled deliberately. The placement math is in VIEWPORT
+ * coordinates, which only hold while no ancestor is a containing block for
+ * fixed-position descendants — and CSS containment creates exactly that, so the
+ * moment any ancestor gains `container-type` (035 gave the preset-tree card one)
+ * an in-place card would silently re-anchor to it.
+ *
+ * Roadmap 069 PR 5 generalised this out of `glossary.tsx`, where it was a card
+ * that could only say a `GlossaryEntry`: the description attribution card names
+ * a preset, prints an import path and offers a jump, and the alternative to a
+ * shared anchor was a second bespoke tooltip with its own focus and Escape
+ * semantics. `Term`/`Explained` are now this component with a glossary body.
+ */
+
+/** The handlers an anchor must spread to open/close its card. */
+export interface HoverCardHandlers {
+  onMouseEnter: () => void;
+  onMouseMove: (e: React.MouseEvent) => void;
+  onMouseLeave: () => void;
+  onFocus: (e: React.FocusEvent) => void;
+  onBlur: () => void;
+  /**
+   * Escape dismisses the card while this card is the topmost thing over the
+   * page — see `useHoverCard` for what it stands aside for. An anchor with a
+   * keydown handler of its own must COMPOSE this one rather than let a later
+   * spread decide which survives — `ProvenanceChip` is the clickable case,
+   * and it would otherwise trade its Enter/Space for this or this for it.
+   */
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+/** The card's preferred width, and how much room it wants below the anchor
+ *  before flipping above it (roughly its own height). */
+const DEFAULT_WIDTH = 320;
+const DEFAULT_FLIP_MARGIN = 200;
+
+export function HoverCardAnchor({
+  card,
+  className,
+  width = DEFAULT_WIDTH,
+  flipMargin = DEFAULT_FLIP_MARGIN,
+  children,
+}: {
+  /** The card's body. Rendered only while the card is up. */
+  card: ReactNode;
+  /** Extra class on the `.option-card` surface. */
+  className?: string;
+  width?: number;
+  flipMargin?: number;
+  /** Renders the anchor element; receives the handlers to spread. */
+  children: (handlers: HoverCardHandlers) => ReactNode;
+}) {
+  const { anchor, show, hide, hideNow, cancelHide, onKeyDown } = useHoverCard();
+  const moveGate = useMoveGatedHover(show);
+  return (
+    <>
+      {children({
+        onMouseEnter: moveGate.onMouseEnter,
+        onMouseMove: moveGate.onMouseMove,
+        onMouseLeave: () => {
+          moveGate.onMouseLeave();
+          hide();
+        },
+        onFocus: (e) => show(e.currentTarget),
+        onBlur: hide,
+        onKeyDown,
+      })}
+      {anchor
+        ? createPortal(
+            // The card's body gets its own dismissal (`hooks/hover-card.ts`):
+            // an action inside the card that moves the page — the attribution
+            // card's tree jump — must close the card it was clicked in, and a
+            // pointer-opened card has no blur to do that for it.
+            <HoverCardCloseProvider value={hideNow}>
+              <div
+                className={className ? `option-card ${className}` : "option-card"}
+                style={anchoredCardStyle(anchor, width, flipMargin)}
+                onMouseEnter={cancelHide}
+                onMouseLeave={hide}
+              >
+                {card}
+              </div>
+            </HoverCardCloseProvider>,
+            document.body,
+          )
+        : null}
+    </>
+  );
+}

--- a/packages/app/src/features/presets/NodeDescriptions.tsx
+++ b/packages/app/src/features/presets/NodeDescriptions.tsx
@@ -10,9 +10,12 @@ import {
 
 /**
  * Roadmap 069 (PR 4): one node's description facts, rendered — the sentences
- * it wrote with where they landed in the final `description` array, the ones
- * Renovate silently deleted (struck through, with the rule that deleted them),
- * and the mute note on a node that causes such drops below it.
+ * it wrote (with where they landed in the final `description` array when they
+ * reached it), and the mute note on a node that silences descriptions below
+ * it. A sentence Renovate dropped on merge reads exactly like the others,
+ * minus the slot marker: wrapper and package-list presets shed their
+ * description by design, so on the node itself it is simply what the preset
+ * says about itself, and the drop mechanics stay on the blame ledger's footer.
  *
  * Two surfaces share this rendering so they cannot drift: the hover card on
  * the preset's name in the tree (`TreeRow`), and the detail panel's

--- a/packages/app/src/features/presets/NodeDescriptions.tsx
+++ b/packages/app/src/features/presets/NodeDescriptions.tsx
@@ -1,0 +1,88 @@
+import { CodeText } from "@/components/CodeText";
+import { useHoverCardClose } from "@/hooks/hover-card";
+import {
+  type DescLineWithMarker,
+  type NodeDescriptionFacts,
+  positionMarkerText,
+  positionMarkerTitle,
+  zipDescLines,
+} from "@/lib/tree-descriptions";
+
+/**
+ * Roadmap 069 (PR 4): one node's description facts, rendered — the sentences
+ * it wrote with where they landed in the final `description` array, the ones
+ * Renovate silently deleted (struck through, with the rule that deleted them),
+ * and the mute note on a node that causes such drops below it.
+ *
+ * Two surfaces share this rendering so they cannot drift: the hover card on
+ * the preset's name in the tree (`TreeRow`), and the detail panel's
+ * Description entry (`PresetDetail`). The facts themselves come from
+ * `lib/tree-descriptions.ts`, which is where every wording lives.
+ */
+
+function DescLineView({ item }: { item: DescLineWithMarker }) {
+  const { line, marker } = item;
+  return (
+    <li className={`preset-desc-line desc-${line.kind}`}>
+      {line.text ? (
+        <span className="preset-desc-text">
+          <CodeText text={line.text} />
+        </span>
+      ) : null}
+      {line.note ? (
+        <span className="preset-desc-note">
+          <CodeText text={line.note} />
+        </span>
+      ) : null}
+      {marker ? (
+        <span className="preset-desc-pos" title={positionMarkerTitle(marker)}>
+          {positionMarkerText(marker)}
+        </span>
+      ) : null}
+    </li>
+  );
+}
+
+export function NodeDescriptionLines({ facts }: { facts: NodeDescriptionFacts }) {
+  return (
+    <ul className="preset-desc-lines">
+      {zipDescLines(facts).map((item) => (
+        <DescLineView key={item.line.key} item={item} />
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * The hover card's body: the lines, plus the jump to the array they landed in
+ * (App plumbing permitting). The jump switches tabs, pulling the page out from
+ * under the card — and a pointer-opened card has no blur to take it down — so
+ * it closes the card it lives in first (`useHoverCardClose`), exactly like the
+ * attribution card's tree jump one PR up.
+ */
+export function NodeDescriptionCard({
+  facts,
+  onShowOrder,
+}: {
+  facts: NodeDescriptionFacts;
+  onShowOrder?: () => void;
+}) {
+  const close = useHoverCardClose();
+  return (
+    <div className="preset-desc-body">
+      <NodeDescriptionLines facts={facts} />
+      {onShowOrder ? (
+        <button
+          type="button"
+          className="preset-desc-order linklike"
+          onClick={() => {
+            close();
+            onShowOrder();
+          }}
+        >
+          Show the full description array →
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/features/presets/PresetDetail.tsx
+++ b/packages/app/src/features/presets/PresetDetail.tsx
@@ -6,6 +6,8 @@ import { type AuthState, GithubAuthHint } from "@/components/GithubAuthHint";
 import { JsonDiff } from "@/components/JsonDiff";
 import { MigrationSteps } from "@/components/MigrationSteps";
 import { findPollutedPath } from "@/lib/input-schemas";
+import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
+import { NodeDescriptionLines } from "./NodeDescriptions";
 import {
   githubAuthFailure,
   type InjectionKeyFn,
@@ -44,31 +46,53 @@ function useContribution(node: PresetNode, parent: PresetNode | undefined) {
   }, [merge, node, parent]);
 }
 
-function SourceDetails({ node }: { node: PresetNode }) {
+/**
+ * Roadmap 069 (PR 4): what this preset says about itself — the same lines the
+ * name's hover card shows (sentences with their slot in the final array, drops
+ * with the rule that deleted them), kept in the panel where a reader inspects
+ * the node. Its own component because the lines nest past the `<dl>`'s depth
+ * budget (`react/jsx-max-depth`).
+ */
+function DescriptionEntry({ facts }: { facts: NodeDescriptionFacts }) {
+  return (
+    <div className="preset-source-desc">
+      <dt>Description</dt>
+      <dd>
+        <NodeDescriptionLines facts={facts} />
+      </dd>
+    </div>
+  );
+}
+
+function SourceDetails({ node, facts }: { node: PresetNode; facts?: NodeDescriptionFacts }) {
   const source = node.source;
-  if (!source?.presetSource) {
+  // Internal presets carry no source block, but can still have a description —
+  // the `<dl>` then holds only the Description entry.
+  const rows: [string, string | undefined][] = source?.presetSource
+    ? [
+        ["Source", source.presetSource],
+        ["Repository", source.repo],
+        ["Path", source.presetPath],
+        ["Preset", source.presetName],
+        ["Tag", source.tag],
+        ["Parameters", source.params?.join(", ")],
+        ["Platform", source.platform],
+        ["Endpoint", source.endpoint],
+      ]
+    : [];
+  const shown = rows.filter(([, v]) => v);
+  if (shown.length === 0 && !facts) {
     return null;
   }
-  const rows: [string, string | undefined][] = [
-    ["Source", source.presetSource],
-    ["Repository", source.repo],
-    ["Path", source.presetPath],
-    ["Preset", source.presetName],
-    ["Tag", source.tag],
-    ["Parameters", source.params?.join(", ")],
-    ["Platform", source.platform],
-    ["Endpoint", source.endpoint],
-  ];
   return (
     <dl className="preset-source">
-      {rows
-        .filter(([, v]) => v)
-        .map(([label, v]) => (
-          <div key={label}>
-            <dt>{label}</dt>
-            <dd>{v}</dd>
-          </div>
-        ))}
+      {shown.map(([label, v]) => (
+        <div key={label}>
+          <dt>{label}</dt>
+          <dd>{v}</dd>
+        </div>
+      ))}
+      {facts ? <DescriptionEntry facts={facts} /> : null}
     </dl>
   );
 }
@@ -149,6 +173,7 @@ function PresetInjector({
 export function PresetDetail({
   node,
   parent,
+  descriptionFacts,
   onClose,
   injectionKey,
   parse,
@@ -161,6 +186,9 @@ export function PresetDetail({
 }: {
   node: PresetNode;
   parent: PresetNode | undefined;
+  /** Roadmap 069 (PR 4): this node's description facts, for the Description
+   *  entry of the source details — `undefined` when it has none. */
+  descriptionFacts?: NodeDescriptionFacts;
   onClose: () => void;
   injectionKey: InjectionKeyFn | null;
   parse: ParseFn | null;
@@ -203,7 +231,7 @@ export function PresetDetail({
           ×
         </button>
       </div>
-      <SourceDetails node={node} />
+      <SourceDetails node={node} facts={descriptionFacts} />
       {userSupplied ? (
         <p className="empty-note">
           Resolved from preset content you supplied manually rather than a fetch.

--- a/packages/app/src/features/presets/PresetDetail.tsx
+++ b/packages/app/src/features/presets/PresetDetail.tsx
@@ -48,9 +48,8 @@ function useContribution(node: PresetNode, parent: PresetNode | undefined) {
 
 /**
  * Roadmap 069 (PR 4): what this preset says about itself — the same lines the
- * name's hover card shows (sentences with their slot in the final array, drops
- * with the rule that deleted them), kept in the panel where a reader inspects
- * the node. Its own component because the lines nest past the `<dl>`'s depth
+ * name's hover card shows, kept in the panel where a reader inspects the
+ * node. Its own component because the lines nest past the `<dl>`'s depth
  * budget (`react/jsx-max-depth`).
  */
 function DescriptionEntry({ facts }: { facts: NodeDescriptionFacts }) {

--- a/packages/app/src/features/presets/PresetListPane.tsx
+++ b/packages/app/src/features/presets/PresetListPane.tsx
@@ -2,9 +2,9 @@ import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { TreeStats } from "@/components/preset-tree-stats";
 import { presetTableRowClass } from "@/lib/preset-row-dom";
 import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
-import type { SortColumn, TableRow, TreeListRow } from "./rows";
+import type { Row, SortColumn, TableRow } from "./rows";
 import { type InjectionKeyFn, ROW_HEIGHT } from "./tree-shared";
-import { TreeDescRow, TreeRow } from "./TreeRow";
+import { TreeRow } from "./TreeRow";
 import type { useWindow } from "./use-window";
 
 /** Roadmap 011/040: the list half of the tree/detail split — the table header
@@ -37,7 +37,7 @@ export function PresetListPane({
   onToggleSort: (column: SortColumn) => void;
   win: ReturnType<typeof useWindow>;
   activeCount: number;
-  treeSlice: TreeListRow[];
+  treeSlice: Row[];
   tableSlice: TableRow[];
   selectedId: string | null;
   onSelectNode: (id: string | null) => void;
@@ -46,7 +46,8 @@ export function PresetListPane({
   injectionKey: InjectionKeyFn | null;
   usedInjections: ReadonlySet<string>;
   stats: TreeStats;
-  /** Roadmap 069 (PR 4): describe mode's per-node index, `null` in compact. */
+  /** Roadmap 069 (PR 4): the per-node description index — `null` when the run
+   *  has no description facts, and then no name carries a hover card. */
   descFacts: ReadonlyMap<string, NodeDescriptionFacts> | null;
   onShowDescriptionOrder?: () => void;
 }) {
@@ -74,25 +75,21 @@ export function PresetListPane({
           <>
             <div style={{ height: win.padTop }} />
             {view === "tree"
-              ? treeSlice.map((item) =>
-                  item.kind === "node" ? (
-                    <TreeRow
-                      key={item.key}
-                      row={item.row}
-                      selectedId={selectedId}
-                      onToggle={onToggle}
-                      onSelect={onSelectNode}
-                      onCycleDup={onCycleDup}
-                      injectionKey={injectionKey}
-                      usedInjections={usedInjections}
-                      dupCount={stats.occurrencesByName.get(item.row.node.name)?.length ?? 1}
-                      markers={descFacts?.get(item.row.node.id)?.markers}
-                      onShowDescriptionOrder={onShowDescriptionOrder}
-                    />
-                  ) : (
-                    <TreeDescRow key={item.key} depth={item.depth} line={item.line} />
-                  ),
-                )
+              ? treeSlice.map((row) => (
+                  <TreeRow
+                    key={row.node.id}
+                    row={row}
+                    selectedId={selectedId}
+                    onToggle={onToggle}
+                    onSelect={onSelectNode}
+                    onCycleDup={onCycleDup}
+                    injectionKey={injectionKey}
+                    usedInjections={usedInjections}
+                    dupCount={stats.occurrencesByName.get(row.node.name)?.length ?? 1}
+                    facts={descFacts?.get(row.node.id)}
+                    onShowDescriptionOrder={onShowDescriptionOrder}
+                  />
+                ))
               : tableSlice.map((r) => (
                   <PresetTableRow
                     key={r.node.id}

--- a/packages/app/src/features/presets/PresetListPane.tsx
+++ b/packages/app/src/features/presets/PresetListPane.tsx
@@ -1,9 +1,10 @@
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { TreeStats } from "@/components/preset-tree-stats";
 import { presetTableRowClass } from "@/lib/preset-row-dom";
-import type { Row, SortColumn, TableRow } from "./rows";
+import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
+import type { SortColumn, TableRow, TreeListRow } from "./rows";
 import { type InjectionKeyFn, ROW_HEIGHT } from "./tree-shared";
-import { TreeRow } from "./TreeRow";
+import { TreeDescRow, TreeRow } from "./TreeRow";
 import type { useWindow } from "./use-window";
 
 /** Roadmap 011/040: the list half of the tree/detail split — the table header
@@ -26,6 +27,8 @@ export function PresetListPane({
   injectionKey,
   usedInjections,
   stats,
+  descFacts,
+  onShowDescriptionOrder,
 }: {
   view: "tree" | "table";
   columns: { key: SortColumn; label: string }[];
@@ -34,7 +37,7 @@ export function PresetListPane({
   onToggleSort: (column: SortColumn) => void;
   win: ReturnType<typeof useWindow>;
   activeCount: number;
-  treeSlice: Row[];
+  treeSlice: TreeListRow[];
   tableSlice: TableRow[];
   selectedId: string | null;
   onSelectNode: (id: string | null) => void;
@@ -43,6 +46,9 @@ export function PresetListPane({
   injectionKey: InjectionKeyFn | null;
   usedInjections: ReadonlySet<string>;
   stats: TreeStats;
+  /** Roadmap 069 (PR 4): describe mode's per-node index, `null` in compact. */
+  descFacts: ReadonlyMap<string, NodeDescriptionFacts> | null;
+  onShowDescriptionOrder?: () => void;
 }) {
   return (
     <div>
@@ -68,19 +74,25 @@ export function PresetListPane({
           <>
             <div style={{ height: win.padTop }} />
             {view === "tree"
-              ? treeSlice.map((row) => (
-                  <TreeRow
-                    key={row.node.id}
-                    row={row}
-                    selectedId={selectedId}
-                    onToggle={onToggle}
-                    onSelect={onSelectNode}
-                    onCycleDup={onCycleDup}
-                    injectionKey={injectionKey}
-                    usedInjections={usedInjections}
-                    dupCount={stats.occurrencesByName.get(row.node.name)?.length ?? 1}
-                  />
-                ))
+              ? treeSlice.map((item) =>
+                  item.kind === "node" ? (
+                    <TreeRow
+                      key={item.key}
+                      row={item.row}
+                      selectedId={selectedId}
+                      onToggle={onToggle}
+                      onSelect={onSelectNode}
+                      onCycleDup={onCycleDup}
+                      injectionKey={injectionKey}
+                      usedInjections={usedInjections}
+                      dupCount={stats.occurrencesByName.get(item.row.node.name)?.length ?? 1}
+                      markers={descFacts?.get(item.row.node.id)?.markers}
+                      onShowDescriptionOrder={onShowDescriptionOrder}
+                    />
+                  ) : (
+                    <TreeDescRow key={item.key} depth={item.depth} line={item.line} />
+                  ),
+                )
               : tableSlice.map((r) => (
                   <PresetTableRow
                     key={r.node.id}

--- a/packages/app/src/features/presets/PresetTree.test.tsx
+++ b/packages/app/src/features/presets/PresetTree.test.tsx
@@ -1,14 +1,14 @@
 /**
- * Roadmap 069 (PR 4): describe mode end to end, over a real (offline) run. The
- * per-node index and every note's wording have their own unit tests, so this
- * covers only what those cannot: that the engine's attribution reaches the
- * DOM, that compact — the default — is byte-for-byte the tree that existed
- * before this PR, that describe mode adds a row only for the nodes that have
- * something to say, and that the position marker really is the jump to the
- * Effective config's ledger.
+ * Roadmap 069 (PR 4): the tree's description surfaces end to end, over a real
+ * (offline) run. The per-node index and every note's wording have their own
+ * unit tests, so this covers only what those cannot: that the engine's
+ * attribution reaches the DOM through the hover card on a described NAME, that
+ * the card's jump really is the App-level cross-link to the blame ledger, that
+ * the detail panel repeats the same facts as a Description entry, and that a
+ * run without descriptions mounts no affordance at all.
  */
 import { runPipeline } from "@renovate-config-debugger/engine";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeAll, expect, it, vi } from "vitest";
 import { PresetTree } from "./PresetTree";
 
@@ -33,62 +33,104 @@ const DASHBOARD_SENTENCE = "Enable Renovate Dependency Dashboard creation.";
 
 function tree(
   result: Awaited<ReturnType<typeof runPipeline>>,
-  onShowDescriptionOrder?: () => void,
+  opts: {
+    onShowDescriptionOrder?: () => void;
+    selectedId?: string | null;
+    onSelectNode?: (id: string | null) => void;
+  } = {},
 ) {
   return (
     <PresetTree
       result={result}
       onInject={() => undefined}
-      selectedId={null}
-      onSelectNode={() => undefined}
+      selectedId={opts.selectedId ?? null}
+      onSelectNode={opts.onSelectNode ?? (() => undefined)}
       authState="unconfigured"
       onSignIn={() => undefined}
       installUrl="https://example.invalid"
-      onShowDescriptionOrder={onShowDescriptionOrder}
+      onShowDescriptionOrder={opts.onShowDescriptionOrder}
     />
   );
 }
 
-it("shows each node's own sentence in describe mode, and nothing in compact", async () => {
+/** The open hover card's body, portalled to `<body>` — `null` when none is. */
+function openCard(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(".preset-desc-body");
+}
+
+it("shows a described node's sentences in a hover card on its name", async () => {
   const result = await runPipeline({
     fileName: "renovate.json",
     content: JSON.stringify(CONFIG),
   });
   const onShowDescriptionOrder = vi.fn();
-  const view = render(tree(result, onShowDescriptionOrder));
+  const view = render(tree(result, { onShowDescriptionOrder }));
 
-  // Provenance is loaded through the engine's dynamic import, so the toggle
-  // (and the title's count) appear a commit later than the tree itself.
-  await waitFor(() => expect(view.queryByRole("radio", { name: "describe" })).not.toBeNull());
-  expect(view.getByText("2 contribute descriptions", { exact: false })).toBeTruthy();
+  // Provenance loads through the engine's dynamic import, so the count (and
+  // the hover affordance) appear a commit later than the tree itself.
+  await waitFor(() =>
+    expect(view.getByText("2 contribute descriptions", { exact: false })).toBeTruthy(),
+  );
 
-  // Compact is the default and renders exactly today's tree: no quote rows, no
-  // position markers.
-  const quoteRows = () => view.container.querySelectorAll(".preset-desc-row");
-  const compactRowCount = view.container.querySelectorAll(".preset-row").length;
-  expect(quoteRows()).toHaveLength(0);
-  expect(view.container.querySelectorAll(".preset-desc-pos")).toHaveLength(0);
+  // The rows themselves stay untouched: no quote rows, no markers — the facts
+  // live on the name, marked by the `described` cue.
+  expect(view.container.querySelector(".preset-desc-line")).toBeNull();
+  const name = view.getByRole("button", { name: ":dependencyDashboard" });
+  expect(name.className).toContain("described");
+  expect(openCard()).toBeNull();
 
-  fireEvent.click(view.getByRole("radio", { name: "describe" }));
+  fireEvent.focus(name);
+  const card = openCard();
+  if (!card) {
+    throw new Error("focusing a described name opened no card");
+  }
+  expect(card.textContent).toContain(DASHBOARD_SENTENCE);
+  // …with the sentence's slot in the FINAL array, non-strings included.
+  expect(card.textContent).toContain("→ #1 of 2");
 
-  // …and describe mode adds a row per FACT, not per node: the two contributing
-  // presets gain a quote line, the nodes around them gain nothing.
-  expect(view.container.querySelectorAll(".preset-row")).toHaveLength(compactRowCount);
-  expect(quoteRows()).toHaveLength(2);
-  expect(view.getByText(DASHBOARD_SENTENCE)).toBeTruthy();
-
-  // The marker ties the node to its slot in the final array…
-  const marker = view.getByText("→ #1 of 2");
-  expect(marker.tagName).toBe("BUTTON");
-  // …and, given App's plumbing, is the jump to the row that prints it.
-  fireEvent.click(marker);
+  // The card's jump is the App-level cross-link to the blame ledger — and it
+  // closes the card it lives in, which is about to point at another tab.
+  fireEvent.click(within(card).getByText("Show the full description array →"));
   expect(onShowDescriptionOrder).toHaveBeenCalledTimes(1);
-
-  fireEvent.click(view.getByRole("radio", { name: "compact" }));
-  expect(quoteRows()).toHaveLength(0);
+  expect(openCard()).toBeNull();
 });
 
-it("offers no describe mode when nothing in the run has a description", async () => {
+it("repeats the selected node's description in the detail panel", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(CONFIG),
+  });
+  // Selection is controlled by App; capture the id the name click reports and
+  // feed it back, exactly as App would.
+  let selected: string | null = null;
+  const onSelectNode = (id: string | null) => {
+    selected = id;
+  };
+  const view = render(tree(result, { onSelectNode }));
+
+  // Wait for the DESCRIBED name, not just the name: when provenance resolves,
+  // the plain button is remounted inside the hover anchor, and a handle taken
+  // before that swap would be a detached node by the time it is clicked.
+  const name = await waitFor(() => {
+    const button = view.getByRole("button", { name: ":dependencyDashboard" });
+    expect(button.className).toContain("described");
+    return button;
+  });
+  fireEvent.click(name);
+  expect(selected).not.toBeNull();
+  view.rerender(tree(result, { onSelectNode, selectedId: selected }));
+
+  const panel = view.container.querySelector<HTMLElement>(".preset-panel");
+  if (!panel) {
+    throw new Error("selecting a node opened no detail panel");
+  }
+  // Provenance may resolve after the panel mounts — the entry appears then.
+  await waitFor(() => expect(within(panel).getByText("Description")).toBeTruthy());
+  expect(within(panel).getByText(DASHBOARD_SENTENCE)).toBeTruthy();
+  expect(within(panel).getByText("→ #1 of 2")).toBeTruthy();
+});
+
+it("offers no description affordance when nothing in the run has one", async () => {
   const result = await runPipeline({
     fileName: "renovate.json",
     content: JSON.stringify({ extends: ["github>test-org/nope"], automerge: true }),
@@ -96,7 +138,11 @@ it("offers no describe mode when nothing in the run has a description", async ()
   const view = render(tree(result));
 
   // A failed preset resolves nothing, so there is neither a sentence nor a
-  // drop to explain — the toggle would be a control over an empty set.
+  // drop to explain — no count in the title, no cue on the name, no card.
   await waitFor(() => expect(view.container.querySelector(".preset-row")).not.toBeNull());
-  expect(view.queryByRole("radio", { name: "describe" })).toBeNull();
+  expect(view.container.textContent).not.toContain("contribute descriptions");
+  const name = view.getByRole("button", { name: "github>test-org/nope" });
+  expect(name.className).not.toContain("described");
+  fireEvent.focus(name);
+  expect(openCard()).toBeNull();
 });

--- a/packages/app/src/features/presets/PresetTree.test.tsx
+++ b/packages/app/src/features/presets/PresetTree.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Roadmap 069 (PR 4): describe mode end to end, over a real (offline) run. The
+ * per-node index and every note's wording have their own unit tests, so this
+ * covers only what those cannot: that the engine's attribution reaches the
+ * DOM, that compact — the default — is byte-for-byte the tree that existed
+ * before this PR, that describe mode adds a row only for the nodes that have
+ * something to say, and that the position marker really is the jump to the
+ * Effective config's ledger.
+ */
+import { runPipeline } from "@renovate-config-debugger/engine";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeAll, expect, it, vi } from "vitest";
+import { PresetTree } from "./PresetTree";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // jsdom lacks the one API the tree's windowing observes.
+  window.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+// Internal presets resolve with no network, so this whole run is offline. Two
+// sentences, from two different nodes, one level down.
+const CONFIG = {
+  extends: [":dependencyDashboard", ":semanticPrefixFixDepsChoreOthers"],
+};
+
+const DASHBOARD_SENTENCE = "Enable Renovate Dependency Dashboard creation.";
+
+function tree(
+  result: Awaited<ReturnType<typeof runPipeline>>,
+  onShowDescriptionOrder?: () => void,
+) {
+  return (
+    <PresetTree
+      result={result}
+      onInject={() => undefined}
+      selectedId={null}
+      onSelectNode={() => undefined}
+      authState="unconfigured"
+      onSignIn={() => undefined}
+      installUrl="https://example.invalid"
+      onShowDescriptionOrder={onShowDescriptionOrder}
+    />
+  );
+}
+
+it("shows each node's own sentence in describe mode, and nothing in compact", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(CONFIG),
+  });
+  const onShowDescriptionOrder = vi.fn();
+  const view = render(tree(result, onShowDescriptionOrder));
+
+  // Provenance is loaded through the engine's dynamic import, so the toggle
+  // (and the title's count) appear a commit later than the tree itself.
+  await waitFor(() => expect(view.queryByRole("radio", { name: "describe" })).not.toBeNull());
+  expect(view.getByText("2 contribute descriptions", { exact: false })).toBeTruthy();
+
+  // Compact is the default and renders exactly today's tree: no quote rows, no
+  // position markers.
+  const quoteRows = () => view.container.querySelectorAll(".preset-desc-row");
+  const compactRowCount = view.container.querySelectorAll(".preset-row").length;
+  expect(quoteRows()).toHaveLength(0);
+  expect(view.container.querySelectorAll(".preset-desc-pos")).toHaveLength(0);
+
+  fireEvent.click(view.getByRole("radio", { name: "describe" }));
+
+  // …and describe mode adds a row per FACT, not per node: the two contributing
+  // presets gain a quote line, the nodes around them gain nothing.
+  expect(view.container.querySelectorAll(".preset-row")).toHaveLength(compactRowCount);
+  expect(quoteRows()).toHaveLength(2);
+  expect(view.getByText(DASHBOARD_SENTENCE)).toBeTruthy();
+
+  // The marker ties the node to its slot in the final array…
+  const marker = view.getByText("→ #1 of 2");
+  expect(marker.tagName).toBe("BUTTON");
+  // …and, given App's plumbing, is the jump to the row that prints it.
+  fireEvent.click(marker);
+  expect(onShowDescriptionOrder).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(view.getByRole("radio", { name: "compact" }));
+  expect(quoteRows()).toHaveLength(0);
+});
+
+it("offers no describe mode when nothing in the run has a description", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ extends: ["github>test-org/nope"], automerge: true }),
+  });
+  const view = render(tree(result));
+
+  // A failed preset resolves nothing, so there is neither a sentence nor a
+  // drop to explain — the toggle would be a control over an empty set.
+  await waitFor(() => expect(view.container.querySelector(".preset-row")).not.toBeNull());
+  expect(view.queryByRole("radio", { name: "describe" })).toBeNull();
+});

--- a/packages/app/src/features/presets/PresetTree.test.tsx
+++ b/packages/app/src/features/presets/PresetTree.test.tsx
@@ -95,6 +95,38 @@ it("shows a described node's sentences in a hover card on its name", async () =>
   expect(openCard()).toBeNull();
 });
 
+it("shows a shed wrapper description plainly, without drop mechanics", async () => {
+  // `config:best-practices` is a wrapper preset — body of only `description` +
+  // `extends` — so Renovate sheds its sentence by design and it never reaches
+  // the final array. That is the EXPECTED case, not a problem: the card shows
+  // the sentence as the preset's own words, with no slot marker, no
+  // strikethrough note, no merge mechanics.
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ extends: ["config:best-practices"] }),
+  });
+  const view = render(tree(result));
+
+  const name = await waitFor(() => {
+    const button = view.getByRole("button", { name: "config:best-practices" });
+    expect(button.className).toContain("described");
+    return button;
+  });
+  fireEvent.focus(name);
+  const card = openCard();
+  if (!card) {
+    throw new Error("focusing the wrapper's name opened no card");
+  }
+  const dropped = card.querySelector<HTMLElement>(".desc-dropped");
+  if (!dropped) {
+    throw new Error("the wrapper's shed sentence rendered no line");
+  }
+  expect(dropped.textContent).toContain("best practices from the Renovate maintainers");
+  expect(dropped.textContent).not.toContain("Renovate drops");
+  expect(dropped.querySelector(".preset-desc-note")).toBeNull();
+  expect(dropped.querySelector(".preset-desc-pos")).toBeNull();
+});
+
 it("repeats the selected node's description in the detail panel", async () => {
   const result = await runPipeline({
     fileName: "renovate.json",

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -3,10 +3,18 @@ import type { PresetNode, TraceEvent, TraceResult } from "@renovate-config-debug
 import { Term } from "@/components/glossary";
 import { computeTreeStats } from "@/components/preset-tree-stats";
 import type { AuthState } from "@/components/GithubAuthHint";
+import { useDescriptionProvenance } from "@/hooks/description-provenance";
+import { buildTreeDescriptions, describeCountText } from "@/lib/tree-descriptions";
 import { OriginFraming } from "./OriginFraming";
 import { PresetDetail } from "./PresetDetail";
 import { PresetListPane } from "./PresetListPane";
-import { buildTableRows, flattenTree, type SortColumn, sortTableRows } from "./rows";
+import {
+  buildTableRows,
+  buildTreeListRows,
+  flattenTree,
+  type SortColumn,
+  sortTableRows,
+} from "./rows";
 import { SummaryHeader } from "./SummaryHeader";
 import { nf, ROW_HEIGHT } from "./tree-shared";
 import { useEngineHelpers } from "./use-engine-helpers";
@@ -24,7 +32,53 @@ import { useWindow } from "./use-window";
  * into an instrument for "what did all of that do?" and "where did this come
  * from?". All per-node/per-subtree aggregates are computed once per result in
  * a single walk (`computeTreeStats`), never per render.
+ *
+ * Roadmap 069 (PR 4) adds `describe` mode: every node that wrote a sentence of
+ * the final `description` shows it as a quote line, and every node whose
+ * sentence Renovate silently deleted says so — the only place in the app where
+ * the two invisible drop rules are visible at the node they happened to.
  */
+
+/** Compact is today's tree, and the default: describe mode is an answer to a
+ *  question ("what does all this say?"), not the tree's resting state. Local
+ *  state, exactly like the Effective config's By key / As JSON switch — no
+ *  view toggle in this app is persisted. */
+type DescribeMode = "compact" | "describe";
+
+/** The mode switch, in the `.seg` chrome every other view toggle in the app
+ *  wears (036) — the Effective config's By key / As JSON control is the
+ *  reference, down to the radiogroup semantics. */
+function DescribeToggle({
+  mode,
+  onChange,
+}: {
+  mode: DescribeMode;
+  onChange: (mode: DescribeMode) => void;
+}) {
+  return (
+    <span className="seg" role="radiogroup" aria-label="Preset tree detail">
+      <button
+        type="button"
+        role="radio"
+        aria-checked={mode === "compact"}
+        className={mode === "compact" ? "active" : undefined}
+        onClick={() => onChange("compact")}
+      >
+        compact
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={mode === "describe"}
+        className={mode === "describe" ? "active" : undefined}
+        title="Show each preset's own description under its name, with where it landed in the final description array"
+        onClick={() => onChange("describe")}
+      >
+        describe
+      </button>
+    </span>
+  );
+}
 
 export const PresetTree = memo(function PresetTree({
   result,
@@ -34,6 +88,7 @@ export const PresetTree = memo(function PresetTree({
   authState,
   onSignIn,
   installUrl,
+  onShowDescriptionOrder,
 }: {
   result: TraceResult;
   onInject: (key: string, content: Record<string, unknown>) => void;
@@ -44,6 +99,10 @@ export const PresetTree = memo(function PresetTree({
   authState: AuthState;
   onSignIn: () => void;
   installUrl: string;
+  /** Roadmap 069 (PR 4): the position marker's cross-link — jumps to the
+   *  Effective config and opens the `description` row's blame ledger (PR 3),
+   *  where the same sentence sits in the array's own order. */
+  onShowDescriptionOrder?: () => void;
 }) {
   const root = result.presetTree;
   const helpers = useEngineHelpers();
@@ -69,7 +128,18 @@ export const PresetTree = memo(function PresetTree({
 
   const stats = useMemo(() => (root ? computeTreeStats(root) : null), [root]);
 
+  // Roadmap 069: the per-string attribution, through the same WeakMap-cached
+  // hook the Overview digest and the blame ledger use — so however many
+  // consumers ask, the walk runs once per run. Inverting it into the per-node
+  // index is a single pass over a few dozen entries, memoized per result.
+  const descriptionProvenance = useDescriptionProvenance(result);
+  const treeDescriptions = useMemo(
+    () => (descriptionProvenance ? buildTreeDescriptions(descriptionProvenance) : null),
+    [descriptionProvenance],
+  );
+
   const [view, setView] = useState<"tree" | "table">("tree");
+  const [describeMode, setDescribeMode] = useState<DescribeMode>("compact");
   const [hideZero, setHideZero] = useState(false);
   const [rawQuery, setRawQuery] = useState("");
   const [query, setQuery] = useState("");
@@ -111,6 +181,13 @@ export const PresetTree = memo(function PresetTree({
     [root, stats, expanded, hideZero, query],
   );
 
+  // `null` in compact mode (and whenever the run has no descriptions at all),
+  // which is what makes describe mode's cost opt-in: `buildTreeListRows` then
+  // adds no rows and `PresetListPane` renders no markers.
+  const descFacts =
+    describeMode === "describe" && treeDescriptions ? treeDescriptions.byNodeId : null;
+  const listRows = useMemo(() => buildTreeListRows(flatRows, descFacts), [flatRows, descFacts]);
+
   const tableRows = useMemo(() => {
     if (!stats) {
       return [];
@@ -121,7 +198,7 @@ export const PresetTree = memo(function PresetTree({
     return sortTableRows(filtered, sortColumn, sortDir);
   }, [stats, query, sortColumn, sortDir]);
 
-  const activeCount = view === "tree" ? flatRows.length : tableRows.length;
+  const activeCount = view === "tree" ? listRows.length : tableRows.length;
   const win = useWindow(activeCount);
 
   // Reverse lookup (005) + dedup cycling: when selection changes, open every
@@ -161,7 +238,9 @@ export const PresetTree = memo(function PresetTree({
     if (!selectedId || view !== "tree") {
       return;
     }
-    const idx = flatRows.findIndex((r) => r.node.id === selectedId);
+    // Over the LIST rows, not the tree rows: describe mode interleaves quote
+    // rows, so a node's pixel offset is its index in the mounted list.
+    const idx = listRows.findIndex((r) => r.kind === "node" && r.row.node.id === selectedId);
     const el = win.el;
     if (idx < 0 || !el) {
       return;
@@ -173,7 +252,7 @@ export const PresetTree = memo(function PresetTree({
     } else if (bottom > el.scrollTop + el.clientHeight) {
       el.scrollTop = bottom - el.clientHeight;
     }
-  }, [selectedId, flatRows, view, win.el]);
+  }, [selectedId, listRows, view, win.el]);
 
   if (!root || root.children.length === 0 || !stats) {
     return null;
@@ -213,7 +292,7 @@ export const PresetTree = memo(function PresetTree({
     }
   }
 
-  const treeSlice = flatRows.slice(win.start, win.end);
+  const treeSlice = listRows.slice(win.start, win.end);
   const tableSlice = tableRows.slice(win.start, win.end);
 
   const columns: { key: SortColumn; label: string }[] = [
@@ -226,9 +305,18 @@ export const PresetTree = memo(function PresetTree({
 
   return (
     <div className="card">
-      <div className="card-title">
-        <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
-        resolved)
+      <div className="card-title preset-card-title">
+        <span>
+          <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
+          resolved
+          {treeDescriptions ? ` · ${describeCountText(treeDescriptions)}` : ""})
+        </span>
+        {/* Describe mode annotates TREE rows, so the toggle belongs to the tree
+            view — the flat table is one row per preset NAME, an aggregate the
+            per-node attribution has no place on. */}
+        {treeDescriptions && view === "tree" ? (
+          <DescribeToggle mode={describeMode} onChange={setDescribeMode} />
+        ) : null}
       </div>
       <OriginFraming root={root} stats={stats} />
       <SummaryHeader summary={stats.summary} />
@@ -293,6 +381,8 @@ export const PresetTree = memo(function PresetTree({
             injectionKey={injectionKey}
             usedInjections={usedInjections}
             stats={stats}
+            descFacts={descFacts}
+            onShowDescriptionOrder={onShowDescriptionOrder}
           />
           {selected ? (
             <PresetDetail

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -8,13 +8,7 @@ import { buildTreeDescriptions, describeCountText } from "@/lib/tree-description
 import { OriginFraming } from "./OriginFraming";
 import { PresetDetail } from "./PresetDetail";
 import { PresetListPane } from "./PresetListPane";
-import {
-  buildTableRows,
-  buildTreeListRows,
-  flattenTree,
-  type SortColumn,
-  sortTableRows,
-} from "./rows";
+import { buildTableRows, flattenTree, type SortColumn, sortTableRows } from "./rows";
 import { SummaryHeader } from "./SummaryHeader";
 import { nf, ROW_HEIGHT } from "./tree-shared";
 import { useEngineHelpers } from "./use-engine-helpers";
@@ -33,52 +27,15 @@ import { useWindow } from "./use-window";
  * from?". All per-node/per-subtree aggregates are computed once per result in
  * a single walk (`computeTreeStats`), never per render.
  *
- * Roadmap 069 (PR 4) adds `describe` mode: every node that wrote a sentence of
- * the final `description` shows it as a quote line, and every node whose
- * sentence Renovate silently deleted says so — the only place in the app where
- * the two invisible drop rules are visible at the node they happened to.
+ * Roadmap 069 (PR 4) puts each node's descriptions ON the node: a name that
+ * wrote a sentence of the final `description` carries a hover card quoting it
+ * (with its slot in the final array), a name whose sentence Renovate silently
+ * deleted says so the same way — the only place in the app where the two
+ * invisible drop rules are visible at the node they happened to — and the
+ * detail panel repeats the same facts as a Description entry. A hover surface
+ * rather than a view mode: the tree already has a tree/table switch, and the
+ * rows stay exactly `ROW_HEIGHT`, which the windowing math depends on.
  */
-
-/** Compact is today's tree, and the default: describe mode is an answer to a
- *  question ("what does all this say?"), not the tree's resting state. Local
- *  state, exactly like the Effective config's By key / As JSON switch — no
- *  view toggle in this app is persisted. */
-type DescribeMode = "compact" | "describe";
-
-/** The mode switch, in the `.seg` chrome every other view toggle in the app
- *  wears (036) — the Effective config's By key / As JSON control is the
- *  reference, down to the radiogroup semantics. */
-function DescribeToggle({
-  mode,
-  onChange,
-}: {
-  mode: DescribeMode;
-  onChange: (mode: DescribeMode) => void;
-}) {
-  return (
-    <span className="seg" role="radiogroup" aria-label="Preset tree detail">
-      <button
-        type="button"
-        role="radio"
-        aria-checked={mode === "compact"}
-        className={mode === "compact" ? "active" : undefined}
-        onClick={() => onChange("compact")}
-      >
-        compact
-      </button>
-      <button
-        type="button"
-        role="radio"
-        aria-checked={mode === "describe"}
-        className={mode === "describe" ? "active" : undefined}
-        title="Show each preset's own description under its name, with where it landed in the final description array"
-        onClick={() => onChange("describe")}
-      >
-        describe
-      </button>
-    </span>
-  );
-}
 
 export const PresetTree = memo(function PresetTree({
   result,
@@ -139,7 +96,6 @@ export const PresetTree = memo(function PresetTree({
   );
 
   const [view, setView] = useState<"tree" | "table">("tree");
-  const [describeMode, setDescribeMode] = useState<DescribeMode>("compact");
   const [hideZero, setHideZero] = useState(false);
   const [rawQuery, setRawQuery] = useState("");
   const [query, setQuery] = useState("");
@@ -173,15 +129,14 @@ export const PresetTree = memo(function PresetTree({
     });
   }, [stats]);
 
-  // `null` in compact mode (and whenever the run has no descriptions at all),
-  // which is what makes describe mode's cost opt-in: `buildTreeListRows` then
-  // adds no rows and `PresetListPane` renders no markers.
-  const descFacts =
-    describeMode === "describe" && treeDescriptions ? treeDescriptions.byNodeId : null;
+  // `null` when the run has no description facts at all — then no name carries
+  // a hover card and the detail panel shows no Description entry.
+  const descFacts = treeDescriptions?.byNodeId ?? null;
   // …and the same nodes as a plain id set, which is all the flattening needs:
-  // hide-zero would otherwise elide the wrapper presets, taking the drop lines
-  // with them (see `FlattenArgs.described`). A few dozen ids, rebuilt only when
-  // the mode or the run changes — never on a keystroke.
+  // hide-zero would otherwise elide the wrapper presets, taking their hover
+  // cards (and the drop lines on them) out of reach (see
+  // `FlattenArgs.described`). A few dozen ids, rebuilt only when the run
+  // changes — never on a keystroke.
   const describedIds = useMemo(() => (descFacts ? new Set(descFacts.keys()) : null), [descFacts]);
 
   const flatRows = useMemo(
@@ -199,8 +154,6 @@ export const PresetTree = memo(function PresetTree({
     [root, stats, expanded, hideZero, query, describedIds],
   );
 
-  const listRows = useMemo(() => buildTreeListRows(flatRows, descFacts), [flatRows, descFacts]);
-
   const tableRows = useMemo(() => {
     if (!stats) {
       return [];
@@ -211,7 +164,7 @@ export const PresetTree = memo(function PresetTree({
     return sortTableRows(filtered, sortColumn, sortDir);
   }, [stats, query, sortColumn, sortDir]);
 
-  const activeCount = view === "tree" ? listRows.length : tableRows.length;
+  const activeCount = view === "tree" ? flatRows.length : tableRows.length;
   const win = useWindow(activeCount);
 
   // Reverse lookup (005) + dedup cycling: when selection changes, open every
@@ -251,9 +204,7 @@ export const PresetTree = memo(function PresetTree({
     if (!selectedId || view !== "tree") {
       return;
     }
-    // Over the LIST rows, not the tree rows: describe mode interleaves quote
-    // rows, so a node's pixel offset is its index in the mounted list.
-    const idx = listRows.findIndex((r) => r.kind === "node" && r.row.node.id === selectedId);
+    const idx = flatRows.findIndex((r) => r.node.id === selectedId);
     const el = win.el;
     if (idx < 0 || !el) {
       return;
@@ -265,7 +216,7 @@ export const PresetTree = memo(function PresetTree({
     } else if (bottom > el.scrollTop + el.clientHeight) {
       el.scrollTop = bottom - el.clientHeight;
     }
-  }, [selectedId, listRows, view, win.el]);
+  }, [selectedId, flatRows, view, win.el]);
 
   if (!root || root.children.length === 0 || !stats) {
     return null;
@@ -305,7 +256,7 @@ export const PresetTree = memo(function PresetTree({
     }
   }
 
-  const treeSlice = listRows.slice(win.start, win.end);
+  const treeSlice = flatRows.slice(win.start, win.end);
   const tableSlice = tableRows.slice(win.start, win.end);
 
   const columns: { key: SortColumn; label: string }[] = [
@@ -318,18 +269,10 @@ export const PresetTree = memo(function PresetTree({
 
   return (
     <div className="card">
-      <div className="card-title preset-card-title">
-        <span>
-          <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
-          resolved
-          {treeDescriptions ? ` · ${describeCountText(treeDescriptions)}` : ""})
-        </span>
-        {/* Describe mode annotates TREE rows, so the toggle belongs to the tree
-            view — the flat table is one row per preset NAME, an aggregate the
-            per-node attribution has no place on. */}
-        {treeDescriptions && view === "tree" ? (
-          <DescribeToggle mode={describeMode} onChange={setDescribeMode} />
-        ) : null}
+      <div className="card-title">
+        <Term id="preset">Preset</Term> resolution tree ({nf.format(stats.summary.resolved)}{" "}
+        resolved
+        {treeDescriptions ? ` · ${describeCountText(treeDescriptions)}` : ""})
       </div>
       <OriginFraming root={root} stats={stats} />
       <SummaryHeader summary={stats.summary} />
@@ -401,6 +344,7 @@ export const PresetTree = memo(function PresetTree({
             <PresetDetail
               node={selected}
               parent={stats.parents.get(selected.id)}
+              descriptionFacts={descFacts?.get(selected.id)}
               onClose={() => onSelectNode(null)}
               injectionKey={injectionKey}
               parse={helpers?.parse ?? null}

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -173,19 +173,32 @@ export const PresetTree = memo(function PresetTree({
     });
   }, [stats]);
 
-  const flatRows = useMemo(
-    () =>
-      root && stats
-        ? flattenTree({ root, stats, expandedIdentities: expanded, hideZero, query })
-        : [],
-    [root, stats, expanded, hideZero, query],
-  );
-
   // `null` in compact mode (and whenever the run has no descriptions at all),
   // which is what makes describe mode's cost opt-in: `buildTreeListRows` then
   // adds no rows and `PresetListPane` renders no markers.
   const descFacts =
     describeMode === "describe" && treeDescriptions ? treeDescriptions.byNodeId : null;
+  // …and the same nodes as a plain id set, which is all the flattening needs:
+  // hide-zero would otherwise elide the wrapper presets, taking the drop lines
+  // with them (see `FlattenArgs.described`). A few dozen ids, rebuilt only when
+  // the mode or the run changes — never on a keystroke.
+  const describedIds = useMemo(() => (descFacts ? new Set(descFacts.keys()) : null), [descFacts]);
+
+  const flatRows = useMemo(
+    () =>
+      root && stats
+        ? flattenTree({
+            root,
+            stats,
+            expandedIdentities: expanded,
+            hideZero,
+            query,
+            described: describedIds,
+          })
+        : [],
+    [root, stats, expanded, hideZero, query, describedIds],
+  );
+
   const listRows = useMemo(() => buildTreeListRows(flatRows, descFacts), [flatRows, descFacts]);
 
   const tableRows = useMemo(() => {

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -27,14 +27,13 @@ import { useWindow } from "./use-window";
  * from?". All per-node/per-subtree aggregates are computed once per result in
  * a single walk (`computeTreeStats`), never per render.
  *
- * Roadmap 069 (PR 4) puts each node's descriptions ON the node: a name that
- * wrote a sentence of the final `description` carries a hover card quoting it
- * (with its slot in the final array), a name whose sentence Renovate silently
- * deleted says so the same way — the only place in the app where the two
- * invisible drop rules are visible at the node they happened to — and the
- * detail panel repeats the same facts as a Description entry. A hover surface
- * rather than a view mode: the tree already has a tree/table switch, and the
- * rows stay exactly `ROW_HEIGHT`, which the windowing math depends on.
+ * Roadmap 069 (PR 4) puts each node's descriptions ON the node: a described
+ * name carries a hover card quoting the preset's own sentences (with their
+ * slot in the final array when they reached it — a wrapper preset's sentence,
+ * which Renovate sheds by design, reads the same and simply has no slot), and
+ * the detail panel repeats the same facts as a Description entry. A hover
+ * surface rather than a view mode: the tree already has a tree/table switch,
+ * and the rows stay exactly `ROW_HEIGHT`, which the windowing math depends on.
  */
 
 export const PresetTree = memo(function PresetTree({

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -1,16 +1,12 @@
 import type { CSSProperties } from "react";
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats } from "@/components/preset-tree-stats";
-import { CodeText } from "@/components/CodeText";
 import { Explained } from "@/components/glossary";
+import { type HoverCardHandlers, HoverCardAnchor } from "@/components/hover-card";
 import { GLOSSARY } from "@/data/glossary-data";
 import { presetTreeNameClass } from "@/lib/preset-row-dom";
-import {
-  type DescLine,
-  type PositionMarker,
-  positionMarkerText,
-  positionMarkerTitle,
-} from "@/lib/tree-descriptions";
+import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
+import { NodeDescriptionCard } from "./NodeDescriptions";
 import type { Row } from "./rows";
 import {
   INDENT,
@@ -57,84 +53,6 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
   );
 }
 
-/**
- * Roadmap 069 (PR 4): where this node's sentences landed in the final
- * `description` array. A button whenever the App-level jump is available — the
- * marker's whole point is that it ties the node to a slot in an array the
- * Effective config prints, so being able to go there completes the link.
- */
-function PositionMarkers({
-  markers,
-  onShowOrder,
-}: {
-  markers: PositionMarker[];
-  onShowOrder?: () => void;
-}) {
-  return (
-    <>
-      {markers.map((marker) =>
-        onShowOrder ? (
-          <button
-            key={marker.key}
-            type="button"
-            className="preset-desc-pos linklike"
-            title={positionMarkerTitle(marker, true)}
-            onClick={onShowOrder}
-          >
-            {positionMarkerText(marker)}
-          </button>
-        ) : (
-          <span
-            key={marker.key}
-            className="preset-desc-pos"
-            title={positionMarkerTitle(marker, false)}
-          >
-            {positionMarkerText(marker)}
-          </span>
-        ),
-      )}
-    </>
-  );
-}
-
-/**
- * Roadmap 069 (PR 4): one description fact, as its own uniform-height row
- * beneath the node that owns it (see `TreeListRow` for why it is a row and not
- * a taller node). Single-line and ellipsized: the tree's windowing depends on
- * every row being exactly `ROW_HEIGHT`, and the full text is one click away in
- * the detail panel and the Effective config's ledger.
- */
-export function TreeDescRow({ depth, line }: { depth: number; line: DescLine }) {
-  const style: CSSProperties = {
-    height: ROW_HEIGHT,
-    // Past the caret column, so the quote hangs under the preset's name.
-    paddingLeft: depth * INDENT + DESC_INDENT,
-  };
-  return (
-    <div className={`preset-desc-row desc-${line.kind}`} style={style} title={line.title}>
-      {line.kind === "mute" ? null : (
-        <span className="preset-desc-mark" aria-hidden="true">
-          ❝
-        </span>
-      )}
-      {line.text ? (
-        <span className="preset-desc-text">
-          <CodeText text={line.text} />
-        </span>
-      ) : null}
-      {line.note ? (
-        <span className="preset-desc-note">
-          <CodeText text={line.note} />
-        </span>
-      ) : null}
-    </div>
-  );
-}
-
-/** Where a quote line starts relative to its node's indent: the caret column
- *  (`1.1rem`) plus the row gap, so the ❝ sits under the preset name. */
-const DESC_INDENT = 22;
-
 export function TreeRow({
   row,
   selectedId,
@@ -144,7 +62,7 @@ export function TreeRow({
   injectionKey,
   usedInjections,
   dupCount,
-  markers,
+  facts,
   onShowDescriptionOrder,
 }: {
   row: Row;
@@ -155,9 +73,12 @@ export function TreeRow({
   injectionKey: InjectionKeyFn | null;
   usedInjections: ReadonlySet<string>;
   dupCount: number;
-  /** Roadmap 069 (PR 4): describe mode only — `null` in compact, and for every
-   *  node that contributed no description. */
-  markers?: PositionMarker[];
+  /** Roadmap 069 (PR 4): this node's description facts — `undefined` for the
+   *  overwhelming majority of nodes, whose name then renders exactly as it
+   *  always did. Present, it puts a hover card on the name. */
+  facts?: NodeDescriptionFacts;
+  /** The card's "Show the full description array →" — jumps to the Effective
+   *  config and opens the `description` row's blame ledger (PR 3). */
   onShowDescriptionOrder?: () => void;
 }) {
   const { node, stats } = row;
@@ -174,6 +95,22 @@ export function TreeRow({
   // Hoisted out of the JSX: the render-prop closure below is created inside a
   // callback, so `node.source?.presetSource` re-widens to `| undefined` there.
   const presetSource = node.source?.presetSource;
+
+  // The name button, with or without the description hover card's handlers —
+  // one render function so the described and plain variants cannot drift.
+  const nameButton = (handlers?: HoverCardHandlers) => (
+    <button
+      type="button"
+      // The class App's landing finds the selected node by — written through
+      // the same module that spells the selector, so the two cannot drift
+      // (`lib/preset-row-dom.ts`). `described` is the hover affordance's cue.
+      className={`${presetTreeNameClass(node.id === selectedId)}${facts ? " described" : ""}`}
+      onClick={() => onSelect(node.id)}
+      {...handlers}
+    >
+      {node.name}
+    </button>
+  );
 
   return (
     <div
@@ -210,16 +147,19 @@ export function TreeRow({
           {chain.length > 1 ? " › … " : " "}›
         </button>
       ) : null}
-      <button
-        type="button"
-        // The class App's landing finds the selected node by — written through
-        // the same module that spells the selector, so the two cannot drift
-        // (`lib/preset-row-dom.ts`).
-        className={presetTreeNameClass(node.id === selectedId)}
-        onClick={() => onSelect(node.id)}
-      >
-        {node.name}
-      </button>
+      {facts ? (
+        // Roadmap 069 (PR 4): a node that wrote (or lost) a sentence of the
+        // final `description` says so on its NAME — a hover card, so the row
+        // itself stays exactly `ROW_HEIGHT`, which the windowing depends on.
+        <HoverCardAnchor
+          className="preset-desc-hover"
+          card={<NodeDescriptionCard facts={facts} onShowOrder={onShowDescriptionOrder} />}
+        >
+          {nameButton}
+        </HoverCardAnchor>
+      ) : (
+        nameButton()
+      )}
       {presetSource ? (
         <Explained entry={sourceKindEntry(presetSource)}>
           {(handlers) => (
@@ -243,9 +183,6 @@ export function TreeRow({
         </span>
       ) : null}
       <ContributionBadges stats={stats} collapsed={row.hasChildren && !row.expanded} />
-      {markers && markers.length > 0 ? (
-        <PositionMarkers markers={markers} onShowOrder={onShowDescriptionOrder} />
-      ) : null}
       {node.duplicate ? (
         <Explained
           entry={{

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -1,9 +1,16 @@
 import type { CSSProperties } from "react";
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats } from "@/components/preset-tree-stats";
+import { CodeText } from "@/components/CodeText";
 import { Explained } from "@/components/glossary";
 import { GLOSSARY } from "@/data/glossary-data";
 import { presetTreeNameClass } from "@/lib/preset-row-dom";
+import {
+  type DescLine,
+  type PositionMarker,
+  positionMarkerText,
+  positionMarkerTitle,
+} from "@/lib/tree-descriptions";
 import type { Row } from "./rows";
 import {
   INDENT,
@@ -50,6 +57,91 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
   );
 }
 
+/**
+ * Roadmap 069 (PR 4): where this node's sentences landed in the final
+ * `description` array. A button whenever the App-level jump is available — the
+ * marker's whole point is that it ties the node to a slot in an array the
+ * Effective config prints, so being able to go there completes the link.
+ */
+function PositionMarkers({
+  markers,
+  onShowOrder,
+}: {
+  markers: PositionMarker[];
+  onShowOrder?: () => void;
+}) {
+  return (
+    <>
+      {markers.map((marker) =>
+        onShowOrder ? (
+          <button
+            key={marker.key}
+            type="button"
+            className="preset-desc-pos linklike"
+            title={positionMarkerTitle(marker, true)}
+            onClick={onShowOrder}
+          >
+            {positionMarkerText(marker)}
+          </button>
+        ) : (
+          <span
+            key={marker.key}
+            className="preset-desc-pos"
+            title={positionMarkerTitle(marker, false)}
+          >
+            {positionMarkerText(marker)}
+          </span>
+        ),
+      )}
+    </>
+  );
+}
+
+/**
+ * Roadmap 069 (PR 4): one description fact, as its own uniform-height row
+ * beneath the node that owns it (see `TreeListRow` for why it is a row and not
+ * a taller node). Single-line and ellipsized: the tree's windowing depends on
+ * every row being exactly `ROW_HEIGHT`, and the full text is one click away in
+ * the detail panel and the Effective config's ledger.
+ */
+export function TreeDescRow({ depth, line }: { depth: number; line: DescLine }) {
+  const style: CSSProperties = {
+    height: ROW_HEIGHT,
+    // Past the caret column, so the quote hangs under the preset's name.
+    paddingLeft: depth * INDENT + DESC_INDENT,
+  };
+  return (
+    <div className={`preset-desc-row desc-${line.kind}`} style={style} title={descRowTitle(line)}>
+      {line.kind === "mute" ? null : (
+        <span className="preset-desc-mark" aria-hidden="true">
+          ❝
+        </span>
+      )}
+      {line.text ? (
+        <span className="preset-desc-text">
+          <CodeText text={line.text} />
+        </span>
+      ) : null}
+      {line.note ? (
+        <span className="preset-desc-note">
+          <CodeText text={line.note} />
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** The row is ellipsized, so the untruncated text is the tooltip — backticks
+ *  stripped, since a `title` cannot render `<code>`. */
+function descRowTitle(line: DescLine): string {
+  const parts = [line.text, line.note].filter((part) => part).join(" — ");
+  return parts.replaceAll("`", "");
+}
+
+/** Where a quote line starts relative to its node's indent: the caret column
+ *  (`1.1rem`) plus the row gap, so the ❝ sits under the preset name. */
+const DESC_INDENT = 22;
+
 export function TreeRow({
   row,
   selectedId,
@@ -59,6 +151,8 @@ export function TreeRow({
   injectionKey,
   usedInjections,
   dupCount,
+  markers,
+  onShowDescriptionOrder,
 }: {
   row: Row;
   selectedId: string | null;
@@ -68,6 +162,10 @@ export function TreeRow({
   injectionKey: InjectionKeyFn | null;
   usedInjections: ReadonlySet<string>;
   dupCount: number;
+  /** Roadmap 069 (PR 4): describe mode only — `null` in compact, and for every
+   *  node that contributed no description. */
+  markers?: PositionMarker[];
+  onShowDescriptionOrder?: () => void;
 }) {
   const { node, stats } = row;
   // Roadmap 009: `failed` for every error except the two a user can act on —
@@ -152,6 +250,9 @@ export function TreeRow({
         </span>
       ) : null}
       <ContributionBadges stats={stats} collapsed={row.hasChildren && !row.expanded} />
+      {markers && markers.length > 0 ? (
+        <PositionMarkers markers={markers} onShowOrder={onShowDescriptionOrder} />
+      ) : null}
       {node.duplicate ? (
         <Explained
           entry={{

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -111,7 +111,7 @@ export function TreeDescRow({ depth, line }: { depth: number; line: DescLine }) 
     paddingLeft: depth * INDENT + DESC_INDENT,
   };
   return (
-    <div className={`preset-desc-row desc-${line.kind}`} style={style} title={descRowTitle(line)}>
+    <div className={`preset-desc-row desc-${line.kind}`} style={style} title={line.title}>
       {line.kind === "mute" ? null : (
         <span className="preset-desc-mark" aria-hidden="true">
           ❝
@@ -129,13 +129,6 @@ export function TreeDescRow({ depth, line }: { depth: number; line: DescLine }) 
       ) : null}
     </div>
   );
-}
-
-/** The row is ellipsized, so the untruncated text is the tooltip — backticks
- *  stripped, since a `title` cannot render `<code>`. */
-function descRowTitle(line: DescLine): string {
-  const parts = [line.text, line.note].filter((part) => part).join(" — ");
-  return parts.replaceAll("`", "");
 }
 
 /** Where a quote line starts relative to its node's indent: the caret column

--- a/packages/app/src/features/presets/rows.test.ts
+++ b/packages/app/src/features/presets/rows.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "vitest";
+import type { PresetNode } from "@renovate-config-debugger/engine";
+import type { NodeStats } from "@/components/preset-tree-stats";
+import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
+import { buildTreeListRows, type Row } from "./rows";
+
+/**
+ * Roadmap 069 (PR 4): the interleaving of description quote lines into the
+ * windowed row list. The invariant under test is the one the windowing math
+ * depends on — one mounted row per node in compact mode, and in describe mode
+ * exactly one EXTRA row per description fact and none for the nodes that have
+ * no facts, which is what keeps a 1,088-node tree from growing 1,088 rows.
+ */
+
+function node(id: string, name = id): PresetNode {
+  return { id, name, children: [], state: "resolved" } as unknown as PresetNode;
+}
+
+function row(id: string, depth: number): Row {
+  return {
+    node: node(id),
+    depth,
+    hasChildren: false,
+    expanded: false,
+    dimmed: false,
+    elidedChain: null,
+    stats: {} as NodeStats,
+  };
+}
+
+function facts(lines: NodeDescriptionFacts["lines"]): NodeDescriptionFacts {
+  return { markers: [], lines };
+}
+
+const ROWS = [row("p1", 0), row("p2", 1), row("p3", 1)];
+
+describe("buildTreeListRows", () => {
+  test("compact mode mounts exactly the rows it did before describe mode existed", () => {
+    const list = buildTreeListRows(ROWS, null);
+
+    expect(list).toHaveLength(ROWS.length);
+    expect(list.map((item) => item.kind)).toEqual(["node", "node", "node"]);
+    expect(list.map((item) => item.key)).toEqual(["p1", "p2", "p3"]);
+  });
+
+  test("adds one row per fact, directly under the node that owns it", () => {
+    const list = buildTreeListRows(
+      ROWS,
+      new Map([
+        ["p2", facts([{ key: "c0", kind: "contribution", text: "Pin Docker digests." }])],
+        [
+          "p3",
+          facts([
+            { key: "c1", kind: "contribution", text: "Group monorepos." },
+            { key: "mute", kind: "mute", text: "", note: "mutes 3 descriptions below" },
+          ]),
+        ],
+      ]),
+    );
+
+    expect(list.map((item) => `${item.kind}:${item.key}`)).toEqual([
+      "node:p1",
+      "node:p2",
+      "desc:p2:c0",
+      "node:p3",
+      "desc:p3:c1",
+      "desc:p3:mute",
+    ]);
+  });
+
+  test("a quote row inherits its node's indent, so it hangs under the name", () => {
+    const list = buildTreeListRows(
+      [row("p2", 3)],
+      new Map([["p2", facts([{ key: "c0", kind: "contribution", text: "Pin Docker digests." }])]]),
+    );
+
+    const quote = list[1];
+    expect(quote?.kind === "desc" ? quote.depth : null).toBe(3);
+  });
+
+  test("nodes absent from the index add nothing at all", () => {
+    const list = buildTreeListRows(ROWS, new Map());
+
+    expect(list).toHaveLength(ROWS.length);
+  });
+});

--- a/packages/app/src/features/presets/rows.test.ts
+++ b/packages/app/src/features/presets/rows.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats } from "@/components/preset-tree-stats";
-import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
+import type { DescLine, DescLineKind, NodeDescriptionFacts } from "@/lib/tree-descriptions";
 import { buildTreeListRows, type Row } from "./rows";
 
 /**
@@ -32,6 +32,10 @@ function facts(lines: NodeDescriptionFacts["lines"]): NodeDescriptionFacts {
   return { markers: [], lines };
 }
 
+function line(key: string, kind: DescLineKind, text: string, note?: string): DescLine {
+  return { key, kind, text, note, title: text };
+}
+
 const ROWS = [row("p1", 0), row("p2", 1), row("p3", 1)];
 
 describe("buildTreeListRows", () => {
@@ -47,12 +51,12 @@ describe("buildTreeListRows", () => {
     const list = buildTreeListRows(
       ROWS,
       new Map([
-        ["p2", facts([{ key: "c0", kind: "contribution", text: "Pin Docker digests." }])],
+        ["p2", facts([line("c0", "contribution", "Pin Docker digests.")])],
         [
           "p3",
           facts([
-            { key: "c1", kind: "contribution", text: "Group monorepos." },
-            { key: "mute", kind: "mute", text: "", note: "mutes 3 descriptions below" },
+            line("c1", "contribution", "Group monorepos."),
+            line("mute", "mute", "", "mutes 3 descriptions below"),
           ]),
         ],
       ]),
@@ -71,7 +75,7 @@ describe("buildTreeListRows", () => {
   test("a quote row inherits its node's indent, so it hangs under the name", () => {
     const list = buildTreeListRows(
       [row("p2", 3)],
-      new Map([["p2", facts([{ key: "c0", kind: "contribution", text: "Pin Docker digests." }])]]),
+      new Map([["p2", facts([line("c0", "contribution", "Pin Docker digests.")])]]),
     );
 
     const quote = list[1];

--- a/packages/app/src/features/presets/rows.test.ts
+++ b/packages/app/src/features/presets/rows.test.ts
@@ -1,93 +1,15 @@
 import { describe, expect, test } from "vitest";
 import type { PresetNode } from "@renovate-config-debugger/engine";
-import { computeTreeStats, type NodeStats } from "@/components/preset-tree-stats";
-import type { DescLine, DescLineKind, NodeDescriptionFacts } from "@/lib/tree-descriptions";
-import { buildTreeListRows, flattenTree, type Row } from "./rows";
+import { computeTreeStats } from "@/components/preset-tree-stats";
+import { flattenTree, type Row } from "./rows";
 
 /**
- * Roadmap 069 (PR 4): the interleaving of description quote lines into the
- * windowed row list. The invariant under test is the one the windowing math
- * depends on — one mounted row per node in compact mode, and in describe mode
- * exactly one EXTRA row per description fact and none for the nodes that have
- * no facts, which is what keeps a 1,088-node tree from growing 1,088 rows.
+ * Roadmap 069 (PR 4): described nodes and the flattened row list. The
+ * invariant under test is reachability — a node whose name carries the
+ * description hover card must actually mount a row, whatever hide-zero would
+ * otherwise do with it — while a run without descriptions flattens exactly as
+ * it always did.
  */
-
-function node(id: string, name = id): PresetNode {
-  return { id, name, children: [], state: "resolved" } as unknown as PresetNode;
-}
-
-function row(id: string, depth: number): Row {
-  return {
-    node: node(id),
-    depth,
-    hasChildren: false,
-    expanded: false,
-    dimmed: false,
-    elidedChain: null,
-    stats: {} as NodeStats,
-  };
-}
-
-function facts(lines: NodeDescriptionFacts["lines"]): NodeDescriptionFacts {
-  return { markers: [], lines };
-}
-
-function line(key: string, kind: DescLineKind, text: string, note?: string): DescLine {
-  return { key, kind, text, note, title: text };
-}
-
-const ROWS = [row("p1", 0), row("p2", 1), row("p3", 1)];
-
-describe("buildTreeListRows", () => {
-  test("compact mode mounts exactly the rows it did before describe mode existed", () => {
-    const list = buildTreeListRows(ROWS, null);
-
-    expect(list).toHaveLength(ROWS.length);
-    expect(list.map((item) => item.kind)).toEqual(["node", "node", "node"]);
-    expect(list.map((item) => item.key)).toEqual(["p1", "p2", "p3"]);
-  });
-
-  test("adds one row per fact, directly under the node that owns it", () => {
-    const list = buildTreeListRows(
-      ROWS,
-      new Map([
-        ["p2", facts([line("c0", "contribution", "Pin Docker digests.")])],
-        [
-          "p3",
-          facts([
-            line("c1", "contribution", "Group monorepos."),
-            line("mute", "mute", "", "mutes 3 descriptions below"),
-          ]),
-        ],
-      ]),
-    );
-
-    expect(list.map((item) => `${item.kind}:${item.key}`)).toEqual([
-      "node:p1",
-      "node:p2",
-      "desc:p2:c0",
-      "node:p3",
-      "desc:p3:c1",
-      "desc:p3:mute",
-    ]);
-  });
-
-  test("a quote row inherits its node's indent, so it hangs under the name", () => {
-    const list = buildTreeListRows(
-      [row("p2", 3)],
-      new Map([["p2", facts([line("c0", "contribution", "Pin Docker digests.")])]]),
-    );
-
-    const quote = list[1];
-    expect(quote?.kind === "desc" ? quote.depth : null).toBe(3);
-  });
-
-  test("nodes absent from the index add nothing at all", () => {
-    const list = buildTreeListRows(ROWS, new Map());
-
-    expect(list).toHaveLength(ROWS.length);
-  });
-});
 
 /** A resolved preset with a body, which is all `computeTreeStats` reads. */
 function preset(id: string, name: string, input: unknown, children: PresetNode[] = []): PresetNode {
@@ -95,16 +17,16 @@ function preset(id: string, name: string, input: unknown, children: PresetNode[]
 }
 
 /**
- * Roadmap 069 (PR 4): the collision between describe mode and hide-zero. A
- * wrapper preset's body is only `extends` — Renovate deleted its description,
- * which is exactly what describe mode reports — so the "hide zero-contribution
- * routers" toggle would elide the very row the drop line belongs to.
+ * The collision between described nodes and hide-zero. A wrapper preset's body
+ * is only `extends` — Renovate deleted its description, which is exactly what
+ * its hover card reports — so the "hide zero-contribution routers" toggle
+ * would elide the very row that card hangs from.
  */
 const LEAF = preset("p2", "docker:pinDigests", { pinDigests: true });
 const WRAPPER = preset("p1", "config:best-practices", { extends: ["docker:pinDigests"] }, [LEAF]);
 const ROOT = preset("root", "(input config)", { extends: ["config:best-practices"] }, [WRAPPER]);
 
-describe("flattenTree — describe mode under hide zero-contribution", () => {
+describe("flattenTree — described nodes under hide zero-contribution", () => {
   const stats = computeTreeStats(ROOT);
   const flatten = (hideZero: boolean, described: ReadonlySet<string> | null): Row[] =>
     flattenTree({
@@ -116,7 +38,7 @@ describe("flattenTree — describe mode under hide zero-contribution", () => {
       described,
     });
 
-  test("compact mode elides the wrapper exactly as it always did", () => {
+  test("with no described nodes the wrapper is elided exactly as it always was", () => {
     const rows = flatten(true, null);
 
     expect(rows.map((r) => r.node.id)).toEqual(["p2"]);
@@ -133,24 +55,6 @@ describe("flattenTree — describe mode under hide zero-contribution", () => {
     expect(rows[1]?.depth).toBe(1);
   });
 
-  test("and its drop line therefore mounts, which is the whole point", () => {
-    const list = buildTreeListRows(
-      flatten(true, new Set(["p1"])),
-      new Map([
-        [
-          "p1",
-          facts([line("x0", "dropped", "The config that Renovate recommends.", "wrapper preset")]),
-        ],
-      ]),
-    );
-
-    expect(list.map((item) => `${item.kind}:${item.key}`)).toEqual([
-      "node:p1",
-      "desc:p1:x0",
-      "node:p2",
-    ]);
-  });
-
   test("changes nothing while hide-zero is off", () => {
     expect(flatten(false, new Set(["p1"]))).toEqual(flatten(false, null));
   });
@@ -158,8 +62,8 @@ describe("flattenTree — describe mode under hide zero-contribution", () => {
 
 describe("flattenTree — a described node behind a caret", () => {
   // hide-zero's caret test counts CONTRIBUTING descendants, and this subtree
-  // has none: without describe mode the parent is a leaf and the wrapper below
-  // it unreachable.
+  // has none: without the described set the parent is a leaf and the wrapper
+  // below it unreachable.
   const buried = preset("q3", "group:empty", { extends: [] });
   const wrapper = preset("q2", "config:recommended", { extends: ["group:empty"] }, [buried]);
   const contributor = preset("q1", "custom:base", { rangeStrategy: "bump" }, [wrapper]);

--- a/packages/app/src/features/presets/rows.test.ts
+++ b/packages/app/src/features/presets/rows.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest";
 import type { PresetNode } from "@renovate-config-debugger/engine";
-import type { NodeStats } from "@/components/preset-tree-stats";
+import { computeTreeStats, type NodeStats } from "@/components/preset-tree-stats";
 import type { DescLine, DescLineKind, NodeDescriptionFacts } from "@/lib/tree-descriptions";
-import { buildTreeListRows, type Row } from "./rows";
+import { buildTreeListRows, flattenTree, type Row } from "./rows";
 
 /**
  * Roadmap 069 (PR 4): the interleaving of description quote lines into the
@@ -86,5 +86,96 @@ describe("buildTreeListRows", () => {
     const list = buildTreeListRows(ROWS, new Map());
 
     expect(list).toHaveLength(ROWS.length);
+  });
+});
+
+/** A resolved preset with a body, which is all `computeTreeStats` reads. */
+function preset(id: string, name: string, input: unknown, children: PresetNode[] = []): PresetNode {
+  return { id, name, state: "resolved", input, children };
+}
+
+/**
+ * Roadmap 069 (PR 4): the collision between describe mode and hide-zero. A
+ * wrapper preset's body is only `extends` — Renovate deleted its description,
+ * which is exactly what describe mode reports — so the "hide zero-contribution
+ * routers" toggle would elide the very row the drop line belongs to.
+ */
+const LEAF = preset("p2", "docker:pinDigests", { pinDigests: true });
+const WRAPPER = preset("p1", "config:best-practices", { extends: ["docker:pinDigests"] }, [LEAF]);
+const ROOT = preset("root", "(input config)", { extends: ["config:best-practices"] }, [WRAPPER]);
+
+describe("flattenTree — describe mode under hide zero-contribution", () => {
+  const stats = computeTreeStats(ROOT);
+  const flatten = (hideZero: boolean, described: ReadonlySet<string> | null): Row[] =>
+    flattenTree({
+      root: ROOT,
+      stats,
+      expandedIdentities: new Set(),
+      hideZero,
+      query: "",
+      described,
+    });
+
+  test("compact mode elides the wrapper exactly as it always did", () => {
+    const rows = flatten(true, null);
+
+    expect(rows.map((r) => r.node.id)).toEqual(["p2"]);
+    expect(rows[0]?.elidedChain?.map((n) => n.name)).toEqual(["config:best-practices"]);
+  });
+
+  test("a described wrapper keeps its row, its subtree still shortcut through it", () => {
+    const rows = flatten(true, new Set(["p1"]));
+
+    expect(rows.map((r) => r.node.id)).toEqual(["p1", "p2"]);
+    // No caret: hide-zero shows the subtree through it unconditionally, so
+    // there is nothing to collapse — and the contributor still appears.
+    expect(rows[0]).toMatchObject({ depth: 0, hasChildren: false, elidedChain: null });
+    expect(rows[1]?.depth).toBe(1);
+  });
+
+  test("and its drop line therefore mounts, which is the whole point", () => {
+    const list = buildTreeListRows(
+      flatten(true, new Set(["p1"])),
+      new Map([
+        [
+          "p1",
+          facts([line("x0", "dropped", "The config that Renovate recommends.", "wrapper preset")]),
+        ],
+      ]),
+    );
+
+    expect(list.map((item) => `${item.kind}:${item.key}`)).toEqual([
+      "node:p1",
+      "desc:p1:x0",
+      "node:p2",
+    ]);
+  });
+
+  test("changes nothing while hide-zero is off", () => {
+    expect(flatten(false, new Set(["p1"]))).toEqual(flatten(false, null));
+  });
+});
+
+describe("flattenTree — a described node behind a caret", () => {
+  // hide-zero's caret test counts CONTRIBUTING descendants, and this subtree
+  // has none: without describe mode the parent is a leaf and the wrapper below
+  // it unreachable.
+  const buried = preset("q3", "group:empty", { extends: [] });
+  const wrapper = preset("q2", "config:recommended", { extends: ["group:empty"] }, [buried]);
+  const contributor = preset("q1", "custom:base", { rangeStrategy: "bump" }, [wrapper]);
+  const root = preset("root", "(input config)", { extends: ["custom:base"] }, [contributor]);
+  const stats = computeTreeStats(root);
+  const flatten = (described: ReadonlySet<string> | null, expandedIdentities: Set<string>): Row[] =>
+    flattenTree({ root, stats, expandedIdentities, hideZero: true, query: "", described });
+
+  test("gets a caret on the parent that leads to it", () => {
+    expect(flatten(null, new Set())[0]?.hasChildren).toBe(false);
+    expect(flatten(new Set(["q2"]), new Set())[0]?.hasChildren).toBe(true);
+  });
+
+  test("and shows up once that caret is opened", () => {
+    const rows = flatten(new Set(["q2"]), new Set([">custom:base"]));
+
+    expect(rows.map((r) => r.node.id)).toEqual(["q1", "q2"]);
   });
 });

--- a/packages/app/src/features/presets/rows.ts
+++ b/packages/app/src/features/presets/rows.ts
@@ -1,5 +1,6 @@
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats, TreeStats } from "@/components/preset-tree-stats";
+import type { DescLine, NodeDescriptionFacts } from "@/lib/tree-descriptions";
 
 /** Node ids whose subtree (self or any descendant) matches the query. */
 function computeSubtreeMatch(
@@ -115,6 +116,49 @@ export function flattenTree({
     emit(child, 0, []);
   }
   return rows;
+}
+
+/**
+ * Roadmap 069 (PR 4): what the tree pane actually mounts — a preset node, or
+ * one of its description quote lines.
+ *
+ * A quote line is its own ROW rather than a second line inside the node's row,
+ * and that is load-bearing: the windowing math (`use-window.ts`) is
+ * uniform-height, so `padTop`/`padBottom` and the scroll-into-view arithmetic
+ * only add up while every mounted row is exactly `ROW_HEIGHT` tall. Making
+ * described nodes taller would desynchronise the spacers from the content;
+ * making every node taller would pay two lines of height for the ~1,070 nodes
+ * that have nothing to say. One extra uniform row per FACT costs neither.
+ */
+export type TreeListRow =
+  | { kind: "node"; key: string; row: Row }
+  | { kind: "desc"; key: string; depth: number; line: DescLine };
+
+/**
+ * Interleaves the description lines (069 PR 4) into the visible rows. `facts`
+ * is `null` in compact mode — and then this is a straight wrapping of the rows
+ * with no extra entries, so compact mode mounts exactly what it did before
+ * describe mode existed.
+ */
+export function buildTreeListRows(
+  rows: Row[],
+  facts: ReadonlyMap<string, NodeDescriptionFacts> | null,
+): TreeListRow[] {
+  const list: TreeListRow[] = [];
+  for (const row of rows) {
+    const id = row.node.id;
+    list.push({ kind: "node", key: id, row });
+    // The map holds only nodes WITH a description fact, so this is `undefined`
+    // for the overwhelming majority and describe mode adds no row for them.
+    const lines = facts?.get(id)?.lines;
+    if (!lines) {
+      continue;
+    }
+    for (const line of lines) {
+      list.push({ kind: "desc", key: `${id}:${line.key}`, depth: row.depth, line });
+    }
+  }
+  return list;
 }
 
 export interface TableRow {

--- a/packages/app/src/features/presets/rows.ts
+++ b/packages/app/src/features/presets/rows.ts
@@ -27,6 +27,34 @@ function computeSubtreeMatch(
   return set;
 }
 
+/**
+ * Node ids with a description fact somewhere in their subtree (self included).
+ *
+ * Roadmap 069 (PR 4): hide-zero's caret suppression (`descContrib > 0`) counts
+ * CONTRIBUTING descendants, and a wrapper preset contributes nothing — so
+ * without this a described node could sit behind a caret that never renders.
+ * The same shape as `computeSubtreeMatch`, and computed for the same reason.
+ */
+function computeDescribedSubtree(root: PresetNode, described: ReadonlySet<string>): Set<string> {
+  const set = new Set<string>();
+  const visit = (node: PresetNode): boolean => {
+    let any = described.has(node.id);
+    for (const child of node.children) {
+      if (visit(child)) {
+        any = true;
+      }
+    }
+    if (any) {
+      set.add(node.id);
+    }
+    return any;
+  };
+  for (const child of root.children) {
+    visit(child);
+  }
+  return set;
+}
+
 export interface Row {
   node: PresetNode;
   depth: number;
@@ -45,6 +73,18 @@ interface FlattenArgs {
   expandedIdentities: ReadonlySet<string>;
   hideZero: boolean;
   query: string;
+  /**
+   * Roadmap 069 (PR 4): node ids describe mode has a line for — `null` in
+   * compact mode, where this argument changes nothing at all.
+   *
+   * Hide-zero shortcuts pure `extends` routers, and a WRAPPER preset is one:
+   * `getPreset` deletes its description, leaving a body of only `extends`. Its
+   * row would therefore be elided exactly when describe mode has the drop line
+   * to show on it — the one line the mode exists for. So a described node is
+   * never elided; hide-zero still applies to its subtree, which is promoted
+   * through it as before.
+   */
+  described?: ReadonlySet<string> | null;
 }
 
 /** The tree collapsed to the ordered list of currently-visible rows. */
@@ -54,11 +94,16 @@ export function flattenTree({
   expandedIdentities,
   hideZero,
   query,
+  described = null,
 }: FlattenArgs): Row[] {
   const { statsById, identityById } = stats;
   const q = query.trim().toLowerCase();
   const searching = q.length > 0;
   const subtreeMatch = searching ? computeSubtreeMatch(root, statsById, q) : null;
+  // Only hide-zero elides or suppresses carets, so this is the only mode that
+  // has to know where the described nodes are.
+  const describedSubtree =
+    hideZero && described && described.size > 0 ? computeDescribedSubtree(root, described) : null;
   const rows: Row[] = [];
 
   const emit = (node: PresetNode, depth: number, elided: PresetNode[]): void => {
@@ -72,9 +117,14 @@ export function flattenTree({
     const isResolved = node.state === "resolved";
     const selfMatch = searching ? st.search.includes(q) : false;
 
+    const shortcut = hideZero && isResolved && st.zero && !selfMatch;
+    // …unless describe mode has a line for it (see `described`): then the row
+    // mounts, and the shortcut applies to its subtree only.
+    const describedSelf = described?.has(node.id) ?? false;
+
     // Hide-zero: pure resolved routers are shortcut, promoting their
     // contributing descendants into this level with an elided-path chip.
-    if (hideZero && isResolved && st.zero && !selfMatch) {
+    if (shortcut && !describedSelf) {
       if (node.children.length > 0) {
         for (const child of node.children) {
           emit(child, depth, [...elided, node]);
@@ -84,10 +134,16 @@ export function flattenTree({
     }
 
     let hasChildren: boolean;
-    if (searching) {
+    if (shortcut) {
+      // Kept only for its description: its subtree is shown THROUGH it below,
+      // unconditionally, so there is nothing a caret could collapse.
+      hasChildren = false;
+    } else if (searching) {
       hasChildren = node.children.some((c) => subtreeMatch?.has(c.id));
     } else if (hideZero) {
-      hasChildren = st.descContrib > 0;
+      hasChildren =
+        st.descContrib > 0 ||
+        (describedSubtree !== null && node.children.some((c) => describedSubtree.has(c.id)));
     } else {
       hasChildren = node.children.length > 0;
     }
@@ -105,7 +161,7 @@ export function flattenTree({
       stats: st,
     });
 
-    if (expanded) {
+    if (expanded || shortcut) {
       for (const child of node.children) {
         emit(child, depth + 1, []);
       }

--- a/packages/app/src/features/presets/rows.ts
+++ b/packages/app/src/features/presets/rows.ts
@@ -1,6 +1,5 @@
 import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { NodeStats, TreeStats } from "@/components/preset-tree-stats";
-import type { DescLine, NodeDescriptionFacts } from "@/lib/tree-descriptions";
 
 /** Node ids whose subtree (self or any descendant) matches the query. */
 function computeSubtreeMatch(
@@ -32,8 +31,9 @@ function computeSubtreeMatch(
  *
  * Roadmap 069 (PR 4): hide-zero's caret suppression (`descContrib > 0`) counts
  * CONTRIBUTING descendants, and a wrapper preset contributes nothing — so
- * without this a described node could sit behind a caret that never renders.
- * The same shape as `computeSubtreeMatch`, and computed for the same reason.
+ * without this a described node could sit behind a caret that never renders,
+ * leaving its description hover card unreachable. The same shape as
+ * `computeSubtreeMatch`, and computed for the same reason.
  */
 function computeDescribedSubtree(root: PresetNode, described: ReadonlySet<string>): Set<string> {
   const set = new Set<string>();
@@ -74,15 +74,15 @@ interface FlattenArgs {
   hideZero: boolean;
   query: string;
   /**
-   * Roadmap 069 (PR 4): node ids describe mode has a line for — `null` in
-   * compact mode, where this argument changes nothing at all.
+   * Roadmap 069 (PR 4): node ids that carry a description fact — `null` when
+   * the run has none, where this argument changes nothing at all.
    *
    * Hide-zero shortcuts pure `extends` routers, and a WRAPPER preset is one:
    * `getPreset` deletes its description, leaving a body of only `extends`. Its
-   * row would therefore be elided exactly when describe mode has the drop line
-   * to show on it — the one line the mode exists for. So a described node is
-   * never elided; hide-zero still applies to its subtree, which is promoted
-   * through it as before.
+   * row would therefore be elided exactly when it has a drop to report — and
+   * the hover card on its name is the only place in the tree that drop is
+   * visible. So a described node is never elided; hide-zero still applies to
+   * its subtree, which is promoted through it as before.
    */
   described?: ReadonlySet<string> | null;
 }
@@ -118,7 +118,7 @@ export function flattenTree({
     const selfMatch = searching ? st.search.includes(q) : false;
 
     const shortcut = hideZero && isResolved && st.zero && !selfMatch;
-    // …unless describe mode has a line for it (see `described`): then the row
+    // …unless it carries a description fact (see `described`): then the row
     // mounts, and the shortcut applies to its subtree only.
     const describedSelf = described?.has(node.id) ?? false;
 
@@ -172,49 +172,6 @@ export function flattenTree({
     emit(child, 0, []);
   }
   return rows;
-}
-
-/**
- * Roadmap 069 (PR 4): what the tree pane actually mounts — a preset node, or
- * one of its description quote lines.
- *
- * A quote line is its own ROW rather than a second line inside the node's row,
- * and that is load-bearing: the windowing math (`use-window.ts`) is
- * uniform-height, so `padTop`/`padBottom` and the scroll-into-view arithmetic
- * only add up while every mounted row is exactly `ROW_HEIGHT` tall. Making
- * described nodes taller would desynchronise the spacers from the content;
- * making every node taller would pay two lines of height for the ~1,070 nodes
- * that have nothing to say. One extra uniform row per FACT costs neither.
- */
-export type TreeListRow =
-  | { kind: "node"; key: string; row: Row }
-  | { kind: "desc"; key: string; depth: number; line: DescLine };
-
-/**
- * Interleaves the description lines (069 PR 4) into the visible rows. `facts`
- * is `null` in compact mode — and then this is a straight wrapping of the rows
- * with no extra entries, so compact mode mounts exactly what it did before
- * describe mode existed.
- */
-export function buildTreeListRows(
-  rows: Row[],
-  facts: ReadonlyMap<string, NodeDescriptionFacts> | null,
-): TreeListRow[] {
-  const list: TreeListRow[] = [];
-  for (const row of rows) {
-    const id = row.node.id;
-    list.push({ kind: "node", key: id, row });
-    // The map holds only nodes WITH a description fact, so this is `undefined`
-    // for the overwhelming majority and describe mode adds no row for them.
-    const lines = facts?.get(id)?.lines;
-    if (!lines) {
-      continue;
-    }
-    for (const line of lines) {
-      list.push({ kind: "desc", key: `${id}:${line.key}`, depth: row.depth, line });
-    }
-  }
-  return list;
 }
 
 export interface TableRow {

--- a/packages/app/src/features/presets/rows.ts
+++ b/packages/app/src/features/presets/rows.ts
@@ -79,10 +79,10 @@ interface FlattenArgs {
    *
    * Hide-zero shortcuts pure `extends` routers, and a WRAPPER preset is one:
    * `getPreset` deletes its description, leaving a body of only `extends`. Its
-   * row would therefore be elided exactly when it has a drop to report — and
-   * the hover card on its name is the only place in the tree that drop is
-   * visible. So a described node is never elided; hide-zero still applies to
-   * its subtree, which is promoted through it as before.
+   * row would therefore be elided exactly when it has a description to show —
+   * and the hover card on its name is the only place in the tree that shows
+   * it. So a described node is never elided; hide-zero still applies to its
+   * subtree, which is promoted through it as before.
    */
   described?: ReadonlySet<string> | null;
 }

--- a/packages/app/src/hooks/hover-card.test.tsx
+++ b/packages/app/src/hooks/hover-card.test.tsx
@@ -1,0 +1,145 @@
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HoverCardAnchor } from "@/components/hover-card";
+import { SHOW_SCROLL_GRACE_MS } from "./hover-card";
+
+/**
+ * Roadmap 069 review — WHICH scrolls take a hover card down with them.
+ *
+ * The card is `position: fixed` at coordinates read once, when it opened, so
+ * any scroll that moves its anchor leaves it pointing at whatever slid under
+ * it. Scroll events do not bubble, so the hide-on-scroll listener only heard
+ * the document until it registered in the CAPTURE phase — and every anchor the
+ * card actually serves (a `description` string in `pre.config-view`, a term in
+ * the preset tree's windowed list) sits inside a nested `overflow: auto` box.
+ *
+ * The other direction, which the review after it found: the scroll a browser
+ * fires to bring a Tab-focused anchor into view must NOT be one of them.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+// The hide-on-scroll now has a wall-clock grace, so every test in this file has
+// to say which side of it its scroll falls on.
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Puts a scroll outside the show's own grace window — i.e. makes it the
+ *  reader's, which is the only kind that dismisses. */
+function leaveShowGrace(): void {
+  act(() => {
+    vi.advanceTimersByTime(SHOW_SCROLL_GRACE_MS);
+  });
+}
+
+/** An anchor inside a nested scroller — the arrangement of every real one. */
+function Scene() {
+  return (
+    <div data-testid="scroller">
+      <HoverCardAnchor className="probe-card" card={<p>who wrote this</p>}>
+        {(handlers) => (
+          <span tabIndex={0} {...handlers}>
+            an anchor
+          </span>
+        )}
+      </HoverCardAnchor>
+    </div>
+  );
+}
+
+function openCard(anchor: HTMLElement) {
+  fireEvent.focus(anchor);
+  expect(document.querySelector(".probe-card")).not.toBeNull();
+}
+
+/** jsdom lays nothing out, so an anchor's box is whatever we say it is. */
+function placeAt(el: HTMLElement, top: number): void {
+  el.getBoundingClientRect = (): DOMRect => {
+    const rect = {
+      x: 10,
+      y: top,
+      left: 10,
+      right: 110,
+      top,
+      bottom: top + 20,
+      width: 100,
+      height: 20,
+    };
+    return { ...rect, toJSON: () => rect };
+  };
+}
+
+/** The portalled card's `top`, i.e. the anchor box it is currently placed against. */
+function cardTop(): string | undefined {
+  return document.querySelector<HTMLElement>(".probe-card")?.style.top;
+}
+
+describe("the hover card's hide-on-scroll", () => {
+  it("hides when the container the anchor sits in scrolls", () => {
+    // `fireEvent.scroll` dispatches a non-bubbling event, exactly as a browser
+    // does for an element scroll: before the capture flag this reached no
+    // window listener at all and the card stayed, fixed, over new content.
+    const { getByText, getByTestId } = render(<Scene />);
+    openCard(getByText("an anchor"));
+
+    leaveShowGrace();
+    fireEvent.scroll(getByTestId("scroller"));
+    expect(document.querySelector(".probe-card")).toBeNull();
+  });
+
+  it("still hides on a document scroll", () => {
+    const { getByText } = render(<Scene />);
+    openCard(getByText("an anchor"));
+
+    leaveShowGrace();
+    fireEvent.scroll(window);
+    expect(document.querySelector(".probe-card")).toBeNull();
+  });
+});
+
+/**
+ * Tab onto an anchor that is only partly in view and the browser scrolls it
+ * into view itself. That scroll is queued BEFORE the card paints, so it lands
+ * in the freshly registered capture listener a frame after the card opened —
+ * which used to close it again, making every not-fully-visible anchor
+ * unreachable by keyboard. The grace is wall-clock, so fake timers decide which
+ * side of it a scroll falls on.
+ */
+describe("the scroll the show itself caused", () => {
+  it("re-anchors the card instead of dismissing it", () => {
+    const { getByText, getByTestId } = render(<Scene />);
+    const anchor = getByText("an anchor");
+
+    placeAt(anchor, 40);
+    openCard(anchor);
+    expect(cardTop()).toBe("66px");
+
+    // `scrollIntoView` moved the anchor up the viewport; the event arrives in
+    // the same tick the card opened in.
+    placeAt(anchor, 100);
+    fireEvent.scroll(getByTestId("scroller"));
+
+    expect(document.querySelector(".probe-card")).not.toBeNull();
+    // …and follows the anchor, rather than staying at the box it opened with.
+    expect(cardTop()).toBe("126px");
+  });
+
+  it("hides on a scroll that arrives after the grace window", () => {
+    const { getByText, getByTestId } = render(<Scene />);
+    const anchor = getByText("an anchor");
+
+    placeAt(anchor, 40);
+    openCard(anchor);
+
+    leaveShowGrace();
+    placeAt(anchor, 100);
+    fireEvent.scroll(getByTestId("scroller"));
+
+    expect(document.querySelector(".probe-card")).toBeNull();
+  });
+});

--- a/packages/app/src/hooks/hover-card.ts
+++ b/packages/app/src/hooks/hover-card.ts
@@ -1,0 +1,217 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { type AnchorRect, anchorRectOf } from "@/lib/anchored-card";
+import { overlayKeyboardOwned } from "@/lib/escape-stack";
+
+/**
+ * The hover/focus behavior behind every floating card the app anchors to a
+ * piece of text: the glossary's `Term`/`Explained` (016), and — roadmap 069
+ * PR 5 — the attribution card on a `description` string in a JSON view.
+ *
+ * Hoisted out of `components/glossary.tsx` rather than copied: the singleton
+ * below and the Escape ruling underneath it are the whole interaction contract,
+ * and a second card type with its own copy of them would be a second contract.
+ * The hook owns WHEN a card is up; what the card says is the caller's.
+ *
+ * Lives in `hooks/` because a component module that also exports a hook breaks
+ * Fast Refresh (`react/only-export-components`) — the same split
+ * `option-docs.tsx` / `hooks/option-docs-hooks.ts` already makes.
+ */
+
+/** Module-level singleton so only one hover card is ever open — of any kind. */
+let activeHide: (() => void) | null = null;
+
+/**
+ * How long after a card opens a scroll is read as the SHOW's own scroll rather
+ * than the reader's (see the scroll effect below). Long enough to cover the
+ * `scrollIntoView` a browser fires when Tab lands on a partly-off-screen
+ * anchor — which is queued before the card even paints — and short enough that
+ * a wheel the reader turns right after hovering still takes the card down: a
+ * wheel gesture emits events for far longer than this.
+ *
+ * Wall-clock rather than a frame count so it holds in a background tab (where
+ * `requestAnimationFrame` does not run) and stays trivially testable with fake
+ * timers.
+ */
+export const SHOW_SCROLL_GRACE_MS = 150;
+
+function sameRect(a: AnchorRect, b: AnchorRect): boolean {
+  return a.left === b.left && a.top === b.top && a.bottom === b.bottom;
+}
+
+export interface HoverCardControls {
+  /** The anchor's viewport box while a card is up; `null` when none is. */
+  anchor: AnchorRect | null;
+  show: (el: Element) => void;
+  hide: () => void;
+  hideNow: () => void;
+  cancelHide: () => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+/**
+ * Shared hover/focus behavior for an element that explains itself with a
+ * floating card. A grace period lets the pointer travel into the card (to click
+ * a link inside it) without it vanishing.
+ */
+export function useHoverCard(): HoverCardControls {
+  const [anchor, setAnchor] = useState<AnchorRect | null>(null);
+  const hideTimer = useRef<number | undefined>(undefined);
+  // The anchor ELEMENT, not just the box it had: a scroll inside the grace
+  // window re-reads it (see the scroll effect), which a stored rect cannot do.
+  const anchorEl = useRef<Element | null>(null);
+  const shownAt = useRef(0);
+
+  const hideNow = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+    anchorEl.current = null;
+    setAnchor(null);
+  }, []);
+
+  const show = useCallback(
+    (el: Element) => {
+      if (activeHide && activeHide !== hideNow) {
+        activeHide();
+      }
+      activeHide = hideNow;
+      window.clearTimeout(hideTimer.current);
+      anchorEl.current = el;
+      shownAt.current = Date.now();
+      setAnchor(anchorRectOf(el));
+    },
+    [hideNow],
+  );
+
+  const hide = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => setAnchor(null), 250);
+  }, []);
+
+  const cancelHide = useCallback(() => {
+    window.clearTimeout(hideTimer.current);
+  }, []);
+
+  // Roadmap 068: an element-scoped Escape that ACTS must claim the key from the
+  // ladder, or one press hides this card AND pops the topmost ladder layer —
+  // typically the simulator's return pill, which the reader cannot even see from
+  // here. With no card up there is nothing to claim, and the key belongs to the
+  // ladder.
+  //
+  // `preventDefault`, NOT `stopPropagation`, and the difference is the whole
+  // rule. Both stop the ladder (its document listener bails on
+  // `defaultPrevented`), but React's `stopPropagation` also ends the native
+  // event's journey at the root container, so it takes the press away from every
+  // ANCESTOR element handler too — and this card can be inside one. A `Term`
+  // renders in the repo-load panel, whose `<form>` closes the panel on Escape;
+  // focusing that term always opens a card, so claiming by propagation left the
+  // user pressing Escape twice to cancel a panel they had asked to cancel once.
+  // Preventing the default claims exactly the listener that reads it and leaves
+  // the ancestor free to act on the same press, which is the contract the editor
+  // already keeps (see `lib/escape-stack.ts`).
+  //
+  // The other half, which the review after it found: a card the user did not
+  // open cannot outrank a layer they did. This card opens on FOCUS, so Tabbing
+  // onto a `ProvenanceChip` inside an open rule-evidence popover ALWAYS has one
+  // up — claiming there made the popover undismissable by keyboard, every press
+  // stopping at the tooltip. So the rule is not "act whenever there is a card"
+  // but "act only when this card is the topmost thing between the reader and the
+  // page": `overlayKeyboardOwned()` reports exactly when it is not (a popover or
+  // a menu is over the page), and there the press goes to the ladder, which
+  // dismisses the layer the user chose to open — and usually the anchor with it.
+  //
+  // The RANK is the right question here, and the ninth review pushed back on it:
+  // `ambient` is excluded, so with the simulator return pill up a reader walking
+  // a thread — who has a focus-opened tooltip at most stops — needs two presses
+  // to dismiss the pill. That cost is real and it is the lesser one. Widening
+  // this to "any layer at all" was tried and reverted: it means a press aimed at
+  // the tooltip the reader is looking at instead destroys a pill they cannot see
+  // from here, leaving the tooltip up — an invisible destructive action, which is
+  // exactly what the sixth review fixed. A wasted keystroke is recoverable; a
+  // silently destroyed way back is not. The two tests in `glossary.test.tsx` pin
+  // both directions. That is the same ranking the ladder itself applies, asked
+  // rather than joined: registering this card as a layer would make it a stack
+  // entry that pushes and releases on every hover, and Escape would then dismiss
+  // a card the pointer merely rested on instead of the pill the user is looking
+  // at.
+  //
+  // Lives in the shared hook rather than on one anchor: `Term` had it and
+  // `Explained` did not, which made Escape on a preset-source badge's card
+  // destroy the return pill instead of the card the user was looking at.
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== "Escape" || !anchor || overlayKeyboardOwned()) {
+        return;
+      }
+      e.preventDefault();
+      hideNow();
+    },
+    [anchor, hideNow],
+  );
+
+  // Scrolling moves the anchor out from under the fixed-position card; hide
+  // rather than float a card pointing at nothing.
+  //
+  // CAPTURE, and that is the whole listener: a scroll event does not bubble, so
+  // a bubble-phase window listener only ever hears the DOCUMENT scroll. Every
+  // anchor this card serves lives inside a nested `overflow: auto` box — the
+  // `pre.config-view` of a JSON view, the preset tree's windowed list — and
+  // scrolling one of those left the card parked at its old viewport
+  // coordinates, over a DIFFERENT sentence than the one it explains. Capture
+  // runs window-first for any scroll in the tree, which is exactly the set of
+  // scrolls that can move an anchor. `RuleEvidenceCard` repositions on the same
+  // flag for the same reason. The remove must repeat `capture` or it does not
+  // match the registration.
+  //
+  // Except the scroll the SHOW itself caused, which the review after it found:
+  // Tab onto an anchor that is only partly in view and the browser scrolls it
+  // into view, so the very listener this effect just registered hears that
+  // scroll one frame after the card opened and closes it again — every anchor
+  // not already fully visible was unreachable by keyboard. A scroll inside
+  // `SHOW_SCROLL_GRACE_MS` of the show is therefore read as the show's own and
+  // RE-ANCHORS instead of hiding: the anchor has just moved, so the card must
+  // move with it or it points at whatever slid under its old coordinates —
+  // which is the same failure, silently. Only the anchor's own box is re-read;
+  // the singleton, Escape and pointer-grace semantics are untouched.
+  useEffect(() => {
+    if (!anchor) {
+      return;
+    }
+    const onScroll = () => {
+      const el = anchorEl.current;
+      if (!el || Date.now() - shownAt.current >= SHOW_SCROLL_GRACE_MS) {
+        hideNow();
+        return;
+      }
+      const next = anchorRectOf(el);
+      setAnchor((prev) => (prev && sameRect(prev, next) ? prev : next));
+    };
+    window.addEventListener("scroll", onScroll, { capture: true, passive: true });
+    return () => window.removeEventListener("scroll", onScroll, { capture: true });
+  }, [anchor, hideNow]);
+
+  return { anchor, show, hide, hideNow, cancelHide, onKeyDown };
+}
+
+/**
+ * The open card's own dismissal, handed DOWN to its body.
+ *
+ * A card body that navigates the page out from under itself — the attribution
+ * card's "Show in preset tree →" switches tabs — has to take the card with it:
+ * a pointer-opened card never got focus, so there is no blur to close it, and
+ * it stays fixed at its old coordinates over a view that is no longer the one
+ * it describes. The body cannot reach `hideNow` through props, because
+ * `HoverCardAnchor` takes its card as an eager `ReactNode` (a `() => ReactNode`
+ * thunk is what `react/no-unstable-nested-components` rejects), so the handle
+ * travels by context instead. Deliberately just the one function: it is the
+ * only thing a body has any business doing to its own card.
+ *
+ * The default no-ops so a card body renders outside a portal (in a test, say)
+ * without a provider.
+ */
+const HoverCardCloseContext = createContext<() => void>(() => {});
+
+export const HoverCardCloseProvider = HoverCardCloseContext.Provider;
+
+/** The current card's dismissal — see `HoverCardCloseProvider`. */
+export function useHoverCardClose(): () => void {
+  return useContext(HoverCardCloseContext);
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1080,13 +1080,10 @@ button.badge.dup {
   margin-left: 0.35rem;
 }
 
-/* A dropped sentence is struck through rather than hidden — same grammar the
-   blame ledger uses for a duplicate, and the same reason: the fact that it
-   EXISTS and did not survive is the whole point of showing it. */
-.preset-desc-line.desc-dropped .preset-desc-text {
-  color: var(--muted);
-  text-decoration: line-through;
-}
+/* A dropped sentence renders exactly like a contributed one, minus the slot
+   marker: wrapper and package-list presets shed their description by design,
+   so on the node itself the sentence is simply what the preset says about
+   itself. The drop mechanics live on the blame ledger's footer. */
 
 .preset-desc-line code {
   font-family: var(--font-mono);

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1035,87 +1035,83 @@ button.badge.dup {
   text-overflow: ellipsis;
 }
 
-/* ---------- describe mode (roadmap 069 PR 4) ----------
-   The tree card's title becomes a row so the mode switch can sit with the
-   count, the way the digest card's "show raw order" link already does. */
-.preset-card-title {
-  align-items: center;
-  display: flex;
-  gap: 0.5rem;
+/* ---------- preset descriptions (roadmap 069 PR 4) ----------
+   A node that wrote (or lost) a sentence of the final `description` says so
+   ON its name: a hover card, so the rows stay exactly one ROW_HEIGHT (which
+   the windowing math depends on), and the detail panel repeats the same facts
+   as a Description entry. Both render the same `.preset-desc-line`s. */
+
+/* The cue on a described name — the `.opt-key.known` dotted-underline grammar,
+   in the preset hue, because the sentence is the preset's own. The name stays
+   a select button, so it keeps its pointer cursor. */
+.preset-name.described {
+  border-bottom: 1px dotted color-mix(in srgb, var(--accent-purple) 65%, transparent);
 }
 
-.preset-card-title .seg {
-  margin-left: auto;
-}
-
-/* A node's own sentence, as its OWN row beneath the name row — the tree's
-   windowing is uniform-height (see `rows.ts`), so this is exactly one
-   `ROW_HEIGHT` and never wraps; the untruncated text is the row's `title`,
-   the detail panel and the effective config's ledger. */
-.preset-desc-row {
-  align-items: center;
-  color: var(--muted);
-  display: flex;
-  font-size: 0.72rem;
+/* The card body and the panel entry share the line rendering. */
+.preset-desc-lines {
+  display: grid;
   gap: 0.35rem;
-  overflow: hidden;
-  padding: 0 0.1rem;
-  white-space: nowrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.preset-desc-row .preset-desc-mark {
-  color: color-mix(in srgb, var(--accent-purple) 55%, transparent);
-  flex: none;
+/* One fact: the quote behind a left rail in the preset hue, its muted note,
+   and the slot marker. */
+.preset-desc-line {
+  border-left: 2px solid color-mix(in srgb, var(--accent-purple) 45%, transparent);
   font-size: 0.8rem;
+  line-height: 1.45;
+  padding-left: 0.55rem;
 }
 
-/* Both cells shrink and ellipsize: on a dropped line the note ("Renovate drops
-   it on merge — …") is the half that matters, so it must not be pushed off by
-   the sentence it explains, nor push the sentence off itself. */
-.preset-desc-row .preset-desc-text {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+/* A mute line is a fact about the node, not a quotation — no quote rail. */
+.preset-desc-line.desc-mute {
+  border-left-color: transparent;
+}
+
+.preset-desc-line .preset-desc-note {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.preset-desc-line .preset-desc-text + .preset-desc-note {
+  margin-left: 0.35rem;
 }
 
 /* A dropped sentence is struck through rather than hidden — same grammar the
    blame ledger uses for a duplicate, and the same reason: the fact that it
    EXISTS and did not survive is the whole point of showing it. */
-.preset-desc-row.desc-dropped .preset-desc-text {
+.preset-desc-line.desc-dropped .preset-desc-text {
+  color: var(--muted);
   text-decoration: line-through;
 }
 
-.preset-desc-row .preset-desc-note {
-  flex: 0 1 auto;
-  font-style: italic;
-  min-width: 0;
-  opacity: 0.85;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.preset-desc-row .preset-desc-text code,
-.preset-desc-row .preset-desc-note code {
+.preset-desc-line code {
   font-family: var(--font-mono);
   font-size: 0.95em;
 }
 
-/* The position marker in a node's meta area. Padding/border-free so it reads
-   as an annotation next to the contribution badges, not as another badge. */
+/* Where the sentence landed in the final array (`→ #16 of 24 · approx`). */
 .preset-desc-pos {
   color: var(--muted);
-  flex: none;
   font-size: 0.7rem;
+  margin-left: 0.4rem;
   white-space: nowrap;
 }
 
-button.preset-desc-pos {
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  font-size: 0.7rem;
-  padding: 0;
+/* The hover card's jump to the Effective config's description row. */
+.preset-desc-order {
+  display: block;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+/* The Description entry's value is prose — the source grid's break-all is for
+   URLs and paths and must not tear words apart here. */
+.preset-source .preset-source-desc dd {
+  word-break: normal;
 }
 
 /* flat table view */

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1035,6 +1035,89 @@ button.badge.dup {
   text-overflow: ellipsis;
 }
 
+/* ---------- describe mode (roadmap 069 PR 4) ----------
+   The tree card's title becomes a row so the mode switch can sit with the
+   count, the way the digest card's "show raw order" link already does. */
+.preset-card-title {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.preset-card-title .seg {
+  margin-left: auto;
+}
+
+/* A node's own sentence, as its OWN row beneath the name row — the tree's
+   windowing is uniform-height (see `rows.ts`), so this is exactly one
+   `ROW_HEIGHT` and never wraps; the untruncated text is the row's `title`,
+   the detail panel and the effective config's ledger. */
+.preset-desc-row {
+  align-items: center;
+  color: var(--muted);
+  display: flex;
+  font-size: 0.72rem;
+  gap: 0.35rem;
+  overflow: hidden;
+  padding: 0 0.1rem;
+  white-space: nowrap;
+}
+
+.preset-desc-row .preset-desc-mark {
+  color: color-mix(in srgb, var(--accent-purple) 55%, transparent);
+  flex: none;
+  font-size: 0.8rem;
+}
+
+/* Both cells shrink and ellipsize: on a dropped line the note ("Renovate drops
+   it on merge — …") is the half that matters, so it must not be pushed off by
+   the sentence it explains, nor push the sentence off itself. */
+.preset-desc-row .preset-desc-text {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* A dropped sentence is struck through rather than hidden — same grammar the
+   blame ledger uses for a duplicate, and the same reason: the fact that it
+   EXISTS and did not survive is the whole point of showing it. */
+.preset-desc-row.desc-dropped .preset-desc-text {
+  text-decoration: line-through;
+}
+
+.preset-desc-row .preset-desc-note {
+  flex: 0 1 auto;
+  font-style: italic;
+  min-width: 0;
+  opacity: 0.85;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preset-desc-row .preset-desc-text code,
+.preset-desc-row .preset-desc-note code {
+  font-family: var(--font-mono);
+  font-size: 0.95em;
+}
+
+/* The position marker in a node's meta area. Padding/border-free so it reads
+   as an annotation next to the contribution badges, not as another badge. */
+.preset-desc-pos {
+  color: var(--muted);
+  flex: none;
+  font-size: 0.7rem;
+  white-space: nowrap;
+}
+
+button.preset-desc-pos {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0;
+}
+
 /* flat table view */
 .preset-table-head,
 .preset-table-row {

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -170,9 +170,10 @@ describe("buildTreeDescriptions", () => {
     ).toBeNull();
   });
 
-  test("excludes the repo config's own sentences from the contributor count", () => {
-    // The root never renders a row, so counting it would promise a line the
-    // tree cannot show.
+  test("files nothing at all under the repo config, which renders no row", () => {
+    // `flattenTree` starts at the root's CHILDREN, so a fact filed under the
+    // root would never mount — and counting it would promise a line the tree
+    // cannot show.
     const tree = built(
       provenance({
         entries: entries([
@@ -183,7 +184,24 @@ describe("buildTreeDescriptions", () => {
     );
 
     expect(tree.contributorCount).toBe(1);
-    expect(tree.byNodeId.has("root")).toBe(true);
+    expect(tree.byNodeId.has("root")).toBe(false);
+    // The slot numbering still counts the root's sentence: the marker names a
+    // position in the final array, which is where that sentence really is.
+    expect(tree.byNodeId.get("p9")?.markers[0]).toMatchObject({ position: 2, total: 2 });
+  });
+
+  test("returns null when only the repo config wrote descriptions", () => {
+    // Otherwise the mode toggle appears on a describe mode that shows nothing.
+    expect(
+      buildTreeDescriptions(
+        provenance({
+          entries: entries([
+            { value: "Our house rules.", node: "root", nodeName: "(input config)" },
+            { value: "And another.", node: "root", nodeName: "(input config)" },
+          ]),
+        }),
+      ),
+    ).toBeNull();
   });
 
   test("returns null for a run whose description array is empty and lost nothing", () => {
@@ -265,6 +283,18 @@ describe("wording", () => {
     expect(positionMarkerText(marker())).toBe("→ #16 of 24");
     expect(positionMarkerText(marker({ duplicateOfPosition: 1 }))).toBe("→ #16 of 24 · duplicate");
     expect(positionMarkerText(marker({ approximate: true }))).toBe("→ #16 of 24 · approx");
+  });
+
+  test("a duplicate that is also approximate keeps the caveat", () => {
+    // Dropping `approx` here would assert a node-to-slot tie the engine only
+    // guessed at — the one claim a degraded run must not make.
+    expect(positionMarkerText(marker({ duplicateOfPosition: 1, approximate: true }))).toBe(
+      "→ #16 of 24 · duplicate · approx",
+    );
+
+    const title = positionMarkerTitle(marker({ duplicateOfPosition: 3, approximate: true }), false);
+    expect(title).toContain("a repeat of #3");
+    expect(title).toContain(APPROXIMATE_NOTE);
   });
 
   test("its tooltip offers the ledger jump only when there is one", () => {

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -6,7 +6,6 @@ import type {
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
 import { approximateTitle } from "@/components/description-approx";
-import { dropReasonText } from "./drop-reasons";
 import {
   APPROXIMATE_NOTE,
   buildTreeDescriptions,
@@ -252,7 +251,7 @@ describe("buildTreeDescriptions — drops", () => {
     droppedBy: { nodeId: "p4", name: "group:recommended" },
   };
 
-  test("shows a dropped sentence at the preset that authored it", () => {
+  test("shows a dropped sentence plainly at the preset that authored it", () => {
     const tree = built(provenance({ entries: [], dropped: [WRAPPER] }));
 
     expect(tree.byNodeId.get("p2")?.lines).toEqual([
@@ -260,25 +259,25 @@ describe("buildTreeDescriptions — drops", () => {
         key: "x0",
         kind: "dropped",
         text: "The config that Renovate recommends.",
-        // The shared table, so the tree and the ledger footer cannot diverge.
-        note: dropReasonText(WRAPPER),
+        // No drop-reason note: shedding a wrapper's description is Renovate
+        // working as designed, and on the node's own card the sentence is the
+        // point — the mechanics stay on the blame ledger's footer.
+        note: undefined,
       },
     ]);
     // A drop is not a contribution — the title's count must not claim it.
     expect(tree.contributorCount).toBe(0);
   });
 
-  test("an approximate drop hedges in the line's note", () => {
+  test("an approximate drop keeps the attribution hedge, and only that", () => {
     // The drop came out of a subtree the engine had already degraded to its
-    // enclosing node (069 PR 1), so the node it sits on is a guess.
+    // enclosing node (069 PR 1), so the node it sits on is a guess — the one
+    // annotation a dropped line still carries.
     const tree = built(
       provenance({ entries: [], dropped: [{ ...WRAPPER, approximate: true }], degraded: true }),
     );
-    const line = tree.byNodeId.get("p2")?.lines[0];
 
-    expect(line?.note).toContain("; exact preset unknown");
-    // The rule itself is untouched: what Renovate did is certain.
-    expect(line?.note).toBe(`${dropReasonText(WRAPPER)}; exact preset unknown`);
+    expect(tree.byNodeId.get("p2")?.lines[0]?.note).toBe(APPROXIMATE_NOTE);
   });
 
   test("puts the mute note on the node that pressed the button, not the author", () => {
@@ -307,9 +306,8 @@ describe("buildTreeDescriptions — drops", () => {
     );
 
     expect(tree.byNodeId.has("root")).toBe(false);
-    expect(tree.byNodeId.get("p5")?.lines[0]?.note).toBe(
-      "muted by `(input config)` — its empty `ignoreDeps` deletes every description it extends",
-    );
+    // The author's line still exists — plainly, like every dropped sentence.
+    expect(tree.byNodeId.get("p5")?.lines[0]).toMatchObject({ kind: "dropped", note: undefined });
   });
 });
 

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+  DroppedDescription,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import {
+  APPROXIMATE_NOTE,
+  buildTreeDescriptions,
+  describeCountText,
+  droppedNoteText,
+  muteNoteText,
+  type PositionMarker,
+  positionMarkerText,
+  positionMarkerTitle,
+  type TreeDescriptions,
+} from "./tree-descriptions";
+
+/**
+ * Roadmap 069 (PR 4): the per-node index describe mode renders from, and the
+ * wording of every note, over hand-built provenance. The engine's own tests
+ * (PR 1) prove the ATTRIBUTION against the real 1,088-preset tree; what needs
+ * proving here is the inversion — that a node's facts land on that node, that
+ * a drop shows at the preset that authored it while the mute note shows at the
+ * one that pressed the button, and that nodes with nothing to say stay absent
+ * from the map, which is describe mode's whole performance story.
+ */
+
+const REPO: ProvenanceLayer = { kind: "repo" };
+
+function preset(nodeId: string, name = nodeId): ProvenanceLayer {
+  return { kind: "preset", nodeId, name };
+}
+
+const DASHBOARD = preset("p1", ":dependencyDashboard");
+const BEST_PRACTICES = preset("p2", "config:best-practices");
+
+interface EntrySpec {
+  value: string;
+  /** The writing node's id; `undefined` = a layer with no preset tree. */
+  node?: string;
+  nodeName?: string;
+  via?: ProvenanceLayer;
+  approximate?: boolean;
+}
+
+/** Builds `entries` with the indices and duplicate markers the engine assigns. */
+function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+  const firstByValue = new Map<string, number>();
+  return specs.map((spec, index) => {
+    const duplicateOfIndex = firstByValue.get(spec.value);
+    if (duplicateOfIndex === undefined) {
+      firstByValue.set(spec.value, index);
+    }
+    return {
+      index,
+      value: spec.value,
+      node: spec.node ? { nodeId: spec.node, name: spec.nodeName ?? spec.node } : undefined,
+      viaTopLevel: spec.via ?? REPO,
+      duplicateOfIndex,
+      approximate: spec.approximate,
+    };
+  });
+}
+
+function provenance(
+  parts: Partial<DescriptionProvenance> & Pick<DescriptionProvenance, "entries">,
+): DescriptionProvenance {
+  return {
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+    ...parts,
+  };
+}
+
+function built(source: DescriptionProvenance): TreeDescriptions {
+  const tree = buildTreeDescriptions(source);
+  if (!tree) {
+    throw new Error("expected a description index");
+  }
+  return tree;
+}
+
+describe("buildTreeDescriptions", () => {
+  test("indexes each sentence on the node that wrote it, with its array slot", () => {
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "Enable Renovate Dependency Dashboard creation.", node: "p1", via: DASHBOARD },
+          { value: "Pin Docker digests.", node: "p9", via: BEST_PRACTICES },
+        ]),
+      }),
+    );
+
+    expect(tree.total).toBe(2);
+    expect(tree.contributorCount).toBe(2);
+    expect(tree.byNodeId.get("p1")?.lines).toEqual([
+      {
+        key: "c0",
+        kind: "contribution",
+        text: "Enable Renovate Dependency Dashboard creation.",
+        note: undefined,
+      },
+    ]);
+    expect(tree.byNodeId.get("p9")?.markers).toEqual([
+      { key: "p1", position: 2, total: 2, duplicateOfPosition: undefined, approximate: undefined },
+    ]);
+  });
+
+  test("keeps every sentence of a node that wrote several", () => {
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "First.", node: "p1" },
+          { value: "Second.", node: "p1" },
+        ]),
+      }),
+    );
+
+    expect(tree.byNodeId.get("p1")?.lines.map((line) => line.text)).toEqual(["First.", "Second."]);
+    expect(tree.byNodeId.get("p1")?.markers.map((m) => m.position)).toEqual([1, 2]);
+    // Two sentences, ONE contributor — the count in the card title counts nodes.
+    expect(tree.contributorCount).toBe(1);
+  });
+
+  test("nodes with no description fact are absent from the map", () => {
+    const tree = built(provenance({ entries: entries([{ value: "Only me.", node: "p1" }]) }));
+
+    expect(tree.byNodeId.has("p1")).toBe(true);
+    expect(tree.byNodeId.get("p2")).toBeUndefined();
+    expect(tree.byNodeId.size).toBe(1);
+  });
+
+  test("attributes duplicates to their own occurrence, pointing at the first", () => {
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "Enable it.", node: "p1", via: BEST_PRACTICES },
+          { value: "Enable it.", node: "p7", via: DASHBOARD },
+        ]),
+      }),
+    );
+
+    expect(tree.byNodeId.get("p1")?.markers[0]?.duplicateOfPosition).toBeUndefined();
+    expect(tree.byNodeId.get("p7")?.markers[0]).toMatchObject({
+      position: 2,
+      duplicateOfPosition: 1,
+    });
+  });
+
+  test("carries the engine's enclosing-node fallback onto the line and the marker", () => {
+    const tree = built(
+      provenance({
+        entries: entries([{ value: "Something in here.", node: "p2", approximate: true }]),
+        degraded: true,
+      }),
+    );
+
+    expect(tree.byNodeId.get("p2")?.lines[0]?.note).toBe(APPROXIMATE_NOTE);
+    expect(tree.byNodeId.get("p2")?.markers[0]?.approximate).toBe(true);
+  });
+
+  test("ignores strings that no preset-tree node wrote", () => {
+    // A `defaults`/`global`/`inherited` layer has no node to hang a row on.
+    expect(
+      buildTreeDescriptions(provenance({ entries: entries([{ value: "From nowhere." }]) })),
+    ).toBeNull();
+  });
+
+  test("excludes the repo config's own sentences from the contributor count", () => {
+    // The root never renders a row, so counting it would promise a line the
+    // tree cannot show.
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "Our house rules.", node: "root", nodeName: "(input config)" },
+          { value: "Pin Docker digests.", node: "p9" },
+        ]),
+      }),
+    );
+
+    expect(tree.contributorCount).toBe(1);
+    expect(tree.byNodeId.has("root")).toBe(true);
+  });
+
+  test("returns null for a run whose description array is empty and lost nothing", () => {
+    expect(buildTreeDescriptions(provenance({ entries: [] }))).toBeNull();
+  });
+});
+
+describe("buildTreeDescriptions — drops", () => {
+  const WRAPPER: DroppedDescription = {
+    value: "The config that Renovate recommends.",
+    node: { nodeId: "p2", name: "config:best-practices" },
+    reason: "wrapper-preset",
+  };
+  const MUTED: DroppedDescription = {
+    value: "Group known monorepo packages together.",
+    node: { nodeId: "p5", name: "group:monorepos" },
+    reason: "ignore-deps-quirk",
+    droppedBy: { nodeId: "p4", name: "group:recommended" },
+  };
+
+  test("shows a dropped sentence at the preset that authored it", () => {
+    const tree = built(provenance({ entries: [], dropped: [WRAPPER] }));
+
+    expect(tree.byNodeId.get("p2")?.lines).toEqual([
+      {
+        key: "x0",
+        kind: "dropped",
+        text: "The config that Renovate recommends.",
+        note: droppedNoteText(WRAPPER),
+      },
+    ]);
+    // A drop is not a contribution — the title's count must not claim it.
+    expect(tree.contributorCount).toBe(0);
+  });
+
+  test("puts the mute note on the node that pressed the button, not the author", () => {
+    const tree = built(
+      provenance({
+        entries: entries([{ value: "Use the recommended groups.", node: "p4" }]),
+        dropped: [MUTED, { ...MUTED, node: { nodeId: "p6", name: "group:jest" } }],
+      }),
+    );
+
+    // The muting node keeps its own contribution AND gains the note.
+    expect(tree.byNodeId.get("p4")?.lines.map((line) => line.kind)).toEqual([
+      "contribution",
+      "mute",
+    ]);
+    expect(tree.byNodeId.get("p4")?.lines[1]?.note).toBe(muteNoteText(2));
+    expect(tree.byNodeId.get("p5")?.lines[0]?.kind).toBe("dropped");
+  });
+
+  test("does not attach a mute note to the repo config, which renders no row", () => {
+    const tree = built(
+      provenance({
+        entries: [],
+        dropped: [{ ...MUTED, droppedBy: { nodeId: "root", name: "(input config)" } }],
+      }),
+    );
+
+    expect(tree.byNodeId.has("root")).toBe(false);
+    expect(tree.byNodeId.get("p5")?.lines[0]?.note).toBe(
+      "muted by `(input config)` — its empty `ignoreDeps` deletes every description it extends",
+    );
+  });
+});
+
+function marker(parts: Partial<PositionMarker> = {}): PositionMarker {
+  return { key: "p0", position: 16, total: 24, ...parts };
+}
+
+function countText(contributorCount: number): string {
+  return describeCountText({ byNodeId: new Map(), contributorCount, total: 24 });
+}
+
+describe("wording", () => {
+  test("the position marker names the slot in the final array", () => {
+    expect(positionMarkerText(marker())).toBe("→ #16 of 24");
+    expect(positionMarkerText(marker({ duplicateOfPosition: 1 }))).toBe("→ #16 of 24 · duplicate");
+    expect(positionMarkerText(marker({ approximate: true }))).toBe("→ #16 of 24 · approx");
+  });
+
+  test("its tooltip offers the ledger jump only when there is one", () => {
+    expect(positionMarkerTitle(marker(), false)).toBe(
+      "Sentence #16 of 24 in the final description array.",
+    );
+    expect(positionMarkerTitle(marker(), true)).toContain(
+      "Show the full array in the Effective config.",
+    );
+    expect(positionMarkerTitle(marker({ duplicateOfPosition: 3 }), false)).toContain(
+      "a repeat of #3",
+    );
+    expect(positionMarkerTitle(marker({ approximate: true }), false)).toContain(APPROXIMATE_NOTE);
+  });
+
+  test("each drop rule explains itself in the tree's own terms", () => {
+    expect(
+      droppedNoteText({
+        value: "x",
+        node: { nodeId: "p1", name: "config:recommended" },
+        reason: "wrapper-preset",
+      }),
+    ).toBe("Renovate drops it on merge — wrapper preset (body is only `description` + `extends`)");
+    expect(
+      droppedNoteText({
+        value: "x",
+        node: { nodeId: "p1", name: "packages:eslint" },
+        reason: "package-list-preset",
+      }),
+    ).toBe("Renovate drops it on merge — package-name list (body only sets `matchPackageNames`)");
+    expect(
+      droppedNoteText({
+        value: "x",
+        node: { nodeId: "p1", name: "group:jest" },
+        reason: "ignore-deps-quirk",
+      }),
+    ).toBe(
+      "muted by the extending config — its empty `ignoreDeps` deletes every description it extends",
+    );
+  });
+
+  test("the mute note and the title count agree with English", () => {
+    expect(muteNoteText(1)).toBe("mutes 1 description below (empty `ignoreDeps`)");
+    expect(muteNoteText(135)).toBe("mutes 135 descriptions below (empty `ignoreDeps`)");
+
+    expect(countText(0)).toBe("none contribute descriptions");
+    expect(countText(1)).toBe("1 contributes a description");
+    expect(countText(18)).toBe("18 contribute descriptions");
+  });
+});

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -102,6 +102,7 @@ describe("buildTreeDescriptions", () => {
         kind: "contribution",
         text: "Enable Renovate Dependency Dashboard creation.",
         note: undefined,
+        title: "Enable Renovate Dependency Dashboard creation.",
       },
     ]);
     expect(tree.byNodeId.get("p9")?.markers).toEqual([
@@ -212,6 +213,7 @@ describe("buildTreeDescriptions — drops", () => {
         kind: "dropped",
         text: "The config that Renovate recommends.",
         note: droppedNoteText(WRAPPER),
+        title: `The config that Renovate recommends. — ${droppedNoteText(WRAPPER).replaceAll("`", "")}`,
       },
     ]);
     // A drop is not a contribution — the title's count must not claim it.

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -5,11 +5,12 @@ import type {
   DroppedDescription,
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
+import { approximateTitle } from "@/components/description-approx";
+import { dropReasonText } from "./drop-reasons";
 import {
   APPROXIMATE_NOTE,
   buildTreeDescriptions,
   describeCountText,
-  droppedNoteText,
   muteNoteText,
   type PositionMarker,
   positionMarkerText,
@@ -43,12 +44,16 @@ interface EntrySpec {
   nodeName?: string;
   via?: ProvenanceLayer;
   approximate?: boolean;
+  /** The engine's REAL index, when a non-string member sits earlier in the
+   *  array and the string's position is therefore not its ordinal here. */
+  index?: number;
 }
 
 /** Builds `entries` with the indices and duplicate markers the engine assigns. */
 function entries(specs: EntrySpec[]): DescriptionAttribution[] {
   const firstByValue = new Map<string, number>();
-  return specs.map((spec, index) => {
+  return specs.map((spec, ordinal) => {
+    const index = spec.index ?? ordinal;
     const duplicateOfIndex = firstByValue.get(spec.value);
     if (duplicateOfIndex === undefined) {
       firstByValue.set(spec.value, index);
@@ -71,6 +76,10 @@ function provenance(
     dropped: [],
     ruleDescriptions: [],
     degraded: false,
+    unattributed: [],
+    // What the engine reports: every member of the final array, the ones no
+    // preset can be credited for included.
+    finalLength: parts.entries.length + (parts.unattributed?.length ?? 0),
     ...parts,
   };
 }
@@ -124,6 +133,26 @@ describe("buildTreeDescriptions", () => {
     expect(tree.byNodeId.get("p1")?.markers.map((m) => m.position)).toEqual([1, 2]);
     // Two sentences, ONE contributor — the count in the card title counts nodes.
     expect(tree.contributorCount).toBe(1);
+  });
+
+  test("counts the array's real length, non-strings included", () => {
+    // `{"description": ["A", 42, "B"]}` merges with a warning and the `42` holds
+    // index 1 (069 PR 1's `unattributed`), so "B" really is #3 of 3. Counting
+    // the attributable strings would print "#3 of 2" — a marker that cannot be
+    // found in the array the Effective config shows.
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "A.", node: "p1" },
+          { value: "B.", node: "p9", index: 2 },
+        ]),
+        unattributed: [{ index: 1, value: 42 }],
+      }),
+    );
+
+    expect(tree.total).toBe(3);
+    expect(tree.byNodeId.get("p9")?.markers[0]).toMatchObject({ position: 3, total: 3 });
+    expect(positionMarkerText(tree.byNodeId.get("p9")?.markers[0] ?? marker())).toBe("→ #3 of 3");
   });
 
   test("nodes with no description fact are absent from the map", () => {
@@ -230,12 +259,28 @@ describe("buildTreeDescriptions — drops", () => {
         key: "x0",
         kind: "dropped",
         text: "The config that Renovate recommends.",
-        note: droppedNoteText(WRAPPER),
-        title: `The config that Renovate recommends. — ${droppedNoteText(WRAPPER).replaceAll("`", "")}`,
+        // The shared table, so the tree and the ledger footer cannot diverge.
+        note: dropReasonText(WRAPPER),
+        title: `The config that Renovate recommends. — ${dropReasonText(WRAPPER).replaceAll("`", "")}`,
       },
     ]);
     // A drop is not a contribution — the title's count must not claim it.
     expect(tree.contributorCount).toBe(0);
+  });
+
+  test("an approximate drop hedges in the line AND its tooltip", () => {
+    // The drop came out of a subtree the engine had already degraded to its
+    // enclosing node (069 PR 1), so the row it sits on is a guess — and the
+    // tooltip is the only text a truncated row actually shows.
+    const tree = built(
+      provenance({ entries: [], dropped: [{ ...WRAPPER, approximate: true }], degraded: true }),
+    );
+    const line = tree.byNodeId.get("p2")?.lines[0];
+
+    expect(line?.note).toContain("; exact preset unknown");
+    expect(line?.title).toContain("; exact preset unknown");
+    // The rule itself is untouched: what Renovate did is certain.
+    expect(line?.note).toBe(`${dropReasonText(WRAPPER)}; exact preset unknown`);
   });
 
   test("puts the mute note on the node that pressed the button, not the author", () => {
@@ -310,30 +355,10 @@ describe("wording", () => {
     expect(positionMarkerTitle(marker({ approximate: true }), false)).toContain(APPROXIMATE_NOTE);
   });
 
-  test("each drop rule explains itself in the tree's own terms", () => {
-    expect(
-      droppedNoteText({
-        value: "x",
-        node: { nodeId: "p1", name: "config:recommended" },
-        reason: "wrapper-preset",
-      }),
-    ).toBe("Renovate drops it on merge — wrapper preset (body is only `description` + `extends`)");
-    expect(
-      droppedNoteText({
-        value: "x",
-        node: { nodeId: "p1", name: "packages:eslint" },
-        reason: "package-list-preset",
-      }),
-    ).toBe("Renovate drops it on merge — package-name list (body only sets `matchPackageNames`)");
-    expect(
-      droppedNoteText({
-        value: "x",
-        node: { nodeId: "p1", name: "group:jest" },
-        reason: "ignore-deps-quirk",
-      }),
-    ).toBe(
-      "muted by the extending config — its empty `ignoreDeps` deletes every description it extends",
-    );
+  test("the approximate note is the shared hedge, not a fourth phrasing of it", () => {
+    // `description-approx.ts` owns this sentence for every surface; the nameless
+    // form is the tree's, because the line is rendered on the node it would name.
+    expect(APPROXIMATE_NOTE).toBe(approximateTitle());
   });
 
   test("the mute note and the title count agree with English", () => {

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -16,16 +16,18 @@ import {
   positionMarkerText,
   positionMarkerTitle,
   type TreeDescriptions,
+  zipDescLines,
 } from "./tree-descriptions";
 
 /**
- * Roadmap 069 (PR 4): the per-node index describe mode renders from, and the
- * wording of every note, over hand-built provenance. The engine's own tests
- * (PR 1) prove the ATTRIBUTION against the real 1,088-preset tree; what needs
- * proving here is the inversion — that a node's facts land on that node, that
- * a drop shows at the preset that authored it while the mute note shows at the
- * one that pressed the button, and that nodes with nothing to say stay absent
- * from the map, which is describe mode's whole performance story.
+ * Roadmap 069 (PR 4): the per-node index the name hover cards and the detail
+ * panel render from, and the wording of every note, over hand-built
+ * provenance. The engine's own tests (PR 1) prove the ATTRIBUTION against the
+ * real 1,088-preset tree; what needs proving here is the inversion — that a
+ * node's facts land on that node, that a drop shows at the preset that
+ * authored it while the mute note shows at the one that pressed the button,
+ * and that nodes with nothing to say stay absent from the map, which is the
+ * surface's whole performance story.
  */
 
 const REPO: ProvenanceLayer = { kind: "repo" };
@@ -111,7 +113,6 @@ describe("buildTreeDescriptions", () => {
         kind: "contribution",
         text: "Enable Renovate Dependency Dashboard creation.",
         note: undefined,
-        title: "Enable Renovate Dependency Dashboard creation.",
       },
     ]);
     expect(tree.byNodeId.get("p9")?.markers).toEqual([
@@ -220,7 +221,7 @@ describe("buildTreeDescriptions", () => {
   });
 
   test("returns null when only the repo config wrote descriptions", () => {
-    // Otherwise the mode toggle appears on a describe mode that shows nothing.
+    // Otherwise the title advertises descriptions no name in the tree shows.
     expect(
       buildTreeDescriptions(
         provenance({
@@ -261,24 +262,21 @@ describe("buildTreeDescriptions — drops", () => {
         text: "The config that Renovate recommends.",
         // The shared table, so the tree and the ledger footer cannot diverge.
         note: dropReasonText(WRAPPER),
-        title: `The config that Renovate recommends. — ${dropReasonText(WRAPPER).replaceAll("`", "")}`,
       },
     ]);
     // A drop is not a contribution — the title's count must not claim it.
     expect(tree.contributorCount).toBe(0);
   });
 
-  test("an approximate drop hedges in the line AND its tooltip", () => {
+  test("an approximate drop hedges in the line's note", () => {
     // The drop came out of a subtree the engine had already degraded to its
-    // enclosing node (069 PR 1), so the row it sits on is a guess — and the
-    // tooltip is the only text a truncated row actually shows.
+    // enclosing node (069 PR 1), so the node it sits on is a guess.
     const tree = built(
       provenance({ entries: [], dropped: [{ ...WRAPPER, approximate: true }], degraded: true }),
     );
     const line = tree.byNodeId.get("p2")?.lines[0];
 
     expect(line?.note).toContain("; exact preset unknown");
-    expect(line?.title).toContain("; exact preset unknown");
     // The rule itself is untouched: what Renovate did is certain.
     expect(line?.note).toBe(`${dropReasonText(WRAPPER)}; exact preset unknown`);
   });
@@ -337,22 +335,45 @@ describe("wording", () => {
       "→ #16 of 24 · duplicate · approx",
     );
 
-    const title = positionMarkerTitle(marker({ duplicateOfPosition: 3, approximate: true }), false);
+    const title = positionMarkerTitle(marker({ duplicateOfPosition: 3, approximate: true }));
     expect(title).toContain("a repeat of #3");
     expect(title).toContain(APPROXIMATE_NOTE);
   });
 
-  test("its tooltip offers the ledger jump only when there is one", () => {
-    expect(positionMarkerTitle(marker(), false)).toBe(
+  test("its tooltip states the slot, the repeat and the hedge", () => {
+    expect(positionMarkerTitle(marker())).toBe(
       "Sentence #16 of 24 in the final description array.",
     );
-    expect(positionMarkerTitle(marker(), true)).toContain(
-      "Show the full array in the Effective config.",
+    expect(positionMarkerTitle(marker({ duplicateOfPosition: 3 }))).toContain("a repeat of #3");
+    expect(positionMarkerTitle(marker({ approximate: true }))).toContain(APPROXIMATE_NOTE);
+  });
+
+  test("zipDescLines pairs each contribution with its marker, in order", () => {
+    // The pairing is positional (`buildTreeDescriptions` fills both arrays
+    // from the same loop) — this pins that a drop between two contributions
+    // does not shift the second one's marker.
+    const tree = built(
+      provenance({
+        entries: entries([
+          { value: "First.", node: "p1" },
+          { value: "Second.", node: "p1" },
+        ]),
+        dropped: [
+          {
+            value: "Gone.",
+            node: { nodeId: "p1", name: ":dependencyDashboard" },
+            reason: "wrapper-preset",
+          },
+        ],
+      }),
     );
-    expect(positionMarkerTitle(marker({ duplicateOfPosition: 3 }), false)).toContain(
-      "a repeat of #3",
-    );
-    expect(positionMarkerTitle(marker({ approximate: true }), false)).toContain(APPROXIMATE_NOTE);
+    const zipped = zipDescLines(tree.byNodeId.get("p1") ?? { markers: [], lines: [] });
+
+    expect(zipped.map(({ line, marker: m }) => [line.kind, m?.position])).toEqual([
+      ["contribution", 1],
+      ["contribution", 2],
+      ["dropped", undefined],
+    ]);
   });
 
   test("the approximate note is the shared hedge, not a fourth phrasing of it", () => {

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -1,4 +1,5 @@
 import type { DescriptionProvenance, DroppedDescription } from "@renovate-config-debugger/engine";
+import { ROOT_NODE_ID } from "@/components/preset-tree-stats";
 
 /**
  * Roadmap 069 (PR 4): the preset tree's `describe` mode, as data.
@@ -21,11 +22,6 @@ import type { DescriptionProvenance, DroppedDescription } from "@renovate-config
  */
 
 const nf = new Intl.NumberFormat();
-
-/** The repo config's own node id (`trace/preset-tree.ts`). It is the tree's
- *  root and never renders as a row, so its sentences — the user's own — are
- *  excluded from the contributor count the card title prints. */
-const ROOT_NODE_ID = "root";
 
 /** Where one of a node's sentences landed in the final `description` array.
  *  Rendered in the node's own meta area, next to the contribution badges. */
@@ -118,13 +114,15 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
   for (const entry of provenance.entries) {
     const node = entry.node;
     // Strings from a layer with no preset tree (defaults / global / inherited)
-    // have no node to sit on, and the root's own sentences never render a row.
-    if (!node) {
+    // have no node to sit on. The ROOT is skipped for the same reason and not
+    // merely left out of the count: `flattenTree` starts at the root's
+    // CHILDREN, so facts filed under it would never mount — and a run where
+    // only the repo config wrote descriptions has to come back `null`, or the
+    // mode toggle appears and describe mode then shows nothing at all.
+    if (!node || node.nodeId === ROOT_NODE_ID) {
       continue;
     }
-    if (node.nodeId !== ROOT_NODE_ID) {
-      contributors.add(node.nodeId);
-    }
+    contributors.add(node.nodeId);
     const facts = factsFor(node.nodeId);
     facts.markers.push({
       key: `p${entry.index}`,
@@ -145,9 +143,13 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
   }
 
   for (const [index, drop] of provenance.dropped.entries()) {
-    factsFor(drop.node.nodeId).lines.push(
-      descLine(`x${index}`, "dropped", drop.value, droppedNoteText(drop)),
-    );
+    // Same rule as above, on both halves of the story: nothing is ever filed
+    // under the root, which has no row to show it on.
+    if (drop.node.nodeId !== ROOT_NODE_ID) {
+      factsFor(drop.node.nodeId).lines.push(
+        descLine(`x${index}`, "dropped", drop.value, droppedNoteText(drop)),
+      );
+    }
     // …and the mute button that pressed it, which is a different node and the
     // one a reader would actually remove.
     const by = drop.droppedBy;
@@ -166,11 +168,17 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
 /** The node's meta marker: `→ #16 of 24`, the tie between a preset and its
  *  slot in the array the Effective config prints. */
 export function positionMarkerText(marker: PositionMarker): string {
-  const base = `→ #${nf.format(marker.position)} of ${nf.format(marker.total)}`;
+  // The two suffixes are independent facts and a degraded run can carry both:
+  // dropping `approx` for a duplicate would assert a node-to-slot tie the
+  // engine only guessed at.
+  const parts = [`→ #${nf.format(marker.position)} of ${nf.format(marker.total)}`];
   if (marker.duplicateOfPosition !== undefined) {
-    return `${base} · duplicate`;
+    parts.push("duplicate");
   }
-  return marker.approximate ? `${base} · approx` : base;
+  if (marker.approximate) {
+    parts.push("approx");
+  }
+  return parts.join(" · ");
 }
 
 /** …and its tooltip. `linked` is whether the marker is the cross-link to the
@@ -178,7 +186,8 @@ export function positionMarkerText(marker: PositionMarker): string {
 export function positionMarkerTitle(marker: PositionMarker, linked: boolean): string {
   const cta = linked ? " Show the full array in the Effective config." : "";
   if (marker.duplicateOfPosition !== undefined) {
-    return `Sentence #${marker.position} of ${marker.total} in the final description array — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates.${cta}`;
+    const caveat = marker.approximate ? ` It was ${APPROXIMATE_NOTE}.` : "";
+    return `Sentence #${marker.position} of ${marker.total} in the final description array — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates.${caveat}${cta}`;
   }
   if (marker.approximate) {
     return `Landed at #${marker.position} of ${marker.total} in the final description array, ${APPROXIMATE_NOTE}.${cta}`;

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -1,7 +1,6 @@
 import type { DescriptionProvenance } from "@renovate-config-debugger/engine";
 import { approximateTitle } from "@/components/description-approx";
 import { ROOT_NODE_ID } from "@/components/preset-tree-stats";
-import { dropReasonText } from "./drop-reasons";
 
 /**
  * Roadmap 069 (PR 4): the preset tree's description surfaces, as data.
@@ -46,8 +45,12 @@ export interface PositionMarker {
 
 /**
  * `contribution` — a sentence this node wrote that reached the final config.
- * `dropped` — one Renovate deleted before it could merge, shown struck through
- * at the node that authored it, which is the only place the drop is visible.
+ * `dropped` — one Renovate deleted before it could merge. On the node itself
+ * that is the EXPECTED case, not a problem: every wrapper and package-list
+ * preset sheds its description by design, and the sentence is still the
+ * preset's best self-description — so it renders plainly (it simply carries no
+ * slot marker), and the drop mechanics stay on the blame ledger's footer,
+ * where "where did my description go in the final array" is the question.
  * `mute` — the note on the node that CAUSED such drops (`ignoreDeps: []`).
  */
 export type DescLineKind = "contribution" | "dropped" | "mute";
@@ -164,13 +167,17 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
     // Same rule as above, on both halves of the story: nothing is ever filed
     // under the root, which has no row to show it on.
     if (drop.node.nodeId !== ROOT_NODE_ID) {
-      // The reason comes from the shared table (069 PR 3's `drop-reasons.ts`),
-      // which is also what the blame ledger's footer prints — the two surfaces
-      // answer "where did my preset's description go" and must answer it
-      // identically. It hedges itself for an `approximate` drop, so the caveat
-      // reaches the line AND the tooltip `descLine` derives from it.
+      // No drop-reason note here (see `DescLineKind`): on the node's own card
+      // the sentence is what the reader wants, and "Renovate drops it on
+      // merge" is chrome about an array this surface is not showing. Only the
+      // attribution hedge survives — WHO said it can still be a guess.
       factsFor(drop.node.nodeId).lines.push(
-        descLine(`x${index}`, "dropped", drop.value, dropReasonText(drop)),
+        descLine(
+          `x${index}`,
+          "dropped",
+          drop.value,
+          drop.approximate ? APPROXIMATE_NOTE : undefined,
+        ),
       );
     }
     // …and the mute button that pressed it, which is a different node and the

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -1,5 +1,7 @@
-import type { DescriptionProvenance, DroppedDescription } from "@renovate-config-debugger/engine";
+import type { DescriptionProvenance } from "@renovate-config-debugger/engine";
+import { approximateTitle } from "@/components/description-approx";
 import { ROOT_NODE_ID } from "@/components/preset-tree-stats";
+import { dropReasonText } from "./drop-reasons";
 
 /**
  * Roadmap 069 (PR 4): the preset tree's `describe` mode, as data.
@@ -30,7 +32,9 @@ export interface PositionMarker {
   key: string;
   /** 1-based position in the final array — every index this app prints is. */
   position: number;
-  /** Strings in the final array. */
+  /** Members of the final array, non-strings included (the engine's
+   *  `finalLength`): the marker names a slot in the array the Effective config
+   *  prints, so its denominator has to be that array's real length. */
   total: number;
   /** 1-based position of the first occurrence, when this entry repeats one. */
   duplicateOfPosition?: number;
@@ -46,7 +50,17 @@ export interface PositionMarker {
  */
 export type DescLineKind = "contribution" | "dropped" | "mute";
 
-/** One quote line beneath a node's name row. */
+/**
+ * One quote line beneath a node's name row.
+ *
+ * Pure text, deliberately: the `≈` the other surfaces render (069 PR 2's
+ * `ApproximateMark`) qualifies a source CHIP, and this row has none — its
+ * placement under the node is the attribution, so a glyph in front of a
+ * struck-through quote would read as part of the quotation. The hedge travels as
+ * words instead, in the `note` and therefore in the `title` derived from it,
+ * which is the only text an ellipsized row can still show. On a contributing
+ * node the node's own marker carries the `approx` suffix as well.
+ */
 export interface DescLine {
   /** Stable React key within the node. */
   key: string;
@@ -80,14 +94,20 @@ export interface TreeDescriptions {
   byNodeId: ReadonlyMap<string, NodeDescriptionFacts>;
   /** Distinct preset nodes appearing in `entries` (the repo config excluded). */
   contributorCount: number;
-  /** Strings in the final `description` array. */
+  /** Members of the final `description` array — the engine's `finalLength`. */
   total: number;
 }
 
-/** The note on an `approximate` entry — the engine's enclosing-node fallback,
- *  said in the tree's own terms. */
-export const APPROXIMATE_NOTE =
-  "written somewhere inside this preset — the exact one could not be determined";
+/**
+ * The note on an `approximate` entry: the shared hedge, not a fourth phrasing of
+ * it (`components/description-approx.ts`, 069 PR 2).
+ *
+ * The nameless form is the right one here even though the enclosing node is
+ * known — the line is rendered ON that node's row, so naming it again would
+ * repeat the row above it. The `≈` the other surfaces put beside a chip has its
+ * counterpart in the marker's own `approx` suffix.
+ */
+export const APPROXIMATE_NOTE = approximateTitle();
 
 /**
  * Inverts a run's description provenance into the per-node index describe mode
@@ -95,7 +115,11 @@ export const APPROXIMATE_NOTE =
  * case the mode toggle has nothing to offer and is not shown).
  */
 export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDescriptions | null {
-  const total = provenance.entries.length;
+  // The array's REAL length, not `entries.length`: Renovate keeps a non-string
+  // member with a warning, so `{"description": ["a", 42, "b"]}` has "b" at #3 of
+  // 3 while only two members are attributable (069 PR 1's `unattributed` /
+  // `finalLength`). Counting the strings would print "#3 of 2".
+  const total = provenance.finalLength;
   const byNodeId = new Map<string, NodeDescriptionFacts>();
   const contributors = new Set<string>();
   /** Drops each node caused below it, keyed by the muting node. */
@@ -146,8 +170,13 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
     // Same rule as above, on both halves of the story: nothing is ever filed
     // under the root, which has no row to show it on.
     if (drop.node.nodeId !== ROOT_NODE_ID) {
+      // The reason comes from the shared table (069 PR 3's `drop-reasons.ts`),
+      // which is also what the blame ledger's footer prints — the two surfaces
+      // answer "where did my preset's description go" and must answer it
+      // identically. It hedges itself for an `approximate` drop, so the caveat
+      // reaches the line AND the tooltip `descLine` derives from it.
       factsFor(drop.node.nodeId).lines.push(
-        descLine(`x${index}`, "dropped", drop.value, droppedNoteText(drop)),
+        descLine(`x${index}`, "dropped", drop.value, dropReasonText(drop)),
       );
     }
     // …and the mute button that pressed it, which is a different node and the
@@ -181,41 +210,40 @@ export function positionMarkerText(marker: PositionMarker): string {
   return parts.join(" · ");
 }
 
-/** …and its tooltip. `linked` is whether the marker is the cross-link to the
- *  blame ledger, which only App-level plumbing can offer. */
+/**
+ * …and its tooltip. `linked` is whether the marker is the cross-link to the
+ * blame ledger, which only App-level plumbing can offer.
+ *
+ * Built as independent sentences rather than one template per case: the slot,
+ * the repeat, the hedge and the call to action are four facts a degraded run can
+ * carry in any combination, and the hedge is the shared wording, which is
+ * already a sentence of its own.
+ */
 export function positionMarkerTitle(marker: PositionMarker, linked: boolean): string {
-  const cta = linked ? " Show the full array in the Effective config." : "";
+  let slot = `Sentence #${marker.position} of ${marker.total} in the final description array`;
   if (marker.duplicateOfPosition !== undefined) {
-    const caveat = marker.approximate ? ` It was ${APPROXIMATE_NOTE}.` : "";
-    return `Sentence #${marker.position} of ${marker.total} in the final description array — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates.${caveat}${cta}`;
+    slot += ` — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates`;
   }
+  const sentences = [slot];
   if (marker.approximate) {
-    return `Landed at #${marker.position} of ${marker.total} in the final description array, ${APPROXIMATE_NOTE}.${cta}`;
+    sentences.push(APPROXIMATE_NOTE);
   }
-  return `Sentence #${marker.position} of ${marker.total} in the final description array.${cta}`;
+  if (linked) {
+    sentences.push("Show the full array in the Effective config");
+  }
+  return sentences.map((sentence) => `${sentence}.`).join(" ");
 }
 
-const DROP_NOTES: Record<"wrapper-preset" | "package-list-preset", string> = {
-  // Both are `getPreset` deletions, i.e. facts about the preset's SHAPE — and
-  // worth saying in the tree, because the two headline presets ARE the shape.
-  "wrapper-preset":
-    "Renovate drops it on merge — wrapper preset (body is only `description` + `extends`)",
-  "package-list-preset":
-    "Renovate drops it on merge — package-name list (body only sets `matchPackageNames`)",
-};
-
-/** Why this node's own sentence never reached the config. Backtick-marked (the
- *  `CodeText` convention), so option names stay mono. */
-export function droppedNoteText(drop: DroppedDescription): string {
-  if (drop.reason === "ignore-deps-quirk") {
-    const by = drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config";
-    return `muted by ${by} — its empty \`ignoreDeps\` deletes every description it extends`;
-  }
-  return DROP_NOTES[drop.reason];
-}
-
-/** The other half of that story, on the node that pressed the mute button —
- *  `group:recommended` alone silences a hundred-plus sentences below it. */
+/**
+ * The other half of a mute's story, on the node that pressed the button —
+ * `group:recommended` alone silences a hundred-plus sentences below it.
+ *
+ * Tree-only, and therefore local: `drop-reasons.ts` words the rule for the node
+ * whose sentence went missing, which is the fact both surfaces state. This is an
+ * AGGREGATE over the drops of a whole subtree, and it exists because the tree is
+ * the only surface with a row for the muting node to say it on — the ledger
+ * lists drops, never their causes, so there is no twin to drift from.
+ */
 export function muteNoteText(count: number): string {
   return `mutes ${nf.format(count)} description${count === 1 ? "" : "s"} below (empty \`ignoreDeps\`)`;
 }

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -4,29 +4,31 @@ import { ROOT_NODE_ID } from "@/components/preset-tree-stats";
 import { dropReasonText } from "./drop-reasons";
 
 /**
- * Roadmap 069 (PR 4): the preset tree's `describe` mode, as data.
+ * Roadmap 069 (PR 4): the preset tree's description surfaces, as data.
  *
  * The Overview digest (PR 2) regroups the sentences by what each `extends`
  * bought, and the Effective config's blame ledger (PR 3) keeps the final
  * array's own order. This is the third reading of the same attribution and the
  * only one that answers the question BY PLACEMENT: what does THIS node say?
- * The text appears where it was written, so the tree stops being 1,088 cryptic
- * preset names and becomes skimmable prose.
+ * The answer rides on the node itself — a hover card on the preset's name in
+ * the tree, and the Description entry of the detail panel — rather than as a
+ * view mode of its own: the tree already has a tree/table switch, and a second
+ * switch beside it would be a mode over a handful of nodes.
  *
  * Everything here is a single pass over `entries` + `dropped` — tens of items,
  * never the thousand nodes — inverted into a per-node index the tree looks up
  * by `nodeId`. A node with no description fact is simply absent from the map,
- * which is what keeps describe mode from adding DOM to the ~1,070 nodes that
+ * which is what keeps the surface from adding DOM to the ~1,070 nodes that
  * have nothing to say.
  *
- * Pure and DOM-free, so every note's wording is unit-testable and the row
+ * Pure and DOM-free, so every note's wording is unit-testable and the
  * components only decide where things sit.
  */
 
 const nf = new Intl.NumberFormat();
 
 /** Where one of a node's sentences landed in the final `description` array.
- *  Rendered in the node's own meta area, next to the contribution badges. */
+ *  Rendered after the sentence it places, on both description surfaces. */
 export interface PositionMarker {
   /** Stable React key within the node (the entry's canonical index). */
   key: string;
@@ -51,15 +53,14 @@ export interface PositionMarker {
 export type DescLineKind = "contribution" | "dropped" | "mute";
 
 /**
- * One quote line beneath a node's name row.
+ * One line of a node's description card / panel entry.
  *
  * Pure text, deliberately: the `≈` the other surfaces render (069 PR 2's
- * `ApproximateMark`) qualifies a source CHIP, and this row has none — its
- * placement under the node is the attribution, so a glyph in front of a
- * struck-through quote would read as part of the quotation. The hedge travels as
- * words instead, in the `note` and therefore in the `title` derived from it,
- * which is the only text an ellipsized row can still show. On a contributing
- * node the node's own marker carries the `approx` suffix as well.
+ * `ApproximateMark`) qualifies a source CHIP, and this line has none — its
+ * placement on the node is the attribution, so a glyph in front of a
+ * struck-through quote would read as part of the quotation. The hedge travels
+ * as words instead, in the `note`. On a contributing node the entry's marker
+ * carries the `approx` suffix as well.
  */
 export interface DescLine {
   /** Stable React key within the node. */
@@ -70,17 +71,10 @@ export interface DescLine {
   text: string;
   /** The muted explanation after the text. */
   note?: string;
-  /** The row is ellipsized, so the untruncated text is its tooltip —
-   *  backticks stripped, since a `title` cannot render `<code>`. */
-  title: string;
 }
 
 function descLine(key: string, kind: DescLineKind, text: string, note?: string): DescLine {
-  const title = [text, note]
-    .filter((part) => part)
-    .join(" — ")
-    .replaceAll("`", "");
-  return { key, kind, text, note, title };
+  return { key, kind, text, note };
 }
 
 export interface NodeDescriptionFacts {
@@ -103,16 +97,16 @@ export interface TreeDescriptions {
  * it (`components/description-approx.ts`, 069 PR 2).
  *
  * The nameless form is the right one here even though the enclosing node is
- * known — the line is rendered ON that node's row, so naming it again would
- * repeat the row above it. The `≈` the other surfaces put beside a chip has its
- * counterpart in the marker's own `approx` suffix.
+ * known — the line is rendered ON that node's card, so naming it again would
+ * repeat the name the card hangs from. The `≈` the other surfaces put beside a
+ * chip has its counterpart in the marker's own `approx` suffix.
  */
 export const APPROXIMATE_NOTE = approximateTitle();
 
 /**
- * Inverts a run's description provenance into the per-node index describe mode
- * renders from, or `null` when no node has a description fact at all (in which
- * case the mode toggle has nothing to offer and is not shown).
+ * Inverts a run's description provenance into the per-node index the hover
+ * cards and the detail panel render from, or `null` when no node has a
+ * description fact at all (in which case no name carries a card).
  */
 export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDescriptions | null {
   // The array's REAL length, not `entries.length`: Renovate keeps a non-string
@@ -142,7 +136,7 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
     // merely left out of the count: `flattenTree` starts at the root's
     // CHILDREN, so facts filed under it would never mount — and a run where
     // only the repo config wrote descriptions has to come back `null`, or the
-    // mode toggle appears and describe mode then shows nothing at all.
+    // title advertises descriptions no name in the tree can show.
     if (!node || node.nodeId === ROOT_NODE_ID) {
       continue;
     }
@@ -211,15 +205,16 @@ export function positionMarkerText(marker: PositionMarker): string {
 }
 
 /**
- * …and its tooltip. `linked` is whether the marker is the cross-link to the
- * blame ledger, which only App-level plumbing can offer.
+ * …and its tooltip. The jump to the blame ledger is no longer advertised here —
+ * it is the card's own footer link, a control of its own rather than a promise
+ * a `title` makes about a span.
  *
  * Built as independent sentences rather than one template per case: the slot,
- * the repeat, the hedge and the call to action are four facts a degraded run can
- * carry in any combination, and the hedge is the shared wording, which is
- * already a sentence of its own.
+ * the repeat and the hedge are three facts a degraded run can carry in any
+ * combination, and the hedge is the shared wording, which is already a
+ * sentence of its own.
  */
-export function positionMarkerTitle(marker: PositionMarker, linked: boolean): string {
+export function positionMarkerTitle(marker: PositionMarker): string {
   let slot = `Sentence #${marker.position} of ${marker.total} in the final description array`;
   if (marker.duplicateOfPosition !== undefined) {
     slot += ` — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates`;
@@ -228,10 +223,28 @@ export function positionMarkerTitle(marker: PositionMarker, linked: boolean): st
   if (marker.approximate) {
     sentences.push(APPROXIMATE_NOTE);
   }
-  if (linked) {
-    sentences.push("Show the full array in the Effective config");
-  }
   return sentences.map((sentence) => `${sentence}.`).join(" ");
+}
+
+/** A line paired with the marker that places it — contributions only; a
+ *  dropped sentence has no slot and a mute note is not a sentence at all. */
+export interface DescLineWithMarker {
+  line: DescLine;
+  marker?: PositionMarker;
+}
+
+/**
+ * Zips a node's lines with their position markers for rendering. The pairing
+ * is positional and safe by construction: `buildTreeDescriptions` pushes a
+ * node's contribution lines and its markers from the same loop, in the same
+ * order, and only contributions get either.
+ */
+export function zipDescLines(facts: NodeDescriptionFacts): DescLineWithMarker[] {
+  let contribution = 0;
+  return facts.lines.map((line) => ({
+    line,
+    marker: line.kind === "contribution" ? facts.markers[contribution++] : undefined,
+  }));
 }
 
 /**
@@ -248,7 +261,7 @@ export function muteNoteText(count: number): string {
   return `mutes ${nf.format(count)} description${count === 1 ? "" : "s"} below (empty \`ignoreDeps\`)`;
 }
 
-/** The card title's count — the reason to reach for describe mode at all. */
+/** The card title's count — the cue that the tree has descriptions to show. */
 export function describeCountText(tree: TreeDescriptions): string {
   const count = tree.contributorCount;
   if (count === 0) {

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -60,6 +60,17 @@ export interface DescLine {
   text: string;
   /** The muted explanation after the text. */
   note?: string;
+  /** The row is ellipsized, so the untruncated text is its tooltip —
+   *  backticks stripped, since a `title` cannot render `<code>`. */
+  title: string;
+}
+
+function descLine(key: string, kind: DescLineKind, text: string, note?: string): DescLine {
+  const title = [text, note]
+    .filter((part) => part)
+    .join(" — ")
+    .replaceAll("`", "");
+  return { key, kind, text, note, title };
 }
 
 export interface NodeDescriptionFacts {
@@ -123,21 +134,20 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
         entry.duplicateOfIndex === undefined ? undefined : entry.duplicateOfIndex + 1,
       approximate: entry.approximate,
     });
-    facts.lines.push({
-      key: `c${entry.index}`,
-      kind: "contribution",
-      text: entry.value,
-      note: entry.approximate ? APPROXIMATE_NOTE : undefined,
-    });
+    facts.lines.push(
+      descLine(
+        `c${entry.index}`,
+        "contribution",
+        entry.value,
+        entry.approximate ? APPROXIMATE_NOTE : undefined,
+      ),
+    );
   }
 
   for (const [index, drop] of provenance.dropped.entries()) {
-    factsFor(drop.node.nodeId).lines.push({
-      key: `x${index}`,
-      kind: "dropped",
-      text: drop.value,
-      note: droppedNoteText(drop),
-    });
+    factsFor(drop.node.nodeId).lines.push(
+      descLine(`x${index}`, "dropped", drop.value, droppedNoteText(drop)),
+    );
     // …and the mute button that pressed it, which is a different node and the
     // one a reader would actually remove.
     const by = drop.droppedBy;
@@ -147,7 +157,7 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
   }
 
   for (const [nodeId, count] of mutes) {
-    factsFor(nodeId).lines.push({ key: "mute", kind: "mute", text: "", note: muteNoteText(count) });
+    factsFor(nodeId).lines.push(descLine("mute", "mute", "", muteNoteText(count)));
   }
 
   return byNodeId.size === 0 ? null : { byNodeId, contributorCount: contributors.size, total };

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -1,0 +1,213 @@
+import type { DescriptionProvenance, DroppedDescription } from "@renovate-config-debugger/engine";
+
+/**
+ * Roadmap 069 (PR 4): the preset tree's `describe` mode, as data.
+ *
+ * The Overview digest (PR 2) regroups the sentences by what each `extends`
+ * bought, and the Effective config's blame ledger (PR 3) keeps the final
+ * array's own order. This is the third reading of the same attribution and the
+ * only one that answers the question BY PLACEMENT: what does THIS node say?
+ * The text appears where it was written, so the tree stops being 1,088 cryptic
+ * preset names and becomes skimmable prose.
+ *
+ * Everything here is a single pass over `entries` + `dropped` — tens of items,
+ * never the thousand nodes — inverted into a per-node index the tree looks up
+ * by `nodeId`. A node with no description fact is simply absent from the map,
+ * which is what keeps describe mode from adding DOM to the ~1,070 nodes that
+ * have nothing to say.
+ *
+ * Pure and DOM-free, so every note's wording is unit-testable and the row
+ * components only decide where things sit.
+ */
+
+const nf = new Intl.NumberFormat();
+
+/** The repo config's own node id (`trace/preset-tree.ts`). It is the tree's
+ *  root and never renders as a row, so its sentences — the user's own — are
+ *  excluded from the contributor count the card title prints. */
+const ROOT_NODE_ID = "root";
+
+/** Where one of a node's sentences landed in the final `description` array.
+ *  Rendered in the node's own meta area, next to the contribution badges. */
+export interface PositionMarker {
+  /** Stable React key within the node (the entry's canonical index). */
+  key: string;
+  /** 1-based position in the final array — every index this app prints is. */
+  position: number;
+  /** Strings in the final array. */
+  total: number;
+  /** 1-based position of the first occurrence, when this entry repeats one. */
+  duplicateOfPosition?: number;
+  /** The engine could only place this string inside the node's SUBTREE. */
+  approximate?: boolean;
+}
+
+/**
+ * `contribution` — a sentence this node wrote that reached the final config.
+ * `dropped` — one Renovate deleted before it could merge, shown struck through
+ * at the node that authored it, which is the only place the drop is visible.
+ * `mute` — the note on the node that CAUSED such drops (`ignoreDeps: []`).
+ */
+export type DescLineKind = "contribution" | "dropped" | "mute";
+
+/** One quote line beneath a node's name row. */
+export interface DescLine {
+  /** Stable React key within the node. */
+  key: string;
+  kind: DescLineKind;
+  /** The sentence itself, backtick-marked (the `CodeText` convention). Empty
+   *  for a `mute` line, which is a fact about the node, not a quotation. */
+  text: string;
+  /** The muted explanation after the text. */
+  note?: string;
+}
+
+export interface NodeDescriptionFacts {
+  markers: PositionMarker[];
+  lines: DescLine[];
+}
+
+export interface TreeDescriptions {
+  /** Only nodes that have something to say — the lookup returns `undefined`
+   *  for every other node, and that is the performance contract. */
+  byNodeId: ReadonlyMap<string, NodeDescriptionFacts>;
+  /** Distinct preset nodes appearing in `entries` (the repo config excluded). */
+  contributorCount: number;
+  /** Strings in the final `description` array. */
+  total: number;
+}
+
+/** The note on an `approximate` entry — the engine's enclosing-node fallback,
+ *  said in the tree's own terms. */
+export const APPROXIMATE_NOTE =
+  "written somewhere inside this preset — the exact one could not be determined";
+
+/**
+ * Inverts a run's description provenance into the per-node index describe mode
+ * renders from, or `null` when no node has a description fact at all (in which
+ * case the mode toggle has nothing to offer and is not shown).
+ */
+export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDescriptions | null {
+  const total = provenance.entries.length;
+  const byNodeId = new Map<string, NodeDescriptionFacts>();
+  const contributors = new Set<string>();
+  /** Drops each node caused below it, keyed by the muting node. */
+  const mutes = new Map<string, number>();
+
+  const factsFor = (nodeId: string): NodeDescriptionFacts => {
+    const existing = byNodeId.get(nodeId);
+    if (existing) {
+      return existing;
+    }
+    const created: NodeDescriptionFacts = { markers: [], lines: [] };
+    byNodeId.set(nodeId, created);
+    return created;
+  };
+
+  for (const entry of provenance.entries) {
+    const node = entry.node;
+    // Strings from a layer with no preset tree (defaults / global / inherited)
+    // have no node to sit on, and the root's own sentences never render a row.
+    if (!node) {
+      continue;
+    }
+    if (node.nodeId !== ROOT_NODE_ID) {
+      contributors.add(node.nodeId);
+    }
+    const facts = factsFor(node.nodeId);
+    facts.markers.push({
+      key: `p${entry.index}`,
+      position: entry.index + 1,
+      total,
+      duplicateOfPosition:
+        entry.duplicateOfIndex === undefined ? undefined : entry.duplicateOfIndex + 1,
+      approximate: entry.approximate,
+    });
+    facts.lines.push({
+      key: `c${entry.index}`,
+      kind: "contribution",
+      text: entry.value,
+      note: entry.approximate ? APPROXIMATE_NOTE : undefined,
+    });
+  }
+
+  for (const [index, drop] of provenance.dropped.entries()) {
+    factsFor(drop.node.nodeId).lines.push({
+      key: `x${index}`,
+      kind: "dropped",
+      text: drop.value,
+      note: droppedNoteText(drop),
+    });
+    // …and the mute button that pressed it, which is a different node and the
+    // one a reader would actually remove.
+    const by = drop.droppedBy;
+    if (by && by.nodeId !== ROOT_NODE_ID) {
+      mutes.set(by.nodeId, (mutes.get(by.nodeId) ?? 0) + 1);
+    }
+  }
+
+  for (const [nodeId, count] of mutes) {
+    factsFor(nodeId).lines.push({ key: "mute", kind: "mute", text: "", note: muteNoteText(count) });
+  }
+
+  return byNodeId.size === 0 ? null : { byNodeId, contributorCount: contributors.size, total };
+}
+
+/** The node's meta marker: `→ #16 of 24`, the tie between a preset and its
+ *  slot in the array the Effective config prints. */
+export function positionMarkerText(marker: PositionMarker): string {
+  const base = `→ #${nf.format(marker.position)} of ${nf.format(marker.total)}`;
+  if (marker.duplicateOfPosition !== undefined) {
+    return `${base} · duplicate`;
+  }
+  return marker.approximate ? `${base} · approx` : base;
+}
+
+/** …and its tooltip. `linked` is whether the marker is the cross-link to the
+ *  blame ledger, which only App-level plumbing can offer. */
+export function positionMarkerTitle(marker: PositionMarker, linked: boolean): string {
+  const cta = linked ? " Show the full array in the Effective config." : "";
+  if (marker.duplicateOfPosition !== undefined) {
+    return `Sentence #${marker.position} of ${marker.total} in the final description array — a repeat of #${marker.duplicateOfPosition}, which Renovate never deduplicates.${cta}`;
+  }
+  if (marker.approximate) {
+    return `Landed at #${marker.position} of ${marker.total} in the final description array, ${APPROXIMATE_NOTE}.${cta}`;
+  }
+  return `Sentence #${marker.position} of ${marker.total} in the final description array.${cta}`;
+}
+
+const DROP_NOTES: Record<"wrapper-preset" | "package-list-preset", string> = {
+  // Both are `getPreset` deletions, i.e. facts about the preset's SHAPE — and
+  // worth saying in the tree, because the two headline presets ARE the shape.
+  "wrapper-preset":
+    "Renovate drops it on merge — wrapper preset (body is only `description` + `extends`)",
+  "package-list-preset":
+    "Renovate drops it on merge — package-name list (body only sets `matchPackageNames`)",
+};
+
+/** Why this node's own sentence never reached the config. Backtick-marked (the
+ *  `CodeText` convention), so option names stay mono. */
+export function droppedNoteText(drop: DroppedDescription): string {
+  if (drop.reason === "ignore-deps-quirk") {
+    const by = drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config";
+    return `muted by ${by} — its empty \`ignoreDeps\` deletes every description it extends`;
+  }
+  return DROP_NOTES[drop.reason];
+}
+
+/** The other half of that story, on the node that pressed the mute button —
+ *  `group:recommended` alone silences a hundred-plus sentences below it. */
+export function muteNoteText(count: number): string {
+  return `mutes ${nf.format(count)} description${count === 1 ? "" : "s"} below (empty \`ignoreDeps\`)`;
+}
+
+/** The card title's count — the reason to reach for describe mode at all. */
+export function describeCountText(tree: TreeDescriptions): string {
+  const count = tree.contributorCount;
+  if (count === 0) {
+    return "none contribute descriptions";
+  }
+  return count === 1
+    ? "1 contributes a description"
+    : `${nf.format(count)} contribute descriptions`;
+}

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -210,11 +210,13 @@ offline (internal presets need no network):
    to "where did my description go".
 4. **Preset tree: descriptions on the node** — a node that wrote (or lost) a
    sentence carries a hover card on its name quoting it, with a position marker
-   for where it landed in the final array (and a struck-through line for a
-   dropped one); the detail panel repeats the same facts as a Description entry
-   in its source details. A hover surface rather than a view mode: the tree
-   already has a tree/table switch, and the rows keep their uniform height for
-   the windowing.
+   for where it landed in the final array; the detail panel repeats the same
+   facts as a Description entry in its source details. A sentence Renovate shed
+   on merge (wrapper / package-list / mute) reads the same, minus the marker —
+   shedding is Renovate working as designed, so the node's own card shows the
+   sentence, not the mechanics, which stay on the ledger's dropped footer. A
+   hover surface rather than a view mode: the tree already has a tree/table
+   switch, and the rows keep their uniform height for the windowing.
 5. **Hover attribution + simulator rule descriptions** — hovering a sentence
    anywhere highlights its node in the tree; the simulator's rule ledger picks up
    `ruleDescriptions` so a matched rule can say what it is for.

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -208,9 +208,13 @@ offline (internal presets need no network):
    stops being an anonymous string array and becomes a per-string ledger with
    the writing preset, duplicates folded, and the `dropped` list as the answer
    to "where did my description go".
-4. **Preset tree: inline descriptions** — each node shows its own sentence, with
-   a position marker for where it landed in the final array (and a struck-through
-   marker for a dropped one).
+4. **Preset tree: descriptions on the node** — a node that wrote (or lost) a
+   sentence carries a hover card on its name quoting it, with a position marker
+   for where it landed in the final array (and a struck-through line for a
+   dropped one); the detail panel repeats the same facts as a Description entry
+   in its source details. A hover surface rather than a view mode: the tree
+   already has a tree/table switch, and the rows keep their uniform height for
+   the windowing.
 5. **Hover attribution + simulator rule descriptions** — hovering a sentence
    anywhere highlights its node in the tree; the simulator's rule ledger picks up
    `ruleDescriptions` so a matched rule can say what it is for.


### PR DESCRIPTION
Layer 4 of the description-provenance stack (roadmap 069).

A node that wrote (or lost) a sentence of the final `description` now says so ON the node:

- The preset **name** of a described row carries a hover card (the shared `hover-card` primitive, hoisted down from the glossary) quoting its sentences with their slot in the final array (`→ #16 of 24 · duplicate · approx`) — plus the jump to the Effective config's blame ledger.
- A sentence Renovate shed on merge (wrapper / package-list / mute presets) reads exactly like the others, minus the slot marker: shedding is Renovate working as designed, so the card shows the preset's own words rather than flagging mechanics; those stay on the blame ledger's dropped footer.
- The **detail panel** repeats the same facts as a Description entry in the source details, internal presets included.

This replaces the earlier compact/describe segmented switch (reworked in-stack after review: the tree already has a tree/table switch, and a second mode beside it controlled a handful of nodes). Rows stay exactly `ROW_HEIGHT`, so the quote-row interleaving is gone; hide-zero still keeps described nodes mounted so their cards stay reachable.