### PR TITLE
fix(app): cut repeated badge noise in the preset tree

### DIFF
--- a/packages/app/e2e/13-unified-chrome-and-theme.spec.ts
+++ b/packages/app/e2e/13-unified-chrome-and-theme.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test, type Page } from "@playwright/test";
-import { SEMANTIC_COMMITS_CONFIG } from "./fixtures";
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import { IGNORED_PRESET_CONFIG, SEMANTIC_COMMITS_CONFIG } from "./fixtures";
 import {
   must,
   openSessionMenu,
@@ -201,27 +201,62 @@ test("the diff chrome names the active view and offers Copy result (036)", async
   expect(chromeBg).not.toBe("rgba(0, 0, 0, 0)");
 });
 
+/** A badge's painted fill and border, as the browser resolves them. Width, not
+ *  just color: `border: none` leaves `border-top-color` resolving to the
+ *  element's own `color`, so only the width says whether a border is drawn. */
+function paintOf(badge: Locator) {
+  return badge.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      background: style.backgroundColor,
+      borderColor: style.borderTopColor,
+      borderWidth: style.borderTopWidth,
+    };
+  });
+}
+
+/** Transparent is either the keyword or a zero alpha channel. */
+function isTransparent(value: string): boolean {
+  return value === "transparent" || /,\s*0\s*\)$/.test(value);
+}
+
 /**
  * Badges used to be outline-only, which the design review read as "inactive".
  * One `color-mix(… currentColor 13% …)` rule tints every variant from its own
- * hue — so any badge in the tree must now paint a background.
+ * hue — so any badge in the tree that is still a CHIP must paint a background.
+ *
+ * A later design review pulled the other way for the counts: "N opts" /
+ * "N rules" ride every row, and a pill on every row is a fill the eye has to
+ * skip past, so they joined `.rollup` as plain muted text. Both halves are
+ * asserted here, because "filled" and "deliberately not filled" only mean
+ * something together.
  */
-test("preset-tree badges are filled, not outlines (036)", async ({ page }) => {
+test("preset-tree chips are filled, contribution counts are plain text (036)", async ({ page }) => {
   await page.goto("/");
+  await setEditorContent(page, IGNORED_PRESET_CONFIG);
   await runAndAwaitResult(page);
   await openTab(page, "presets");
 
-  const badge = page.locator("#panel-presets .preset-row .badge:not(.rollup)").first();
-  await expect(badge).toBeVisible();
-  const { background, border } = await badge.evaluate((el) => {
-    const style = getComputedStyle(el);
-    return { background: style.backgroundColor, border: style.borderTopColor };
-  });
-  // Transparent is either the keyword or a zero alpha channel.
-  for (const [name, value] of Object.entries({ background, border })) {
-    expect(value, `badge ${name} is ${value}`).not.toBe("transparent");
-    expect(/,\s*0\s*\)$/.test(value), `badge ${name} is fully transparent (${value})`).toBe(false);
-  }
+  const chip = page.locator("#panel-presets .preset-row .badge.state").first();
+  await expect(chip).toBeVisible();
+  const chipPaint = await paintOf(chip);
+  expect(isTransparent(chipPaint.background), `state badge fill ${chipPaint.background}`).toBe(
+    false,
+  );
+  expect(isTransparent(chipPaint.borderColor), `state badge border ${chipPaint.borderColor}`).toBe(
+    false,
+  );
+  expect(chipPaint.borderWidth).not.toBe("0px");
+
+  const count = page.locator("#panel-presets .preset-row .badge.contrib.opts").first();
+  await expect(count).toBeVisible();
+  const countPaint = await paintOf(count);
+  expect(isTransparent(countPaint.background), `count fill ${countPaint.background}`).toBe(true);
+  expect(countPaint.borderWidth).toBe("0px");
+
+  // The tree's rows are all internal presets, and an `internal` pill on all of
+  // them said nothing — only a fetched source still earns one.
+  await expect(page.locator("#panel-presets .preset-row .badge.src")).toHaveCount(0);
 });
 
 test("the header links out to the source and to the issue tracker (055)", async ({ page }) => {

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -249,6 +249,18 @@ export const EXTENDS_RECOMMENDED_CONFIG = `{
 }
 `;
 
+/** Two internal presets at tree depth 1 — always on screen, never windowed
+ *  away — one resolved with options of its own (so its row carries the
+ *  contribution counts) and one ignored (so its row carries a state pill).
+ *  036's "badges are filled" assertion needs both kinds visible at once, and
+ *  needs them without a fetch. */
+export const IGNORED_PRESET_CONFIG = `{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":dependencyDashboard", ":semanticCommits"],
+  "ignorePresets": [":semanticCommits"]
+}
+`;
+
 /** The structural identity (`>`-joined name-path from the tree root) of the
  *  single `config:recommended` node the config above resolves — what a
  *  pre-028 link's `view.node` stored. */

--- a/packages/app/src/features/presets/PresetTree.test.tsx
+++ b/packages/app/src/features/presets/PresetTree.test.tsx
@@ -162,6 +162,33 @@ it("repeats the selected node's description in the detail panel", async () => {
   expect(within(panel).getByText("→ #1 of 2")).toBeTruthy();
 });
 
+it("draws a source pill only for a preset that isn't Renovate's own", async () => {
+  const internal = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify(CONFIG),
+  });
+  const internalView = render(tree(internal));
+  await waitFor(() => expect(internalView.container.querySelector(".preset-row")).not.toBeNull());
+  // Every node here is `internal` — the default, and the overwhelming
+  // majority. A column of identical `internal` pills says nothing, so none
+  // are drawn. The contribution count stays, keeping its glossary affordance.
+  expect(internalView.container.querySelector(".badge.src")).toBeNull();
+  const opts = internalView.container.querySelector<HTMLElement>(".badge.contrib.opts.explained");
+  if (!opts) {
+    throw new Error("a node with options of its own rendered no contribution count");
+  }
+  expect(opts.tabIndex).toBe(0);
+  expect(opts.textContent).toContain("2 opts");
+
+  const fetched = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ extends: ["github>test-org/nope"] }),
+  });
+  const fetchedView = render(tree(fetched));
+  await waitFor(() => expect(fetchedView.container.querySelector(".preset-row")).not.toBeNull());
+  expect(fetchedView.container.querySelector(".badge.src")?.textContent).toBe("github");
+});
+
 it("offers no description affordance when nothing in the run has one", async () => {
   const result = await runPipeline({
     fileName: "renovate.json",

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -25,7 +25,7 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
         <Explained entry={GLOSSARY.presetContribOpts}>
           {(handlers) => (
             <span className="badge contrib opts explained" tabIndex={0} {...handlers}>
-              {stats.ownOptions} opt{stats.ownOptions === 1 ? "" : "s"}
+              · {stats.ownOptions} opt{stats.ownOptions === 1 ? "" : "s"}
             </span>
           )}
         </Explained>
@@ -34,7 +34,7 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
         <Explained entry={GLOSSARY.presetContribRules}>
           {(handlers) => (
             <span className="badge contrib rules explained" tabIndex={0} {...handlers}>
-              {stats.ownRules} rule{stats.ownRules === 1 ? "" : "s"}
+              · {stats.ownRules} rule{stats.ownRules === 1 ? "" : "s"}
             </span>
           )}
         </Explained>
@@ -160,7 +160,14 @@ export function TreeRow({
       ) : (
         nameButton()
       )}
-      {presetSource ? (
+      {presetSource && presetSource !== "internal" ? (
+        // Only the UNUSUAL source earns a pill. `internal` is the default and
+        // the overwhelming majority — twenty identical `internal` chips down
+        // one tree told the reader nothing except where the names ended. A
+        // `github`/`npm`/`local` node is the one worth spotting, so the chip
+        // now means "this one didn't come from Renovate itself". The table
+        // view keeps the badge on every row (PresetListPane): a column of
+        // values is a comparison, not repetition.
         <Explained entry={sourceKindEntry(presetSource)}>
           {(handlers) => (
             <span className={`badge src src-${presetSource} explained`} tabIndex={0} {...handlers}>

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -992,16 +992,16 @@ pre.config-view {
   font-weight: 600;
 }
 
-/* contribution + roll-up badges */
-.badge.contrib.opts {
-  color: var(--accent);
-}
-
-.badge.contrib.rules {
-  color: var(--accent-purple);
-}
-
-/* Deliberate 036 exception: the roll-up is a bare count, not a chip. */
+/* contribution + roll-up counts.
+   Deliberate 036 exception: these are bare counts, not chips. The roll-up
+   always was; the per-node "N opts" / "N rules" joined it, because a chip on
+   every visible row is a fill the eye has to skip past on the way to the
+   name, and the two read as one family of counts anyway ("· 2 opts · 6 rules"
+   next to "· 924 presets · 462 rules"). They keep their `.badge` classes —
+   the glossary hover cards and the e2e selectors hang off those — and keep
+   `.explained`'s accent-on-hover, which is now their only color state. One
+   rule, so no per-variant hue has to be overridden back out. */
+.badge.contrib,
 .badge.rollup {
   background: transparent;
   border: none;


### PR DESCRIPTION
Design review: every preset-tree row carried an `internal` source pill plus "N opts" / "N rules" pills. Twenty identical `internal` chips down one tree convey nothing, and a pill on *every* row is a fill the eye has to skip past on the way to the name. Counts should read like the existing muted rollup text (`· 924 presets · 462 rules`), surfacing only the unusual.

**Source pill** — rendered only when `presetSource` is truthy *and* not `internal`. A `github` / `npm` / `local` node is the one worth spotting, so the chip now means "this one didn't come from Renovate itself". The `Explained` wrapper is kept for the cases that remain.

**Contribution counts** — demoted to the roll-up's muted plain-text treatment: `· 2 opts` / `· 6 rules`, no fill, no border. **Decision the review left open: they go fully muted**, dropping the accent/purple hues rather than keeping a color identity on the numbers — the two now sit next to the roll-up's `· 924 presets · 462 rules` and reading as one family of counts is the whole point. Rather than fighting `.badge.contrib.opts`'s 3-class specificity, the two per-variant color rules are deleted and replaced by one `.badge.contrib, .badge.rollup` rule.

They keep their `.badge contrib opts explained` class names, their `Explained` glossary wrappers, `tabIndex={0}` and `.explained`'s accent-on-hover — which is now their only color state. Row height is unchanged (`ROW_HEIGHT = 26` is set inline; `.rollup` has had exactly this treatment in the same row all along).

The table view's source column (`PresetListPane`) keeps its badge on every row: a column of values is a comparison, not repetition.

**Tests**

- `e2e/08-hover-card-containment.spec.ts` targets `.badge.contrib.opts.explained` — untouched and green, the hover cards still work.
- `e2e/13-unified-chrome-and-theme.spec.ts`'s "badges are filled, not outlines (036)" would now match nothing meaningful with an all-internal tree. It is rewritten rather than deleted, and asserts *both* halves — that a real chip (`.badge.state`) still paints a fill and a border, and that the demoted counts paint neither — plus that no `.badge.src` is drawn at all. It borrows a new offline fixture (`IGNORED_PRESET_CONFIG`) that puts one resolved and one ignored internal preset at tree depth 1, so both kinds are on screen deterministically. The border check moved from `border-top-color` to `border-top-width`: `border: none` leaves the color resolving to the element's own `color`, so only the width says whether a border is drawn.
- `PresetTree.test.tsx` gains a render assertion: an all-internal run shows no `.badge.src` while a `github>` node does, and the contribution count is still present, focusable and labelled.

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, app `test:unit`, specs 08 + 13 — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
