### PR TITLE
feat(app): shorter tagline and a welcome link that analyzes this project's own config

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -27,6 +27,7 @@ import type { ResultsColumnProps } from "@/ResultsColumn";
 import { UntrustedHostBanner } from "@/UntrustedHostBanner";
 import { legacyTabForView, type ResultsTabId } from "@/data/results-tabs";
 import { OptionDocsProvider } from "@/components/option-docs";
+import { REPO_URL } from "@/data/project-repo";
 import { buildPresetLookup, type PresetHoverContext } from "@/lib/preset-hover";
 import { flashTarget, motionScrollOptions, motionScrollToOptions } from "@/lib/motion";
 import { SELECTED_PRESET_ROW } from "@/lib/preset-row-dom";
@@ -1832,8 +1833,8 @@ export function App() {
           />
         </header>
         <p className="subtitle">
-          Understand your Renovate config by watching Renovate&apos;s own code process it, step by
-          step, right here in your browser. Nothing you paste leaves the page.
+          Watch Renovate&apos;s own code process your config, step by step — nothing leaves your
+          browser.
         </p>
 
         {/* Roadmap 028: config on the left, one tabbed results panel on the
@@ -1845,6 +1846,10 @@ export function App() {
             columnRef={configColRef}
             hasResult={Boolean(result)}
             onTryExample={() => loadConfigText(EXAMPLE_CONFIG)}
+            // The dogfood shortcut: fetch and run THIS app's own renovate.json,
+            // live from its repository — a full URL, so the load pins the
+            // github context instead of inheriting whatever host is selected.
+            onAnalyzeThisProject={() => void onLoadRepo(REPO_URL)}
             editorKey={editorKey}
             editorRef={configEditorRef}
             fileName={fileName}

--- a/packages/app/src/ConfigColumn.tsx
+++ b/packages/app/src/ConfigColumn.tsx
@@ -14,6 +14,7 @@ interface ConfigColumnProps {
   columnRef: RefObject<HTMLDivElement | null>;
   hasResult: boolean;
   onTryExample: () => void;
+  onAnalyzeThisProject: () => void;
   // ConfigEditorCard
   editorKey: number;
   editorRef: RefObject<ConfigEditorHandle | null>;
@@ -73,6 +74,7 @@ export function ConfigColumn({
   columnRef,
   hasResult,
   onTryExample,
+  onAnalyzeThisProject,
   editorKey,
   editorRef,
   fileName,
@@ -118,7 +120,9 @@ export function ConfigColumn({
     // jump to a non-focusable container moves the scroll but not the focus,
     // which is the half that matters to a keyboard user.
     <div className="config-col" id="config-column" tabIndex={-1} ref={columnRef}>
-      {hasResult ? null : <WelcomePanel onTryExample={onTryExample} />}
+      {hasResult ? null : (
+        <WelcomePanel onTryExample={onTryExample} onAnalyzeThisProject={onAnalyzeThisProject} />
+      )}
 
       <ConfigEditorCard
         editorKey={editorKey}

--- a/packages/app/src/components/ProjectLinks.tsx
+++ b/packages/app/src/components/ProjectLinks.tsx
@@ -1,4 +1,5 @@
 import { SessionMenuItem } from "@/components/SessionMenuItem";
+import { REPO_URL } from "@/data/project-repo";
 
 /**
  * Roadmap 055 — the two links out of the app and into its repository: the
@@ -13,12 +14,6 @@ import { SessionMenuItem } from "@/components/SessionMenuItem";
  * `title` the reader has to hover to discover.
  */
 
-// The repository's CURRENT name: GitHub renamed `renovate-config-visualizer`
-// to `renovate-config-debugger` (the app's own title since 016), and the old
-// name lives on as a redirect. Verified against
-// `gh api repos/secustor/renovate-config-debugger`. A link a user reads before
-// clicking should carry the name they will land on.
-const REPO_URL = "https://github.com/secustor/renovate-config-debugger";
 const ISSUES_URL = `${REPO_URL}/issues`;
 
 /** Octicons 16px: `mark-github`, `issue-opened`. */

--- a/packages/app/src/data/project-repo.ts
+++ b/packages/app/src/data/project-repo.ts
@@ -1,0 +1,12 @@
+/**
+ * The app's own repository — the UPSTREAM project, not a self-hoster's fork.
+ * Shared by the session-menu links (055/066) and the welcome panel's
+ * "analyze this project's config" dogfood shortcut.
+ *
+ * The repository's CURRENT name: GitHub renamed `renovate-config-visualizer`
+ * to `renovate-config-debugger` (the app's own title since 016), and the old
+ * name lives on as a redirect. Verified against
+ * `gh api repos/secustor/renovate-config-debugger`. A link a user reads before
+ * clicking should carry the name they will land on.
+ */
+export const REPO_URL = "https://github.com/secustor/renovate-config-debugger";

--- a/packages/app/src/features/editor/WelcomePanel.tsx
+++ b/packages/app/src/features/editor/WelcomePanel.tsx
@@ -8,17 +8,23 @@ import { Term } from "@/components/glossary";
 
 interface Props {
   onTryExample: () => void;
+  /** Loads and runs this app's own repository config — a live dogfood demo. */
+  onAnalyzeThisProject: () => void;
 }
 
-export function WelcomePanel({ onTryExample }: Props) {
+export function WelcomePanel({ onTryExample, onAnalyzeThisProject }: Props) {
   return (
     <section className="welcome" aria-label="How it works">
       <ol className="welcome-steps">
         <li>
           <strong>Bring a config.</strong> Paste your <code>renovate.json</code> below, load it
-          straight from a repository, or{" "}
+          straight from a repository,{" "}
           <button type="button" className="linklike" onClick={onTryExample}>
             try an example
+          </button>
+          , or{" "}
+          <button type="button" className="linklike" onClick={onAnalyzeThisProject}>
+            analyze this project&apos;s config
           </button>
           .
         </li>

--- a/packages/app/src/hooks/use-repo-load.ts
+++ b/packages/app/src/hooks/use-repo-load.ts
@@ -144,7 +144,9 @@ export interface RepoLoad {
   /** When a GitHub load fails with a not-found/auth/rate-limit error, offer
    *  the sign-in / install hint next to the failure (009). null = no hint. */
   repoAuthHint: { rateLimited: boolean } | null;
-  onLoadRepo: () => Promise<void>;
+  /** Loads `reference` when given (a welcome-panel shortcut), else the typed
+   *  `repoInput` (the form's submit). */
+  onLoadRepo: (reference?: string) => Promise<void>;
 }
 
 export function useRepoLoad(host: RepoLoadHost): RepoLoad {
@@ -198,9 +200,11 @@ export function useRepoLoad(host: RepoLoadHost): RepoLoad {
   // Fetches a repo's Renovate config file and runs it. Derives the platform
   // from a known host (and sets the platform context so a later run resolves
   // `local>` correctly); a bare slug uses the current platform context.
-  async function onLoadRepo() {
-    const parsed = parseRepoRef(repoInput);
-    const trimmedRef = repoRef.trim();
+  async function onLoadRepo(reference?: string) {
+    const parsed = parseRepoRef(reference ?? repoInput);
+    // An explicit reference is a shortcut to a repo's default branch — the ref
+    // field belongs to the form gesture it bypassed.
+    const trimmedRef = reference !== undefined ? "" : repoRef.trim();
     // Roadmap 030: the parsed host/repo/ref are bounded and control-character
     // free before they compose a request URL/path — the same "Enter a repo
     // as..." notice covers a reference that parsed but shouldn't be trusted.
@@ -276,8 +280,11 @@ export function useRepoLoad(host: RepoLoadHost): RepoLoad {
       setNotice(`Loaded ${loaded.fileName} from ${parsed.repo}`);
       // Roadmap 039: the panel's job is done — it collapses so the config it
       // just fetched gets the height back. A FAILED load leaves it open: the
-      // reference in it is what the user has to correct.
-      closeRepoForm();
+      // reference in it is what the user has to correct. A shortcut load never
+      // opened it, and closing would steal focus for the toggle button.
+      if (repoFormOpen) {
+        closeRepoForm();
+      }
       // Roadmap 045: the inherited-config probe runs between the repo config
       // arriving and the run that processes it — the order a real run resolves
       // the two in, so the very first result already includes the org layer


### PR DESCRIPTION
## What

Two landing-page cleanups:

**Shorter tagline.** The subtitle drops from two sentences to one line:

> Watch Renovate's own code process your config, step by step — nothing leaves your browser.

The privacy claim stays (and the welcome footnote still spells out that config and tokens stay in the tab).

**"Analyze this project's config" link.** The welcome panel's first step now offers three actions: load from a repository, *try an example*, or *analyze this project's config*. The new link is a live dogfood demo — it goes through the real load-from-repo path against `github.com/secustor/renovate-config-debugger`, fetching the repo's actual `renovate.json` and running it (including resolving `local>secustor/renovate-config`), rather than pasting a stale copy.

## How

- `useRepoLoad`'s `onLoadRepo` accepts an optional explicit reference (bypassing the form's input and ref fields), and only collapses/refocuses the repo form when it was actually open — a shortcut load never opened it, and closing would steal focus for the toggle button.
- `REPO_URL` moved from `ProjectLinks.tsx` into a shared `src/data/project-repo.ts` (the fast-refresh lint rule forbids constant exports from component files), so the session-menu links and the welcome shortcut share one canonical URL.
- The prop threads `App.tsx` → `ConfigColumn` → `WelcomePanel` as `onAnalyzeThisProject`.

## Notes

- The link's fetch is unauthenticated GitHub API; a rate-limited visitor gets the existing failure handling (error + sign-in hint when OAuth is configured).
- Lint, typecheck, and the app unit tests are green. No e2e asserts on the changed copy.