### PR TITLE
ci: use create-github-app-token's client-id input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,6 @@ jobs:
         if: ${{ vars.RELEASE_APP_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          # `app-id` is deprecated in favour of `client-id`; the value is passed
-          # through verbatim as the JWT issuer, and GitHub still accepts the
-          # numeric App ID there — so `vars.RELEASE_APP_ID` keeps working and the
-          # repository variable does not have to be re-provisioned.
           client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,11 @@ jobs:
         if: ${{ vars.RELEASE_APP_ID != '' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          # `app-id` is deprecated in favour of `client-id`; the value is passed
+          # through verbatim as the JWT issuer, and GitHub still accepts the
+          # numeric App ID there — so `vars.RELEASE_APP_ID` keeps working and the
+          # repository variable does not have to be re-provisioned.
+          client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       # No "authenticate to npm" step, and deliberately no ~/.npmrc: pnpm mints

--- a/roadmap/067-semantic-release.md
+++ b/roadmap/067-semantic-release.md
@@ -195,7 +195,10 @@ does not exist.
       what a release ships).
    2. Install the app on `renovate-config-debugger` only.
    3. Store the App ID as a repository **variable** `RELEASE_APP_ID` and a
-      generated private key as the **secret** `RELEASE_APP_PRIVATE_KEY`.
+      generated private key as the **secret** `RELEASE_APP_PRIVATE_KEY`. The
+      workflow feeds that variable to `create-github-app-token`'s `client-id`
+      input (its `app-id` input is deprecated); both the numeric App ID and the
+      app's Client ID are accepted as the JWT issuer, so either value works.
    4. Add the app to main's protection bypass list (branch protection: allow
       the app to push; ruleset: add it under "bypass list") — the token is
       only as strong as the app, and without the bypass the push still 403s.


### PR DESCRIPTION
The action deprecated its `app-id` input in favour of `client-id`, which made every release run log:

```
Warning: Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

The action passes that input through verbatim as the JWT issuer (`createAppAuth({ appId })`), and GitHub accepts either the numeric App ID or the app's Client ID there — so the existing `vars.RELEASE_APP_ID` variable keeps working and no repository settings have to change.

Roadmap 067's setup steps note the same.