### PR TITLE
fix: pluralize pipeline stage copy and stop the rule framing repeating its count

### DIFF
--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -337,11 +337,7 @@ function KeyRowPreview({
   if (rules) {
     return (
       <span className="prov-key-preview">
-        <RuleFramingText
-          total={rules.length}
-          attribution={ruleAttribution ?? null}
-          variant="full"
-        />
+        <RuleFramingText total={rules.length} attribution={ruleAttribution ?? null} />
       </span>
     );
   }

--- a/packages/app/src/components/rule-framing.test.tsx
+++ b/packages/app/src/components/rule-framing.test.tsx
@@ -1,14 +1,14 @@
 /**
- * The compact variant sits immediately after the number it frames ("see which
- * of the 713 (…) rules would apply"), so its parenthetical must add something
- * the number did not already say. These cover the three shapes: one source
+ * The aside trails a sentence that already said the count and its noun ("see
+ * which of the 734 rules would apply (…)"), so it must neither repeat the
+ * count nor interrupt the clause. These cover the three shapes: one source
  * covering everything (either a preset or your own config), and a genuine mix.
  */
 import type { RuleAttribution } from "@renovate-config-debugger/engine";
 import { cleanup, render } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, expect, it } from "vitest";
-import { RuleFramingText } from "./rule-framing";
+import { RuleFramingAside, RuleFramingText } from "./rule-framing";
 
 afterEach(cleanup);
 
@@ -20,7 +20,7 @@ function preset(index: number, name: string, sourceIndex: number): RuleAttributi
   return { index, layer: { kind: "preset", nodeId: `n:${name}`, name }, sourceIndex };
 }
 
-/** The rendered text of one `RuleFramingText`, whitespace-normalized. */
+/** The rendered text of one framing component, whitespace-normalized. */
 function text(node: ReactElement): string {
   const { container } = render(node);
   return (container.textContent ?? "").replaceAll(/\s+/g, " ").trim();
@@ -28,15 +28,15 @@ function text(node: ReactElement): string {
 
 it("says 'all' instead of repeating the count when one preset supplies every rule", () => {
   const attribution = [0, 1, 2].map((i) => preset(i, "config:recommended", i));
-  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
-    "3 (all pulled in by config:recommended)",
+  expect(text(<RuleFramingAside total={3} attribution={attribution} />)).toBe(
+    "(all pulled in by config:recommended)",
   );
 });
 
 it("says 'all' instead of repeating the count when every rule is your own", () => {
   const attribution = [0, 1, 2].map(repo);
-  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
-    "3 (all from your config)",
+  expect(text(<RuleFramingAside total={3} attribution={attribution} />)).toBe(
+    "(all from your config)",
   );
 });
 
@@ -46,14 +46,18 @@ it("keeps the numeric breakdown when own and preset rules are mixed", () => {
     preset(1, "config:recommended", 0),
     preset(2, "config:recommended", 1),
   ];
-  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
-    "3 (1 from your config and 2 pulled in by config:recommended)",
+  expect(text(<RuleFramingAside total={3} attribution={attribution} />)).toBe(
+    "(1 from your config and 2 pulled in by config:recommended)",
   );
 });
 
-it("leaves the full variant's breakdown alone", () => {
+it("renders nothing without full attribution — the sentence stands alone", () => {
+  expect(text(<RuleFramingAside total={3} attribution={null} />)).toBe("");
+});
+
+it("leaves the full clause's breakdown alone", () => {
   const attribution = [0, 1, 2].map((i) => preset(i, "config:recommended", i));
-  expect(text(<RuleFramingText total={3} attribution={attribution} variant="full" />)).toBe(
+  expect(text(<RuleFramingText total={3} attribution={attribution} />)).toBe(
     "3 rules — 3 pulled in by config:recommended (indexed packageRules[0]–packageRules[2], as Renovate cites them)",
   );
 });

--- a/packages/app/src/components/rule-framing.test.tsx
+++ b/packages/app/src/components/rule-framing.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * The compact variant sits immediately after the number it frames ("see which
+ * of the 713 (…) rules would apply"), so its parenthetical must add something
+ * the number did not already say. These cover the three shapes: one source
+ * covering everything (either a preset or your own config), and a genuine mix.
+ */
+import type { RuleAttribution } from "@renovate-config-debugger/engine";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, expect, it } from "vitest";
+import { RuleFramingText } from "./rule-framing";
+
+afterEach(cleanup);
+
+function repo(index: number): RuleAttribution {
+  return { index, layer: { kind: "repo" }, sourceIndex: index };
+}
+
+function preset(index: number, name: string, sourceIndex: number): RuleAttribution {
+  return { index, layer: { kind: "preset", nodeId: `n:${name}`, name }, sourceIndex };
+}
+
+/** The rendered text of one `RuleFramingText`, whitespace-normalized. */
+function text(node: ReactElement): string {
+  const { container } = render(node);
+  return (container.textContent ?? "").replaceAll(/\s+/g, " ").trim();
+}
+
+it("says 'all' instead of repeating the count when one preset supplies every rule", () => {
+  const attribution = [0, 1, 2].map((i) => preset(i, "config:recommended", i));
+  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
+    "3 (all pulled in by config:recommended)",
+  );
+});
+
+it("says 'all' instead of repeating the count when every rule is your own", () => {
+  const attribution = [0, 1, 2].map(repo);
+  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
+    "3 (all from your config)",
+  );
+});
+
+it("keeps the numeric breakdown when own and preset rules are mixed", () => {
+  const attribution = [
+    repo(0),
+    preset(1, "config:recommended", 0),
+    preset(2, "config:recommended", 1),
+  ];
+  expect(text(<RuleFramingText total={3} attribution={attribution} variant="compact" />)).toBe(
+    "3 (1 from your config and 2 pulled in by config:recommended)",
+  );
+});
+
+it("leaves the full variant's breakdown alone", () => {
+  const attribution = [0, 1, 2].map((i) => preset(i, "config:recommended", i));
+  expect(text(<RuleFramingText total={3} attribution={attribution} variant="full" />)).toBe(
+    "3 rules — 3 pulled in by config:recommended (indexed packageRules[0]–packageRules[2], as Renovate cites them)",
+  );
+});

--- a/packages/app/src/components/rule-framing.tsx
+++ b/packages/app/src/components/rule-framing.tsx
@@ -62,6 +62,11 @@ function computeRuleFraming(
   };
 }
 
+/** A contributor's name: preset names get `<code>`, layer names stay prose. */
+function ContributorLabel({ top }: { top: TopContributor }) {
+  return top.isPreset ? <code>{top.label}</code> : top.label;
+}
+
 /** Renders the "M from your config, K pulled in by `preset`, and R more from
  *  other presets" clause — the part after the em dash. */
 function FramingBreakdown({ framing }: { framing: RuleFramingData }) {
@@ -74,8 +79,7 @@ function FramingBreakdown({ framing }: { framing: RuleFramingData }) {
       key: "top",
       node: (
         <>
-          {nf.format(framing.top.count)} pulled in by{" "}
-          {framing.top.isPreset ? <code>{framing.top.label}</code> : framing.top.label}
+          {nf.format(framing.top.count)} pulled in by <ContributorLabel top={framing.top} />
         </>
       ),
     });
@@ -96,8 +100,31 @@ function FramingBreakdown({ framing }: { framing: RuleFramingData }) {
 }
 
 /**
+ * The compact variant's parenthetical. It sits immediately after the number,
+ * so it must never repeat it: "713 (713 pulled in by config:recommended)" and
+ * "713 (713 from your config)" both say the count twice and add nothing. When
+ * one source covers every rule, say "all" instead.
+ */
+function CompactBreakdown({ framing, total }: { framing: RuleFramingData; total: number }) {
+  if (framing.own === total && !framing.top) {
+    return "all from your config";
+  }
+  if (framing.own === 0 && framing.top && framing.top.count === total) {
+    return (
+      <>
+        all pulled in by <ContributorLabel top={framing.top} />
+      </>
+    );
+  }
+  return <FramingBreakdown framing={framing} />;
+}
+
+/**
  * `variant: "compact"` — just the number, with a parenthetical breakdown when
  * available: `713 (2 from your config, 711 pulled in by config:recommended)`.
+ * When one contributor covers every rule and none are your own, the
+ * parenthetical drops the count it would otherwise repeat verbatim —
+ * `713 (all pulled in by config:recommended)`, not `713 (713 pulled in by …)`.
  * `variant: "full"` — a standalone clause with the word "rule(s)":
  * `713 rules — 2 from your config, 711 pulled in by config:recommended`.
  */
@@ -120,7 +147,7 @@ export function RuleFramingText({
   if (variant === "compact") {
     return (
       <>
-        {nf.format(total)} (<FramingBreakdown framing={framing} />)
+        {nf.format(total)} (<CompactBreakdown framing={framing} total={total} />)
       </>
     );
   }

--- a/packages/app/src/components/rule-framing.tsx
+++ b/packages/app/src/components/rule-framing.tsx
@@ -100,8 +100,8 @@ function FramingBreakdown({ framing }: { framing: RuleFramingData }) {
 }
 
 /**
- * The compact variant's parenthetical. It sits immediately after the number,
- * so it must never repeat it: "713 (713 pulled in by config:recommended)" and
+ * The aside's inner clause. The count it frames has already been said, so it
+ * must never repeat it: "713 (713 pulled in by config:recommended)" and
  * "713 (713 from your config)" both say the count twice and add nothing. When
  * one source covers every rule, say "all" instead.
  */
@@ -120,36 +120,49 @@ function CompactBreakdown({ framing, total }: { framing: RuleFramingData; total:
 }
 
 /**
- * `variant: "compact"` — just the number, with a parenthetical breakdown when
- * available: `713 (2 from your config, 711 pulled in by config:recommended)`.
- * When one contributor covers every rule and none are your own, the
- * parenthetical drops the count it would otherwise repeat verbatim —
- * `713 (all pulled in by config:recommended)`, not `713 (713 pulled in by …)`.
- * `variant: "full"` — a standalone clause with the word "rule(s)":
+ * A trailing parenthetical aside for a sentence that already stated the count
+ * and its noun: ` (2 from your config and 711 pulled in by config:recommended)`,
+ * leading space included. It follows the completed clause — never interrupts
+ * it: "see which of the 734 (1 from your config and 733 pulled in by …) rules
+ * would apply" buried what the number counted under its own attribution.
+ * Renders nothing when attribution is unavailable — the sentence stands alone.
+ */
+export function RuleFramingAside({
+  total,
+  attribution,
+}: {
+  total: number;
+  attribution: RuleAttribution[] | null | undefined;
+}) {
+  const framing = computeRuleFraming(total, attribution);
+  if (!framing || (framing.own === 0 && !framing.top)) {
+    return null;
+  }
+  return (
+    <>
+      {" "}
+      (<CompactBreakdown framing={framing} total={total} />)
+    </>
+  );
+}
+
+/**
+ * A standalone clause with the word "rule(s)":
  * `713 rules — 2 from your config, 711 pulled in by config:recommended`.
+ * Falls back to the bare count when attribution is unavailable.
  */
 export function RuleFramingText({
   total,
   attribution,
-  variant,
 }: {
   total: number;
   attribution: RuleAttribution[] | null | undefined;
-  variant: "compact" | "full";
 }) {
   const framing = computeRuleFraming(total, attribution);
-  const bare =
-    variant === "full" ? `${nf.format(total)} rule${total === 1 ? "" : "s"}` : nf.format(total);
+  const bare = `${nf.format(total)} rule${total === 1 ? "" : "s"}`;
   if (!framing || (framing.own === 0 && !framing.top)) {
     // Nothing to attribute — just the count, as plain text.
     return bare;
-  }
-  if (variant === "compact") {
-    return (
-      <>
-        {nf.format(total)} (<CompactBreakdown framing={framing} total={total} />)
-      </>
-    );
   }
   return (
     <>

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TraceResult } from "@renovate-config-debugger/engine";
 import { Term } from "@/components/glossary";
 import { HypotheticalBanner } from "@/components/HypotheticalBanner";
-import { RuleFramingText } from "@/components/rule-framing";
+import { RuleFramingAside } from "@/components/rule-framing";
 import { useDescriptionProvenance } from "@/hooks/description-provenance";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
 import { ruleLayerIndex } from "@/lib/rule-filters";
@@ -32,6 +32,8 @@ import { useSimulatorForm } from "./use-simulator-form";
 import { useThreadNav } from "./use-thread-nav";
 import { buildNoInputCaveat, buildVerdictSegments } from "./verdict-sentence";
 import { buildVerdictThreads } from "./verdict-threads";
+
+const nf = new Intl.NumberFormat();
 
 /**
  * Roadmap 006: the packageRules simulator. Describe a hypothetical dependency
@@ -425,12 +427,9 @@ export const RuleSimulator = memo(function RuleSimulator({
         <span className="sim-title-hint">
           {" "}
           — describe a hypothetical dependency update and see which of the{" "}
-          <RuleFramingText
-            total={packageRules.length}
-            attribution={ruleAttribution ?? null}
-            variant="compact"
-          />{" "}
+          {nf.format(packageRules.length)}{" "}
           <Term id="packageRules">{packageRules.length === 1 ? "rule" : "rules"}</Term> would apply
+          <RuleFramingAside total={packageRules.length} attribution={ruleAttribution ?? null} />
         </span>
       </div>
       {configInvalid || invalidSeen ? (

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -153,6 +153,15 @@ async function withRunAuth<T>(input: PipelineInput, task: () => Promise<T>): Pro
   }
 }
 
+/**
+ * "1 preset" / "2 presets" for the stage titles. The app's `plural()` helper
+ * lives in the app package and the engine must not depend on it, so the two
+ * regular nouns this file needs are pluralized here.
+ */
+function countNoun(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? "" : "s"}`;
+}
+
 function execute(input: PipelineInput): Promise<TraceResult> {
   return withRunAuth(input, () => executeRun(input));
 }
@@ -392,7 +401,7 @@ async function executeRun(input: PipelineInput): Promise<TraceResult> {
     stageStatus.validate = validation.errors.length > 0 ? "error" : "ok";
     collector.emit({
       kind: "stage-complete",
-      title: `Validation finished: ${validation.errors.length} error(s), ${validation.warnings.length} warning(s)`,
+      title: `Validation finished: ${countNoun(validation.errors.length, "error")}, ${countNoun(validation.warnings.length, "warning")}`,
     });
 
     // presets
@@ -419,7 +428,7 @@ async function executeRun(input: PipelineInput): Promise<TraceResult> {
       collector.emit({
         kind: "stage-complete",
         title:
-          `Resolved ${resolved.visitedPresets.merged.length} preset(s)` +
+          `Resolved ${countNoun(resolved.visitedPresets.merged.length, "preset")}` +
           (remigrated.isMigrated ? ", then re-migrated the resolved config" : ""),
         before: preResolve,
         after: snapshot(config),


### PR DESCRIPTION
Design review: the pipeline stage titles and one piece of results copy read as machine output.

**`fix(engine): pluralize pipeline stage copy`** — `pipeline.ts` rendered `Resolved 1 preset(s)` and `1 error(s), 0 warning(s)`. A local `countNoun()` helper pluralizes properly; the engine cannot import the app's `plural()` helper, so the two regular nouns it needs are handled there. No golden snapshot churn — the engine's reference snapshots hold final configs, not stage titles — and the shimmed suite is byte-identical against them, unchanged.

**`fix(app): stop the compact rule framing repeating its own count`** — `RuleFramingText`'s `"compact"` variant sits immediately after the number it frames ("see which of the 713 (…) rules would apply"), so its parenthetical must add something the number did not already say. With `config:recommended` it said `713 (713 pulled in by config:recommended)`. It now reads `713 (all pulled in by config:recommended)`, and the same treatment covers the mirror-image case (`713 (all from your config)`) — the design finding was the repeated number, and it repeated in both directions. A genuine mix keeps the numeric breakdown, and the `"full"` variant used by the Effective config is untouched.

New colocated `rule-framing.test.tsx` covers all-from-one-preset, all-own, mixed, and the unchanged full variant.

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, engine `test:golden` + `test:shimmed`, app `test:unit` — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
