### PR TITLE
feat(app): mark results stale when the config has changed since the run

### DIFF
--- a/packages/app/e2e/11-tabbed-shell.spec.ts
+++ b/packages/app/e2e/11-tabbed-shell.spec.ts
@@ -319,3 +319,35 @@ test("a narrow viewport stacks the panes and a run scrolls the results into view
   );
   expect(box.y).toBeLessThan(720);
 });
+
+/**
+ * Design review: the two columns sit side by side, so a reader has every
+ * reason to assume they describe each other — but after an edit (or a Revert)
+ * the results kept showing the previous run with nothing to say so. The shell's
+ * run-level banner slot says it, on whichever tab the reader is on.
+ */
+test("the results say so once the config has changed since the run", async ({ page }) => {
+  await page.goto("/");
+  await runAndAwaitResult(page);
+
+  const stale = page.locator(".stale-banner");
+  await expect(stale).toHaveCount(0);
+
+  await setEditorContent(page, PACKAGE_RULES_CONFIG);
+  await expect(stale).toBeVisible();
+  await expect(stale).toContainText("changed since this run");
+
+  // Still there on another tab — the run is stale, not one instrument.
+  await openTab(page, "effective");
+  await expect(stale).toBeVisible();
+
+  // Running against the edited text is what clears it.
+  await runAndAwaitResult(page);
+  await expect(stale).toHaveCount(0);
+
+  // …and so does going back: Revert is an edit like any other.
+  await setEditorContent(page, SEMANTIC_COMMITS_CONFIG);
+  await expect(stale).toBeVisible();
+  await page.getByRole("button", { name: "Revert to loaded config" }).click();
+  await expect(stale).toBeVisible();
+});

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -212,6 +212,10 @@ export function App() {
   // fix) — as opposed to whatever the user has typed since. The "revert to
   // loaded config" button restores this; it never changes on a plain edit.
   const [loadedContent, setLoadedContent] = useState(DEFAULT_CONFIG);
+  // The config text the displayed result was actually computed from. Compared
+  // against `content` to tell the reader that what they are looking at no
+  // longer describes what is in the editor — see `resultsStale` below.
+  const [lastRunContent, setLastRunContent] = useState<string | null>(null);
   // Roadmap 016: bumped by `loadConfigText` to force the CodeMirror instance
   // to remount. The editor's own prop→doc sync defers to a ~200ms "typing
   // latch" that can be starved by browser timer throttling (backgrounded
@@ -964,6 +968,9 @@ export function App() {
       // sentence inherits the lead of the run before it.
       outcomeLeadRef.current = opts?.outcomeLead ?? null;
       setResult(traceResult);
+      // Committed WITH the result, never before it: a run that threw or was
+      // abandoned must not mark the previous run's output fresh.
+      setLastRunContent(inputs.content);
       const firstError = (Object.entries(traceResult.stageStatus) as [StageId, string][]).find(
         ([, status]) => status === "error",
       );
@@ -1942,6 +1949,7 @@ export function App() {
               onWalkTab={walkToTab}
               backTab={backTab}
               onBack={() => setTab(backTab ?? "overview")}
+              resultsStale={content !== lastRunContent}
               validateHasErrors={validateHasErrors}
               jumpToTab={jumpToTab}
               migrateSteps={migrateSteps}

--- a/packages/app/src/ResultsColumn.tsx
+++ b/packages/app/src/ResultsColumn.tsx
@@ -19,6 +19,7 @@ import { ResultsPanel, type ResultsTabDescriptor } from "@/components/ResultsPan
 import { RuleSimulator } from "@/features/simulator/RuleSimulator";
 import { StageDiff } from "@/components/StageDiff";
 import { StageTimeline } from "@/components/StageTimeline";
+import { StaleResultsBanner } from "@/components/StaleResultsBanner";
 import type { ResultsTabId } from "@/data/results-tabs";
 import { motionScrollOptions } from "@/lib/motion";
 import type { DigestClause } from "@/lib/run-digest";
@@ -52,6 +53,11 @@ export interface ResultsColumnProps {
   onWalkTab: (tab: ResultsTabId) => void;
   backTab: ResultsTabId | null;
   onBack: () => void;
+  /** The editor's text has diverged from the text `result` was computed from.
+   *  The ONE prop here that changes on a keystroke — it feeds the `banner`
+   *  memo and nothing else, deliberately not the `panels` memo below, whose
+   *  032 contract is that typing reconciles none of the seven panels. */
+  resultsStale: boolean;
 
   // —— shared across tabs ——
   /** Consumed by: overview, pipeline, effective, simulator. */
@@ -158,6 +164,7 @@ export function ResultsColumn({
   onWalkTab,
   backTab,
   onBack,
+  resultsStale,
   validateHasErrors,
   jumpToTab,
   migrateSteps,
@@ -233,18 +240,24 @@ export function ResultsColumn({
   // failure is a property of the run, and the tab a run lands on depends on
   // which stage errored — a preset-stage failure lands on Problems, so an
   // Overview-only banner would be exactly invisible in its own main case.
+  // `resultsStale` is the one keystroke-sensitive input in this file, and it
+  // reaches exactly this memo: a divergent keystroke re-renders the banner and
+  // nothing else, because `panels` below does not read it (roadmap 032).
   const banner = useMemo(
     () => (
-      <AuthFailureBanner
-        failures={authFailures.failures}
-        rateLimited={authFailures.rateLimited}
-        authState={authState}
-        onSignIn={onSignIn}
-        installUrl={installUrl}
-        onRunAgain={onRunAgain}
-      />
+      <>
+        {resultsStale ? <StaleResultsBanner /> : null}
+        <AuthFailureBanner
+          failures={authFailures.failures}
+          rateLimited={authFailures.rateLimited}
+          authState={authState}
+          onSignIn={onSignIn}
+          installUrl={installUrl}
+          onRunAgain={onRunAgain}
+        />
+      </>
     ),
-    [authFailures, authState, onSignIn, installUrl, onRunAgain],
+    [resultsStale, authFailures, authState, onSignIn, installUrl, onRunAgain],
   );
 
   // Roadmap 032: the seven tab panels render RUN RESULTS — they change when a

--- a/packages/app/src/components/StaleResultsBanner.tsx
+++ b/packages/app/src/components/StaleResultsBanner.tsx
@@ -1,0 +1,25 @@
+import { formatShortcut, RUN_SHORTCUT } from "@/lib/shortcuts";
+
+/**
+ * Design review: after an edit (or a Revert) the results panel kept showing
+ * the previous run with nothing to say it no longer matched the editor — the
+ * two columns sit side by side, so a reader has every reason to assume they
+ * describe each other.
+ *
+ * The run-level sibling of the simulator's `SimStaleBanner`, and deliberately
+ * the same warn-tinted sentence: one visual language for "what you are
+ * looking at is behind the inputs above it". It lives in the tab shell's
+ * run-level `banner` slot, so it shows on whichever tab the reader is on.
+ *
+ * Staleness is decided on the editor TEXT alone (App's `resultsStale`) — the
+ * advanced-zone inputs are out of scope, so this never fires for a changed
+ * token or endpoint.
+ */
+export function StaleResultsBanner() {
+  return (
+    <p className="stale-banner" role="status">
+      The config changed since this run — these results describe the earlier text. Press Run (
+      {formatShortcut(RUN_SHORTCUT)}) to refresh.
+    </p>
+  );
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -3568,7 +3568,13 @@ pre.config-view.prov-before {
   margin: -0.25rem 0.75rem 0.75rem;
 }
 
-.sim-stale-banner {
+/* One sentence shape for "what you are looking at is behind the inputs above
+   it", at two scopes: the simulator's own form (015) and the whole run
+   (`StaleResultsBanner`, in the tab shell's run-level banner slot). Sharing
+   the rule is the point — the two must not drift into two different warnings
+   for the same idea. */
+.sim-stale-banner,
+.stale-banner {
   background: var(--warn-bg);
   border: 1px solid var(--warn-border);
   border-radius: 6px;
@@ -3576,6 +3582,11 @@ pre.config-view.prov-before {
   font-size: 0.85rem;
   margin: 0 0 0.6rem;
   padding: 0.5rem 0.65rem;
+}
+
+/* The run-level one sits inside `.tab-body`'s padding, above the tab panel. */
+.stale-banner {
+  margin: 0 0 0.75rem;
 }
 
 /* Replay-02 R1: once the hypothetical banner has been shown, its box stays


### PR DESCRIPTION
Design review: after editing (or reverting) the config, the results panel kept showing the previous run with no cue that it no longer matched the editor. The two columns sit side by side, so a reader has every reason to assume they describe each other.

**The derivation** — App retains `lastRunContent`, set inside `executeRun` on the statement after `setResult(traceResult)`, so a run that threw or was abandoned never marks the previous run's output fresh. `content !== lastRunContent` is passed down as `resultsStale`.

**Scope, deliberately narrowed:** staleness compares the editor TEXT only. The advanced-zone inputs — tokens, platform, endpoint, injected presets — do not raise it. Those change the *result* too, but they change it in ways the reader did not just type, and widening the comparison would have meant defining an equality over the whole `RunInputs` shape. Worth revisiting; out of scope here.

**Roadmap 032** — `resultsStale` is the one keystroke-sensitive value in `ResultsColumn`, and it reaches exactly one place: the `banner` memo. The `panels` memo does not read it, so a divergent keystroke re-renders the banner and nothing else. Proof, from this branch:

```
[032] app commits during 20 keystrokes: 20; panel re-renders:
{"OverviewTab":0,"PresetTree":0,"EffectiveConfig":0,"RuleSimulator":0,"MessagesPanel":0}
```

`keystroke-render.test.tsx` is green.

**The banner** — a new `StaleResultsBanner` in the tab shell's run-level `banner` slot (alongside `AuthFailureBanner`), so it shows on whichever tab the reader is on rather than only on the Overview. Copy states what happened and the action: *"The config changed since this run — these results describe the earlier text. Press Run (⌘⏎) to refresh."* The shortcut comes from `formatShortcut(RUN_SHORTCUT)`, not hardcoded glyphs, so it spells itself correctly per platform.

Visually it reuses the simulator's stale treatment: `.sim-stale-banner` and `.stale-banner` now share **one** rule (warn tint tokens) rather than being two independent warnings for the same idea. `jsx-max-depth` respected — the banner is a single `<p>`.

**Skipped, deliberately:** the veil treatment (`.sim-results-body.stale`) applied to the results panels. Reaching the panels means reaching the `panels` memo, which is the one thing the 032 contract forbids. Not worth the risk for a second cue on top of the banner.

**Test:** `e2e/11-tabbed-shell.spec.ts` gains a case — no banner after a run, banner after an edit, still there on another tab, cleared by re-running, and raised again by Revert (a revert is an edit like any other).

**Gates:** `pnpm lint`, `pnpm format:check`, `pnpm typecheck`, app `test:unit` (617 tests, `keystroke-render` included), engine `test:shimmed`, and the **full 111-test Playwright suite** — all green.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
