### PR TITLE
fix(app): soften dark-mode diff row backgrounds

### DIFF
--- a/packages/app/e2e/13-unified-chrome-and-theme.spec.ts
+++ b/packages/app/e2e/13-unified-chrome-and-theme.spec.ts
@@ -138,9 +138,9 @@ test.describe("theme switcher (037)", () => {
     await expect
       .poll(() => deleted.evaluate((el) => getComputedStyle(el).backgroundColor))
       .not.toBe(lightBg);
-    // The dark delete row, verbatim from the 035 palette.
+    // The dark delete row, verbatim from the `.diff-wrapper` palette (#301c1e).
     expect(await deleted.evaluate((el) => getComputedStyle(el).backgroundColor)).toBe(
-      "rgb(61, 20, 24)",
+      "rgb(48, 28, 30)",
     );
   });
 });

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1683,22 +1683,39 @@ textarea.layer-editor:focus {
    a guard if that ever changes.) */
 .diff-wrapper {
   --diff-background-color: transparent;
-  --diff-code-delete-background-color: light-dark(#fdeff0, #3d1418);
+  /* Dark halves are a quiet WASH, not an alarm color: the light theme gets
+     soft pastels while the dark row fills used to be fully saturated
+     (#3d1418 / #103218, ~51% HSL saturation), which made the fill, not the
+     code, the foreground. Both row fills are now the same hues at ~26%
+     saturation and roughly the surface's own lightness — #151b23 with a tint,
+     the same relationship every other tinted surface in this file has to it.
+     Contrast against --ink (#f0f6fc, relative luminance 0.9146) is unchanged
+     or better: 14.72:1 delete (was 14.71), 13.41:1 insert (was 12.94). */
+  --diff-code-delete-background-color: light-dark(#fdeff0, #301c1e);
   /* The word-level edit highlight was never dark-themed at all: the library
      paints it #f39ea2/#c0dc91, which left light text on a light chip inside
-     an otherwise dark row. Both pass 4.5:1 against --diff-text-color. */
-  --diff-code-delete-edit-background-color: light-dark(#f39ea2, #8e2f36);
+     an otherwise dark row. Both pass 4.5:1 against --diff-text-color. The
+     dark halves stay ~4x and ~3x the luminance of the row fill they sit in,
+     so the word-level emphasis still reads as the stronger mark: 8.65:1
+     delete (L 0.0616 over the row's 0.0155), 8.10:1 insert (0.0690 over
+     0.0220). */
+  --diff-code-delete-edit-background-color: light-dark(#f39ea2, #6e3539);
   --diff-code-delete-edit-text-color: var(--ink);
   --diff-code-delete-text-color: var(--ink);
-  --diff-code-insert-background-color: light-dark(#eaffee, #103218);
-  --diff-code-insert-edit-background-color: light-dark(#c0dc91, #1a5c2e);
+  --diff-code-insert-background-color: light-dark(#eaffee, #1a2d1f);
+  --diff-code-insert-edit-background-color: light-dark(#c0dc91, #285336);
   --diff-code-insert-edit-text-color: var(--ink);
   --diff-code-insert-text-color: var(--ink);
   --diff-code-selected-background-color: var(--highlight);
   --diff-code-selected-text-color: var(--ink);
-  --diff-gutter-delete-background-color: light-dark(#fadde0, #67060c);
+  /* The gutter is chrome; it must never shout louder than the row it labels.
+     The old dark halves did exactly that (#67060c / #033a16 at luminance
+     0.0304 / 0.0310, roughly twice their own row fills). Each is now a shade
+     BELOW its row: 0.0122 vs 0.0155 delete, 0.0172 vs 0.0220 insert.
+     15.51:1 and 14.36:1 against --ink. */
+  --diff-gutter-delete-background-color: light-dark(#fadde0, #2a181a);
   --diff-gutter-delete-text-color: var(--ink);
-  --diff-gutter-insert-background-color: light-dark(#d6fedb, #033a16);
+  --diff-gutter-insert-background-color: light-dark(#d6fedb, #17271c);
   --diff-gutter-insert-text-color: var(--ink);
   --diff-gutter-selected-background-color: var(--highlight);
   --diff-gutter-selected-text-color: var(--ink);


### PR DESCRIPTION
Design review: in dark mode the unified diff rows (Pipeline / Rewrites) used fully saturated red and green fills while light mode got soft pastels — the fill, not the code, was the foreground. The gutter fills were louder still, roughly twice the luminance of the rows they label.

Both row fills drop to ~26% HSL saturation at roughly the surface's own lightness (`#151b23` with a tint — the same relationship every other tinted surface in `index.css` has to it). Each gutter lands a shade *below* its row. The word-level edit emphasis stays 3–4x the row luminance, so it still reads as the stronger mark. Light-mode values are untouched. All changes live inside the documented `.diff-wrapper` stylelint-disable island.

### WCAG contrast against `--ink` (`#f0f6fc`, relative luminance 0.9146)

| variable | before | L | ratio | after | L | ratio |
| --- | --- | --- | --- | --- | --- | --- |
| `--diff-code-delete-background-color` | `#3d1418` | 0.01558 | 14.71:1 | `#301c1e` | 0.01553 | **14.72:1** |
| `--diff-code-insert-background-color` | `#103218` | 0.02457 | 12.94:1 | `#1a2d1f` | 0.02195 | **13.41:1** |
| `--diff-code-delete-edit-background-color` | `#8e2f36` | 0.08050 | 7.39:1 | `#6e3539` | 0.06157 | **8.65:1** |
| `--diff-code-insert-edit-background-color` | `#1a5c2e` | 0.08071 | 7.38:1 | `#285336` | 0.06904 | **8.10:1** |
| `--diff-gutter-delete-background-color` | `#67060c` | 0.03040 | 12.00:1 | `#2a181a` | 0.01220 | **15.51:1** |
| `--diff-gutter-insert-background-color` | `#033a16` | 0.03103 | 11.90:1 | `#17271c` | 0.01717 | **14.36:1** |

`L` is the WCAG 2.1 relative luminance; the ratio is `(0.9646) / (L + 0.05)`. Every new value clears 4.5:1 with a wide margin, and every one improves on its predecessor.

The three invariants the review asked for, in those numbers:

- **delete vs insert stay distinguishable** — delete is warm (48, 28, 30), insert is green (26, 45, 31), against a surface of (21, 27, 35).
- **edit emphasis stays visibly stronger than its row** — 0.0616 over 0.0155 (4.0x) for delete, 0.0690 over 0.0220 (3.1x) for insert.
- **gutters are no louder than the rows** — 0.0122 < 0.0155 delete, 0.0172 < 0.0220 insert (they were 0.0304 and 0.0310).

**Guard:** `e2e/12-layout-regressions.spec.ts` asserts ≥ 4.5:1 on `#panel-rewrites .diff-code-delete/insert` in dark mode — green. `e2e/13-unified-chrome-and-theme.spec.ts` pinned the old dark delete row verbatim (`rgb(61, 20, 24)`); it now pins the new one.

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and specs 12 + 13 — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
