### PR TITLE
feat(app): editor line wrapping and a Format button

### DIFF
--- a/packages/app/e2e/12-layout-regressions.spec.ts
+++ b/packages/app/e2e/12-layout-regressions.spec.ts
@@ -206,6 +206,37 @@ test("Revert to loaded config appears only while the config has unsaved edits", 
   await expect(page.locator(".cm-content")).toContainText("config:recommended");
 });
 
+/**
+ * Design review: a pasted config arrives on one line and there was no way to
+ * make it readable. Format re-indents in place — and it is an EDIT, not a
+ * load, so the revert baseline must stay where it was (that distinction is
+ * exactly what "Revert to loaded config" above means).
+ */
+test("Format re-indents in place and leaves the revert baseline alone", async ({ page }) => {
+  await page.goto("/");
+  const editor = page.locator(".cm-content");
+  await expect(editor).toContainText("config:recommended");
+
+  const format = page.getByRole("button", { name: "Format", exact: true });
+  await setEditorContent(page, '{"extends":["config:recommended"],"automerge":true}');
+  expect(await editor.locator(".cm-line").count()).toBe(1);
+
+  await format.click();
+  await expect(editor).toContainText('"automerge": true');
+  expect(await editor.locator(".cm-line").count()).toBeGreaterThan(1);
+
+  // The baseline is still the DEFAULT config the page opened with: one revert
+  // undoes the paste and the formatting together.
+  const revert = page.getByRole("button", { name: "Revert to loaded config" });
+  await revert.click();
+  await expect(editor).not.toContainText("automerge");
+
+  // A document that cannot be parsed says so instead of doing nothing.
+  await setEditorContent(page, "{ nope");
+  await format.click();
+  await expect(page.locator(".app-notice")).toContainText("fix the JSON syntax first");
+});
+
 /** Selects the first preset in the tree and returns its detail panel. */
 async function openFirstPresetDetail(page: Page): Promise<Locator> {
   await openTab(page, "presets");

--- a/packages/app/e2e/12-layout-regressions.spec.ts
+++ b/packages/app/e2e/12-layout-regressions.spec.ts
@@ -218,8 +218,16 @@ test("Format re-indents in place and leaves the revert baseline alone", async ({
   await expect(editor).toContainText("config:recommended");
 
   const format = page.getByRole("button", { name: "Format", exact: true });
+  const revert = page.getByRole("button", { name: "Revert to loaded config" });
   await setEditorContent(page, '{"extends":["config:recommended"],"automerge":true}');
   expect(await editor.locator(".cm-line").count()).toBe(1);
+
+  // Position stability: the conditional Revert sits AFTER Format in the row.
+  // Formatting is an edit that summons Revert — were it the other way around,
+  // the button under the cursor would jump sideways the moment it was clicked.
+  const formatBox = await format.boundingBox();
+  const revertBox = await revert.boundingBox();
+  expect(formatBox !== null && revertBox !== null && formatBox.x < revertBox.x).toBe(true);
 
   await format.click();
   await expect(editor).toContainText('"automerge": true');
@@ -227,7 +235,6 @@ test("Format re-indents in place and leaves the revert baseline alone", async ({
 
   // The baseline is still the DEFAULT config the page opened with: one revert
   // undoes the paste and the formatting together.
-  const revert = page.getByRole("button", { name: "Revert to loaded config" });
   await revert.click();
   await expect(editor).not.toContainText("automerge");
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -561,6 +561,40 @@ export function App() {
     setEditorKey((k) => k + 1);
   }
 
+  /**
+   * Design review: a pasted config arrives as one long line and the app had no
+   * way to make it readable. Two-space indentation, in place.
+   *
+   * The parse happens HERE, on the click — never per keystroke, which roadmap
+   * 032 measures and this must not make more expensive. Deliberately NOT
+   * `loadConfigText`: formatting is an edit, not a load, and moving the revert
+   * baseline would quietly retire "Revert to loaded config". Strict JSON only —
+   * a `.json5` document that is also valid JSON reformats, and one using
+   * JSON5's own syntax says so rather than being silently rewritten into JSON
+   * with its comments discarded.
+   */
+  function formatConfig() {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      setNotice(
+        fileName.endsWith(".json5")
+          ? "Can't format: this reformats strict JSON, and this document is either invalid or uses JSON5 syntax (comments, unquoted keys, trailing commas) that reformatting would discard."
+          : "Can't format: fix the JSON syntax first — the editor's markers show where.",
+      );
+      return;
+    }
+    const formatted = `${JSON.stringify(parsed, null, 2)}\n`;
+    if (formatted === content) {
+      showToast("Already formatted");
+      return;
+    }
+    setNotice(null);
+    setContent(formatted);
+    setEditorKey((k) => k + 1);
+  }
+
   useEffect(() => {
     setSelectedNodeId(null);
     setMigrationStepIndex(0);
@@ -1875,6 +1909,7 @@ export function App() {
             onFileNameChange={(value) => setFileName(value as typeof fileName)}
             canRevert={content !== loadedContent}
             onRevert={() => loadConfigText(loadedContent)}
+            onFormat={formatConfig}
             onSignIn={onSignIn}
             untrustedHost={untrustedGuard ? untrustedGuard.host : null}
             onTrustUntrustedHost={onTrustUntrustedHost}

--- a/packages/app/src/ConfigColumn.tsx
+++ b/packages/app/src/ConfigColumn.tsx
@@ -42,6 +42,8 @@ interface ConfigColumnProps {
   onFileNameChange: (value: string) => void;
   canRevert: boolean;
   onRevert: () => void;
+  /** Re-indents the editor's text in place — see ConfigToolbar's prop doc. */
+  onFormat: () => void;
   /** Roadmap 066: the session itself moved to the header — what is left here
    *  is the auth hint's call to action, which belongs beside the failure. */
   onSignIn: () => void;
@@ -100,6 +102,7 @@ export function ConfigColumn({
   onFileNameChange,
   canRevert,
   onRevert,
+  onFormat,
   onSignIn,
   untrustedHost,
   onTrustUntrustedHost,
@@ -155,6 +158,7 @@ export function ConfigColumn({
         onFileNameChange={onFileNameChange}
         canRevert={canRevert}
         onRevert={onRevert}
+        onFormat={onFormat}
         untrustedHost={untrustedHost}
         onTrustUntrustedHost={onTrustUntrustedHost}
         running={running}

--- a/packages/app/src/features/editor/ConfigEditor.tsx
+++ b/packages/app/src/features/editor/ConfigEditor.tsx
@@ -67,6 +67,12 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
     () => [
       runKeymap(onRunRef),
       compartment.of(json()),
+      // Design review: this box receives PASTED configs more than typed ones,
+      // and a minified one arrives as a single line whose start scrolls out of
+      // view the moment the caret moves. Wrapping keeps the whole document
+      // reachable without a horizontal scrollbar; the Format button next to it
+      // (ConfigToolbar) is the other half of that answer.
+      EditorView.lineWrapping,
       // PageSpeed a11y: CodeMirror's contenteditable is a role="textbox" with
       // no accessible name of its own.
       EditorView.contentAttributes.of({ "aria-label": "Renovate config" }),

--- a/packages/app/src/features/editor/ConfigToolbar.tsx
+++ b/packages/app/src/features/editor/ConfigToolbar.tsx
@@ -65,6 +65,20 @@ export function ConfigToolbar({
         <option value="renovate.json">renovate.json</option>
         <option value="renovate.json5">renovate.json5</option>
       </select>
+      {/* Design review: a pasted config is one long line, and the app offered
+          no way to make it readable. Two-space indentation, in place — the
+          editor's own text, not a copy shown somewhere else. Ordered BEFORE
+          the conditional Revert: formatting is itself an edit that summons
+          Revert, and a control must not displace the button under the cursor
+          that just clicked it. */}
+      <button
+        type="button"
+        className="btn"
+        onClick={onFormat}
+        title="Re-indent this config with two-space indentation"
+      >
+        Format
+      </button>
       {/* Roadmap 035: rendered only when there is something to revert.
           It used to be permanently present and merely `disabled`, which
           looked identical to the enabled state — an offer of an action
@@ -79,17 +93,6 @@ export function ConfigToolbar({
           Revert to loaded config
         </button>
       ) : null}
-      {/* Design review: a pasted config is one long line, and the app offered
-          no way to make it readable. Two-space indentation, in place — the
-          editor's own text, not a copy shown somewhere else. */}
-      <button
-        type="button"
-        className="btn"
-        onClick={onFormat}
-        title="Re-indent this config with two-space indentation"
-      >
-        Format
-      </button>
       <span className="toolbar-spacer" />
       {/* Security 2026-07-25: the standing reminder. Small, but right
           where the risk materializes — the Run button — and it never

--- a/packages/app/src/features/editor/ConfigToolbar.tsx
+++ b/packages/app/src/features/editor/ConfigToolbar.tsx
@@ -20,6 +20,11 @@ interface Props {
   /** Roadmap 035: there is something to revert TO — see the button's comment. */
   canRevert: boolean;
   onRevert: () => void;
+  /** Re-indents the config. Always offered — the parse happens on the click,
+   *  never per keystroke, so there is no cheap validity signal to gate it on
+   *  and a disabled-looking button would be the 035 mistake again. App reports
+   *  a document it cannot format through the notice bar. */
+  onFormat: () => void;
   /** Security 2026-07-25: the host a share link chose, while its guard stands. */
   untrustedHost: string | null;
   onTrustUntrustedHost: () => void;
@@ -35,6 +40,7 @@ export function ConfigToolbar({
   onFileNameChange,
   canRevert,
   onRevert,
+  onFormat,
   untrustedHost,
   onTrustUntrustedHost,
   running,
@@ -73,6 +79,17 @@ export function ConfigToolbar({
           Revert to loaded config
         </button>
       ) : null}
+      {/* Design review: a pasted config is one long line, and the app offered
+          no way to make it readable. Two-space indentation, in place — the
+          editor's own text, not a copy shown somewhere else. */}
+      <button
+        type="button"
+        className="btn"
+        onClick={onFormat}
+        title="Re-indent this config with two-space indentation"
+      >
+        Format
+      </button>
       <span className="toolbar-spacer" />
       {/* Security 2026-07-25: the standing reminder. Small, but right
           where the risk materializes — the Run button — and it never


### PR DESCRIPTION
Design review: a pasted single-line JSON config stayed unwrapped with its start scrolled out of view the moment the caret moved, and there was no format action anywhere in the app.

**Wrapping** — `EditorView.lineWrapping` added to `ConfigEditor`'s extensions. `EditorView` was already imported from `@uiw/react-codemirror`, so no new specifier enters the graph; `check:dev-graph` passes (844 modules crawled, no Node-only imports).

**Format button** — a plain `.btn` next to Revert, before the toolbar spacer, always enabled. `onFormat` threads App → `ConfigColumn` → `ConfigToolbar`.

**The handler** (`App.formatConfig`), and the three decisions in it:

- **Parse on click, never per keystroke.** Roadmap 032 measures typing, and a per-keystroke `JSON.parse` would show up there. `keystroke-render.test.tsx` is green and unchanged.
- **Not `loadConfigText`.** Formatting is an edit, not a load. Going through `loadConfigText` would move the revert baseline and quietly retire "Revert to loaded config" — so it sets `content` and bumps `editorKey` directly, which is `loadConfigText` minus `setLoadedContent`.
- **Strict JSON only.** No JSON5 parser is reachable from the app without either a new dependency or pulling the engine into the critical path, and re-serializing a JSON5 document through `JSON.stringify` would silently discard its comments. So a `.json5` file that is *also* valid JSON reformats normally, and one using JSON5's own syntax is told that reformatting would discard its comments instead of having them discarded.

A document that fails to parse is not a silent no-op: it reports through the existing notice bar ("Can't format: fix the JSON syntax first — the editor's markers show where"). An already-formatted document gets a toast rather than a no-op.

**Test:** `e2e/12-layout-regressions.spec.ts` gains a case — paste one line, Format, assert it became several and the value survived; revert and assert the baseline never moved; then Format an unparseable document and assert the notice appears.

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, app `test:unit`, `check:dev-graph`, and the **full 109-test Playwright suite** (wrapping changes editor layout, so the whole suite ran rather than a subset) — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
