### PR TITLE
fix(cli): honest severity, index addressing and surgical fixes for explain_message

### DIFF
--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -740,6 +740,116 @@ describe("explain_message and get_option_docs", () => {
     expect(explained.severity).toBe("warning");
   });
 
+  /**
+   * The severity used to be "error unless the run's warnings hold this exact
+   * text" — so every near miss, and every call without a run, came back a
+   * confident `error`. The realistic near miss is not a typo: it is the digest,
+   * which quotes the first problem shortened and with the trailing period
+   * stripped. An agent pasting that back was told the wrong list with no hint
+   * that anything had failed to match.
+   */
+  test("a message the run does not hold gets severity null, not a guess", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"labels":5}',
+    })) as { runId: string; errors: { message: string }[] };
+    const full = summary.errors[0]?.message ?? "";
+    const nearMiss = `${full.slice(0, Math.floor(full.length / 2))}…`;
+    const explained = (await call("explain_message", {
+      runId: summary.runId,
+      message: nearMiss,
+    })) as { severity: string | null; severityNote?: string };
+    expect(explained.severity).toBeNull();
+    expect(explained.severityNote).toContain("errors");
+  });
+
+  test("without a runId nothing decides the severity either", async () => {
+    const explained = (await call("explain_message", {
+      message: "Configuration option `labels` should be a list (Array)",
+    })) as { severity: string | null; severityNote?: string };
+    expect(explained.severity).toBeNull();
+    expect(explained.severityNote).toMatch(/nothing decided/);
+  });
+
+  /**
+   * Renovate files WARNINGS under the topic "Configuration Error" too, so an
+   * agent that reasons the topic out from the severity it observed gets an
+   * exact-match miss. The text alone is the retry tier.
+   */
+  test("a wrong topic falls back to the text and still finds the warning", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"dryRun":"full"}',
+    })) as { runId: string; warnings: { topic: string; message: string }[] };
+    expect(summary.warnings[0]?.topic).toBe("Configuration Error");
+    const explained = (await call("explain_message", {
+      runId: summary.runId,
+      topic: "Configuration Warning",
+      message: summary.warnings[0]?.message,
+    })) as { severity: string | null };
+    expect(explained.severity).toBe("warning");
+  });
+
+  test("run_config numbers every message, and points at the parameter that takes it", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"labels":5,"dryRun":"full"}',
+    })) as {
+      errors: { index: number }[];
+      warnings: { index: number }[];
+      messagesNote?: string;
+    };
+    expect(summary.errors[0]?.index).toBe(0);
+    expect(summary.warnings[0]?.index).toBe(0);
+    expect(summary.messagesNote).toContain("errorIndex");
+  });
+
+  test("a clean run carries no messagesNote", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: CONFIG,
+    })) as Record<string, unknown>;
+    expect(summary).not.toHaveProperty("messagesNote");
+  });
+
+  test("a message addressed by index needs no text at all", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: '{"labels":5,"dryRun":"full"}',
+    })) as { runId: string; errors: { message: string }[] };
+    const explained = (await call("explain_message", {
+      runId: summary.runId,
+      errorIndex: 0,
+    })) as { severity: string; message: string };
+    expect(explained.severity).toBe("error");
+    expect(explained.message).toBe(summary.errors[0]?.message);
+  });
+
+  test("an indexed warning reaches the fix path", async () => {
+    const runId = await runConfig('{"dryRun":"full"}');
+    const explained = (await call("explain_message", { runId, warningIndex: 0 })) as {
+      severity: string;
+      translationKnown: boolean;
+      fix?: { summary: string };
+    };
+    expect(explained.severity).toBe("warning");
+    expect(explained.translationKnown).toBe(true);
+    expect(explained.fix?.summary).toBeTruthy();
+  });
+
+  test("an index that names nothing, or names it twice, is rejected with the reason", async () => {
+    const runId = await runConfig('{"labels":5}');
+    await expect(call("explain_message", { runId, errorIndex: 4 })).rejects.toThrow(/has 1 errors/);
+    await expect(call("explain_message", { errorIndex: 0 })).rejects.toThrow(/runId/);
+    await expect(
+      call("explain_message", { runId, errorIndex: 0, message: "anything" }),
+    ).rejects.toThrow(/exactly once/);
+    await expect(call("explain_message", { runId })).rejects.toThrow(/exactly once/);
+    await expect(
+      call("explain_message", { runId, errorIndex: 0, topic: "Configuration Error" }),
+    ).rejects.toThrow(/carries the run's own topic/);
+  });
+
   test("option docs are for the pinned Renovate, and misses point at search", async () => {
     const doc = (await call("get_option_docs", { name: "packageRules" })) as {
       name: string;
@@ -796,8 +906,11 @@ describe("held runs carry only what the tools read", () => {
     const explained = (await call("explain_message", {
       runId,
       message: "Configuration option `labels` should be a list (Array)",
-    })) as { severity: string };
-    expect(explained.severity).toBe("error");
+    })) as { severity: string | null; message: string };
+    // CONFIG is a clean run, so it holds no message with this text and nothing
+    // decides its severity — the explanation is still the library's.
+    expect(explained.severity).toBeNull();
+    expect(explained.message).toContain("labels");
     const sim = (await call("simulate", { runId, dep: { depName: "react" } })) as {
       rules: unknown[];
     };

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -26,7 +26,7 @@ import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
 import { buildRuleView, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
-import { describeMessage } from "../projections/messages";
+import { describeMessage, type MessageSeverity } from "../projections/messages";
 import {
   entryView,
   indexView,
@@ -337,6 +337,18 @@ function simulationPayload(sim: SimulationResult, detail: SimulateDetail) {
   };
 }
 
+/** Each validator message with the position `explain_message` addresses it by.
+ *  The array's own index is NOT that position: a large answer is elided
+ *  structurally (see ./result), which drops elements out of the middle. */
+function withIndex(messages: readonly ValidationMessage[]) {
+  return messages.map((message, index) => ({ index, ...message }));
+}
+
+const MESSAGES_NOTE =
+  "explain_message takes these by POSITION — pass this runId with errorIndex/warningIndex (the " +
+  "`index` on each message) rather than re-typing the text; a re-typed message that does not " +
+  "match the run exactly comes back with severity null.";
+
 function runSummary(run: HeldRun, notes: string[]) {
   const { result, facts } = run;
   const payload = digestPayload(result, facts);
@@ -347,8 +359,9 @@ function runSummary(run: HeldRun, notes: string[]) {
     accepted: payload.accepted,
     digest: payload.digest,
     stageStatus: result.stageStatus,
-    errors: result.errors,
-    warnings: result.warnings,
+    errors: withIndex(result.errors),
+    warnings: withIndex(result.warnings),
+    ...(result.errors.length + result.warnings.length > 0 ? { messagesNote: MESSAGES_NOTE } : {}),
     presetErrors: facts.presetErrors.map((event) => event.title),
     treeSummary: stats?.summary ?? null,
     ...(notes.length > 0 ? { notes } : {}),
@@ -360,17 +373,54 @@ const sameMessage = (candidate: ValidationMessage, message: string, topic?: stri
 
 /**
  * Which list the message came from. A warning explained as an error is a
- * misreport an agent then acts on, so the run — when one is given — decides.
+ * misreport an agent then acts on, so the RUN decides — and when the run does
+ * not decide it, the answer is `null` rather than a plausible guess. Nothing
+ * outside the run's own lists can stand in: Renovate files warnings under the
+ * topic "Configuration Error" too, so the topic carries no severity.
  */
 function severityOf(
   run: HeldRun | null,
   message: string,
   topic: string | undefined,
-): "error" | "warning" {
-  if (run?.result.warnings.some((w) => sameMessage(w, message, topic))) {
-    return "warning";
+): MessageSeverity | null {
+  if (!run) {
+    return null;
   }
-  return "error";
+  const inErrors = run.result.errors.some((m) => sameMessage(m, message, topic));
+  const inWarnings = run.result.warnings.some((m) => sameMessage(m, message, topic));
+  if (inErrors !== inWarnings) {
+    return inErrors ? "error" : "warning";
+  }
+  if (inErrors && inWarnings) {
+    // The same text in both lists — the run does not disambiguate it.
+    return null;
+  }
+  // A topic that did not match is the likelier miss than the text: a caller
+  // who reasoned the topic out from the severity gets no hit at all. Retry on
+  // the text alone; the recursion cannot loop, the second call passes none.
+  return topic === undefined ? null : severityOf(run, message, undefined);
+}
+
+/** One of a held run's own messages, addressed by position — so its severity
+ *  and its topic are the run's by construction and no text has to match. */
+function pickMessage(
+  run: HeldRun | null,
+  list: "errors" | "warnings",
+  param: string,
+  index: number,
+): ValidationMessage {
+  if (!run) {
+    throw new Error(`${param} indexes into a run's ${list} — pass the runId those came from.`);
+  }
+  const held = run.result[list];
+  const found = held[index];
+  if (!found) {
+    throw new Error(
+      `${run.runId} has ${held.length} ${list}; there is no ${list}[${index}]. ` +
+        "run_config lists them, each with the `index` this parameter takes.",
+    );
+  }
+  return found;
 }
 
 /** The body a node holds, or an explicit null saying it holds none — a key
@@ -764,24 +814,79 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "Translates one of Renovate's validator messages into what it actually means, with a " +
         "docs link and — when the library knows one — a concrete fix. It always says which you " +
         "got: `translationKnown` is false, with a `note` explaining why, when the curated " +
-        "library has no entry for the message, so a bare echo is never ambiguous. Pass the " +
-        "runId the message came from and the fix is computed against that exact config " +
-        "snapshot, including the edited file text, and the reported severity is the list the " +
-        "run itself put it in.",
+        "library has no entry for the message, so a bare echo is never ambiguous. Address the " +
+        "message BY POSITION — this runId plus errorIndex/warningIndex, the `index` run_config " +
+        "reported — and the fix is computed against that exact config snapshot, including the " +
+        "edited file text, with the run's own severity and topic. Quoting the text instead " +
+        "works, but `severity` is then only as good as the quote: it is the list the run itself " +
+        "put the message in, and `null` with a `severityNote` when the run holds no message " +
+        "with this text at all.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
-        message: z.string().describe("The message text, verbatim."),
-        topic: z.string().optional().describe("The message's topic, e.g. `Configuration Error`."),
+        message: z
+          .string()
+          .optional()
+          .describe(
+            "The message text, VERBATIM as run_config returned it. Prefer errorIndex/" +
+              "warningIndex when you have a runId — a quote that differs by a character cannot " +
+              "be matched to the run.",
+          ),
+        topic: z
+          .string()
+          .optional()
+          .describe(
+            "The message's topic, e.g. `Configuration Error`. Only meaningful with `message`.",
+          ),
         runId: z.string().optional().describe("The run the message came from."),
+        errorIndex: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "Position in this runId's `errors` — the `index` run_config reported. Needs runId.",
+          ),
+        warningIndex: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe("Position in this runId's `warnings`. Needs runId."),
       }),
     },
-    answer(({ message, topic, runId }) => {
+    answer(({ message, topic, runId, errorIndex, warningIndex }) => {
       const run = runId ? store.get(runId) : null;
+      const config = run ? validatedConfigOf(run.result) : null;
+      const text = run?.input.content ?? null;
+      const selectors = [message, errorIndex, warningIndex].filter((v) => v !== undefined).length;
+      if (selectors !== 1) {
+        throw new Error(
+          "name the message exactly once: `message` with its verbatim text, or `errorIndex` / " +
+            "`warningIndex` from run_config's lists for this runId.",
+        );
+      }
+      if (topic !== undefined && (errorIndex !== undefined || warningIndex !== undefined)) {
+        throw new Error(
+          "`topic` describes a `message`; an indexed message carries the run's own topic.",
+        );
+      }
+      if (errorIndex !== undefined) {
+        const picked = pickMessage(run, "errors", "errorIndex", errorIndex);
+        return describeMessage(picked, "error", config, text);
+      }
+      if (warningIndex !== undefined) {
+        const picked = pickMessage(run, "warnings", "warningIndex", warningIndex);
+        return describeMessage(picked, "warning", config, text);
+      }
+      if (message === undefined) {
+        // Unreachable after the count check; keeps `message` narrowed to string.
+        throw new Error("`message` is required when no index selects one.");
+      }
       return describeMessage(
         { topic: topic ?? "Configuration Error", message },
         severityOf(run, message, topic),
-        run ? validatedConfigOf(run.result) : null,
-        run?.input.content ?? null,
+        config,
+        text,
       );
     }),
   );

--- a/packages/cli/src/projections/messages.test.ts
+++ b/packages/cli/src/projections/messages.test.ts
@@ -37,10 +37,52 @@ describe("describeMessage — a known warning", () => {
         },
       ],
     });
-    // The edit replaces a whole array element, which the surgical text patcher
-    // does not address — the document is re-serialized, and says so.
-    expect(reported.fix?.fixedTextRewritesDocument).toBe(true);
+    // The edit replaces a whole array element, and that is a MINIMAL patch:
+    // the document is not re-serialized, so nothing else in it moves.
+    expect(reported.fix?.fixedTextRewritesDocument).toBeUndefined();
+    expect(reported.fix?.fixedText).toContain('{\n  "packageRules": [');
     expect(JSON.parse(reported.fix?.fixedText ?? "null")).toEqual(reported.fix?.fixedConfig);
+  });
+
+  /**
+   * What the persona sessions actually meant by "minimal patch": a config with
+   * comments comes back with its comments. A whole-document rewrite loses
+   * them silently — the fix is still correct, and the file is still ruined.
+   */
+  test("a comment-bearing config keeps its comments and its untouched siblings", () => {
+    const commented = [
+      "{",
+      "  // renovate config",
+      '  "extends": ["config:recommended"],',
+      '  "packageRules": [',
+      '    { "matchDepTypes": ["devDependencies"], "automerge": true },',
+      '    { "extends": ["group:jestMonorepo"] }',
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const reported = describeMessage(
+      {
+        topic: "Configuration Warning",
+        message: 'packageRules[1].extends: you should not extend "group:" presets',
+      },
+      "warning",
+      {
+        extends: ["config:recommended"],
+        packageRules: [
+          { matchDepTypes: ["devDependencies"], automerge: true },
+          { extends: ["group:jestMonorepo"] },
+        ],
+      },
+      commented,
+    );
+    const fixedText = reported.fix?.fixedText ?? "";
+    expect(reported.fix?.fixedTextRewritesDocument).toBeUndefined();
+    expect(fixedText).toContain("  // renovate config");
+    expect(fixedText).toContain('  "extends": ["config:recommended"],');
+    expect(fixedText).toContain('    { "matchDepTypes": ["devDependencies"], "automerge": true },');
+    expect(fixedText).toContain("monorepo:jest");
+    expect(fixedText).not.toContain("group:jestMonorepo");
   });
 
   test("without a config snapshot it explains, and says why there is no fix", () => {
@@ -72,6 +114,17 @@ describe("describeMessage — no translation known", () => {
       note: expect.stringContaining("No translation for this message"),
     });
     expect(reported.note).toMatch(/Renovate's own/);
+  });
+
+  test("a severity nothing decided is null, and says so", () => {
+    const reported = describeMessage(
+      { topic: "Configuration Error", message: "Something else entirely" },
+      null,
+      {},
+      null,
+    );
+    expect(reported.severity).toBeNull();
+    expect(reported.severityNote).toMatch(/nothing decided/);
   });
 
   test("still offers the option's docs link when the message names one", () => {

--- a/packages/cli/src/projections/messages.ts
+++ b/packages/cli/src/projections/messages.ts
@@ -19,8 +19,12 @@ import {
  * half its answer". Three replay sessions read the silent shape as a broken
  * promise.
  */
+export type MessageSeverity = "error" | "warning";
+
 export interface ReportedMessage {
-  severity: "error" | "warning";
+  /** The list the RUN put this message in — `null` when nothing decided that:
+   *  no run was given, or the run holds no message with this exact text. */
+  severity: MessageSeverity | null;
   topic: string;
   message: string;
   /** Whether roadmap 014's curated library has an entry for this message.
@@ -31,6 +35,8 @@ export interface ReportedMessage {
   docsUrl?: string;
   /** Present exactly when there is no `fix` — why there isn't one. */
   note?: string;
+  /** Present exactly when `severity` is null — why it could not be decided. */
+  severityNote?: string;
   fix?: {
     summary: string;
     path: (string | number)[];
@@ -40,10 +46,20 @@ export interface ReportedMessage {
     fixedText?: string;
     /** True when `fixedText` is the whole document re-serialized from
      *  `fixedConfig` because the edit couldn't be located in the original
-     *  text — still correct, but comments and formatting are lost. */
+     *  text — still correct, but comments and formatting are lost. Rare: it
+     *  takes a config written in a key style the locator doesn't read
+     *  (unquoted or single-quoted keys), or a path that isn't in this exact
+     *  text. Absent means the edit was a minimal in-place patch. */
     fixedTextRewritesDocument?: true;
   };
 }
+
+const UNKNOWN_SEVERITY_NOTE =
+  "Severity is null: nothing decided which list this message is in. Either no runId was given, " +
+  "or that run's `errors`/`warnings` hold no message with this exact text — a paraphrase, a " +
+  "quote shortened by the digest, or another Renovate version's wording all land here. The " +
+  "explanation below is still the library's; the severity is not the run's. Address the message " +
+  "by position instead: run_config lists each message with its `index`.";
 
 const NO_TRANSLATION_NOTE =
   "No translation for this message — the message text and severity are Renovate's own, " +
@@ -67,7 +83,7 @@ const NO_SAFE_FIX_NOTE =
  */
 export function describeMessage(
   message: ValidationMessage,
-  severity: "error" | "warning",
+  severity: MessageSeverity | null,
   config: Record<string, unknown> | null,
   text: string | null,
 ): ReportedMessage {
@@ -76,6 +92,7 @@ export function describeMessage(
   const applied = translated?.fix && text ? applyFixToText(text, translated.fix) : null;
   return {
     severity,
+    ...(severity === null ? { severityNote: UNKNOWN_SEVERITY_NOTE } : {}),
     topic: message.topic,
     message: message.message,
     translationKnown: translated !== null,

--- a/packages/engine/src/error-fix-text.ts
+++ b/packages/engine/src/error-fix-text.ts
@@ -9,7 +9,10 @@
  * recognizes standard double-quoted JSON/JSON5 object keys and `//`/`/* *\/`
  * comments, which covers the overwhelming convention (including generated
  * `.json5` files, which mainly use JSON5 for comments/trailing commas, not
- * unquoted or single-quoted keys). When a path segment can't be located —
+ * unquoted or single-quoted keys). A path may end on an ARRAY INDEX — the
+ * `group:`-preset rule rewrite does — and that element is patched in place
+ * like any other value; only a `renameTo` is impossible there, an index having
+ * no key. When a path segment can't be located —
  * most commonly because the config uses that rare unquoted/single-quoted key
  * style, or the path doesn't exist in this exact text — `applyFixToText`
  * falls back to re-serializing the ENTIRE document from `fix.fixedConfig`
@@ -30,27 +33,40 @@ export interface AppliedTextFix {
 /** Applies `fix` to `text` (the editor's raw config content). */
 export function applyFixToText(text: string, fix: ErrorFixResult): AppliedTextFix | null {
   const located = locateEntry(text, fix.path);
-  if (located) {
-    if (fix.remove) {
-      return { text: spliceRemove(text, located), surgical: true };
-    }
-    if (fix.renameTo) {
-      return {
-        text:
-          text.slice(0, located.keyStart) +
-          JSON.stringify(fix.renameTo) +
-          text.slice(located.keyEnd),
-        surgical: true,
-      };
+  if (!located) {
+    return rewriteDocument(fix);
+  }
+  if (fix.remove) {
+    return { text: spliceRemove(text, located), surgical: true };
+  }
+  if (fix.renameTo) {
+    // An ARRAY ELEMENT has no key to rename. Splicing anything here would
+    // corrupt the document, so this is the one surgical path that declines:
+    // losing the formatting beats emitting invalid JSON. No curated fix is
+    // shaped this way today, but the function is engine-public.
+    if (!located.key) {
+      return rewriteDocument(fix);
     }
     return {
       text:
-        text.slice(0, located.valueStart) +
-        JSON.stringify(fix.value) +
-        text.slice(located.valueEnd),
+        text.slice(0, located.key.start) +
+        JSON.stringify(fix.renameTo) +
+        text.slice(located.key.end),
       surgical: true,
     };
   }
+  return {
+    text:
+      text.slice(0, located.valueStart) +
+      serializeValue(text, located, fix.value) +
+      text.slice(located.valueEnd),
+    surgical: true,
+  };
+}
+
+/** The last resort: the whole document from `fixedConfig`. Always correct,
+ *  always at the cost of every comment and every formatting choice. */
+function rewriteDocument(fix: ErrorFixResult): AppliedTextFix | null {
   try {
     return { text: JSON.stringify(fix.fixedConfig, null, 2), surgical: false };
   } catch {
@@ -59,10 +75,42 @@ export function applyFixToText(text: string, fix: ErrorFixResult): AppliedTextFi
 }
 
 interface EntryLocation {
-  keyStart: number;
-  keyEnd: number;
+  /** The `"key"` span. Absent when the entry is an ARRAY ELEMENT: an index has
+   *  no key to rename, and none to eat when removing. */
+  key?: { start: number; end: number };
   valueStart: number;
   valueEnd: number;
+}
+
+/** The line indentation the value at `valueStart` hangs off — the whitespace
+ *  before it when nothing else shares its line, otherwise none. */
+function columnIndentAt(text: string, valueStart: number): string {
+  let i = valueStart;
+  while (i > 0 && isIndentAt(text, i - 1)) {
+    i--;
+  }
+  return i === 0 || text[i - 1] === "\n" ? text.slice(i, valueStart) : "";
+}
+
+/**
+ * The replacement text for a value.
+ *
+ * Compact `JSON.stringify` is right for what the curated fixes mostly replace
+ * — `["!gradle"]` belongs on one line, and every span that was one line to
+ * begin with keeps its shape byte for byte. A span that spans LINES in the
+ * source is a formatted block (a whole `packageRules` entry, say), and
+ * collapsing it into one long line would be a worse diff than the one the
+ * caller asked for; that case is pretty-printed and re-indented to the value's
+ * own column.
+ */
+function serializeValue(text: string, loc: EntryLocation, value: unknown): string {
+  const compact = JSON.stringify(value);
+  if (!text.slice(loc.valueStart, loc.valueEnd).includes("\n")) {
+    return compact;
+  }
+  const pretty = JSON.stringify(value, null, 2);
+  const indent = columnIndentAt(text, loc.valueStart);
+  return indent === "" ? pretty : pretty.split("\n").join(`\n${indent}`);
 }
 
 /** Skips a double-quoted JSON string starting at `start`; returns the index just past it. */
@@ -223,7 +271,7 @@ function findKeyInObject(text: string, objStart: number, key: string): EntryLoca
       return null;
     }
     if (keyText === key) {
-      return { keyStart, keyEnd, valueStart, valueEnd };
+      return { key: { start: keyStart, end: keyEnd }, valueStart, valueEnd };
     }
     i = skipTrivia(text, valueEnd);
     if (text[i] === ",") {
@@ -298,12 +346,14 @@ function locateEntry(text: string, path: ConfigPathSegment[]): EntryLocation | n
       containerStart = found.valueStart;
     } else {
       const found = findArrayElement(text, containerStart, seg);
-      if (!found || isLast) {
-        // A path ending on an array index has no surgical patch here — the
-        // one curated fix shaped that way (the `group:`-preset rule rewrite)
-        // deliberately falls back to re-serializing the document, and says so
-        // via `fixedTextRewritesDocument`.
+      if (!found) {
         return null;
+      }
+      if (isLast) {
+        // An array element is a located entry with no key span — the whole
+        // element is the value, which is exactly what a replace or a remove
+        // needs. (The `group:`-preset rule rewrite is shaped this way.)
+        return { valueStart: found.valueStart, valueEnd: found.valueEnd };
       }
       containerStart = found.valueStart;
     }
@@ -311,15 +361,21 @@ function locateEntry(text: string, path: ConfigPathSegment[]): EntryLocation | n
   return null;
 }
 
-/** Removes a `"key": value` member, cleaning up the adjacent comma so the result stays valid JSON. */
+/**
+ * Removes a `"key": value` member — or, when the entry has no key span, an
+ * array ELEMENT — cleaning up the adjacent comma so the result stays valid
+ * JSON. The two cases differ only in where the removal starts: the key, or the
+ * value itself.
+ */
 function spliceRemove(text: string, loc: EntryLocation): string {
-  // Eat back to the start of the line if only indentation precedes the key,
+  const start = loc.key?.start ?? loc.valueStart;
+  // Eat back to the start of the line if only indentation precedes the entry,
   // so removal doesn't leave a blank indented line behind.
-  let lineStart = loc.keyStart;
+  let lineStart = start;
   while (lineStart > 0 && text[lineStart - 1] !== "\n" && isIndentAt(text, lineStart - 1)) {
     lineStart--;
   }
-  const cutStart = /^[ \t]*$/.test(text.slice(lineStart, loc.keyStart)) ? lineStart : loc.keyStart;
+  const cutStart = /^[ \t]*$/.test(text.slice(lineStart, start)) ? lineStart : start;
 
   let before = lineStart;
   while (before > 0 && isSpaceAt(text, before - 1)) {

--- a/packages/engine/test/error-fix-text.node.test.ts
+++ b/packages/engine/test/error-fix-text.node.test.ts
@@ -129,6 +129,135 @@ describe("applyFixToText — remove (pattern 3: global-only option)", () => {
   });
 });
 
+/**
+ * The `group:`-preset fix (pattern 4) replaces a WHOLE `packageRules` entry,
+ * so its path ends on an array index. That used to be the one shape the
+ * locator refused, which sent every such fix through the whole-document
+ * re-serialization — reflowing the siblings and dropping every comment to
+ * change one rule. An index locates an element as well as a key locates a
+ * member; the only thing an index cannot do is be renamed.
+ */
+describe("applyFixToText — array element (pattern 4: group: preset in a rule)", () => {
+  const GROUPED_RULE = {
+    extends: ["monorepo:jest"],
+    groupName: "jest monorepo",
+    automerge: true,
+  };
+
+  it("replaces one rule in place, leaving the siblings, the comments and the rest verbatim", () => {
+    const text = [
+      "{",
+      "  // keep these presets",
+      '  "extends": ["config:recommended"],',
+      '  "packageRules": [',
+      '    { "matchDepTypes": ["devDependencies"], "automerge": true },',
+      '    { "extends": ["group:jestMonorepo"], "automerge": true } // the bad one',
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const fix = valueFix({ path: ["packageRules", 1], value: GROUPED_RULE });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(true);
+    expect(result.text).toContain(
+      '{"extends":["monorepo:jest"],"groupName":"jest monorepo","automerge":true}',
+    );
+    // Everything the fix did not name survives byte for byte.
+    expect(result.text).toContain("  // keep these presets");
+    expect(result.text).toContain('  "extends": ["config:recommended"],');
+    expect(result.text).toContain(
+      '    { "matchDepTypes": ["devDependencies"], "automerge": true },',
+    );
+    expect(result.text).toContain("// the bad one");
+    expect(result.text).not.toContain("group:jestMonorepo");
+  });
+
+  it("re-indents a pretty-printed replacement when the element it replaces spans lines", () => {
+    const text = [
+      "{",
+      '  "packageRules": [',
+      '    { "matchDepTypes": ["devDependencies"] },',
+      "    {",
+      '      "extends": ["group:jestMonorepo"],',
+      '      "automerge": true',
+      "    }",
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const fix = valueFix({ path: ["packageRules", 1], value: GROUPED_RULE });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(true);
+    // Every continuation line hangs off the element's own column, not column 0.
+    expect(result.text).toContain('\n      "groupName": "jest monorepo",');
+    expect(result.text).toContain("\n    }\n  ]");
+    expect(result.text).not.toContain("\n}\n  ]");
+    expect(JSON.parse(result.text)).toEqual({
+      packageRules: [{ matchDepTypes: ["devDependencies"] }, GROUPED_RULE],
+    });
+  });
+
+  it("removes an array element and its comma, keeping the siblings", () => {
+    const text = [
+      "{",
+      '  "packageRules": [',
+      '    { "matchDepTypes": ["devDependencies"] },',
+      '    { "extends": ["group:jestMonorepo"] }',
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const fix = valueFix({ path: ["packageRules", 1], remove: true });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(true);
+    expect(JSON.parse(result.text)).toEqual({
+      packageRules: [{ matchDepTypes: ["devDependencies"] }],
+    });
+  });
+
+  it("removes the FIRST array element without leaving a leading comma", () => {
+    const text = [
+      "{",
+      '  "packageRules": [',
+      '    { "extends": ["group:jestMonorepo"] },',
+      '    { "matchDepTypes": ["devDependencies"] }',
+      "  ]",
+      "}",
+      "",
+    ].join("\n");
+    const fix = valueFix({ path: ["packageRules", 0], remove: true });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(true);
+    expect(JSON.parse(result.text)).toEqual({
+      packageRules: [{ matchDepTypes: ["devDependencies"] }],
+    });
+  });
+
+  it("still falls back when the index is past the end of the array", () => {
+    const text = '{\n  "packageRules": [\n    { "automerge": true }\n  ]\n}\n';
+    const fix = valueFix({
+      path: ["packageRules", 7],
+      value: GROUPED_RULE,
+      fixedConfig: { packageRules: [{ automerge: true }] },
+    });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ packageRules: [{ automerge: true }] });
+  });
+
+  it("declines to rename an index — there is no key — and rewrites the document instead", () => {
+    const text = '{\n  "packageRules": [\n    { "automerge": true }\n  ]\n}\n';
+    const fix = valueFix({
+      path: ["packageRules", 0],
+      renameTo: "nonsense",
+      fixedConfig: { packageRules: [{ automerge: true }] },
+    });
+    const result = must(applyFixToText(text, fix), "an applied text fix");
+    expect(result.surgical).toBe(false);
+    expect(JSON.parse(result.text)).toEqual({ packageRules: [{ automerge: true }] });
+  });
+});
+
 describe("applyFixToText — fallback when the path can't be located", () => {
   it("falls back to re-serializing fixedConfig when the key uses an unsupported style (single-quoted)", () => {
     const text = "{ 'token': 'abc' }"; // valid JSON5, not the supported double-quoted-key convention


### PR DESCRIPTION
Three defects from the persona replay: `severityOf` stamped `error` on messages the run never produced (now `severity: null` + note, with a text-only retry tier); callers had to re-paste verbatim text the server already held (run_config messages now carry an `index`, explain_message accepts `errorIndex`/`warningIndex`); and array-index-terminated fix paths always fell back to a whole-document rewrite (`locateEntry` now patches `packageRules[N]` surgically, preserving comments and formatting).

Part of the persona-replay fix stack.