### PR TITLE
feat(app): description attribution at point of contact

### DIFF
--- a/packages/app/src/components/ConfigJson.tsx
+++ b/packages/app/src/components/ConfigJson.tsx
@@ -1,4 +1,6 @@
-import { Fragment, type ReactNode } from "react";
+import { Fragment, type ReactNode, useMemo } from "react";
+import { type DescriptionCard, descriptionCardsFor } from "@/lib/description-attribution";
+import { DescriptionValue } from "./DescriptionAttribution";
 import { OptionKey } from "./option-docs";
 import { useOptionDocs } from "@/hooks/option-docs-hooks";
 
@@ -6,12 +8,40 @@ import { useOptionDocs } from "@/hooks/option-docs-hooks";
  * Pretty-prints a config value exactly like `JSON.stringify(v, null, 2)`, but
  * with every object key rendered as an interactive option (hover docs,
  * unknown-key flagging). Meant to be placed inside a `<pre>`.
+ *
+ * Roadmap 069 (PR 5): the VALUES of one array can be interactive too — the
+ * top-level `description` of a resolved-config document, where each string
+ * gains the hover card naming the preset that wrote it. Only there, and only
+ * when the array positionally matches the attribution (`descriptionCardsFor`):
+ * a preset body's own `description` is a different array, and the As-JSON
+ * view's keep-internal/hydrated documents are different arrays too.
  */
-export function ConfigJson({ value }: { value: unknown }) {
+export function ConfigJson({
+  value,
+  descriptions,
+  onSelectPreset,
+}: {
+  value: unknown;
+  /** Roadmap 069: per-string attribution for the TOP-LEVEL `description` array
+   *  of `value`, in that array's order. Ignored unless it matches (see above);
+   *  omit it and this renders exactly as it always did. */
+  descriptions?: readonly DescriptionCard[] | null;
+  /** The attribution card's "Show in preset tree →". Without it the card still
+   *  renders — it simply names the preset instead of offering the jump. */
+  onSelectPreset?: (nodeId: string) => void;
+}) {
   const { index } = useOptionDocs();
   const containers = index?.containers;
+  const cards = useMemo(() => descriptionCardsFor(value, descriptions), [value, descriptions]);
 
-  function render(v: unknown, indent: number, configContext: boolean): ReactNode {
+  function render(
+    v: unknown,
+    indent: number,
+    configContext: boolean,
+    /** Attribution for THIS array's elements — set only for the top-level
+     *  `description`, so nothing else can pick it up by accident. */
+    attributed?: DescriptionCard[] | null,
+  ): ReactNode {
     if (Array.isArray(v)) {
       if (v.length === 0) {
         return "[]";
@@ -24,15 +54,22 @@ export function ConfigJson({ value }: { value: unknown }) {
       return (
         <>
           {"[\n"}
-          {v.map((item, i) => (
-            // oxlint-disable-next-line react/no-array-index-key -- see above
-            <Fragment key={i}>
-              {pad}
-              {render(item, indent + 1, configContext)}
-              {i < v.length - 1 ? "," : ""}
-              {"\n"}
-            </Fragment>
-          ))}
+          {v.map((item, i) => {
+            const card = attributed?.[i];
+            return (
+              // oxlint-disable-next-line react/no-array-index-key -- see above
+              <Fragment key={i}>
+                {pad}
+                {card ? (
+                  <DescriptionValue card={card} onSelectPreset={onSelectPreset} />
+                ) : (
+                  render(item, indent + 1, configContext)
+                )}
+                {i < v.length - 1 ? "," : ""}
+                {"\n"}
+              </Fragment>
+            );
+          })}
           {"  ".repeat(indent)}]
         </>
       );
@@ -52,7 +89,12 @@ export function ConfigJson({ value }: { value: unknown }) {
               {'"'}
               <OptionKey name={key} flagUnknown={configContext} />
               {'": '}
-              {render(val, indent + 1, containers?.has(key) ?? false)}
+              {render(
+                val,
+                indent + 1,
+                containers?.has(key) ?? false,
+                indent === 0 && key === "description" ? cards : null,
+              )}
               {i < entries.length - 1 ? "," : ""}
               {"\n"}
             </Fragment>

--- a/packages/app/src/components/ConfigJson.tsx
+++ b/packages/app/src/components/ConfigJson.tsx
@@ -1,5 +1,9 @@
 import { Fragment, type ReactNode, useMemo } from "react";
-import { type DescriptionCard, descriptionCardsFor } from "@/lib/description-attribution";
+import {
+  type DescriptionCard,
+  type DescriptionCards,
+  descriptionCardsFor,
+} from "@/lib/description-attribution";
 import { DescriptionValue } from "./DescriptionAttribution";
 import { OptionKey } from "./option-docs";
 import { useOptionDocs } from "@/hooks/option-docs-hooks";
@@ -23,9 +27,9 @@ export function ConfigJson({
 }: {
   value: unknown;
   /** Roadmap 069: per-string attribution for the TOP-LEVEL `description` array
-   *  of `value`, in that array's order. Ignored unless it matches (see above);
-   *  omit it and this renders exactly as it always did. */
-  descriptions?: readonly DescriptionCard[] | null;
+   *  of `value`. Ignored unless it matches (see above); omit it and this
+   *  renders exactly as it always did. */
+  descriptions?: DescriptionCards | null;
   /** The attribution card's "Show in preset tree →". Without it the card still
    *  renders — it simply names the preset instead of offering the jump. */
   onSelectPreset?: (nodeId: string) => void;
@@ -38,9 +42,11 @@ export function ConfigJson({
     v: unknown,
     indent: number,
     configContext: boolean,
-    /** Attribution for THIS array's elements — set only for the top-level
-     *  `description`, so nothing else can pick it up by accident. */
-    attributed?: readonly DescriptionCard[] | null,
+    /** Attribution for THIS array's elements, indexed the way the array is —
+     *  set only for the top-level `description`, so nothing else can pick it up
+     *  by accident, and holed at every member no preset wrote (a non-string,
+     *  which renders as plain JSON like any other value). */
+    attributed?: readonly (DescriptionCard | undefined)[] | null,
   ): ReactNode {
     if (Array.isArray(v)) {
       if (v.length === 0) {

--- a/packages/app/src/components/ConfigJson.tsx
+++ b/packages/app/src/components/ConfigJson.tsx
@@ -40,7 +40,7 @@ export function ConfigJson({
     configContext: boolean,
     /** Attribution for THIS array's elements — set only for the top-level
      *  `description`, so nothing else can pick it up by accident. */
-    attributed?: DescriptionCard[] | null,
+    attributed?: readonly DescriptionCard[] | null,
   ): ReactNode {
     if (Array.isArray(v)) {
       if (v.length === 0) {

--- a/packages/app/src/components/DescriptionAttribution.test.tsx
+++ b/packages/app/src/components/DescriptionAttribution.test.tsx
@@ -1,0 +1,41 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { DescriptionCard } from "@/lib/description-attribution";
+import { DescriptionValue } from "./DescriptionAttribution";
+
+/**
+ * Roadmap 069 review — the jump takes its own card with it.
+ *
+ * A pointer-opened card never held focus, so no blur closes it; the jump
+ * switches tabs, and the portalled card outlived the view it was explaining,
+ * fixed at its old coordinates over the preset tree.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+const CARD: DescriptionCard = {
+  index: 0,
+  value: "Use the recommended config",
+  layer: { kind: "preset", nodeId: "node-1", name: "config:recommended" },
+  path: ["config:recommended"],
+  position: 1,
+  total: 1,
+  nodeId: "node-1",
+};
+
+it("closes the card when its tree jump is taken", () => {
+  const onSelectPreset = vi.fn();
+  const { getByText } = render(<DescriptionValue card={CARD} onSelectPreset={onSelectPreset} />);
+
+  // Opened by POINTER, which is the case with nothing else to close it — the
+  // hover gate (roadmap 025) wants the move, not just the enter.
+  const anchor = getByText(JSON.stringify(CARD.value));
+  fireEvent.mouseEnter(anchor);
+  fireEvent.mouseMove(anchor);
+  expect(document.querySelector(".desc-attr-card")).not.toBeNull();
+
+  fireEvent.click(getByText("Show in preset tree →"));
+  expect(onSelectPreset).toHaveBeenCalledWith("node-1");
+  expect(document.querySelector(".desc-attr-card")).toBeNull();
+});

--- a/packages/app/src/components/DescriptionAttribution.tsx
+++ b/packages/app/src/components/DescriptionAttribution.tsx
@@ -1,0 +1,93 @@
+import {
+  cardPathText,
+  cardPositionText,
+  type DescriptionCard,
+  WROTE_THIS,
+} from "@/lib/description-attribution";
+import { APPROXIMATE_NOTE } from "@/lib/tree-descriptions";
+import { HoverCardAnchor } from "./hover-card";
+import { layerClass, layerLabel } from "./provenance-layer";
+
+/**
+ * Roadmap 069 (PR 5): the attribution card on a `description` string, and the
+ * string that anchors it.
+ *
+ * The card is the app's standard hover card (`HoverCardAnchor` — one open at a
+ * time, focus-reachable, Escape-dismissible), carrying the three facts the
+ * blame ledger prints in three columns: who wrote the sentence, the `extends`
+ * path it arrived by, and where it landed in the array.
+ *
+ * The preset chip here is deliberately NOT a `ProvenanceChip`: that chip opens a
+ * glossary card of its own, and the single-card singleton means opening it
+ * closes the card it is standing in — taking itself with it. So the chip is
+ * static (same class, same hue, no affordance) and the jump it would have
+ * offered is the explicit link at the bottom instead.
+ */
+
+function AttributionCard({
+  card,
+  onSelectPreset,
+}: {
+  card: DescriptionCard;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  const path = cardPathText(card);
+  // Hoisted out of the JSX: read inside the click closure, `card.nodeId`
+  // re-widens to `string | undefined`.
+  const nodeId = card.nodeId;
+  return (
+    <>
+      <div className="option-card-head">
+        <span className={`badge prov-layer ${layerClass(card.layer)}`}>
+          {layerLabel(card.layer)}
+        </span>
+        <span className="desc-attr-head">{WROTE_THIS}</span>
+      </div>
+      {path ? <p className="desc-attr-path">{path}</p> : null}
+      <p className="option-card-row">{cardPositionText(card)}</p>
+      {card.approximate ? <p className="option-card-row">{APPROXIMATE_NOTE}</p> : null}
+      {nodeId && onSelectPreset ? (
+        <p className="option-card-row">
+          <button type="button" className="linklike" onClick={() => onSelectPreset(nodeId)}>
+            Show in preset tree →
+          </button>
+        </p>
+      ) : null}
+    </>
+  );
+}
+
+/** The card's preferred width and flip margin — wider than a glossary card
+ *  because the import path is one mono line that should not wrap twice. */
+const CARD_WIDTH = 360;
+const CARD_FLIP_MARGIN = 220;
+
+/**
+ * One string of a rendered `description` array: the JSON literal exactly as
+ * `ConfigJson` would have printed it, plus the hover/focus affordance. Keyboard
+ * reachable, so the attribution is not pointer-only — the card's own jump link
+ * is (it lives in a portal), which is why the link is an extra rather than the
+ * only way to the same node.
+ */
+export function DescriptionValue({
+  card,
+  onSelectPreset,
+}: {
+  card: DescriptionCard;
+  onSelectPreset?: (nodeId: string) => void;
+}) {
+  return (
+    <HoverCardAnchor
+      className="desc-attr-card"
+      width={CARD_WIDTH}
+      flipMargin={CARD_FLIP_MARGIN}
+      card={<AttributionCard card={card} onSelectPreset={onSelectPreset} />}
+    >
+      {(handlers) => (
+        <span className="json-desc" tabIndex={0} {...handlers}>
+          {JSON.stringify(card.value)}
+        </span>
+      )}
+    </HoverCardAnchor>
+  );
+}

--- a/packages/app/src/components/DescriptionAttribution.tsx
+++ b/packages/app/src/components/DescriptionAttribution.tsx
@@ -1,3 +1,4 @@
+import { useHoverCardClose } from "@/hooks/hover-card";
 import {
   cardPathText,
   cardPositionText,
@@ -35,6 +36,12 @@ function AttributionCard({
   // Hoisted out of the JSX: read inside the click closure, `card.nodeId`
   // re-widens to `string | undefined`.
   const nodeId = card.nodeId;
+  // The jump switches tabs, so the card must go with it. Nothing else would
+  // take it: opened by pointer it never held focus, so there is no blur, and
+  // the portalled card would sit at its old viewport coordinates over the
+  // preset tree until the pointer left its box or the reader pressed Escape —
+  // pointing, by then, at a sentence that is no longer under it.
+  const closeCard = useHoverCardClose();
   return (
     <>
       <div className="option-card-head">
@@ -48,7 +55,14 @@ function AttributionCard({
       {card.approximate ? <p className="option-card-row">{APPROXIMATE_NOTE}</p> : null}
       {nodeId && onSelectPreset ? (
         <p className="option-card-row">
-          <button type="button" className="linklike" onClick={() => onSelectPreset(nodeId)}>
+          <button
+            type="button"
+            className="linklike"
+            onClick={() => {
+              closeCard();
+              onSelectPreset(nodeId);
+            }}
+          >
             Show in preset tree →
           </button>
         </p>

--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -282,5 +282,4 @@ it("attributes the description strings of the As-JSON document", async () => {
   expect(repoCard?.textContent).toContain("repo config");
   expect(repoCard?.querySelector(".desc-attr-path")).toBeNull();
   expect(repoCard?.textContent).not.toContain("Show in preset tree");
->>>>>>> 54fe338 (feat(app): description attribution at point of contact)
 });

--- a/packages/app/src/components/EffectiveConfig.test.tsx
+++ b/packages/app/src/components/EffectiveConfig.test.tsx
@@ -218,3 +218,69 @@ it("clears the other filters when the digest card lands on the description row",
   expect((layerSelect as HTMLSelectElement).value).toBe("all");
   expect((onlyOverridden as HTMLInputElement).checked).toBe(false);
 });
+
+/**
+ * Roadmap 069 (PR 5): the same attribution at the point of contact — the
+ * As-JSON document's `description` strings. The model and its wording are unit
+ * tested (lib/description-attribution.test.ts); what this covers is the wiring
+ * plus the one thing no unit test can: that the POSITIONAL GUARD is really what
+ * decides, so the keep-internal document (whose array is not the attributed
+ * one) stays plain while the fully expanded one gains the cards.
+ */
+it("attributes the description strings of the As-JSON document", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({
+      extends: [":dependencyDashboard"],
+      description: "My own summary.",
+    }),
+  });
+
+  const onSelectPreset = vi.fn();
+  const view = render(<EffectiveConfig result={result} onSelectPreset={onSelectPreset} />);
+  await waitFor(() => expect(view.getByRole("radio", { name: "As JSON" })).toBeTruthy());
+  fireEvent.click(view.getByRole("radio", { name: "As JSON" }));
+  await waitFor(() => expect(view.container.querySelector(".config-view")).toBeTruthy());
+
+  // Default mode keeps `:dependencyDashboard` as an `extends` reference, so the
+  // document's `description` is NOT the array the attribution indexes — no
+  // cards at all rather than cards naming the wrong preset.
+  expect(view.container.querySelectorAll(".json-desc")).toHaveLength(0);
+
+  fireEvent.change(view.getByLabelText("Expand presets:"), { target: { value: "full" } });
+  await waitFor(() => expect(view.container.querySelectorAll(".json-desc")).toHaveLength(2));
+
+  // The preset's sentence comes first (own body merges last), and its card
+  // names the preset, the path it arrived by and its slot in the array.
+  const strings = [...view.container.querySelectorAll<HTMLElement>(".json-desc")];
+  const preset = strings[0];
+  if (!preset) {
+    throw new Error("expected the preset's own sentence to be attributed");
+  }
+  fireEvent.focus(preset);
+  const card = document.querySelector<HTMLElement>(".desc-attr-card");
+  if (!card) {
+    throw new Error("focusing an attributed string opened no card");
+  }
+  expect(card.textContent).toContain("wrote this description");
+  expect(card.querySelector(".desc-attr-path")?.textContent).toBe(
+    "(input config) › :dependencyDashboard",
+  );
+  expect(card.textContent).toContain("Position 1 of 2");
+
+  // …and its jump is the same tree selection every other chip in this view offers.
+  fireEvent.click(within(card).getByText("Show in preset tree →"));
+  expect(onSelectPreset).toHaveBeenCalledTimes(1);
+
+  // The reader's own sentence is not a preset: repo chip, no path, no jump.
+  const own = strings[1];
+  if (!own) {
+    throw new Error("expected the repo's own sentence to be attributed");
+  }
+  fireEvent.focus(own);
+  const repoCard = document.querySelector<HTMLElement>(".desc-attr-card");
+  expect(repoCard?.textContent).toContain("repo config");
+  expect(repoCard?.querySelector(".desc-attr-path")).toBeNull();
+  expect(repoCard?.textContent).not.toContain("Show in preset tree");
+>>>>>>> 54fe338 (feat(app): description attribution at point of contact)
+});

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -25,7 +25,7 @@ import { ProvenanceChip } from "./ProvenanceChip";
 import { layerId, layerLabel, type LayerId, layerNodeKey } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
 import { useDescriptionProvenance } from "@/hooks/description-provenance";
-import { buildDescriptionCards, type DescriptionCard } from "@/lib/description-attribution";
+import { buildDescriptionCards, type DescriptionCards } from "@/lib/description-attribution";
 import {
   buildDescriptionLedger,
   type DescriptionLedger,
@@ -679,7 +679,7 @@ function ResolvedJsonView({
   /** Roadmap 069 (PR 5): per-string `description` attribution, attached to the
    *  document's own strings when this document IS the array it indexes — which
    *  `ConfigJson` decides, since only the emitted document can answer that. */
-  descriptions?: readonly DescriptionCard[] | null;
+  descriptions?: DescriptionCards | null;
   onSelectPreset?: (nodeId: string) => void;
 }) {
   return (

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -25,6 +25,7 @@ import { ProvenanceChip } from "./ProvenanceChip";
 import { layerId, layerLabel, type LayerId, layerNodeKey } from "./provenance-layer";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
 import { useDescriptionProvenance } from "@/hooks/description-provenance";
+import { buildDescriptionCards, type DescriptionCard } from "@/lib/description-attribution";
 import {
   buildDescriptionLedger,
   type DescriptionLedger,
@@ -666,6 +667,8 @@ function ResolvedJsonView({
   includeDefaults,
   onIncludeDefaultsChange,
   defaultsCount,
+  descriptions,
+  onSelectPreset,
 }: {
   output: ResolvedConfigOutput | null | undefined;
   expand: ResolvedConfigMode;
@@ -673,6 +676,11 @@ function ResolvedJsonView({
   includeDefaults: boolean;
   onIncludeDefaultsChange: (checked: boolean) => void;
   defaultsCount: number;
+  /** Roadmap 069 (PR 5): per-string `description` attribution, attached to the
+   *  document's own strings when this document IS the array it indexes — which
+   *  `ConfigJson` decides, since only the emitted document can answer that. */
+  descriptions?: readonly DescriptionCard[] | null;
+  onSelectPreset?: (nodeId: string) => void;
 }) {
   return (
     <>
@@ -692,7 +700,11 @@ function ResolvedJsonView({
       ) : null}
       {output ? (
         <pre className="config-view">
-          <ConfigJson value={output.config} />
+          <ConfigJson
+            value={output.config}
+            descriptions={descriptions}
+            onSelectPreset={onSelectPreset}
+          />
         </pre>
       ) : null}
       {output && output.divergingKeys.length > 0 ? (
@@ -743,6 +755,16 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   const ledger = useMemo(
     () => (descriptionProvenance ? buildDescriptionLedger(descriptionProvenance) : null),
     [descriptionProvenance],
+  );
+  // Roadmap 069 (PR 5): the same walk again, read the other way round — one
+  // card per string for the As-JSON document, where the sentences are already
+  // on screen and the attribution has nowhere else to live.
+  const descriptionCards = useMemo(
+    () =>
+      descriptionProvenance
+        ? buildDescriptionCards(descriptionProvenance, result.presetTree)
+        : null,
+    [descriptionProvenance, result.presetTree],
   );
   const filterInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
@@ -900,6 +922,8 @@ export const EffectiveConfig = memo(function EffectiveConfig({
           includeDefaults={includeDefaults}
           onIncludeDefaultsChange={setIncludeDefaults}
           defaultsCount={hiddenDefaults}
+          descriptions={descriptionCards}
+          onSelectPreset={onSelectPreset}
         />
       ) : null}
       {provenance !== undefined && view === "keys" ? (

--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -756,16 +756,6 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     () => (descriptionProvenance ? buildDescriptionLedger(descriptionProvenance) : null),
     [descriptionProvenance],
   );
-  // Roadmap 069 (PR 5): the same walk again, read the other way round — one
-  // card per string for the As-JSON document, where the sentences are already
-  // on screen and the attribution has nowhere else to live.
-  const descriptionCards = useMemo(
-    () =>
-      descriptionProvenance
-        ? buildDescriptionCards(descriptionProvenance, result.presetTree)
-        : null,
-    [descriptionProvenance, result.presetTree],
-  );
   const filterInputRef = useRef<HTMLInputElement>(null);
   const [query, setQuery] = useState("");
   const [layerFilter, setLayerFilter] = useState<LayerFilterValue>("all");
@@ -776,6 +766,17 @@ export const EffectiveConfig = memo(function EffectiveConfig({
   const [view, setView] = useState<EffectiveView>("keys");
   const [expand, setExpand] = useState<ResolvedConfigMode>("keep-internal");
   const [includeDefaults, setIncludeDefaults] = useState(false);
+  // Roadmap 069 (PR 5): the same walk again, read the other way round — one
+  // card per string for the As-JSON document, where the sentences are already
+  // on screen and the attribution has nowhere else to live. Gated on the view
+  // like `resolvedOutput` below: derived only once the reader opens As-JSON.
+  const descriptionCards = useMemo(
+    () =>
+      descriptionProvenance && view === "json"
+        ? buildDescriptionCards(descriptionProvenance, result.presetTree)
+        : null,
+    [descriptionProvenance, result.presetTree, view],
+  );
   const resolvedOutput = useResolvedConfig(
     result,
     provenance !== undefined && view === "json",

--- a/packages/app/src/features/simulator/RuleDescriptionQuote.tsx
+++ b/packages/app/src/features/simulator/RuleDescriptionQuote.tsx
@@ -1,0 +1,28 @@
+import { CodeText } from "@/components/CodeText";
+import type { RuleDescriptionNote } from "./rule-descriptions";
+
+/**
+ * Roadmap 069 (PR 5): a matched rule's own description, quoted where the rule
+ * is shown — the left-bordered quote of the 069 mockup, then a muted line
+ * naming whose words they are.
+ *
+ * Only for rules that HAVE one, and only on rows that MATCHED: on a no-match
+ * row the sentence explains a rule that did nothing, which is noise in a list
+ * the reader is scanning for the one that did.
+ */
+export function RuleDescriptionQuote({ note }: { note: RuleDescriptionNote }) {
+  return (
+    <div className="sim-rule-why">
+      {note.values.map((value, i) => (
+        // Roadmap 041 — index key, deliberately: these are the strings of ONE
+        // immutable rule body in their own order, they can legally repeat, and
+        // nothing ever inserts into or reorders the list.
+        // oxlint-disable-next-line react/no-array-index-key -- see above
+        <p key={i} className="sim-rule-why-line">
+          <CodeText text={value} />
+        </p>
+      ))}
+      <p className="sim-rule-why-attr">— {note.attribution}</p>
+    </div>
+  );
+}

--- a/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.test.tsx
@@ -105,6 +105,35 @@ describe("RuleEvidenceCard", () => {
   // Layer 7 — the two affordances the popover lost by not being the matched-
   // rules drawer: every written key is an option-docs hook, and the digest is
   // exportable as markdown like the drawer's applied diff always was.
+  // Roadmap 069 (PR 5): the rule says what it is FOR, above the clause
+  // evidence — the mockup's quote plus its muted attribution line.
+  it("quotes the rule author's description when the rule has one", () => {
+    const described: RuleEvidence = {
+      ...EVIDENCE,
+      description: {
+        ruleIndex: 201,
+        values: ["Wait until the npm package is three days old.", "Malware researchers need time."],
+        attribution: "author's description of this rule",
+      },
+    };
+    const view = render(<RuleEvidenceAnchor ruleIndex={201} evidenceFor={() => described} />);
+    act(() => {
+      fireEvent.click(view.getByRole("button", { name: "packageRules[201]" }));
+    });
+
+    const quote = document.querySelector(".sim-rule-why");
+    // Each string is its own line: they are separate sentences, not one split.
+    expect(quote?.querySelectorAll(".sim-rule-why-line")).toHaveLength(2);
+    expect(quote?.textContent).toContain("Wait until the npm package is three days old.");
+    expect(quote?.querySelector(".sim-rule-why-attr")?.textContent).toBe(
+      "— author's description of this rule",
+    );
+    // The undescribed rule of every other test renders no quote chrome at all.
+    cleanup();
+    open();
+    expect(document.querySelector(".sim-rule-why")).toBeNull();
+  });
+
   it("gives every written key the option-docs hook and offers the markdown export", () => {
     const { view } = open();
     const dialog = view.getByRole("dialog", { name: "packageRules[201] — rule evidence" });

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -8,6 +8,7 @@ import { ESCAPE_PRIORITY, modalKeyboardOwned } from "@/lib/escape-stack";
 import { tookFocus } from "@/lib/focus-restore";
 import { useEscapeLayer } from "@/hooks/use-escape-layer";
 import { ClauseGrid } from "./ClauseGrid";
+import { RuleDescriptionQuote } from "./RuleDescriptionQuote";
 import { RULE_POP_CLASS, RULE_POP_SELECTOR } from "./rule-pop-dom";
 import { ruleAppliedMarkdown, ruleVerdictLabel, writeMark } from "./rule-format";
 import type { RuleEvidence, RuleWrite } from "./rule-evidence";
@@ -166,6 +167,9 @@ function RuleEvidenceBody({
   return (
     <>
       <RuleEvidenceHead evidence={evidence} onSelectPreset={onSelectPreset} />
+      {/* Roadmap 069 (PR 5): above the clause evidence, because "what this rule
+          is for" is the frame the clauses below are read in. */}
+      {evidence.description ? <RuleDescriptionQuote note={evidence.description} /> : null}
       {evidence.clauses.length > 0 ? <ClauseGrid clauses={evidence.clauses} /> : null}
       <RuleEvidenceSummary evidence={evidence} />
       <div className="kv sim-writes">

--- a/packages/app/src/features/simulator/RuleRow.test.tsx
+++ b/packages/app/src/features/simulator/RuleRow.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { RuleEvaluation } from "@renovate-config-debugger/engine";
+import type { RuleDescriptionNote } from "./rule-descriptions";
+import { RuleRow } from "./RuleRow";
+
+/**
+ * Roadmap 069 (PR 5): the matched-rules drawer's half of "the rule explains why
+ * it exists". The wording is unit tested (`rule-descriptions.test.ts`); what a
+ * row decides is WHERE the quote goes and WHETHER it appears at all — outside
+ * the head button (prose in a button is neither selectable nor announced as
+ * prose) and only on a row that matched.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+const NOTE: RuleDescriptionNote = {
+  ruleIndex: 3,
+  values: ["Pin Docker digests."],
+  attribution: "author's description of this rule",
+};
+
+function rule(verdict: RuleEvaluation["verdict"]): RuleEvaluation {
+  return { index: 3, verdict, clauses: [], notes: [] };
+}
+
+describe("RuleRow", () => {
+  it("quotes a matched rule's description outside the collapsed head", () => {
+    const view = render(<RuleRow rule={rule("matched")} description={NOTE} />);
+    const quote = view.container.querySelector(".sim-rule-why");
+    expect(quote?.textContent).toContain("Pin Docker digests.");
+    expect(quote?.textContent).toContain("— author's description of this rule");
+    // Visible with the row still collapsed, and not inside its toggle.
+    expect(view.container.querySelector(".sim-rule-detail")).toBeNull();
+    expect(view.container.querySelector(".sim-rule-head .sim-rule-why")).toBeNull();
+  });
+
+  it("says nothing on a row that did not match, described or not", () => {
+    const view = render(<RuleRow rule={rule("no-match")} description={NOTE} />);
+    expect(view.container.querySelector(".sim-rule-why")).toBeNull();
+  });
+
+  it("adds no quote chrome to an undescribed rule", () => {
+    const view = render(<RuleRow rule={rule("matched")} />);
+    expect(view.container.querySelector(".sim-rule-why")).toBeNull();
+  });
+});

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -6,6 +6,8 @@ import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { GLOSSARY } from "@/data/glossary-data";
 import { isNoInputNoMatch } from "@/lib/rule-verdict";
 import { ClauseGrid } from "./ClauseGrid";
+import type { RuleDescriptionNote } from "./rule-descriptions";
+import { RuleDescriptionQuote } from "./RuleDescriptionQuote";
 import { ruleAppliedMarkdown, ruleLabel, ruleVerdictLabel, writeMark } from "./rule-format";
 import { WriteRow } from "./WriteRow";
 
@@ -65,11 +67,15 @@ function RuleVerdictBadge({ rule }: { rule: RuleEvaluation }) {
 export function RuleRow({
   rule,
   layer,
+  description,
   onSelectPreset,
   defaultExpanded = false,
 }: {
   rule: RuleEvaluation;
   layer?: ProvenanceLayer;
+  /** Roadmap 069 (PR 5): the rule author's own description, when the rule has
+   *  one. Quoted only on a MATCHED row — see `RuleDescriptionQuote`. */
+  description?: RuleDescriptionNote;
   onSelectPreset?: (nodeId: string) => void;
   /** Roadmap 023: the "my rules only" filter pre-expands its rows' clause evidence. */
   defaultExpanded?: boolean;
@@ -77,6 +83,7 @@ export function RuleRow({
   const [expanded, setExpanded] = useState(defaultExpanded);
   // Re-sync when the filter toggles (re-expand my-rules rows, collapse otherwise).
   useEffect(() => setExpanded(defaultExpanded), [defaultExpanded]);
+  const quote = rule.verdict === "matched" ? description : undefined;
   return (
     // Roadmap 068: a cross-link lands ON this row (`landOnTarget`), so it has
     // to be able to hold focus — the flash marks it for the eye, the focus
@@ -111,6 +118,11 @@ export function RuleRow({
           </span>
         ) : null}
       </button>
+      {/* Outside the head button, and always visible: the sentence is the
+          answer to "why does this rule exist", so it must not be behind the
+          same disclosure as the clause evidence — and prose inside a button is
+          neither selectable nor announced as prose. */}
+      {quote ? <RuleDescriptionQuote note={quote} /> : null}
       {expanded ? (
         <div className="sim-rule-detail">
           {rule.clauses.length === 0 ? (

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -3,6 +3,7 @@ import type { TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
 import { RuleFramingText } from "@/components/rule-framing";
+import { useDescriptionProvenance } from "@/hooks/description-provenance";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
 import { ruleLayerIndex } from "@/lib/rule-filters";
 import type { ShareSimulator } from "@/lib/share";
@@ -13,6 +14,7 @@ import { SIM_FORM_ID } from "./datalist-ids";
 import { EMPTY_FORM, type FormState, hasMeaningfulInput } from "./form";
 import { buildMergeStops } from "./merge-stops";
 import { ReturnPill } from "./ReturnPill";
+import { buildRuleDescriptions } from "./rule-descriptions";
 import { buildRuleEvidence } from "./rule-evidence";
 import { SimMergeDrawer } from "./SimMergeDrawer";
 import { SimMessages } from "./SimMessages";
@@ -108,6 +110,14 @@ export const RuleSimulator = memo(function RuleSimulator({
   onMergeStepChange?: (index: number) => void;
 }) {
   const ruleAttribution = useRuleProvenance(result);
+  // Roadmap 069 (PR 5): the author's description of every described rule, from
+  // the same per-run walk the Overview digest and the blame ledger read (the
+  // hook caches it per result, so this is a third consumer, not a third walk).
+  const descriptionProvenance = useDescriptionProvenance(result);
+  const ruleDescriptions = useMemo(
+    () => buildRuleDescriptions(descriptionProvenance),
+    [descriptionProvenance],
+  );
   const engineModule = useEngineModule();
   const {
     form,
@@ -299,8 +309,9 @@ export const RuleSimulator = memo(function RuleSimulator({
   // a run can have hundreds of rules, so deriving every rule's evidence up
   // front would be work for a card nobody opens.
   const evidenceFor = useCallback(
-    (ruleIndex: number) => buildRuleEvidence(ruleIndex, mergeStops, layerByIndex, sim),
-    [mergeStops, layerByIndex, sim],
+    (ruleIndex: number) =>
+      buildRuleEvidence(ruleIndex, mergeStops, layerByIndex, sim, ruleDescriptions),
+    [mergeStops, layerByIndex, sim, ruleDescriptions],
   );
 
   if (!finalConfig) {
@@ -575,6 +586,7 @@ export const RuleSimulator = memo(function RuleSimulator({
               filters={ruleFilters}
               onFiltersChange={setRuleFilters}
               layerByIndex={layerByIndex}
+              descriptionByIndex={ruleDescriptions}
               onSelectPreset={onSelectPreset}
               open={rulesOpen}
               onToggle={setRulesOpen}

--- a/packages/app/src/features/simulator/SimRulesBody.tsx
+++ b/packages/app/src/features/simulator/SimRulesBody.tsx
@@ -12,6 +12,7 @@ import {
   verdictFilterOptions,
 } from "@/lib/rule-filters";
 import { openPickerOnEnter } from "@/lib/select-picker";
+import type { RuleDescriptionNote } from "./rule-descriptions";
 import { RuleRow } from "./RuleRow";
 
 function optionLabel(option: FilterOption): string {
@@ -139,6 +140,7 @@ export function SimRulesBody({
   filters,
   onFiltersChange,
   layerByIndex,
+  descriptionByIndex,
   onSelectPreset,
 }: {
   rules: RuleEvaluation[];
@@ -146,6 +148,8 @@ export function SimRulesBody({
   filters: RuleFilters;
   onFiltersChange: (filters: RuleFilters) => void;
   layerByIndex: Map<number, ProvenanceLayer>;
+  /** Roadmap 069 (PR 5): the author's description of each described rule. */
+  descriptionByIndex?: ReadonlyMap<number, RuleDescriptionNote>;
   onSelectPreset?: (nodeId: string) => void;
 }) {
   return (
@@ -165,6 +169,7 @@ export function SimRulesBody({
               key={rule.index}
               rule={rule}
               layer={layerByIndex.get(rule.index)}
+              description={descriptionByIndex?.get(rule.index)}
               onSelectPreset={onSelectPreset}
               // Roadmap 023: narrowing to the user's OWN rules is the "where is
               // my rule?" move — those few rows open with their clause evidence

--- a/packages/app/src/features/simulator/SimRulesDrawer.tsx
+++ b/packages/app/src/features/simulator/SimRulesDrawer.tsx
@@ -5,6 +5,7 @@ import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { SummaryDrawer } from "./SummaryDrawer";
 import { type LayerMatchCount, matchedLayerCounts } from "./layer-counts";
 import { filterRules, type RuleFilters } from "@/lib/rule-filters";
+import type { RuleDescriptionNote } from "./rule-descriptions";
 import { SimRulesBody } from "./SimRulesBody";
 
 /** How many distinct provenance layers the rules drawer names before it
@@ -63,6 +64,7 @@ export const SimRulesDrawer = memo(function SimRulesDrawer({
   filters,
   onFiltersChange,
   layerByIndex,
+  descriptionByIndex,
   onSelectPreset,
   open,
   onToggle,
@@ -73,6 +75,8 @@ export const SimRulesDrawer = memo(function SimRulesDrawer({
   filters: RuleFilters;
   onFiltersChange: (filters: RuleFilters) => void;
   layerByIndex: Map<number, ProvenanceLayer>;
+  /** Roadmap 069 (PR 5): the author's description of each described rule. */
+  descriptionByIndex?: ReadonlyMap<number, RuleDescriptionNote>;
   onSelectPreset?: (nodeId: string) => void;
   open: boolean;
   onToggle: (open: boolean) => void;
@@ -100,6 +104,7 @@ export const SimRulesDrawer = memo(function SimRulesDrawer({
         filters={filters}
         onFiltersChange={onFiltersChange}
         layerByIndex={layerByIndex}
+        descriptionByIndex={descriptionByIndex}
         onSelectPreset={onSelectPreset}
       />
     </SummaryDrawer>

--- a/packages/app/src/features/simulator/rule-descriptions.test.ts
+++ b/packages/app/src/features/simulator/rule-descriptions.test.ts
@@ -26,7 +26,14 @@ function attribution(parts: Partial<RuleDescriptionAttribution>): RuleDescriptio
 }
 
 function provenance(ruleDescriptions: RuleDescriptionAttribution[]): DescriptionProvenance {
-  return { entries: [], dropped: [], ruleDescriptions, degraded: false };
+  return {
+    entries: [],
+    unattributed: [],
+    finalLength: 0,
+    dropped: [],
+    ruleDescriptions,
+    degraded: false,
+  };
 }
 
 describe("ruleDescriptionAttribution", () => {

--- a/packages/app/src/features/simulator/rule-descriptions.test.ts
+++ b/packages/app/src/features/simulator/rule-descriptions.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DescriptionProvenance,
+  ProvenanceLayer,
+  RuleDescriptionAttribution,
+} from "@renovate-config-debugger/engine";
+import { buildRuleDescriptions, ruleDescriptionAttribution } from "./rule-descriptions";
+
+/**
+ * Roadmap 069 (PR 5): the wording of the quote's attribution line, and the
+ * index it is built from. The engine (PR 1) proves that a described rule is
+ * attributed to the right LAYER; what matters here is that the line says the
+ * right thing about each of them — above all that the reader's own rule is
+ * cited by the index it has in THEIR config, not by the merged index.
+ */
+
+const PRESET: ProvenanceLayer = {
+  kind: "preset",
+  nodeId: "p2",
+  name: "security:minimumReleaseAgeNpm",
+};
+const REPO: ProvenanceLayer = { kind: "repo" };
+
+function attribution(parts: Partial<RuleDescriptionAttribution>): RuleDescriptionAttribution {
+  return { ruleIndex: 0, sourceIndex: 0, layer: PRESET, values: ["Because."], ...parts };
+}
+
+function provenance(ruleDescriptions: RuleDescriptionAttribution[]): DescriptionProvenance {
+  return { entries: [], dropped: [], ruleDescriptions, degraded: false };
+}
+
+describe("ruleDescriptionAttribution", () => {
+  test("a preset rule's line names no one — the row's chip already does", () => {
+    expect(ruleDescriptionAttribution(attribution({}))).toBe("author's description of this rule");
+  });
+
+  test("the reader's own rule is cited by its index in their config", () => {
+    // `packageRules[312]` is the merged index the row prints; `packageRules[0]`
+    // is the one they can find in the editor, and that is the citation.
+    expect(
+      ruleDescriptionAttribution(attribution({ ruleIndex: 312, sourceIndex: 0, layer: REPO })),
+    ).toBe("your description, packageRules[0] in your repo config");
+  });
+
+  test("a layer with no author names the level instead", () => {
+    expect(ruleDescriptionAttribution(attribution({ layer: { kind: "inherited" } }))).toBe(
+      "description from the inherited config",
+    );
+  });
+});
+
+describe("buildRuleDescriptions", () => {
+  test("indexes by the MERGED rule index — the id every simulator row carries", () => {
+    const byIndex = buildRuleDescriptions(
+      provenance([
+        attribution({
+          ruleIndex: 312,
+          sourceIndex: 4,
+          values: ["accounts monorepo", "Group packages from accounts monorepo together."],
+        }),
+      ]),
+    );
+
+    expect([...byIndex.keys()]).toEqual([312]);
+    // Both strings survive as separate lines: they are separate sentences, not
+    // one sentence split, and the quote renders one per line.
+    expect(byIndex.get(312)?.values).toEqual([
+      "accounts monorepo",
+      "Group packages from accounts monorepo together.",
+    ]);
+    expect(byIndex.get(312)?.attribution).toBe("author's description of this rule");
+  });
+
+  test("is empty when the run has no attribution at all", () => {
+    expect(buildRuleDescriptions(null).size).toBe(0);
+    expect(buildRuleDescriptions(undefined).size).toBe(0);
+  });
+
+  test("skips an entry with no strings — no empty quote chrome", () => {
+    expect(buildRuleDescriptions(provenance([attribution({ values: [] })])).size).toBe(0);
+  });
+});

--- a/packages/app/src/features/simulator/rule-descriptions.ts
+++ b/packages/app/src/features/simulator/rule-descriptions.ts
@@ -1,0 +1,81 @@
+import type {
+  DescriptionProvenance,
+  RuleDescriptionAttribution,
+} from "@renovate-config-debugger/engine";
+import { layerLabel } from "@/components/provenance-layer";
+
+/**
+ * Roadmap 069 (PR 5): the author's own words on a matched `packageRules` entry.
+ *
+ * Every serious preset rule carries a `description` its author wrote —
+ * "Wait until the npm package is three days old before raising the update…" —
+ * and Renovate keeps it on the rule body (nested descriptions are never hoisted
+ * to the top level, 069 PR 1). The simulator already says WHICH rule fired and
+ * WHAT it set; this is the missing half: why it exists at all. "Why is my
+ * update delayed 14 days" stops being a merge trace and becomes a sentence.
+ *
+ * The attribution comes from the engine's `ruleDescriptions`, which joins
+ * `computeRuleProvenance` (which layer contributed each merged rule, and that
+ * layer's own index for it) with the rule body's own description. Its
+ * granularity is the LAYER, not the exact preset node — which is all this
+ * wording needs, because the row already wears the layer's chip: the quote only
+ * has to say whose voice it is, and for the reader's own rules, which of their
+ * rules it was.
+ *
+ * Pure and DOM-free, so the wording is unit-testable and the components only
+ * decide where the quote sits.
+ */
+
+/** One matched rule's description, ready to render. */
+export interface RuleDescriptionNote {
+  /** Index into the final merged `packageRules` array — the row's own id. */
+  ruleIndex: number;
+  /** The rule's description strings, in order. Multi-string descriptions are
+   *  common (`["accounts monorepo", "Group packages from accounts monorepo
+   *  together."]`) and each is its own line: they are separate sentences, not
+   *  one sentence split. */
+  values: string[];
+  /** The muted line under the quote — who is talking. */
+  attribution: string;
+}
+
+/**
+ * The attribution line. A preset rule's author is a stranger whose name the
+ * row's chip already prints, so the line says only whose words these are; the
+ * reader's OWN rule gets the index it has in their config (`sourceIndex`, not
+ * the merged index — `packageRules[312]` is not a number they can find in their
+ * editor, and `packageRules[0]` is).
+ */
+export function ruleDescriptionAttribution(entry: RuleDescriptionAttribution): string {
+  if (entry.layer.kind === "repo") {
+    return `your description, packageRules[${entry.sourceIndex}] in your repo config`;
+  }
+  if (entry.layer.kind === "preset") {
+    return "author's description of this rule";
+  }
+  // defaults / global / inherited: no author to name, so the level is the
+  // answer — and it is the same label the chip beside it carries.
+  return `description from the ${layerLabel(entry.layer)}`;
+}
+
+/**
+ * Indexes a run's rule descriptions by merged rule index, or an empty map when
+ * the run has no attribution (no completed preset resolution) — in which case
+ * every row renders exactly as it did before.
+ */
+export function buildRuleDescriptions(
+  provenance: DescriptionProvenance | null | undefined,
+): Map<number, RuleDescriptionNote> {
+  const byIndex = new Map<number, RuleDescriptionNote>();
+  for (const entry of provenance?.ruleDescriptions ?? []) {
+    if (entry.values.length === 0) {
+      continue;
+    }
+    byIndex.set(entry.ruleIndex, {
+      ruleIndex: entry.ruleIndex,
+      values: entry.values,
+      attribution: ruleDescriptionAttribution(entry),
+    });
+  }
+  return byIndex;
+}

--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -160,6 +160,27 @@ describe("buildRuleEvidence", () => {
     expect(evidence.clauses).toEqual([MATCHED_CLAUSE]);
   });
 
+  // Roadmap 069 (PR 5): the author's own words ride along on the evidence, so
+  // the popover quotes them without a second lookup of its own.
+  test("carries the rule author's description — but only for a rule that matched", () => {
+    const note = {
+      ruleIndex: 201,
+      values: ["Pin Docker digests."],
+      attribution: "author's description of this rule",
+    };
+    const descriptions = new Map([
+      [201, note],
+      [12, { ...note, ruleIndex: 12 }],
+    ]);
+
+    expect(buildRuleEvidence(201, STOPS, LAYERS, SIM, descriptions).description).toEqual(note);
+    // A no-match rule's description explains a rule that did nothing here.
+    const noMatch = simFixture([{ index: 12, verdict: "no-match", clauses: [], notes: [] }]);
+    expect(buildRuleEvidence(12, STOPS, LAYERS, noMatch, descriptions).description).toBeUndefined();
+    // …and an undescribed rule adds no empty quote chrome.
+    expect(buildRuleEvidence(458, STOPS, LAYERS, SIM, descriptions).description).toBeUndefined();
+  });
+
   test("without a simulation there is no verdict and no clause evidence", () => {
     const evidence = buildRuleEvidence(201, STOPS, LAYERS, null);
     expect(evidence.verdict).toBeUndefined();

--- a/packages/app/src/features/simulator/rule-evidence.ts
+++ b/packages/app/src/features/simulator/rule-evidence.ts
@@ -5,6 +5,7 @@ import type {
   SimulationResult,
 } from "@renovate-config-debugger/engine";
 import type { MergeStop } from "./merge-stops";
+import type { RuleDescriptionNote } from "./rule-descriptions";
 import { stopLabels } from "./verdict-threads";
 
 /**
@@ -52,6 +53,9 @@ export interface RuleEvidence {
   ruleIndex: number;
   verdict?: RuleEvaluation["verdict"];
   layer?: ProvenanceLayer;
+  /** Roadmap 069 (PR 5): the rule author's own description, on a rule that
+   *  matched and has one — the card's answer to "why does this rule exist". */
+  description?: RuleDescriptionNote;
   clauses: ClauseEvaluation[];
   stopIndex?: number;
   stopOrdinal?: number;
@@ -78,14 +82,21 @@ export function buildRuleEvidence(
   mergeStops: MergeStop[],
   layerByIndex: Map<number, ProvenanceLayer>,
   sim: SimulationResult | null,
+  /** Roadmap 069 (PR 5): the run's rule descriptions, by merged rule index. */
+  descriptionByIndex?: ReadonlyMap<number, RuleDescriptionNote>,
 ): RuleEvidence {
   const labels = stopLabels(mergeStops);
   const stopIndex = mergeStops.findIndex((s) => s.kind === "rule" && s.ruleIndex === ruleIndex);
   const rule = sim?.rules.find((r) => r.index === ruleIndex);
+  // Only a matched rule quotes its author: this card is reachable for a rule
+  // that merged, but the wording ("why this rule exists") is a claim about a
+  // rule that DID something.
+  const description = rule?.verdict === "matched" ? descriptionByIndex?.get(ruleIndex) : undefined;
   const base: RuleEvidence = {
     ruleIndex,
     verdict: rule?.verdict,
     layer: layerByIndex.get(ruleIndex),
+    ...(description ? { description } : {}),
     clauses: rule?.clauses ?? [],
     writes: [],
     survivedCount: 0,

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -4578,3 +4578,74 @@ button.desc-digest-leaf:focus-visible {
   font-weight: 400;
   margin-left: auto;
 }
+
+/* ---------- 069 PR 5: attribution at the point of contact ----------
+
+   Two surfaces, one fact each. A `description` string in the resolved-config
+   document carries the hover card naming the preset that wrote it; a matched
+   simulator rule quotes its author's own sentence. Neither adds a panel — the
+   text was already on screen, only anonymous. */
+
+/* The anchor: a string in the JSON document that has an attribution. Marked
+   the way every other card-bearing element in the app is (016's `explained`
+   grammar — cursor:help, accent on hover/focus), plus the purple wash of the
+   preset hue, because "a preset wrote this" is what the mark announces. */
+.json-desc {
+  border-radius: 3px;
+  cursor: help;
+  padding: 0 0.1em;
+}
+
+.json-desc:hover,
+.json-desc:focus-visible {
+  background: color-mix(in srgb, var(--accent-purple) 14%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--accent-purple) 45%, transparent);
+}
+
+/* The card's own head line, after the preset chip. */
+.desc-attr-head {
+  font-weight: 600;
+}
+
+/* The import path — mono, and muted, because it is a route rather than a
+   name: `(input config) › config:best-practices › docker:pinDigests`. */
+.desc-attr-path {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+.desc-attr-card {
+  line-height: 1.45;
+}
+
+/* The matched rule's own words, in the mockup's quote form: a left rule in the
+   preset hue rather than quotation marks, so a multi-sentence description
+   still reads as one quoted block. Sits between the row's head and its clause
+   evidence, on both surfaces that show a rule (the drawer row and the verdict
+   card's rule popover). */
+.sim-rule-why {
+  border-left: 3px solid color-mix(in srgb, var(--accent-purple) 45%, transparent);
+  margin: 0.1rem 0.6rem 0.4rem 1.9rem;
+  padding-left: 0.7rem;
+}
+
+.sim-rule-why-line {
+  font-size: 0.8rem;
+  line-height: 1.45;
+  margin: 0.15rem 0;
+}
+
+.sim-rule-why-attr {
+  color: var(--muted);
+  font-size: 0.7rem;
+  margin: 0.15rem 0 0;
+}
+
+/* Inside the rule-evidence popover the row's indent does not apply — the card
+   is already a box of its own. */
+.sim-rule-pop .sim-rule-why {
+  margin-left: 0;
+  margin-right: 0;
+}

--- a/packages/app/src/lib/description-attribution.test.ts
+++ b/packages/app/src/lib/description-attribution.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "vitest";
+import type {
+  DescriptionAttribution,
+  DescriptionProvenance,
+  PresetNode,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import {
+  buildDescriptionCards,
+  cardPathText,
+  cardPositionText,
+  type DescriptionCard,
+  descriptionCardsFor,
+  PATH_SEGMENT_CAP,
+} from "./description-attribution";
+
+/**
+ * Roadmap 069 (PR 5): the hover card's model. The engine's own tests (PR 1)
+ * prove the attribution against the real 1,088-preset tree; what needs proving
+ * here is what this module adds — the root-to-writer path (including the
+ * elision that keeps a deep chain a path), the facts line, the repo config's
+ * own sentences not masquerading as a preset, and above all the positional
+ * guard, which is what stands between "hover a string" and "name the wrong
+ * preset in a document that is not the array we indexed".
+ */
+
+const REPO: ProvenanceLayer = { kind: "repo" };
+
+function presetLayer(nodeId: string, name = nodeId): ProvenanceLayer {
+  return { kind: "preset", nodeId, name };
+}
+
+interface EntrySpec {
+  value: string;
+  node?: { nodeId: string; name: string };
+  via?: ProvenanceLayer;
+  approximate?: boolean;
+}
+
+function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+  const firstByValue = new Map<string, number>();
+  return specs.map((spec, index) => {
+    const duplicateOfIndex = firstByValue.get(spec.value);
+    if (duplicateOfIndex === undefined) {
+      firstByValue.set(spec.value, index);
+    }
+    return {
+      index,
+      value: spec.value,
+      node: spec.node,
+      viaTopLevel: spec.via ?? REPO,
+      duplicateOfIndex,
+      approximate: spec.approximate,
+    };
+  });
+}
+
+function provenance(specs: EntrySpec[]): DescriptionProvenance {
+  return { entries: entries(specs), dropped: [], ruleDescriptions: [], degraded: false };
+}
+
+/** A preset node, as `computeTreeStats` reads it: `input` is what its own
+ *  contribution counts come from. */
+function node(id: string, name: string, extra?: Partial<PresetNode>): PresetNode {
+  return { id, name, state: "resolved", input: {}, resolved: {}, children: [], ...extra };
+}
+
+/** `(input config) › config:best-practices › docker:pinDigests`, with two
+ *  packageRules on the leaf. */
+function tree(): PresetNode {
+  const pinDigests = node("p3", "docker:pinDigests", {
+    input: { packageRules: [{ matchDatasources: ["docker"] }, { matchDatasources: ["orb"] }] },
+  });
+  const bestPractices = node("p2", "config:best-practices", { children: [pinDigests] });
+  return node("root", "(input config)", { children: [bestPractices] });
+}
+
+function cardsOf(specs: EntrySpec[], root: PresetNode | null = tree()): DescriptionCard[] {
+  return buildDescriptionCards(provenance(specs), root);
+}
+
+function at(cards: DescriptionCard[], index: number): DescriptionCard {
+  const card = cards[index];
+  if (!card) {
+    throw new Error(`expected a card at ${index}, got ${cards.length}`);
+  }
+  return card;
+}
+
+function firstCard(specs: EntrySpec[], root: PresetNode | null = tree()): DescriptionCard {
+  return at(cardsOf(specs, root), 0);
+}
+
+describe("buildDescriptionCards", () => {
+  test("names the writing preset, the path it arrived by, and what else it sets", () => {
+    const card = firstCard([
+      {
+        value: "Pin Docker digests.",
+        node: { nodeId: "p3", name: "docker:pinDigests" },
+        via: presetLayer("p2", "config:best-practices"),
+      },
+    ]);
+
+    expect(card.layer).toEqual(presetLayer("p3", "docker:pinDigests"));
+    expect(cardPathText(card)).toBe("(input config) › config:best-practices › docker:pinDigests");
+    // The tree jump is offered because this node really is in this run's tree.
+    expect(card.nodeId).toBe("p3");
+    expect(cardPositionText(card)).toBe("Position 1 of 1 · also sets 2 packageRules");
+  });
+
+  test("the repo's own sentence is the repo config, not a preset named after the input", () => {
+    const card = firstCard([
+      { value: "Our house rules.", node: { nodeId: "root", name: "(input config)" }, via: REPO },
+    ]);
+
+    // The root is a config: no purple preset chip, no path, and no tree jump —
+    // the tree never renders a row for it.
+    expect(card.layer).toEqual(REPO);
+    expect(cardPathText(card)).toBe("");
+    expect(card.nodeId).toBeUndefined();
+    expect(card.ownRules).toBeUndefined();
+  });
+
+  test("a string from a layer with no preset tree keeps its arrival layer", () => {
+    const card = firstCard([{ value: "Org-wide policy.", via: { kind: "inherited" } }]);
+
+    expect(card.layer).toEqual({ kind: "inherited" });
+    expect(cardPathText(card)).toBe("");
+  });
+
+  test("carries the duplicate marker and the approximate flag through", () => {
+    const cards = cardsOf([
+      { value: "Enable Renovate Dependency Dashboard creation.", via: presetLayer("p2") },
+      {
+        value: "Enable Renovate Dependency Dashboard creation.",
+        node: { nodeId: "p3", name: "docker:pinDigests" },
+        via: presetLayer("p2"),
+        approximate: true,
+      },
+    ]);
+
+    expect(cardPositionText(at(cards, 0))).toBe("Position 1 of 2");
+    expect(at(cards, 1).approximate).toBe(true);
+    expect(cardPositionText(at(cards, 1))).toBe(
+      "Position 2 of 2 · duplicate of #1 · also sets 2 packageRules",
+    );
+  });
+
+  test("elides the middle of a path too deep to read, keeping both ends", () => {
+    // A chain deeper than the cap: the extend the reader wrote and the preset
+    // that wrote the sentence are what identify it, so those are what survive.
+    const names = ["(input config)", "org:all", "org:base", "config:recommended", "a", "b", "c"];
+    const root = names.reduceRight<PresetNode | undefined>(
+      (child, name, i) =>
+        node(i === 0 ? "root" : `n${i}`, name, child ? { children: [child] } : {}),
+      undefined,
+    );
+    if (!root) {
+      throw new Error("expected a tree");
+    }
+
+    const card = firstCard(
+      [{ value: "Deep.", node: { nodeId: "n6", name: "c" }, via: REPO }],
+      root,
+    );
+    expect(card.path).toHaveLength(PATH_SEGMENT_CAP);
+    expect(cardPathText(card)).toBe("(input config) › org:all › … › a › b › c");
+  });
+
+  test("works without a preset tree at all — the chip still names the writer", () => {
+    const card = firstCard(
+      [{ value: "Pin Docker digests.", node: { nodeId: "p3", name: "docker:pinDigests" } }],
+      null,
+    );
+
+    expect(card.layer).toEqual(presetLayer("p3", "docker:pinDigests"));
+    expect(card.path).toEqual([]);
+    // Nothing to select in a tree this run does not have.
+    expect(card.nodeId).toBeUndefined();
+  });
+});
+
+describe("descriptionCardsFor", () => {
+  const specs: EntrySpec[] = [
+    { value: "Enable Renovate Dependency Dashboard creation.", via: presetLayer("p1") },
+    { value: "Pin Docker digests.", via: presetLayer("p2") },
+  ];
+
+  test("attaches the cards to the document that IS the attributed array", () => {
+    const cards = cardsOf(specs);
+    const doc = { description: cards.map((card) => card.value), automerge: true };
+    expect(descriptionCardsFor(doc, cards)).toHaveLength(2);
+  });
+
+  test("refuses a document whose description is a different array", () => {
+    const cards = cardsOf(specs);
+    // The As-JSON view's keep-internal document: the presets are still
+    // `extends` references, so their sentences are simply not in it.
+    expect(descriptionCardsFor({ description: ["Pin Docker digests."] }, cards)).toBeNull();
+    // Same length, different order — value matching alone would have accepted
+    // this and named the wrong preset for both strings.
+    expect(
+      descriptionCardsFor({ description: cards.toReversed().map((c) => c.value) }, cards),
+    ).toBeNull();
+    expect(descriptionCardsFor({ automerge: true }, cards)).toBeNull();
+    expect(descriptionCardsFor({ description: "a string" }, cards)).toBeNull();
+  });
+
+  test("refuses when there is no attribution to attach", () => {
+    expect(descriptionCardsFor({ description: ["x"] }, null)).toBeNull();
+    expect(descriptionCardsFor({ description: [] }, [])).toBeNull();
+  });
+});

--- a/packages/app/src/lib/description-attribution.test.ts
+++ b/packages/app/src/lib/description-attribution.test.ts
@@ -10,6 +10,7 @@ import {
   cardPathText,
   cardPositionText,
   type DescriptionCard,
+  type DescriptionCards,
   descriptionCardsFor,
   PATH_SEGMENT_CAP,
 } from "./description-attribution";
@@ -37,26 +38,57 @@ interface EntrySpec {
   approximate?: boolean;
 }
 
-function entries(specs: EntrySpec[]): DescriptionAttribution[] {
+/**
+ * A member of the final array. A plain spec is an attributed string; a
+ * `nonString` is one of the members Renovate warns about and keeps
+ * (`{"description": ["a", 42]}`), which no preset wrote — it occupies a real
+ * index all the same, which is the whole reason the cards are placed by index.
+ */
+type MemberSpec = EntrySpec | { nonString: unknown };
+
+function isNonString(spec: MemberSpec): spec is { nonString: unknown } {
+  return "nonString" in spec;
+}
+
+function entries(specs: MemberSpec[]): DescriptionAttribution[] {
   const firstByValue = new Map<string, number>();
-  return specs.map((spec, index) => {
+  const out: DescriptionAttribution[] = [];
+  for (const [index, spec] of specs.entries()) {
+    if (isNonString(spec)) {
+      continue;
+    }
     const duplicateOfIndex = firstByValue.get(spec.value);
     if (duplicateOfIndex === undefined) {
       firstByValue.set(spec.value, index);
     }
-    return {
+    out.push({
       index,
       value: spec.value,
       node: spec.node,
       viaTopLevel: spec.via ?? REPO,
       duplicateOfIndex,
       approximate: spec.approximate,
-    };
-  });
+    });
+  }
+  return out;
 }
 
-function provenance(specs: EntrySpec[]): DescriptionProvenance {
-  return { entries: entries(specs), dropped: [], ruleDescriptions: [], degraded: false };
+function provenance(specs: MemberSpec[]): DescriptionProvenance {
+  return {
+    entries: entries(specs),
+    unattributed: specs.flatMap((spec, index) =>
+      isNonString(spec) ? [{ index, value: spec.nonString }] : [],
+    ),
+    finalLength: specs.length,
+    dropped: [],
+    ruleDescriptions: [],
+    degraded: false,
+  };
+}
+
+/** The document the As-JSON view renders for these specs. */
+function docFor(specs: MemberSpec[]): { description: unknown[] } {
+  return { description: specs.map((spec) => (isNonString(spec) ? spec.nonString : spec.value)) };
 }
 
 /** A preset node, as `computeTreeStats` reads it: `input` is what its own
@@ -75,11 +107,11 @@ function tree(): PresetNode {
   return node("root", "(input config)", { children: [bestPractices] });
 }
 
-function cardsOf(specs: EntrySpec[], root: PresetNode | null = tree()): DescriptionCard[] {
+function cardsOf(specs: MemberSpec[], root: PresetNode | null = tree()): DescriptionCards {
   return buildDescriptionCards(provenance(specs), root);
 }
 
-function at(cards: DescriptionCard[], index: number): DescriptionCard {
+function at(cards: readonly (DescriptionCard | undefined)[], index: number): DescriptionCard {
   const card = cards[index];
   if (!card) {
     throw new Error(`expected a card at ${index}, got ${cards.length}`);
@@ -87,8 +119,8 @@ function at(cards: DescriptionCard[], index: number): DescriptionCard {
   return card;
 }
 
-function firstCard(specs: EntrySpec[], root: PresetNode | null = tree()): DescriptionCard {
-  return at(cardsOf(specs, root), 0);
+function firstCard(specs: MemberSpec[], root: PresetNode | null = tree()): DescriptionCard {
+  return at(cardsOf(specs, root).cards, 0);
 }
 
 describe("buildDescriptionCards", () => {
@@ -129,7 +161,7 @@ describe("buildDescriptionCards", () => {
   });
 
   test("carries the duplicate marker and the approximate flag through", () => {
-    const cards = cardsOf([
+    const { cards } = cardsOf([
       { value: "Enable Renovate Dependency Dashboard creation.", via: presetLayer("p2") },
       {
         value: "Enable Renovate Dependency Dashboard creation.",
@@ -167,6 +199,27 @@ describe("buildDescriptionCards", () => {
     expect(cardPathText(card)).toBe("(input config) › org:all › … › a › b › c");
   });
 
+  test("counts the positions of the REAL array, non-strings included", () => {
+    // `{"description": ["A", 42, "B", "C"]}` — Renovate warns about the `42`
+    // and keeps it, so it holds index 1 and "B" really is the third of four.
+    const { cards, finalLength, unattributedIndices } = cardsOf([
+      { value: "A", via: presetLayer("p2") },
+      { nonString: 42 },
+      { value: "B", via: presetLayer("p2") },
+      { value: "C", via: presetLayer("p2") },
+    ]);
+
+    expect(finalLength).toBe(4);
+    expect([...unattributedIndices]).toEqual([1]);
+    // Three cards for four members, each carrying the index it really has.
+    expect(cards.map((card) => card.index)).toEqual([0, 2, 3]);
+    expect(cards.map(cardPositionText)).toEqual([
+      "Position 1 of 4",
+      "Position 3 of 4",
+      "Position 4 of 4",
+    ]);
+  });
+
   test("works without a preset tree at all — the chip still names the writer", () => {
     const card = firstCard(
       [{ value: "Pin Docker digests.", node: { nodeId: "p3", name: "docker:pinDigests" } }],
@@ -181,33 +234,68 @@ describe("buildDescriptionCards", () => {
 });
 
 describe("descriptionCardsFor", () => {
-  const specs: EntrySpec[] = [
+  const specs: MemberSpec[] = [
     { value: "Enable Renovate Dependency Dashboard creation.", via: presetLayer("p1") },
     { value: "Pin Docker digests.", via: presetLayer("p2") },
   ];
 
   test("attaches the cards to the document that IS the attributed array", () => {
-    const cards = cardsOf(specs);
-    const doc = { description: cards.map((card) => card.value), automerge: true };
-    expect(descriptionCardsFor(doc, cards)).toHaveLength(2);
+    const attribution = cardsOf(specs);
+    const placed = descriptionCardsFor({ ...docFor(specs), automerge: true }, attribution);
+
+    expect(placed).toHaveLength(2);
+    expect(at(placed ?? [], 1).value).toBe("Pin Docker digests.");
+  });
+
+  test("places the cards at their real indices and leaves the non-string bare", () => {
+    const mixed: MemberSpec[] = [
+      { value: "A", via: presetLayer("p1") },
+      { nonString: 42 },
+      { value: "B", via: presetLayer("p2") },
+    ];
+    const placed = descriptionCardsFor(docFor(mixed), cardsOf(mixed));
+
+    // Indexed like the array the view prints, so element i asks for [i] —
+    // and index 1, which no preset wrote, renders as plain JSON.
+    expect(placed).toHaveLength(3);
+    expect(at(placed ?? [], 0).value).toBe("A");
+    expect(placed?.[1]).toBeUndefined();
+    expect(at(placed ?? [], 2).value).toBe("B");
   });
 
   test("refuses a document whose description is a different array", () => {
-    const cards = cardsOf(specs);
+    const attribution = cardsOf(specs);
     // The As-JSON view's keep-internal document: the presets are still
     // `extends` references, so their sentences are simply not in it.
-    expect(descriptionCardsFor({ description: ["Pin Docker digests."] }, cards)).toBeNull();
+    expect(descriptionCardsFor({ description: ["Pin Docker digests."] }, attribution)).toBeNull();
     // Same length, different order — value matching alone would have accepted
     // this and named the wrong preset for both strings.
     expect(
-      descriptionCardsFor({ description: cards.toReversed().map((c) => c.value) }, cards),
+      descriptionCardsFor(
+        { description: attribution.cards.toReversed().map((c) => c.value) },
+        attribution,
+      ),
     ).toBeNull();
-    expect(descriptionCardsFor({ automerge: true }, cards)).toBeNull();
-    expect(descriptionCardsFor({ description: "a string" }, cards)).toBeNull();
+    expect(descriptionCardsFor({ automerge: true }, attribution)).toBeNull();
+    expect(descriptionCardsFor({ description: "a string" }, attribution)).toBeNull();
+  });
+
+  test("refuses a document that has a sentence where the non-string belongs", () => {
+    const mixed: MemberSpec[] = [
+      { value: "A", via: presetLayer("p1") },
+      { nonString: 42 },
+      { value: "B", via: presetLayer("p2") },
+    ];
+    // Right length, and every card's own index still matches — but the member
+    // nobody wrote is a string here, so this is not the array we indexed and
+    // the sentence at index 1 would wear another preset's name.
+    expect(
+      descriptionCardsFor({ description: ["A", "Something else.", "B"] }, cardsOf(mixed)),
+    ).toBeNull();
   });
 
   test("refuses when there is no attribution to attach", () => {
     expect(descriptionCardsFor({ description: ["x"] }, null)).toBeNull();
-    expect(descriptionCardsFor({ description: [] }, [])).toBeNull();
+    expect(descriptionCardsFor({ description: [] }, cardsOf([]))).toBeNull();
   });
 });

--- a/packages/app/src/lib/description-attribution.ts
+++ b/packages/app/src/lib/description-attribution.ts
@@ -1,0 +1,197 @@
+import type {
+  DescriptionProvenance,
+  PresetNode,
+  ProvenanceLayer,
+} from "@renovate-config-debugger/engine";
+import { computeTreeStats } from "@/components/preset-tree-stats";
+
+/**
+ * Roadmap 069 (PR 5): attribution at the point of contact — the model behind
+ * the hover card on a `description` string in a JSON view.
+ *
+ * The blame ledger (PR 3) and the Overview digest (PR 2) are places a reader
+ * GOES to ask who wrote what. This is the answer where the string already is:
+ * hover a sentence in the resolved-config document and the card names the
+ * preset that wrote it, the `extends` path it arrived by, and where it sits in
+ * the array — the same three facts the ledger prints in three columns, minus
+ * the trip.
+ *
+ * Two things this module owns that the ledger does not need:
+ *
+ * - **The import path.** `docker:pinDigests` writes "Pin Docker digests." four
+ *   levels below the `config:best-practices` the reader actually wrote, and the
+ *   chain between them is the answer to "which line do I delete". It comes from
+ *   `computeTreeStats`' `parents` map — one cached walk per run, shared with the
+ *   tree itself, so a card costs a handful of map lookups.
+ * - **The positional guard** (`descriptionCardsFor`). Attribution is by INDEX
+ *   into the final `description` array, so it may only be attached to a document
+ *   whose `description` IS that array. The Effective config's As-JSON view can
+ *   render a keep-internal document (presets still referenced, so most sentences
+ *   are absent) or a defaults-hydrated one — neither is index-compatible, and a
+ *   card that names the wrong preset is worse than no card. The guard compares
+ *   the rendered array against the attribution value for value and hands back
+ *   `null` on any disagreement.
+ *
+ * Pure and DOM-free, so every wording is unit-testable.
+ */
+
+const nf = new Intl.NumberFormat();
+
+/** The repo config's own node id (`trace/preset-tree.ts`). It is a config, not
+ *  a preset: its sentences wear the `repo config` chip and offer no tree jump,
+ *  because the tree never renders a row for the root. */
+const ROOT_NODE_ID = "root";
+
+/**
+ * How many path segments a card prints before the middle is elided. The real
+ * tree reaches four levels under `config:best-practices` and a hosted org
+ * preset adds two more; past this the path stops being a path and becomes a
+ * paragraph.
+ */
+export const PATH_SEGMENT_CAP = 6;
+
+/** The elision marker, and the separator — the tree's own (`TreeRow` elides
+ *  router chains with the same two). */
+const ELLIPSIS = "…";
+const PATH_SEPARATOR = " › ";
+
+/** One string of the final top-level `description`, as its hover card shows it. */
+export interface DescriptionCard {
+  /** 0-based index into the final `description` array — the canonical id. */
+  index: number;
+  value: string;
+  /** The chip: the preset that wrote it, or the layer it arrived from when no
+   *  preset tree node owns it (defaults / global / inherited / the repo's own). */
+  layer: ProvenanceLayer;
+  /** Root-to-writer `extends` path, already elided; empty when there is no
+   *  chain worth printing (a repo-written sentence, or a layer with no tree). */
+  path: string[];
+  /** 1-based position in the final array — every index this app prints is. */
+  position: number;
+  total: number;
+  /** 1-based position of the first occurrence, when this repeats one. */
+  duplicateOfPosition?: number;
+  /** The engine could only place this string inside the node's SUBTREE. */
+  approximate?: boolean;
+  /** `packageRules` the writing preset contributes itself — the other half of
+   *  what extending it buys, and free from the tree stats. */
+  ownRules?: number;
+  /** The writing preset's node id, when the card can offer the tree jump. */
+  nodeId?: string;
+}
+
+/** Elides the middle of an over-long path, keeping both ends — the ends are
+ *  what identify it: the extend the reader wrote, and the preset that wrote
+ *  the sentence. */
+function elidePath(names: string[]): string[] {
+  if (names.length <= PATH_SEGMENT_CAP) {
+    return names;
+  }
+  const head = names.slice(0, 2);
+  const tail = names.slice(names.length - (PATH_SEGMENT_CAP - 3));
+  return [...head, ELLIPSIS, ...tail];
+}
+
+/** Root-to-node name chain, or `[]` when the node is the root itself (or is not
+ *  in this run's tree at all — a degraded attribution can name a node the walk
+ *  reached through a subtree that the stats map still knows, but the guard
+ *  below keeps the honest answer either way). */
+function pathTo(tree: PresetNode, nodeId: string): string[] {
+  const { nodesById, parents } = computeTreeStats(tree);
+  const node = nodesById.get(nodeId);
+  if (!node || node.id === ROOT_NODE_ID) {
+    return [];
+  }
+  const names: string[] = [];
+  let current: PresetNode | undefined = node;
+  // Guarded by the map itself: `parents` is built from one finite walk, so the
+  // chain always terminates at the root (which has no parent entry).
+  while (current) {
+    names.unshift(current.name);
+    current = parents.get(current.id);
+  }
+  return elidePath(names);
+}
+
+/**
+ * Builds one card per string of the final `description` array, in that array's
+ * order — so `cards[i]` describes `description[i]`, which is what makes the
+ * positional guard below a single length + value comparison.
+ */
+export function buildDescriptionCards(
+  provenance: DescriptionProvenance,
+  tree: PresetNode | null | undefined,
+): DescriptionCard[] {
+  const stats = tree ? computeTreeStats(tree) : null;
+  const total = provenance.entries.length;
+  return provenance.entries.map((entry): DescriptionCard => {
+    // The root is the repo config, not a preset: it wears the `repo config`
+    // chip, has no path worth printing and offers no tree jump.
+    const preset = entry.node?.nodeId === ROOT_NODE_ID ? undefined : entry.node;
+    const ownRules = preset ? stats?.statsById.get(preset.nodeId)?.ownRules : undefined;
+    return {
+      index: entry.index,
+      value: entry.value,
+      layer: preset
+        ? { kind: "preset", nodeId: preset.nodeId, name: preset.name }
+        : entry.viaTopLevel,
+      path: preset && tree ? pathTo(tree, preset.nodeId) : [],
+      position: entry.index + 1,
+      total,
+      ...(entry.duplicateOfIndex === undefined
+        ? {}
+        : { duplicateOfPosition: entry.duplicateOfIndex + 1 }),
+      ...(entry.approximate ? { approximate: true } : {}),
+      ...(ownRules !== undefined && ownRules > 0 ? { ownRules } : {}),
+      // Only a node the tree can actually select.
+      ...(preset && stats?.nodesById.has(preset.nodeId) ? { nodeId: preset.nodeId } : {}),
+    };
+  });
+}
+
+/**
+ * The cards for a rendered config document, or `null` when this document's
+ * `description` is not the array the attribution indexes — a keep-internal
+ * document (presets still referenced), a defaults-hydrated one, or anything
+ * else that is not the final config. Matched by POSITION and value, never by
+ * value alone: two presets legitimately write the same sentence.
+ */
+export function descriptionCardsFor(
+  doc: unknown,
+  cards: readonly DescriptionCard[] | null | undefined,
+): DescriptionCard[] | null {
+  if (!cards || cards.length === 0 || typeof doc !== "object" || doc === null) {
+    return null;
+  }
+  const values = (doc as Record<string, unknown>).description;
+  if (!Array.isArray(values) || values.length !== cards.length) {
+    return null;
+  }
+  return values.every((value, i) => value === cards[i]?.value) ? [...cards] : null;
+}
+
+/** The card's head, after the preset chip: `docker:pinDigests` — *wrote this
+ *  description*. */
+export const WROTE_THIS = "wrote this description";
+
+/** The import path line, mono in the card: `(input config) › config:best-practices
+ *  › docker:pinDigests`. Empty string when there is no chain to print, which is
+ *  the signal to omit the line. */
+export function cardPathText(card: DescriptionCard): string {
+  return card.path.length > 1 ? card.path.join(PATH_SEPARATOR) : "";
+}
+
+/** The facts line: `Position 16 of 24 · also sets 2 packageRules`, plus the
+ *  duplicate call-out when Renovate concatenated this sentence twice. */
+export function cardPositionText(card: DescriptionCard): string {
+  const parts = [`Position ${nf.format(card.position)} of ${nf.format(card.total)}`];
+  if (card.duplicateOfPosition !== undefined) {
+    parts.push(`duplicate of #${nf.format(card.duplicateOfPosition)}`);
+  }
+  if (card.ownRules !== undefined) {
+    parts.push(
+      `also sets ${nf.format(card.ownRules)} packageRule${card.ownRules === 1 ? "" : "s"}`,
+    );
+  }
+  return parts.join(" · ");
+}

--- a/packages/app/src/lib/description-attribution.ts
+++ b/packages/app/src/lib/description-attribution.ts
@@ -3,7 +3,7 @@ import type {
   PresetNode,
   ProvenanceLayer,
 } from "@renovate-config-debugger/engine";
-import { computeTreeStats } from "@/components/preset-tree-stats";
+import { computeTreeStats, ROOT_NODE_ID } from "@/components/preset-tree-stats";
 
 /**
  * Roadmap 069 (PR 5): attribution at the point of contact — the model behind
@@ -29,18 +29,17 @@ import { computeTreeStats } from "@/components/preset-tree-stats";
  *   render a keep-internal document (presets still referenced, so most sentences
  *   are absent) or a defaults-hydrated one — neither is index-compatible, and a
  *   card that names the wrong preset is worse than no card. The guard compares
- *   the rendered array against the attribution value for value and hands back
- *   `null` on any disagreement.
+ *   the rendered array against the attribution value for value, at each entry's
+ *   REAL index, and hands back `null` on any disagreement. Real, because a
+ *   `description` array may legally hold non-strings (Renovate only warns about
+ *   `["a", 42]`): they occupy indices no preset wrote, so the cards are not a
+ *   1:1 list of the array — they are placed BY index, and the members between
+ *   them render plainly.
  *
  * Pure and DOM-free, so every wording is unit-testable.
  */
 
 const nf = new Intl.NumberFormat();
-
-/** The repo config's own node id (`trace/preset-tree.ts`). It is a config, not
- *  a preset: its sentences wear the `repo config` chip and offer no tree jump,
- *  because the tree never renders a row for the root. */
-const ROOT_NODE_ID = "root";
 
 /**
  * How many path segments a card prints before the middle is elided. The real
@@ -114,17 +113,38 @@ function pathTo(tree: PresetNode, nodeId: string): string[] {
 }
 
 /**
+ * The cards of one run, plus what the positional guard needs to place them: the
+ * length of the real final array and which of its indices hold a non-string.
+ * Both come straight from the engine's provenance — re-deriving them from the
+ * cards would be re-deriving exactly the thing being checked.
+ */
+export interface DescriptionCards {
+  /** One card per ATTRIBUTED string, in array order. Sparser than the array
+   *  itself whenever a non-string sits between two sentences — read `index`,
+   *  never the position in this list. */
+  cards: readonly DescriptionCard[];
+  /** Length of the real final `description` array, non-strings included. */
+  finalLength: number;
+  /** Indices of the members no preset wrote (they are not strings). */
+  unattributedIndices: ReadonlySet<number>;
+}
+
+/**
  * Builds one card per string of the final `description` array, in that array's
- * order — so `cards[i]` describes `description[i]`, which is what makes the
- * positional guard below a single length + value comparison.
+ * order. `cards[i]` is NOT `description[i]` when the array holds a non-string:
+ * each card carries its real `index`, which is what the guard below places it
+ * by.
  */
 export function buildDescriptionCards(
   provenance: DescriptionProvenance,
   tree: PresetNode | null | undefined,
-): DescriptionCard[] {
+): DescriptionCards {
   const stats = tree ? computeTreeStats(tree) : null;
-  const total = provenance.entries.length;
-  return provenance.entries.map((entry): DescriptionCard => {
+  // The REAL array's length, so "position 3 of 4" counts the member Renovate
+  // kept but nobody wrote — counting only the attributed strings would print a
+  // total the reader cannot find in the document in front of them.
+  const total = provenance.finalLength;
+  const cards = provenance.entries.map((entry): DescriptionCard => {
     // The root is the repo config, not a preset: it wears the `repo config`
     // chip, has no path worth printing and offers no tree jump.
     const preset = entry.node?.nodeId === ROOT_NODE_ID ? undefined : entry.node;
@@ -147,27 +167,53 @@ export function buildDescriptionCards(
       ...(preset && stats?.nodesById.has(preset.nodeId) ? { nodeId: preset.nodeId } : {}),
     };
   });
+  return {
+    cards,
+    finalLength: provenance.finalLength,
+    unattributedIndices: new Set(provenance.unattributed.map((u) => u.index)),
+  };
 }
 
 /**
- * The cards for a rendered config document, or `null` when this document's
- * `description` is not the array the attribution indexes — a keep-internal
+ * The cards for a rendered config document, BY INDEX into that document's
+ * `description` array (so a caller printing element `i` asks for `[i]` and gets
+ * `undefined` where nothing is attributed) — or `null` when this document's
+ * `description` is not the array the attribution indexes: a keep-internal
  * document (presets still referenced), a defaults-hydrated one, or anything
  * else that is not the final config. Matched by POSITION and value, never by
  * value alone: two presets legitimately write the same sentence.
+ *
+ * The non-string members are checked too, though they never get a card: they
+ * are the reason the indices are what they are, so a document that has a
+ * SENTENCE where the attribution says a `42` sits is a different array, and
+ * accepting it would attribute every later sentence to the wrong preset.
  */
 export function descriptionCardsFor(
   doc: unknown,
-  cards: readonly DescriptionCard[] | null | undefined,
-): readonly DescriptionCard[] | null {
-  if (!cards || cards.length === 0 || typeof doc !== "object" || doc === null) {
+  attribution: DescriptionCards | null | undefined,
+): readonly (DescriptionCard | undefined)[] | null {
+  if (!attribution || attribution.cards.length === 0 || typeof doc !== "object" || doc === null) {
     return null;
   }
   const values = (doc as Record<string, unknown>).description;
-  if (!Array.isArray(values) || values.length !== cards.length) {
+  if (!Array.isArray(values) || values.length !== attribution.finalLength) {
     return null;
   }
-  return values.every((value, i) => value === cards[i]?.value) ? cards : null;
+  const byIndex: (DescriptionCard | undefined)[] = Array.from({
+    length: attribution.finalLength,
+  });
+  for (const card of attribution.cards) {
+    if (values[card.index] !== card.value) {
+      return null;
+    }
+    byIndex[card.index] = card;
+  }
+  for (const index of attribution.unattributedIndices) {
+    if (typeof values[index] === "string") {
+      return null;
+    }
+  }
+  return byIndex;
 }
 
 /** The card's head, after the preset chip: `docker:pinDigests` — *wrote this

--- a/packages/app/src/lib/description-attribution.ts
+++ b/packages/app/src/lib/description-attribution.ts
@@ -159,7 +159,7 @@ export function buildDescriptionCards(
 export function descriptionCardsFor(
   doc: unknown,
   cards: readonly DescriptionCard[] | null | undefined,
-): DescriptionCard[] | null {
+): readonly DescriptionCard[] | null {
   if (!cards || cards.length === 0 || typeof doc !== "object" || doc === null) {
     return null;
   }
@@ -167,7 +167,7 @@ export function descriptionCardsFor(
   if (!Array.isArray(values) || values.length !== cards.length) {
     return null;
   }
-  return values.every((value, i) => value === cards[i]?.value) ? [...cards] : null;
+  return values.every((value, i) => value === cards[i]?.value) ? cards : null;
 }
 
 /** The card's head, after the preset chip: `docker:pinDigests` — *wrote this

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -1,6 +1,6 @@
 # 069 — Per-string `description` provenance: who said what about this config
 
-Milestone: M19 · Status: in progress (PR 1 of 5 landed)
+Milestone: M19 · Status: in progress (PRs 1–5 written; the stack is in review)
 
 Mockups: [mockups/069/](mockups/069/)
 
@@ -47,7 +47,8 @@ consequences, all confirmed against the pinned Renovate 44.7.4:
   `extends` order (depth-first), then the node's own sentence.
 
 `packageRules[n].description` is a different thing entirely: nested bodies are
-resolved separately and never hoisted to the top level.
+resolved separately and never hoisted to the top level — which is why the
+simulator (PR 5) is the only place they surface.
 
 ## The attribution algorithm
 
@@ -174,6 +175,17 @@ annotation and no more. Per-node attribution of nested bodies would need the
 nested `resolveConfigPresets` invocations threaded through the tree; if PR 5
 wants it, that is its own piece of work.
 
+**PR 5 did not want it, and the reason generalises.** The quote's attribution
+line has exactly two jobs: say whose voice it is, and — for the reader's own
+rules — say which of their rules it was. The first is already answered beside
+it by the row's provenance chip, which names the layer; the second needs
+`sourceIndex`, which is layer-granular by construction (it is an index into
+that layer's own `packageRules`). A node-granular attribution would let the
+line name `security:minimumReleaseAgeNpm` instead of the extend that carried
+it — a nicer sentence, bought with the nested-resolution threading, in a place
+where the chip already says as much. So the layer granularity shipped as-is and
+the nested machinery stays unbuilt.
+
 ## What the real tree does
 
 Verified against `{"extends": ["config:best-practices", ":dependencyDashboard",
@@ -217,9 +229,11 @@ offline (internal presets need no network):
    sentence, not the mechanics, which stay on the ledger's dropped footer. A
    hover surface rather than a view mode: the tree already has a tree/table
    switch, and the rows keep their uniform height for the windowing.
-5. **Hover attribution + simulator rule descriptions** — hovering a sentence
-   anywhere highlights its node in the tree; the simulator's rule ledger picks up
-   `ruleDescriptions` so a matched rule can say what it is for.
+5. **Hover attribution + simulator rule descriptions** — attribution at the
+   point of contact (mockup variant D): a `description` string in the resolved
+   JSON document carries a hover card naming the preset that wrote it, and a
+   matched simulator rule quotes its author's own sentence. See "What PR 5
+   shipped" below for what that turned into.
 
 ## Verification (PR 1)
 
@@ -238,3 +252,74 @@ offline (internal presets need no network):
   each drop rule, the enclosing-node fallback proving that a contradicting
   subtree degrades alone while its siblings keep exact attribution, and that
   fallback's `approximate` surviving into a drop when the quirk mutes it.
+
+## What PR 5 shipped
+
+Two surfaces, no new panel — the text was already on screen, only anonymous.
+
+**The JSON document's strings.** In the Effective config's "As JSON" view, each
+string of the top-level `description` array is an anchor for the app's standard
+hover card (`components/hover-card.tsx`): the writing preset's chip and _wrote
+this description_, the root-to-writer `extends` path (`(input config) ›
+config:best-practices › docker:pinDigests`, elided in the middle past six
+segments), `Position 16 of 24 · duplicate of #4 · also sets 2 packageRules`, and
+a _Show in preset tree →_ jump on the same `onSelectPreset` plumbing every chip
+in that view uses. The path and the rule count are free: `computeTreeStats`
+already keeps a per-run `parents` map and each node's own rule count.
+
+The scope is what the attribution can honestly carry. Attribution is by INDEX
+into the final `description` array, so `descriptionCardsFor` compares the
+rendered document's array against it value by value and attaches nothing on any
+disagreement — which is exactly what happens in the As-JSON view's default
+keep-internal mode (presets still referenced, so their sentences are absent) and
+in the defaults-hydrated document. Preset-body views (`PresetDetail`) keep plain
+rendering: a preset's own `description` is a different array again.
+
+The affordance is the glossary's, not a new one. `useHoverCard` and the anchor
+component were hoisted out of `components/glossary.tsx` (`hooks/hover-card.ts` +
+`components/hover-card.tsx`), so the attribution card inherits the
+one-card-at-a-time singleton, the pointer grace period, focus reachability and
+the 068 Escape ruling rather than restating them. `Term`/`Explained` are now
+that primitive with a glossary body. Two consequences worth knowing: the chip
+inside the card is a static badge, not a `ProvenanceChip` (a `ProvenanceChip`
+opens a card of its own, and the singleton would close the card it stands in),
+and the _Show in preset tree_ link is pointer-reachable only, since the card is
+portalled to `<body>` and closes on blur — the attribution itself is fully
+keyboard-readable, the jump is the extra.
+
+**The simulator's matched rules.** `buildRuleDescriptions` indexes the engine's
+`ruleDescriptions` by merged rule index; a matched row then quotes the author's
+sentences (one line each — a rule description is commonly two separate
+sentences) with a muted attribution line: _author's description of this rule_
+for a preset rule, _your description, packageRules[0] in your repo config_ for
+the reader's own, using `sourceIndex` so the citation is an index they can find
+in their editor rather than `packageRules[312]`. It renders on both surfaces
+that show a rule — the matched-rules drawer row (`RuleRow`) and the verdict
+card's rule-evidence popover, which carries it on `RuleEvidence` so the popover
+needs no lookup of its own. Never on a no-match row: there the sentence explains
+a rule that did nothing.
+
+`rcd simulate` needs no change — it formats its verdict lines from the engine's
+`RuleEvaluation` directly rather than from an app derivation, and no headless
+export changed.
+
+Deviations from the mockup, both deliberate: the path's root segment is the
+tree's own `(input config)` rather than the mockup's shortened `(input)`, and
+the repo-rule citation says "in your repo config" rather than naming
+`renovate.json` — the simulator is not told the config's file name, and naming
+the wrong file would be worse than naming none.
+
+### Verification (PR 5)
+
+- `src/lib/description-attribution.test.ts` — the card model: the path (and its
+  elision), the facts line with its duplicate and packageRules clauses, the repo
+  config's own sentences not masquerading as a preset, and the positional guard
+  refusing a shorter array, a reordered one and a non-array.
+- `src/features/simulator/rule-descriptions.test.ts` — the three attribution
+  wordings, the merged-index keying, and the empty cases.
+- `src/components/EffectiveConfig.test.tsx` — the wiring end to end on a real
+  run: no cards in keep-internal mode, cards in fully-expanded mode, the card's
+  path and position, and its tree jump.
+- `src/features/simulator/RuleRow.test.tsx`, `RuleEvidenceCard.test.tsx` and
+  `rule-evidence.test.ts` — the quote where it belongs (outside the head button,
+  above the clause evidence), and only on a matched, described rule.

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -269,11 +269,17 @@ already keeps a per-run `parents` map and each node's own rule count.
 
 The scope is what the attribution can honestly carry. Attribution is by INDEX
 into the final `description` array, so `descriptionCardsFor` compares the
-rendered document's array against it value by value and attaches nothing on any
-disagreement — which is exactly what happens in the As-JSON view's default
-keep-internal mode (presets still referenced, so their sentences are absent) and
-in the defaults-hydrated document. Preset-body views (`PresetDetail`) keep plain
-rendering: a preset's own `description` is a different array again.
+rendered document's array against it — each entry at its REAL index, and every
+index the engine reports as unattributed still holding a non-string — and
+attaches nothing on any disagreement, which is exactly what happens in the
+As-JSON view's default keep-internal mode (presets still referenced, so their
+sentences are absent) and in the defaults-hydrated document. Real indices,
+because a `description` array may legally hold non-strings (Renovate only warns
+about `["a", 42]`): those members get no card and render as plain JSON, but they
+occupy positions, so the cards are handed back placed BY index and the facts
+line counts the whole array — `Position 3 of 4`, not `3 of 3`. Preset-body views
+(`PresetDetail`) keep plain rendering: a preset's own `description` is a
+different array again.
 
 The affordance is the glossary's, not a new one. `useHoverCard` and the anchor
 component were hoisted out of `components/glossary.tsx` (`hooks/hover-card.ts` +
@@ -286,6 +292,15 @@ opens a card of its own, and the singleton would close the card it stands in),
 and the _Show in preset tree_ link is pointer-reachable only, since the card is
 portalled to `<body>` and closes on blur — the attribution itself is fully
 keyboard-readable, the jump is the extra.
+
+One thing the hoist had to add for that keyboard reachability: the hide-on-scroll
+ignores scrolls arriving within `SHOW_SCROLL_GRACE_MS` of the show, and
+re-anchors on them instead. Tab onto a string only partly in view and the browser
+scrolls it into view itself; that scroll landed in the capture listener a frame
+after the card opened and closed it again, so every anchor that was not already
+fully visible had no keyboard card at all. Re-anchoring rather than merely
+ignoring, because the anchor really did move — a card left at its opening
+coordinates points at whatever slid under it.
 
 **The simulator's matched rules.** `buildRuleDescriptions` indexes the engine's
 `ruleDescriptions` by merged rule index; a matched row then quotes the author's


### PR DESCRIPTION
Hovering a top-level description string in the resolved-config JSON
view now pops the standard hover card naming the preset that wrote it,
its path in the resolution tree, its position among the accumulated
strings, and a jump into the preset tree. Simulator verdicts quote the
matched rule's author-written description with an attribution line, so
a rule explains why it exists. The glossary hover-card affordance is
hoisted into a shared primitive both surfaces reuse.
Roadmap 069, PR 5 of 5.