### PR TITLE
feat(app): keep the config column in view alongside long results

### DIFF
--- a/packages/app/e2e/12-layout-regressions.spec.ts
+++ b/packages/app/e2e/12-layout-regressions.spec.ts
@@ -244,6 +244,43 @@ test("Format re-indents in place and leaves the revert baseline alone", async ({
   await expect(page.locator(".app-notice")).toContainText("fix the JSON syntax first");
 });
 
+/**
+ * Design review: the config column is a handful of rows while the results
+ * beside it run to thousands of lines, so scrolling the results scrolled the
+ * editor — the thing being explained — off the top of the page. Both columns
+ * stick now, at the same offset.
+ */
+test("the config column stays in view while long results scroll", async ({ page }) => {
+  // Wide enough for the split, short enough that the results outrun the page:
+  // every long panel caps itself against the viewport, so a tall window has
+  // nothing to scroll at all.
+  await page.setViewportSize({ width: 1400, height: 620 });
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+  await runAndAwaitResult(page);
+  await openTab(page, "pipeline");
+
+  const column = page.locator(".config-col");
+  await expect(column).toHaveCSS("position", "sticky");
+
+  const editor = page.locator(".config-col .cm-editor");
+  const before = must(await editor.boundingBox(), "the editor's box before scrolling");
+  const scrolled = await page.evaluate(() => {
+    window.scrollTo(0, document.documentElement.scrollHeight);
+    return window.scrollY;
+  });
+  // The whole point is a page long enough to scroll the editor away.
+  expect(scrolled, "the results panel was not tall enough to scroll").toBeGreaterThan(200);
+
+  // Still on screen at the bottom of the page — the whole point.
+  await expect(editor).toBeInViewport();
+  const after = must(await editor.boundingBox(), "the editor's box after scrolling");
+  expect(after.y).toBeGreaterThanOrEqual(0);
+  // It rose only as far as the sticky offset and then stopped, rather than
+  // travelling the page's whole scroll distance the way it used to.
+  expect(before.y - after.y).toBeLessThan(scrolled / 2);
+});
+
 /** Selects the first preset in the tree and returns its detail panel. */
 async function openFirstPresetDetail(page: Page): Promise<Locator> {
   await openTab(page, "presets");

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -3805,6 +3805,28 @@ main:has(.app-split.has-results) {
   top: 0.75rem;
 }
 
+/* Design review: the config column is ~5 rows tall while the results beside
+   it can run to thousands of diff lines, so scrolling the results scrolled
+   the editor — the thing being explained — off the top of the page, leaving
+   dead space bottom-left. It sticks too, at the same offset, so the config
+   and its consequence stay side by side.
+
+   The cap is what makes sticky safe: a column TALLER than the viewport (the
+   Advanced zone open on a short screen) would otherwise pin its top and put
+   its own bottom permanently out of reach, since the page scroll no longer
+   moves it. It scrolls itself instead, and `auto` means no scrollbar appears
+   until that actually happens. Every hover card in the app portals to
+   `document.body` (`components/hover-card.tsx`), so the new scroll container
+   cannot clip one; CodeMirror's own tooltips already live inside the
+   editor's `maxHeight` scroller. Scoped to `.app-split.has-results` — the
+   pre-run page is one column with nothing to stick to. */
+.app-split.has-results > .config-col {
+  max-height: calc(100dvh - 1.5rem);
+  overflow-y: auto;
+  position: sticky;
+  top: 0.75rem;
+}
+
 /* Below this width the panes stack — config on top, results below, full
    width. Keep in sync with STACKED_VIEWPORT_QUERY in App.tsx. */
 @media (max-width: 60rem) {
@@ -3813,6 +3835,15 @@ main:has(.app-split.has-results) {
   }
 
   .results-col {
+    position: static;
+  }
+
+  /* Stacked, the config is simply the first thing on the page — sticking it
+     would park it over the results it sits above, and the cap would make a
+     nested scroller out of a column that now has the whole width. */
+  .app-split.has-results > .config-col {
+    max-height: none;
+    overflow-y: visible;
     position: static;
   }
 }


### PR DESCRIPTION
Design review: the config column is a handful of rows tall while the results beside it can run to thousands of lines. Scrolling the results scrolled the editor — the thing being explained — off the top of the page, leaving dead space bottom-left.

`.app-split.has-results` already had `align-items: start` and `.results-col` was already sticky at `top: 0.75rem`. This adds the mirror rule for `.config-col` (which had no layout rule at all before — only a focus ring), and resets it to static inside the existing 60rem stacking query, where the config is simply the first thing on the page and sticking it would park it over the results below.

**On the cap** — the review asked me to decide between a capped sticky column and a plain one. I capped it: `max-height: calc(100dvh - 1.5rem); overflow-y: auto`.

A sticky column taller than the viewport (the Advanced zone open on a short screen) is the failure mode that matters — it pins its top and puts its own bottom permanently out of reach, because the page scroll no longer moves it. `overflow-y: auto` produces no scrollbar until that actually happens.

The clipping risk that argued against it does not apply here: every hover card in the app portals to `document.body` (`components/hover-card.tsx` → `createPortal(…, document.body)`), which is what the glossary `Explained` cards, the preset-description cards and the option cards all go through. CodeMirror's own tooltips already live inside the editor's `maxHeight: 28rem` scroller, unchanged by a scroll container further out. The full Playwright suite (including `08-hover-card-containment` and `09-schema-option`, which drive those cards) is green.

**Test:** `e2e/12-layout-regressions.spec.ts` gains a case. It uses a deliberately *short* viewport (1400×620) — worth recording, because every long panel in the app already caps itself against the viewport (`.diff-wrapper` 32rem, `.prov-list` 40rem, `.preset-tree`/`.preset-panel` `min(44rem, 100dvh - 10rem)`), so at a tall window the page has nothing to scroll at all. At 620px the Pipeline tab gives ~337px of page scroll; the test asserts the column computes to `position: sticky`, the editor is still in the viewport at the bottom of the page, and it rose far less than the page did.

**Existing guards that had to stay green:** `11-tabbed-shell.spec.ts` (narrow-viewport stacking, bounding-box assertions) and `12-layout-regressions.spec.ts` (`.config-col .cm-editor` measurements). Both pass.

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and the **full 110-test Playwright suite** — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
