### PR TITLE
fix(app): dress the editor's schema hover as a bounded popover

### DIFF
--- a/packages/app/e2e/08-hover-card-containment.spec.ts
+++ b/packages/app/e2e/08-hover-card-containment.spec.ts
@@ -44,3 +44,42 @@ test("the preset-tree 'own options' hover card wraps its text and stays on-scree
   expect(box.x + box.width).toBeLessThanOrEqual(viewport.width + 1);
   expect(box.y + box.height).toBeLessThanOrEqual(viewport.height + 1);
 });
+
+/**
+ * Design review follow-up — the editor's JSON-schema hover is `position:
+ * fixed`, and nothing bounded it: a docs URL on one unbreakable line sized
+ * the tooltip to ~800px, running it across the results column with no
+ * border or shadow to mark it as a popover. Guard the fix: the tooltip is
+ * width-capped, opaque, and framed.
+ */
+test("the editor's schema hover is a bounded popover, not a page-wide strip", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator(".cm-content")).toContainText("config:recommended");
+
+  // The schema layer loads lazily, so the first hover may land before the
+  // hover extension exists — retry until the tooltip materializes. Hover by
+  // coordinates a few characters into the line, squarely on the `"extends"`
+  // KEY: the string value beside it opens the preset card instead.
+  const line = page.locator(".cm-line", { hasText: '"extends"' }).first();
+  const lineBox = must(await line.boundingBox(), "the extends line's bounding box");
+  const tooltip = page.locator(".cm-tooltip");
+  for (let attempt = 0; attempt < 5 && !(await tooltip.isVisible()); attempt++) {
+    await page.mouse.move(10, 10);
+    await page.mouse.move(lineBox.x + 30, lineBox.y + lineBox.height / 2);
+    await page.waitForTimeout(1_500);
+  }
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip.locator(".cm6-json-schema-hover")).toBeVisible();
+
+  const box = must(await tooltip.boundingBox(), "the schema tooltip's bounding box");
+  // 26rem cap (416px) plus padding and border, with room to spare.
+  expect(box.width).toBeLessThanOrEqual(450);
+
+  const chrome = await tooltip.evaluate((el) => {
+    const s = getComputedStyle(el);
+    return { background: s.backgroundColor, borderWidth: s.borderTopWidth };
+  });
+  // Opaque popover surface with a frame — not the syntax theme's bare strip.
+  expect(chrome.background).not.toBe("rgba(0, 0, 0, 0)");
+  expect(chrome.borderWidth).toBe("1px");
+});

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -3658,6 +3658,50 @@ pre.config-view.prov-before {
   cursor: help;
 }
 
+/* ---------- editor hover tooltips ----------
+   CodeMirror positions tooltips `fixed`, so they escape the editor card and
+   the sticky column's scroll container by design — which is fine for a
+   popover, except nothing dressed the schema hover as one: `packageRules`
+   carries a full docs URL on one unbreakable line, so the tooltip ran edge
+   to edge across the results column, width-sized by its longest word and
+   wearing only the syntax theme's flat background. The `.cm-tooltip` box
+   itself must stay chromeless: for preset strings it is a tiny anchor whose
+   `.option-card` child paints its own popover — dressing the container puts
+   an empty pill behind that card. So the container goes transparent, and
+   only a tooltip actually holding the schema hover's markup (`:has`) gets
+   the popover plane, the option-card width cap, and URL breaking. Three
+   classes to out-spec the theme's injected `.ͼ* .cm-tooltip` rules, which
+   land later in the cascade. */
+.card .cm-editor .cm-tooltip {
+  background: transparent;
+  border: none;
+  z-index: var(--z-popover);
+}
+
+.card .cm-editor .cm-tooltip:has(.cm6-json-schema-hover) {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: var(--shadow-popover);
+  color: var(--ink);
+  font-size: 0.8rem;
+  max-width: min(26rem, calc(100vw - 2rem));
+  overflow-wrap: anywhere;
+  padding: 0.45rem 0.65rem;
+}
+
+/* The library's hover markup brings document-flow <p> margins with it;
+   inside a tooltip they read as stray whitespace. */
+.cm-tooltip .cm6-json-schema-hover p {
+  margin: 0;
+}
+
+.cm-tooltip .cm6-json-schema-hover--code-wrapper {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  margin-top: 0.35rem;
+}
+
 /* The hover shifts `color`, which (036) carries the badge's fill and border
    with it — the whole chip lights up, not just its outline. */
 .badge.explained:hover,


### PR DESCRIPTION
CodeMirror positions hover tooltips fixed, and nothing bounded the
JSON-schema one: a docs URL on one unbreakable line sized it to ~800px,
running it over the results column with only the syntax theme's flat
background. It now caps at the option-card width, breaks long URLs, and
sits on the app's popover plane (surface, border, shadow, z-index). The
tooltip container itself stays chromeless so the preset hover card —
whose tiny anchor tooltip paints nothing — gains no empty pill behind
it. Guarded in the hover-containment e2e spec.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>