### PR TITLE
fix(cli): keep zod's error locale in the published MCP bundle

### DIFF
--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -515,12 +515,41 @@ describe("strict input schemas", () => {
   });
 
   /**
+   * The dependency schema is the single biggest thing in `tools/list`, and
+   * `compare_simulations` used to carry two verbatim copies of it. One shared
+   * zod instance carrying `.meta({ id })` makes the SDK's conversion emit one
+   * `$defs` entry and two `$ref`s — a size win only as long as the def itself
+   * stays strict, which is what the last assertion is for.
+   */
+  test("the repeated dependency schema is one $defs entry, still strict", async () => {
+    const { tools } = await client.listTools();
+    const schema = tools.find((t) => t.name === "compare_simulations")?.inputSchema as
+      | {
+          properties?: Record<string, { $ref?: string }>;
+          $defs?: Record<string, { additionalProperties?: boolean }>;
+        }
+      | undefined;
+    const ref = schema?.properties?.dep?.$ref;
+    expect(ref).toBe("#/$defs/dependency");
+    expect(schema?.properties?.depB?.$ref).toBe(ref);
+    expect(schema?.$defs?.dependency?.additionalProperties).toBe(false);
+  });
+
+  /**
    * Roadmap 068, from the persona study: two sessions burned actions on an
    * "Invalid input, Invalid input" rejection that named no field. This pins
    * what the SDK actually reports for the shapes those sessions produced —
    * the zod issue PATH, joined and prefixed — so a schema change that loses
    * the field name is a failing test rather than a lost session. The commonest
    * mistake by far is the first one: `content` is the file's TEXT.
+   *
+   * This pins the SCHEMA side only: in-process, zod's English locale is
+   * installed by its own module-level side effect, so these messages are free
+   * here and stay green even when the shipped artifact says `Invalid input`
+   * and nothing else. The LOCALE side — that the published bundle still has
+   * one — is `test/bundle/mcp-messages.test.ts`, and only that regime can
+   * fail for it. Do not read a green run here as proof users see these
+   * strings.
    */
   test("a rejected argument names the field, and its type", async () => {
     const errorFor = async (name: string, args: Record<string, unknown>): Promise<string> => {
@@ -539,6 +568,9 @@ describe("strict input schemas", () => {
     );
     expect(await errorFor("simulate", { runId: "run-1", dep: {}, verdict: "sometimes" })).toContain(
       'verdict: Invalid option: expected one of "notable"',
+    );
+    expect(await errorFor("simulate", { runId: "run-1", dep: {}, source: "bogus" })).toContain(
+      'source: Invalid option: expected one of "all"',
     );
   });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -47,6 +47,7 @@ import {
 import { resolveRunAuth } from "../run-input";
 import { textResult } from "./result";
 import { type HeldRun, RunStore } from "./run-store";
+import { installZodLocale } from "./zod-locale";
 
 /**
  * Roadmap 060: the same answers as the subcommands, over MCP.
@@ -228,13 +229,14 @@ const DEP = z
   })
   .describe(
     "The hypothetical update. Every field is optional; a matcher whose fields you left unset " +
-      "reports `no-input` rather than silently passing. updateType is derived from " +
-      "currentValue/newValue when you omit it. Unknown fields are rejected — the field names are " +
-      "Renovate's own (depName, packageName, datasource, manager, depType, packageFile, " +
-      "currentValue, currentVersion, newValue, updateType, versioning, sourceUrl, registryUrls, " +
-      "categories, baseBranch, currentVersionTimestamp, and lockedVersion/lockFiles/isBump/" +
-      "repository/mergeConfidenceLevel for the matchers that read them).",
-  );
+      "reports `no-input` instead of passing. updateType is derived from currentValue/newValue " +
+      "when you omit it. Unknown fields are rejected.",
+  )
+  // One `$defs.dependency` entry plus `$ref`s instead of the schema inlined
+  // per property: `extractDefs` lifts any schema carrying `id` metadata, which
+  // is the only dedup the SDK's conversion leaves reachable. Serialization
+  // only — validation, and the strictness above, are untouched.
+  .meta({ id: "dependency" });
 
 type DepInput = z.infer<typeof DEP>;
 
@@ -394,6 +396,11 @@ export interface McpServerOptions {
 }
 
 export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServer {
+  // First, and before any argument is validated: the published bundle loses
+  // zod's locale to tree-shaking, and without it every rejection reads
+  // `Invalid input`. Global config is read when an issue is finalized, so
+  // calling it here — after the module-level schema constants — is correct.
+  installZodLocale();
   const store = options?.store ?? new RunStore();
   const server = new McpServer(
     {

--- a/packages/cli/src/mcp/zod-locale.ts
+++ b/packages/cli/src/mcp/zod-locale.ts
@@ -1,0 +1,24 @@
+import { config } from "zod";
+import { en } from "zod/locales";
+
+/**
+ * Re-installs zod's English locale, which the PUBLISHED bundle otherwise ships
+ * without.
+ *
+ * zod installs it as a top-level side effect (`config(en())` in
+ * `zod/v4/classic/external.js`), but its `package.json` declares
+ * `"sideEffects": false` — so rolldown, building this package with
+ * `ssr.noExternal: true` (`vite.config.ts`), is entitled to drop that call and
+ * does. Without a locale, `finalizeIssue` falls through `config.localeError`
+ * to the literal fallback, and every validation error the MCP server reports
+ * degrades to a bare `Invalid input`: no typo'd key named, no enum members
+ * listed, no expected type. That voids the promise the tool descriptions make
+ * — that a rejection tells the model what to fix.
+ *
+ * Nothing catches this in-process: `src/` runs zod unbundled, locale intact.
+ * `test/bundle/mcp-messages.test.ts` spawns the built bin and asserts the real
+ * messages, which is the only regime where the loss is visible.
+ */
+export function installZodLocale(): void {
+  config(en());
+}

--- a/packages/cli/test/bundle/mcp-messages.test.ts
+++ b/packages/cli/test/bundle/mcp-messages.test.ts
@@ -1,0 +1,121 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+/**
+ * The validation messages the PUBLISHED bin emits, over a real pipe.
+ *
+ * This is the only regime that can catch the failure it pins. zod declares
+ * `"sideEffects": false` while installing its English locale as a top-level
+ * side effect, so rolldown — building this package with `ssr.noExternal: true`
+ * — drops the call, and every rejection the shipped artifact reports collapses
+ * to a bare `Invalid input`: the typo'd key unnamed, the enum members unlisted,
+ * the expected type gone. `src/mcp/server.test.ts` runs zod unbundled and
+ * stays green throughout; `src/mcp/zod-locale.ts` is the fix.
+ *
+ * So the target here is `bin/rcd.mjs` (needs `dist/`, hence the `bundle`
+ * project rather than `cli`), not the dev runner `test/bin.test.ts` drives.
+ * One child, one handshake, every case in it: each spawn loads the whole
+ * bundle.
+ */
+
+const BIN = fileURLToPath(new URL("../../bin/rcd.mjs", import.meta.url));
+const CLI_DIR = fileURLToPath(new URL("../..", import.meta.url));
+
+// Same reason as `test/bin.test.ts`: the bin hands the REAL environment to
+// `main`, and no assertion may depend on the session that runs the suite.
+const CHILD_ENV: Record<string, string | undefined> = { ...process.env };
+for (const key of Object.keys(CHILD_ENV)) {
+  if (key === "CLAUDECODE" || key.startsWith("RCD_") || key.endsWith("_TOKEN")) {
+    delete CHILD_ENV[key];
+  }
+}
+
+interface JsonRpcMessage {
+  jsonrpc: string;
+  id?: number;
+  result?: { content?: { type: string; text?: string }[]; isError?: boolean };
+}
+
+/** The rejection text for one bad `tools/call`, keyed by request id. */
+interface BadCall {
+  id: number;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+const BAD_CALLS: BadCall[] = [
+  { id: 10, name: "get_preset_tree", args: { runId: "run-1", dept: 3 } },
+  { id: 11, name: "simulate", args: { runId: "run-1", dep: {}, source: "bogus" } },
+  { id: 12, name: "run_config", args: { content: { extends: ["config:recommended"] } } },
+];
+
+async function rejectionTexts(): Promise<Map<number, string>> {
+  const child = spawn(process.execPath, [BIN, "mcp"], {
+    cwd: CLI_DIR,
+    env: CHILD_ENV,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  // A stderr nobody reads fills its pipe buffer and stalls the child.
+  child.stderr.resume();
+
+  const texts = new Map<number, string>();
+  const answered = new Promise<void>((resolve) => {
+    const lines = createInterface({ input: child.stdout });
+    lines.on("line", (line) => {
+      if (line.trim() === "") {
+        return;
+      }
+      // Every line is protocol — a stray log on stdout is a bug this catches.
+      const message = JSON.parse(line) as JsonRpcMessage;
+      if (message.id === undefined || message.id < 10) {
+        return;
+      }
+      texts.set(message.id, message.result?.content?.[0]?.text ?? "");
+      if (texts.size === BAD_CALLS.length) {
+        resolve();
+      }
+    });
+  });
+
+  for (const message of [
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "rcd-bundle-test", version: "0" },
+      },
+    },
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    ...BAD_CALLS.map((call) => ({
+      jsonrpc: "2.0",
+      id: call.id,
+      method: "tools/call",
+      params: { name: call.name, arguments: call.args },
+    })),
+  ]) {
+    child.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  await answered;
+  child.stdin.end();
+  await once(child, "exit");
+  return texts;
+}
+
+describe("bin/rcd.mjs mcp", () => {
+  test("a rejected argument still names the field in the built bundle", async () => {
+    const texts = await rejectionTexts();
+    // The typo'd tool parameter, by name.
+    expect(texts.get(10)).toContain('Unrecognized key: "dept"');
+    // The enum, with its members — what tells a model which value to retry.
+    expect(texts.get(11)).toContain('Invalid option: expected one of "all"');
+    // The commonest mistake of all: `content` is the file's TEXT.
+    expect(texts.get(12)).toContain("expected string, received object");
+  }, 120_000);
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -24,6 +24,9 @@ const bundledEngine = fileURLToPath(new URL("./dist/engine-surface.js", import.m
  *   tested against the thing that ships rather than inferred from both having
  *   been built with the same plugin. Needs `pnpm build` first; CI runs it
  *   right after, and it is NOT part of `pnpm test` for exactly that reason.
+ *   `test/bundle/` holds the suites that drive the built artifact directly —
+ *   the subdirectory is what keeps them out of the "cli" project's
+ *   `test/*.test.ts` glob, so `pnpm test` never fails for a missing `dist/`.
  */
 export default defineConfig({
   test: {
@@ -59,7 +62,7 @@ export default defineConfig({
         plugins: [renovateShims()],
         test: {
           name: "bundle",
-          include: ["../engine/test/*.shimmed.test.ts"],
+          include: ["../engine/test/*.shimmed.test.ts", "test/bundle/*.test.ts"],
           environment: "node",
           testTimeout: 60_000,
           server: { deps: { inline: [/renovate/] } },

--- a/roadmap/060-mcp-server-and-agent-discovery.md
+++ b/roadmap/060-mcp-server-and-agent-discovery.md
@@ -87,3 +87,39 @@ provenance,messages}.ts` now hold the shapes, and the subcommands and the
 Still open here: the discovery half — the app footer, the READMEs, llms.txt
 and the Claude Code hint marker — which lands once 059 has published the
 package every one-liner names.
+
+## Validation messages, and the listing budget (2026-08-16)
+
+The persona study reported rejections reading `Invalid input, Invalid input`,
+naming no field; the in-process suite said otherwise, and both were right —
+they were measuring different module regimes. zod installs its English locale
+as a top-level side effect while its `package.json` declares
+`"sideEffects": false`, so rolldown drops the call when 059's
+`ssr.noExternal: true` build inlines it. Under `src/` the locale is intact and
+every message names its key; in the published `dist/main.js` the same rejection
+degrades to a bare `Invalid input` — no typo'd key, no enum members, no
+expected type — which voids exactly the self-correction the tool descriptions
+promise. `src/mcp/zod-locale.ts` re-installs it as the first statement of
+`createMcpServer`. The lesson generalizes past zod: the bundle regime can
+silently degrade behavior that lives in a dependency's side effects, and no
+in-process test can see it, so `test/bundle/` now holds suites that spawn the
+built bin — the `bundle` vitest project runs them right after `pnpm build`,
+same as 059's parity proof. (Sibling, untouched: the app's `zod/mini` schemas
+in `src/lib/input-schemas-zod.ts` get the same treatment in the browser bundle.)
+
+Measured against the same probe, `tools/list` was 15 289 B compact / 652 pretty
+lines — descriptions 4 024 B, schemas 9 512 B. The dependency object alone was
+1 528 B inlined three times (`simulate.dep`, `compare_simulations.dep`/`depB`):
+48 % of schema bytes. Two changes, no capability lost: trimming its
+object-level describe from 573 to ~210 chars (it ended in a parenthetical
+re-listing the property keys immediately below it), and `.meta({ id:
+"dependency" })` on the one shared schema instance, which makes zod's
+`extractDefs` lift it into `$defs` with `$ref`s — the only dedup the SDK's
+conversion leaves reachable, since it never passes `reused`. Result: 13 784 B /
+574 lines, −10 % bytes and −12 % lines. `$ref` support is uneven in
+non-Anthropic clients, so that half is the revertable one. The levers left on
+the table, if the listing ever has to halve: dropping `depB` (−1 528 B) or
+replacing `compare_simulations`'s two dependency objects with simulation ids
+(−3 056 B) — both remove capability the study saw personas use. Not available
+at all: the SDK has no brief mode, and its `tools/list` ignores the pagination
+cursor.


### PR DESCRIPTION
zod's `sideEffects: false` lets rolldown tree-shake the locale install out of `dist/main.js`, so every validation error in the published artifact degraded to a bare `Invalid input`. Restores the locale at server creation and adds a bundle-regime test suite that spawns `bin/rcd.mjs mcp` over a real pipe (the in-process suite runs `src/` and can never catch this). Also trims and dedups the DEP schema in tools/list (~15.3 KB → ~13.8 KB).

Part of the persona-replay fix stack (roadmap research 2026-08-16).