### PR TITLE
feat(cli): project simulate and config answers by keys and scope

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,10 +89,53 @@ The rest belong to one command each.
 | `simulate` | `--dep <json>`, `--dep-file` | the dependency update to simulate                                          |
 |            | `--verdict <which>`          | `notable\|all\|matched\|no-input\|no-match` (pretty `notable`, JSON `all`) |
 |            | `--source <which>`           | which config level contributed the rule: `repo\|presets\|all`              |
+|            | `--detail <which>`           | `verdict` (default) \| `full` — `full` adds the merge trace                |
+|            | `--keys <a,b,…>`             | only these options of `finalDependencyConfig`                              |
+|            | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
 | `compare`  | `--dep`/`--dep-file`         | the A-side dependency                                                      |
 |            | `--dep-b`/`--dep-b-file`     | the B-side dependency                                                      |
+|            | `--keys <a,b,…>`             | only these options of the config delta                                     |
+|            | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
 | `run`      | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`     |
+|            | `--keys <a,b,…>`             | only these options of `--select final`                                     |
+|            | `--config-scope <which>`     | `full` (default) \| `package-rules`                                        |
 | `docs`     | `--search`                   | list options whose name matches                                            |
+
+### Narrowing a config answer
+
+Three commands answer with a config document, and two flags project it. Both
+only ever narrow, so any answer is a subset of the one you would have got
+without them, and every projected payload carries a `configView` saying which
+view produced it.
+
+`--config-scope package-rules` drops the ~107 `globalOnly` options — the ones
+read from a self-hosted global config, which no `packageRule` can read or
+write. That is the default where the document is a PER-DEPENDENCY config
+(`simulate`, `compare`), because the class is provably inert there. It is not
+the default for `rcd run --select final`, which is the run's whole effective
+config: when you are debugging a global or inherited layer, those options are
+the answer.
+
+`--keys a,b` selects top-level options by name, out of what the scope left. A
+name the scope removed is not resurrected — it comes back in
+`configView.withheld` with the reason, and `--config-scope full` is the way to
+it:
+
+```console
+$ rcd simulate renovate.json --dep '{"depName":"react"}' --format json --keys groupName,onboardingConfig
+{
+  "finalDependencyConfig": { "groupName": "react monorepo" },
+  "configView": {
+    "scope": "package-rules",
+    "keys": 1,
+    "droppedGlobalOnly": 107,
+    "withheld": [{ "key": "onboardingConfig", "reason": "global-only" }]
+  }
+}
+```
+
+On the fixture measured for this feature that call is 2.9 kB, against 24.5 kB
+for the default answer and 106 kB for `--detail full`.
 
 ## A debugging session
 
@@ -187,6 +230,20 @@ what `--verdict` and `--source` are for. A filtered list always ends by saying
 how many rules it hid. `--format json` keeps the full `rules` array unless you
 pass one of those two flags, and adds a `ruleFilter` object with
 `total`/`shown`/`hidden` when you do.
+
+`simulate --format json` answers at `--detail verdict`: `mergeSteps` and
+`rawFinalConfig` describe how the merge proceeded — ~1 MB on a
+`config:recommended` run — and are opt-in through `--detail full`, which returns
+the whole simulation result unprojected, exactly as it comes out of the engine.
+The same flag exists as `detail` on the MCP `simulate` tool; the two transports
+are one implementation.
+
+One more shape both commands share: `description` is a mergeable array, so
+Renovate concatenates it on nearly every merge, and a merged diff used to
+re-embed all of it on both sides. An append is now stated as what it appended
+(`{"collapsed": "append", "beforeLength": 22, "afterLength": 24, "added": […]}`)
+— a replacement still shows both sides, and the full array is one
+`rcd provenance renovate.json description` away.
 
 </details>
 

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -98,6 +98,22 @@ export const OPTIONS = {
     flags: "--source <which>",
     description: "which config level contributed the rule: repo|presets|all (default: all)",
   },
+  detail: {
+    flags: "--detail <which>",
+    description:
+      "verdict|full — `full` adds the merge trace (mergeSteps, rawFinalConfig) " +
+      "(default: verdict)",
+  },
+  keys: {
+    flags: "--keys <a,b,…>",
+    description: "only these top-level config options (narrows, never widens)",
+  },
+  "config-scope": {
+    flags: "--config-scope <which>",
+    description:
+      "which config keys to report: package-rules (drop the globalOnly options a rule " +
+      "cannot reach) | full",
+  },
 } as const satisfies Record<string, OptionSpec>;
 
 export type OptionName = keyof typeof OPTIONS;

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, test } from "vitest";
 import { main } from "../main";
 import { fixture, recordingIo } from "../test-harness";
 
+/** One config, two dependencies: only `react` picks up the rule's own
+ *  description, so B's array is A's plus one sentence. */
+function describedArgs(...extra: string[]): string[] {
+  return [
+    "compare",
+    fixture("described.json"),
+    "--dep",
+    '{"depName":"lodash"}',
+    "--dep-b",
+    '{"depName":"react"}',
+    ...extra,
+  ];
+}
+
 describe("compare", () => {
   test("two configs, one dependency: the edit oracle", async () => {
     const io = recordingIo();
@@ -23,10 +37,13 @@ describe("compare", () => {
       noChange: boolean;
       matchedOnlyInB: { label: string }[];
       configDelta: { key: string }[];
+      configView: { scope: string };
     };
     expect(comparison.noChange).toBe(false);
     expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
     expect(comparison.configDelta.map((d) => d.key)).toContain("groupName");
+    // Roadmap 070: the delta is a VIEW now, and it says which one it is.
+    expect(comparison.configView.scope).toBe("package-rules");
   });
 
   test("the same config twice changes nothing", async () => {
@@ -87,9 +104,76 @@ describe("compare", () => {
         io,
       ),
     ).toBe(0);
-    const { summary } = io.json() as { summary: string };
+    const { summary, configDelta } = io.json() as {
+      summary: string;
+      configDelta: { key: string }[];
+    };
     expect(summary).toBe("differs: dependencyDashboard, description, groupName");
     expect(io.stdout).toContain("summary");
+    // Roadmap 070: the summary is built from the delta's KEYS, and collapsing
+    // a value is only safe because it never moves one. Pinned explicitly.
+    expect(configDelta.map((d) => d.key)).toEqual([
+      "dependencyDashboard",
+      "description",
+      "groupName",
+    ]);
+  });
+
+  /** Roadmap 070: `description` is the array `mergeChildConfig` concatenates on
+   *  nearly every merge, and the delta used to re-embed it whole on both
+   *  sides. An append is now stated as what it appended. */
+  test("a description append renders as what it appended", async () => {
+    const args = describedArgs;
+    const io = recordingIo();
+    expect(await main(args("--format", "json"), io)).toBe(0);
+    const { configDelta } = io.json() as { configDelta: Record<string, unknown>[] };
+    const description = configDelta.find((d) => d.key === "description");
+    expect(description).toMatchObject({
+      collapsed: "append",
+      beforeLength: 2,
+      afterLength: 3,
+      added: ["Group the react packages into one PR."],
+    });
+
+    const pretty = recordingIo();
+    expect(await main(args(), pretty)).toBe(0);
+    expect(pretty.stdout).toContain(
+      'description: 2 entries + 1 appended (now 3) — ["Group the react packages into one PR."]',
+    );
+    expect(pretty.stdout).not.toContain("Reviewed every quarter.");
+  });
+
+  test("--keys narrows the delta without moving the verdict", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "compare",
+          fixture("clean.json"),
+          fixture("grouped.json"),
+          "--dep",
+          '{"depName":"react","packageName":"react"}',
+          "--keys",
+          "groupName,onboardingConfig",
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const comparison = io.json() as {
+      summary: string;
+      configDelta: { key: string }[];
+      configView: { withheld?: { key: string; reason: string }[] };
+    };
+    expect(comparison.configDelta.map((d) => d.key)).toEqual(["groupName"]);
+    // The verdict describes the whole comparison, not the view of it.
+    expect(comparison.summary).toBe("differs: dependencyDashboard, description, groupName");
+    // The reason a caller can act on: `--config-scope full` is what would
+    // make a globalOnly name answerable, whether or not the delta held it.
+    expect(comparison.configView.withheld).toEqual([
+      { key: "onboardingConfig", reason: "global-only" },
+    ]);
   });
 });
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -2,9 +2,11 @@ import { compareSimulations, type SimulationComparison } from "@renovate-config-
 import { outputFormat, stringOption } from "../args";
 import type { Command } from "../command";
 import { EXIT_OK, EXIT_REFUSED } from "../io";
-import { emitJson, emitLines, preview, writeNotes } from "../output";
+import { emitJson, emitLines, writeNotes } from "../output";
 import { INPUT_OPTIONS, refusalNote, runOne, takeInputFile, wouldRefuse } from "../run-input";
 import { readDependency } from "../dep";
+import { diffLine, parseConfigScope, parseKeys } from "../projections/config-view";
+import { comparisonPayload } from "../projections/simulate";
 import { simulateAgainst } from "./simulate";
 
 /**
@@ -26,11 +28,15 @@ import { simulateAgainst } from "./simulate";
  */
 /** The comparison's own one-liner without its `identical:`/`differs:` prefix —
  *  the headline states the verdict in its own words. */
-function netEffect(comparison: SimulationComparison): string {
+function netEffect(comparison: ComparisonVerdict): string {
   return comparison.summary.slice(comparison.summary.indexOf(": ") + 2);
 }
 
-export function comparisonHeadline(comparison: SimulationComparison): string {
+/** The headline reads the VERDICT fields only — which is what lets it take a
+ *  projected comparison (whose delta may be narrowed) unchanged. */
+type ComparisonVerdict = Pick<SimulationComparison, "summary" | "noChange" | "rulesChanged">;
+
+export function comparisonHeadline(comparison: ComparisonVerdict): string {
   if (!comparison.noChange) {
     return `Behavior differs between A and B — ${netEffect(comparison)}.`;
   }
@@ -56,10 +62,26 @@ export const compareCommand: Command = {
     "doing something. IDENTITY (`rulesChanged`, `signatureChanges`) only says a",
     "selector's text moved — unavoidable when the edit is to the matched array",
     "itself, and not a behavior change on its own.",
+    "",
+    "The key delta is reported at `--config-scope package-rules` (the globalOnly",
+    "options no rule can reach are dropped) and `--keys a,b` narrows it further.",
+    "Neither touches the verdict: `summary` states what the comparison found",
+    "over the WHOLE delta, and `configView` says what the view withheld.",
   ],
-  options: [...INPUT_OPTIONS, "dep", "dep-file", "dep-b", "dep-b-file", "format"],
+  options: [
+    ...INPUT_OPTIONS,
+    "dep",
+    "dep-file",
+    "dep-b",
+    "dep-b-file",
+    "keys",
+    "config-scope",
+    "format",
+  ],
   async run(args, io) {
     const format = outputFormat(args);
+    const keys = parseKeys(stringOption(args, "keys"));
+    const scope = parseConfigScope(stringOption(args, "config-scope"), "--config-scope");
     const { file, rest } = takeInputFile(args);
     const fileB = rest[0];
     const depA = await readDependency(args, "dep", "dep-file");
@@ -75,7 +97,10 @@ export const compareCommand: Command = {
 
     const simA = await simulateAgainst(a.result, depA);
     const simB = await simulateAgainst(b.result, depB);
-    const comparison = compareSimulations(simA, simB);
+    const comparison = comparisonPayload(compareSimulations(simA, simB), {
+      scope: scope ?? "package-rules",
+      ...(keys ? { keys } : {}),
+    });
 
     const refusedA = wouldRefuse(a.result);
     const refusedB = wouldRefuse(b.result);
@@ -101,13 +126,7 @@ export const compareCommand: Command = {
           ? ["", "Matched only in B:", ...comparison.behaviorOnlyInB.map((r) => `  ${r.label}`)]
           : []),
         ...(comparison.configDelta.length > 0
-          ? [
-              "",
-              "Config delta:",
-              ...comparison.configDelta.map(
-                (d) => `  ${d.key}: ${preview(d.before)} → ${preview(d.after)}`,
-              ),
-            ]
+          ? ["", "Config delta:", ...comparison.configDelta.map((d) => `  ${diffLine(d)}`)]
           : []),
         ...(comparison.signatureChanges.length > 0
           ? [

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -2,6 +2,7 @@ import { outputFormat, stringOption } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, json, messageLines, stageLines, writeNotes } from "../output";
+import { parseConfigScope, parseKeys, projectConfig } from "../projections/config-view";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
@@ -51,13 +52,25 @@ export const runCommand: Command = {
     "`--select tree` are the firehose: a `config:recommended` run carries",
     "over a thousand tree nodes with four config bodies each — prefer",
     "`rcd tree` / `rcd provenance`, which project them.",
+    "",
+    "`--keys` and `--config-scope` project `--select final` ONLY — this is the",
+    "run's whole effective config, so it is reported at `--config-scope full`:",
+    "the globalOnly options are the answer when you are debugging a self-hosted",
+    "global or inherited layer. `--config-scope package-rules` drops them.",
   ],
-  options: [...INPUT_OPTIONS, "select", "format"],
+  options: [...INPUT_OPTIONS, "select", "keys", "config-scope", "format"],
   async run(args, io) {
     const format = outputFormat(args);
     const selection = parseSelection(stringOption(args, "select"));
+    const keys = parseKeys(stringOption(args, "keys"));
+    const scope = parseConfigScope(stringOption(args, "config-scope"), "--config-scope");
     const { result, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
+
+    const projected =
+      result.finalConfig && (keys || scope)
+        ? projectConfig(result.finalConfig, { scope: scope ?? "full", ...(keys ? { keys } : {}) })
+        : undefined;
 
     const slices: Record<string, unknown> = {};
     for (const key of selection) {
@@ -72,7 +85,10 @@ export const runCommand: Command = {
           slices.warnings = result.warnings;
           break;
         case "final":
-          slices.finalConfig = result.finalConfig;
+          slices.finalConfig = projected ? projected.config : result.finalConfig;
+          if (projected) {
+            slices.configView = projected.view;
+          }
           break;
         case "events":
           slices.events = result.events;
@@ -109,7 +125,14 @@ export const runCommand: Command = {
         );
       }
       if (selection.includes("final")) {
-        lines.push("", "Effective config:", json(result.finalConfig));
+        lines.push(
+          "",
+          "Effective config:",
+          json(projected ? projected.config : result.finalConfig),
+        );
+        if (projected) {
+          lines.push(`(${json(projected.view)})`);
+        }
       }
       if (selection.includes("layers")) {
         lines.push("", "Layers:", json(result.layerConfigs));

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -44,8 +44,7 @@ describe("simulate", () => {
       ),
     ).toBe(0);
     const sim = io.json() as {
-      rules: { verdict: string; clauses: { key: string; state: string }[] }[];
-      mergeSteps: unknown[];
+      rules: { verdict: string; clauses: { key: string; state: string }[]; merged?: unknown }[];
     };
     expect(sim.rules[0]?.verdict).toBe("no-match");
     expect(sim.rules[0]?.clauses[0]).toMatchObject({
@@ -53,9 +52,142 @@ describe("simulate", () => {
       state: "no-match",
     });
     // Nothing matched, so nothing was merged for this dependency.
-    expect(sim.mergeSteps).toEqual([]);
+    expect(sim.rules[0]?.merged).toBeUndefined();
   });
 
+  test("a dependency is required", async () => {
+    const io = recordingIo();
+    expect(await main(["simulate", fixture("grouped.json")], io)).toBe(1);
+    expect(io.stderr).toContain("--dep");
+  });
+});
+
+/**
+ * Roadmap 070: `--format json` used to spread the whole `SimulationResult` —
+ * 106 kB for this fixture, 74% of it the merge trace nobody asked for, and a
+ * `finalDependencyConfig` carrying 107 globalOnly options no packageRule can
+ * read. It now answers at the same `detail` the MCP `simulate` tool does,
+ * through the same projection.
+ */
+async function simulateJson(...flags: string[]) {
+  const io = recordingIo();
+  const code = await main(
+    [
+      "simulate",
+      fixture("described.json"),
+      "--dep",
+      '{"depName":"react"}',
+      "--format",
+      "json",
+      ...flags,
+    ],
+    io,
+  );
+  return { io, code, payload: io.json() as Record<string, unknown> };
+}
+
+describe("simulate --detail / --keys / --config-scope", () => {
+  test("the default json answer is the verdict, not the merge trace", async () => {
+    const { payload, code } = await simulateJson();
+    expect(code).toBe(0);
+    expect(payload).not.toHaveProperty("mergeSteps");
+    expect(payload).not.toHaveProperty("rawFinalConfig");
+    // The omission is stated, with the flag that undoes it.
+    expect(payload.detailNote).toContain('detail: "full"');
+    expect(payload.rules).toBeDefined();
+    expect(payload.flattened).toBeDefined();
+  });
+
+  test("--detail full restores the whole result, byte for byte", async () => {
+    const { payload } = await simulateJson("--detail", "full");
+    expect(payload.mergeSteps).toBeDefined();
+    expect(payload.rawFinalConfig).toBeDefined();
+    expect(payload.detailNote).toBeUndefined();
+    expect(payload.configView).toBeUndefined();
+    // Nothing collapsed, nothing pruned — the escape hatch is the raw shape.
+    const rules = payload.rules as { merged?: { key: string }[] }[];
+    expect(rules[0]?.merged?.[0]).toHaveProperty("before");
+  });
+
+  test("the per-dependency config drops the options no rule can reach", async () => {
+    const { payload } = await simulateJson();
+    const config = payload.finalDependencyConfig as Record<string, unknown>;
+    expect(payload.configView).toMatchObject({
+      scope: "package-rules",
+      droppedGlobalOnly: 107,
+    });
+    expect(config).not.toHaveProperty("onboardingConfig");
+    expect(config).toHaveProperty("groupName", "react monorepo");
+  });
+
+  test("--config-scope full puts the 107 back", async () => {
+    const { payload } = await simulateJson("--config-scope", "full");
+    const config = payload.finalDependencyConfig as Record<string, unknown>;
+    expect(payload.configView).toMatchObject({ scope: "full" });
+    expect(config).toHaveProperty("onboardingConfig");
+  });
+
+  test("--keys narrows the config and leaves the rules alone", async () => {
+    const { payload } = await simulateJson("--keys", "groupName,onboardingConfig");
+    expect(payload.finalDependencyConfig).toEqual({ groupName: "react monorepo" });
+    // `keys` never widens: a key the scope removed comes back as a REASON.
+    expect(payload.configView).toMatchObject({
+      withheld: [{ key: "onboardingConfig", reason: "global-only" }],
+    });
+    expect(payload.rules).toHaveLength(1);
+  });
+
+  test("an unknown value names the ones that exist", async () => {
+    const io = recordingIo();
+    const code = await main(
+      [
+        "simulate",
+        fixture("described.json"),
+        "--dep",
+        '{"depName":"react"}',
+        "--config-scope",
+        "global",
+      ],
+      io,
+    );
+    expect(code).toBe(1);
+    expect(io.stderr).toContain("package-rules|full");
+  });
+
+  /** The measured defect: `mergeChildConfig` concatenates `description` on
+   *  nearly every merge, so the array was re-embedded in full on BOTH sides of
+   *  every diff that touched it. */
+  test("a description append is collapsed into what it appended", async () => {
+    const { payload } = await simulateJson();
+    const rules = payload.rules as { merged: Record<string, unknown>[] }[];
+    const description = rules[0]?.merged.find((m) => m.key === "description");
+    expect(description).toEqual({
+      key: "description",
+      collapsed: "append",
+      beforeLength: 2,
+      afterLength: 3,
+      added: ["Group the react packages into one PR."],
+    });
+    const full = await simulateJson("--detail", "full");
+    const verbatim = (
+      full.payload.rules as { merged: Record<string, unknown>[] }[]
+    )[0]?.merged.find((m) => m.key === "description");
+    expect(JSON.stringify(description).length).toBeLessThan(JSON.stringify(verbatim).length);
+  });
+
+  test("pretty output says what the rule appended, not the whole array", async () => {
+    const io = recordingIo();
+    expect(
+      await main(["simulate", fixture("described.json"), "--dep", '{"depName":"react"}'], io),
+    ).toBe(0);
+    expect(io.stdout).toContain(
+      'sets description += 1 of 3 entries: ["Group the react packages into one PR."]',
+    );
+    expect(io.stdout).not.toContain("The base config for this repository.");
+  });
+});
+
+describe("simulate errors", () => {
   test("a dependency is required", async () => {
     const io = recordingIo();
     expect(await main(["simulate", fixture("grouped.json")], io)).toBe(1);

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -4,10 +4,10 @@ import {
   type SimulationResult,
   type TraceResult,
 } from "@renovate-config-debugger/engine";
-import { outputFormat } from "../args";
+import { outputFormat, stringOption } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
-import { emitJson, emitLines, preview, writeNotes } from "../output";
+import { emitJson, emitLines, writeNotes } from "../output";
 import { INPUT_OPTIONS, refusalNote, runFromArgs, wouldRefuse } from "../run-input";
 import { readDependency } from "../dep";
 import {
@@ -16,6 +16,8 @@ import {
   ruleFilterPayload,
   ruleFilterSelection,
 } from "../rule-view";
+import { collapseDiffs, mergedLine, parseConfigScope, parseKeys } from "../projections/config-view";
+import { collapseRuleMerges, parseDetail, simulationPayload } from "../projections/simulate";
 
 /**
  * "Would this PR be grouped/labeled/blocked here?" — every packageRule
@@ -38,8 +40,8 @@ export function verdictLines(rules: readonly RuleEvaluation[]): string[] {
   for (const rule of rules) {
     const clauses = rule.clauses.map((c) => `${c.key}=${c.state}`).join(", ");
     lines.push(`  #${rule.index + 1} ${rule.verdict}${clauses ? ` (${clauses})` : ""}`);
-    for (const merged of rule.merged ?? []) {
-      lines.push(`      sets ${merged.key} = ${preview(merged.after)}`);
+    for (const merged of collapseDiffs(rule.merged ?? [])) {
+      lines.push(`      sets ${mergedLine(merged)}`);
     }
     for (const note of rule.notes) {
       lines.push(`      note: ${note}`);
@@ -61,11 +63,31 @@ export const simulateCommand: Command = {
     "output prints the notable ones (matched + unresolved) and says how many it",
     "hid. `--verdict`/`--source` scope it; `--format json` keeps the full array",
     "unless you pass one of them.",
+    "",
+    "`--format json` answers at `--detail verdict`: the merge trace",
+    "(`mergeSteps`, `rawFinalConfig`) is ~1 MB on a `config:recommended` run and",
+    "is opt-in through `--detail full`, which returns the whole simulation",
+    "result unprojected. `finalDependencyConfig` is reported at",
+    "`--config-scope package-rules` — the globalOnly options no rule can read",
+    "are dropped — and `--keys a,b` narrows it to the options you asked about.",
   ],
-  options: [...INPUT_OPTIONS, "dep", "dep-file", "verdict", "source", "format"],
+  options: [
+    ...INPUT_OPTIONS,
+    "dep",
+    "dep-file",
+    "verdict",
+    "source",
+    "detail",
+    "keys",
+    "config-scope",
+    "format",
+  ],
   async run(args, io) {
     const format = outputFormat(args);
     const selection = ruleFilterSelection(args, format);
+    const detail = parseDetail(stringOption(args, "detail")) ?? "verdict";
+    const keys = parseKeys(stringOption(args, "keys"));
+    const scope = parseConfigScope(stringOption(args, "config-scope"), "--config-scope");
     const dep = await readDependency(args, "dep", "dep-file");
     const { result, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
@@ -79,8 +101,12 @@ export const simulateCommand: Command = {
     if (format === "json") {
       emitJson(io, {
         dep,
-        ...sim,
-        rules: view.rules,
+        ...simulationPayload(sim, {
+          detail,
+          scope: scope ?? "package-rules",
+          ...(keys ? { keys } : {}),
+        }),
+        rules: detail === "full" ? view.rules : collapseRuleMerges(view.rules),
         ...(selection.explicit ? ruleFilterPayload(view) : {}),
         wouldRefuse: refused,
         ...(refusal ? { exitNote: refusal } : {}),
@@ -91,9 +117,9 @@ export const simulateCommand: Command = {
       // answer. What the rules DID is the delta they merged; `--format json`
       // carries the full document for anyone who wants it.
       const changes = sim.mergeSteps.flatMap((step) =>
-        step.merged.map(
+        collapseDiffs(step.merged).map(
           (m) =>
-            `  ${m.key} = ${preview(m.after)}` +
+            `  ${mergedLine(m)}` +
             (step.kind === "flatten"
               ? `  (${step.updateType} block)`
               : `  (rule #${(step.ruleIndex ?? 0) + 1})`),

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -402,6 +402,41 @@ describe("drill-down", () => {
     expect(output.config.extends).toEqual([":dependencyDashboard"]);
   });
 
+  /**
+   * Roadmap 070: the same two parameters on every config-shaped answer, with
+   * a DIFFERENT default per tool — because the documents are different.
+   * `get_final_config` is the run's whole effective config, the surface
+   * someone debugs a self-hosted globalConfig layer on, so the globalOnly
+   * options are the answer there and stay by default. `simulate`'s
+   * per-dependency config prunes them (asserted in "simulate and compare").
+   */
+  test("the effective config keeps the globalOnly options — they are its answer", async () => {
+    const runId = await runConfig('{"labels":["deps"]}');
+    const payload = (await call("get_final_config", { runId })) as {
+      finalConfig: Record<string, unknown>;
+      configView: { scope: string; keys: number; droppedGlobalOnly?: number };
+    };
+    expect(payload.configView.scope).toBe("full");
+    expect(payload.configView.droppedGlobalOnly).toBeUndefined();
+    expect(payload.finalConfig).toHaveProperty("onboardingConfig");
+
+    // A globalOnly key IS returnable here — the per-tool asymmetry, pinned.
+    const keyed = (await call("get_final_config", {
+      runId,
+      keys: ["labels", "onboardingConfig"],
+    })) as { finalConfig: Record<string, unknown>; configView: { keys: number } };
+    expect(Object.keys(keyed.finalConfig).toSorted()).toEqual(["labels", "onboardingConfig"]);
+    expect(keyed.configView.keys).toBe(2);
+
+    // …and asking for this document at the other scope drops the class.
+    const scoped = (await call("get_final_config", {
+      runId,
+      configScope: "package-rules",
+    })) as { finalConfig: Record<string, unknown>; configView: { droppedGlobalOnly?: number } };
+    expect(scoped.configView.droppedGlobalOnly).toBe(107);
+    expect(scoped.finalConfig).not.toHaveProperty("onboardingConfig");
+  });
+
   test("an expired or invented runId says which runs are held", async () => {
     await expect(call("get_final_config", { runId: "run-404" })).rejects.toThrow(
       /no run "run-404"/,
@@ -491,6 +526,33 @@ describe("size budget", () => {
     expect(rules.truncated).toBe(true);
     expect(rules.omitted).toBeGreaterThan(0);
     expect(rules.shown).toBeGreaterThan(0);
+  });
+
+  /**
+   * Roadmap 070: the elision is a transport safety net, not a filter — it
+   * shrinks arrays and, at the last resort, deletes whole keys by name. The
+   * reduction that answers the question has to happen at CONSTRUCTION, which
+   * is what `keys` does: the same run, the same tool, asked precisely, comes
+   * back whole.
+   */
+  test("a keys-projected answer comes back un-elided", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const text = await callText("get_final_config", {
+      runId,
+      keys: ["labels", "dependencyDashboard", "minimumReleaseAge"],
+    });
+    const payload = JSON.parse(text) as {
+      truncated?: boolean;
+      omittedKeys?: string[];
+      finalConfig: { labels: string[] };
+      configView: { withheld?: { key: string }[] };
+    };
+    // The test above asked the SAME run for the same document unprojected and
+    // got it truncated, with `packageRules` cut in place.
+    expect(payload.truncated).toBeUndefined();
+    expect(payload.omittedKeys).toBeUndefined();
+    expect(payload.finalConfig.labels).toEqual(["deps"]);
+    expect(text.length).toBeLessThan(1_000);
   });
 });
 
@@ -621,6 +683,7 @@ describe("simulate and compare", () => {
       omittedKeys?: string[];
       detailNote: string;
       finalDependencyConfig: Record<string, unknown>;
+      configView: { scope: string; keys: number; droppedGlobalOnly?: number };
       flattened: unknown;
       rules: { truncated: boolean; shown: number; omitted: number } | unknown[];
     };
@@ -632,6 +695,19 @@ describe("simulate and compare", () => {
     expect(parsed.omittedKeys).toBeUndefined();
     expect(parsed.flattened).toBeDefined();
     expect(Object.keys(parsed.finalDependencyConfig).length).toBeGreaterThan(10);
+    /**
+     * Roadmap 070: this document is "what applyPackageRules produced for ONE
+     * dependency", so the globalOnly class — 107 options a matcher cannot
+     * read and a rule cannot write — is provably inert in it and goes by
+     * default. The answer states which view produced it.
+     */
+    expect(parsed.configView).toMatchObject({
+      scope: "package-rules",
+      droppedGlobalOnly: 107,
+    });
+    expect(parsed.finalDependencyConfig).not.toHaveProperty("onboardingConfig");
+    expect(parsed.finalDependencyConfig).not.toHaveProperty("dryRun");
+    expect(parsed.configView.keys).toBe(Object.keys(parsed.finalDependencyConfig).length);
     // And the rule list is a real sample of 713, not a token two.
     const rules = parsed.rules as { shown: number; omitted: number };
     expect(rules.shown + rules.omitted).toBeGreaterThan(700);
@@ -659,6 +735,50 @@ describe("simulate and compare", () => {
     // The default answer for the same question never got that big.
     const verdict = (await call("simulate", { runId, dep })) as { truncated?: boolean };
     expect(verdict.truncated).toBeUndefined();
+  });
+
+  /**
+   * Roadmap 070. The `keys` axis composes with the others and only ever
+   * narrows: what it names, of what `configScope` left, and a REASON for
+   * everything it did not answer with.
+   */
+  test("keys narrows the per-dependency config, and names what it withheld", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const dep = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
+    const text = await callText("simulate", {
+      runId,
+      dep,
+      keys: ["labels", "automerge", "onboardingConfig"],
+    });
+    const parsed = JSON.parse(text) as {
+      truncated?: boolean;
+      finalDependencyConfig: Record<string, unknown>;
+      configView: { withheld?: { key: string; reason: string }[] };
+      rules: unknown;
+    };
+    expect(Object.keys(parsed.finalDependencyConfig).toSorted()).toEqual(["automerge", "labels"]);
+    // A globalOnly name is not resurrected — it is explained. `absent` and
+    // `global-only` are different answers, and a silently empty result is
+    // indistinguishable from a bug.
+    expect(parsed.configView.withheld).toEqual([
+      { key: "onboardingConfig", reason: "global-only" },
+    ]);
+    // …and `keys` never touches the rule list.
+    expect(parsed.rules).toBeDefined();
+  });
+
+  test("configScope full is the way back to the whole document", async () => {
+    const runId = await runConfig(GROUPED);
+    const dep = { depName: "react", packageName: "react" };
+    const scoped = (await call("simulate", { runId, dep, configScope: "full" })) as {
+      finalDependencyConfig: Record<string, unknown>;
+      configView: { scope: string; droppedGlobalOnly?: number };
+    };
+    expect(scoped.configView).toEqual({
+      scope: "full",
+      keys: Object.keys(scoped.finalDependencyConfig).length,
+    });
+    expect(scoped.finalDependencyConfig).toHaveProperty("onboardingConfig");
   });
 
   test("verdict/source scope the rule list and say what they hid", async () => {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -26,7 +26,14 @@ import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
 import { buildRuleView, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
+import { CONFIG_SCOPES, projectConfig } from "../projections/config-view";
 import { describeMessage, type MessageSeverity } from "../projections/messages";
+import {
+  collapseRuleMerges,
+  comparisonPayload,
+  SIMULATE_DETAIL,
+  simulationPayload,
+} from "../projections/simulate";
 import {
   entryView,
   indexView,
@@ -98,7 +105,7 @@ const HELD_RUN_ANNOTATIONS = {
  */
 const HINTS = {
   finalConfig:
-    "the effective config is too large to return whole — ask get_provenance for one `key`, or get_resolved_config for the document without the defaults.",
+    "the effective config is too large to return whole — pass `keys: [...]` for the options you care about, ask get_provenance for one `key`, or get_resolved_config for the document without the defaults.",
   tree: "the tree is too large at this depth — lower `depth`, pass a `query`, or query one node with get_preset_node.",
   node: "this node's body is too large to return whole — ask for a deeper child instead, or omit `body` and read the contribution stats.",
   provenance:
@@ -106,9 +113,9 @@ const HINTS = {
   resolved:
     'the resolved document is too large to return whole — try mode "keep-internal" without includeDefaults, or read one preset\'s contribution with get_preset_node.',
   simulate:
-    "this config has too many packageRules to report whole — the omission is marked; narrow the dependency (a datasource, a depType) so fewer rules report `no-input`.",
+    "this config has too many packageRules to report whole — the omission is marked; scope the list with `verdict`/`source`, pass `keys: [...]` for the options you care about, or narrow the dependency (a datasource, a depType) so fewer rules report `no-input`.",
   compare:
-    "the comparison is too large to return whole — narrow the dependency, or ask simulate for one side at a time.",
+    "the comparison is too large to return whole — pass `keys: [...]` for the options you care about, narrow the dependency, or ask simulate for one side at a time.",
   optionDocs: "too many options matched — search for a longer substring.",
 } as const;
 
@@ -296,46 +303,27 @@ function simulateRun(run: HeldRun, dep: DepInput, ctx: ToolContext): Promise<Sim
 }
 
 /**
- * H1 (roadmap 068, 6 of 9 persona sessions): what a simulate answer carries by
- * default.
- *
- * Measured on `config:recommended` + a react update, the whole
- * `SimulationResult` is 1.36 MB — of which `mergeSteps` is 797 kB (two
- * elements, each a full config snapshot) and `rawFinalConfig` 199 kB. Those
- * two answer "how did the merge proceed", a question nobody asked, and they
- * drowned the one that was: the elision spent its budget on them and returned
- * 2 of 713 rules, with the merge trace dropped whole anyway. Personas at every
- * level asked for the same shape by hand — the matched rules, `flattened` and
- * `finalDependencyConfig`.
- *
- * So the merge trace is opt-in. `full` is the old payload, unchanged, for the
- * caller who is actually stepping through the merge.
+ * Roadmap 070: the two config-projection parameters, spelled the same on every
+ * tool that answers with a config document. The DEFAULT differs per tool, and
+ * deliberately — see `get_final_config` and `simulate` below.
  */
-const SIMULATE_DETAIL = ["verdict", "full"] as const;
-type SimulateDetail = (typeof SIMULATE_DETAIL)[number];
+const CONFIG_KEYS = z
+  .array(z.string())
+  .optional()
+  .describe(
+    'Only these TOP-LEVEL config options, e.g. ["automerge", "labels"] (no dot paths — the ' +
+      "same `key` get_provenance takes). It only ever narrows: a key `configScope` removed is " +
+      'not resurrected, it comes back in `configView.withheld` with reason "global-only".',
+  );
 
-const VERDICT_DETAIL_NOTE =
-  "`mergeSteps` and `rawFinalConfig` are omitted at this detail level — on a `config:recommended` " +
-  'run they are ~1 MB of the payload and describe how the merge proceeded. Pass detail: "full" ' +
-  "for them.";
-
-/** The simulation, at the requested detail. Listed key by key rather than
- *  subtracted from the result, so the default shape is legible here and a
- *  future field has to be admitted on purpose. */
-function simulationPayload(sim: SimulationResult, detail: SimulateDetail) {
-  if (detail === "full") {
-    return sim;
-  }
-  return {
-    rules: sim.rules,
-    flattened: sim.flattened,
-    finalDependencyConfig: sim.finalDependencyConfig,
-    errors: sim.errors,
-    warnings: sim.warnings,
-    notes: sim.notes,
-    detailNote: VERDICT_DETAIL_NOTE,
-  };
-}
+const CONFIG_SCOPE = z
+  .enum(CONFIG_SCOPES)
+  .optional()
+  .describe(
+    "Which CLASS of config key to report: `package-rules` drops the ~107 globalOnly options no " +
+      "packageRule can read or write, `full` keeps everything. The answer always states which " +
+      "one produced it, in `configView`.",
+  );
 
 /** Each validator message with the position `explain_message` addresses it by.
  *  The array's own index is NOT that position: a large answer is elided
@@ -567,12 +555,21 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Effective config",
       description:
         "The effective config the run produced — everything merged, Renovate's defaults " +
-        "included. Large. If the question is 'who set this option', get_provenance answers it " +
-        "better; if it is 'what would I write instead of these presets', use get_resolved_config.",
+        "included. Large: pass `keys` for the options you care about. If the question is 'who " +
+        "set this option', get_provenance answers it better; if it is 'what would I write " +
+        "instead of these presets', use get_resolved_config. This is the RUN's whole config, so " +
+        'it reports `configScope: "full"` by default — the globalOnly options are the answer ' +
+        "when you are debugging a self-hosted global or inherited layer.",
       annotations: HELD_RUN_ANNOTATIONS,
-      inputSchema: z.strictObject({ runId: RUN_ID }),
+      inputSchema: z.strictObject({ runId: RUN_ID, keys: CONFIG_KEYS, configScope: CONFIG_SCOPE }),
     },
-    answer(({ runId }) => ({ finalConfig: finalConfigOf(store.get(runId)) }), HINTS.finalConfig),
+    answer(({ runId, keys, configScope }) => {
+      const projected = projectConfig(finalConfigOf(store.get(runId)), {
+        scope: configScope ?? "full",
+        ...(keys ? { keys } : {}),
+      });
+      return { finalConfig: projected.config, configView: projected.view };
+    }, HINTS.finalConfig),
   );
 
   server.registerTool(
@@ -731,7 +728,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "what it read), the options the matching rules set for that dependency " +
         "(`finalDependencyConfig`) and how they got there (`flattened`). " +
         "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
-        '(`source: "repo"` is "just my own config\'s rules"). The step-by-step merge trace is ' +
+        '(`source: "repo"` is "just my own config\'s rules"), and `keys` narrows ' +
+        "`finalDependencyConfig` to the options you asked about. The step-by-step merge trace is " +
         'NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
@@ -739,6 +737,8 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         dep: DEP,
         verdict: RULE_VERDICT,
         source: RULE_SOURCE,
+        keys: CONFIG_KEYS,
+        configScope: CONFIG_SCOPE,
         detail: z
           .enum(SIMULATE_DETAIL)
           .optional()
@@ -750,10 +750,19 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           ),
       }),
     },
-    answer(async ({ runId, dep, verdict, source, detail }, ctx) => {
+    answer(async ({ runId, dep, verdict, source, keys, configScope, detail }, ctx) => {
       const run = store.get(runId);
       const sim = await simulateRun(run, dep, ctx);
-      const payload = simulationPayload(sim, detail ?? "verdict");
+      const resolvedDetail = detail ?? "verdict";
+      // `finalDependencyConfig` is by construction "what applyPackageRules
+      // produced for ONE dependency", so the globalOnly class is provably
+      // inert here and goes by default — the opposite of get_final_config's
+      // document, and stated as such in `configView`.
+      const payload = simulationPayload(sim, {
+        detail: resolvedDetail,
+        scope: configScope ?? "package-rules",
+        ...(keys ? { keys } : {}),
+      });
       if (verdict === undefined && source === undefined) {
         return { dep: toDependency(dep), ...payload };
       }
@@ -766,7 +775,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       return {
         dep: toDependency(dep),
         ...payload,
-        rules: view.rules,
+        rules: resolvedDetail === "full" ? view.rules : collapseRuleMerges(view.rules),
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
         ...ruleFilterPayload(view),
       };
@@ -782,16 +791,20 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "the two runs against the same dependency — `summary` is the whole verdict in one line " +
         "(`identical: …` / `differs: …`), with the rules that started or stopped matching and " +
         "the key-level delta of the resulting config underneath it. Pass runIdB to compare two " +
-        "configs, or depB to compare two dependencies against the same config.",
+        "configs, or depB to compare two dependencies against the same config. `keys` narrows " +
+        "the delta to the options you care about; `summary` and the verdict booleans always " +
+        "describe the WHOLE delta, so narrowing the view never moves the verdict.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
         dep: DEP,
         runIdB: z.string().optional().describe("The B-side run. Defaults to runId."),
         depB: DEP.optional().describe("The B-side dependency. Defaults to dep."),
+        keys: CONFIG_KEYS,
+        configScope: CONFIG_SCOPE,
       }),
     },
-    answer(async ({ runId, dep, runIdB, depB }, ctx) => {
+    answer(async ({ runId, dep, runIdB, depB, keys, configScope }, ctx) => {
       const a = store.get(runId);
       const b = runIdB ? store.get(runIdB) : a;
       const [simA, simB] = await Promise.all([
@@ -801,7 +814,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       return {
         a: { runId: a.runId, dep: toDependency(dep) },
         b: { runId: b.runId, dep: toDependency(depB ?? dep) },
-        ...compareSimulations(simA, simB),
+        ...comparisonPayload(compareSimulations(simA, simB), {
+          scope: configScope ?? "package-rules",
+          ...(keys ? { keys } : {}),
+        }),
       };
     }, HINTS.compare),
   );

--- a/packages/cli/src/projections/config-view.test.ts
+++ b/packages/cli/src/projections/config-view.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "vitest";
+import { globalOnlyOptionNames } from "@renovate-config-debugger/engine";
+import {
+  collapseDescriptionDiff,
+  collapseDiffs,
+  type ConfigScope,
+  diffLine,
+  mergedLine,
+  parseConfigScope,
+  parseKeys,
+  projectConfig,
+} from "./config-view";
+
+/**
+ * Roadmap 070. Pure — no pipeline run: the whole point of the module is that
+ * the projection is decidable from the document plus Renovate's option
+ * metadata.
+ */
+
+/** A globalOnly option: no packageRule can read or write it, and Renovate
+ *  itself strips the class from a repo config. */
+const GLOBAL_ONLY = "onboardingConfig";
+
+const CONFIG = {
+  automerge: true,
+  groupName: "react monorepo",
+  labels: ["deps"],
+  [GLOBAL_ONLY]: { extends: ["config:recommended"] },
+};
+
+describe("projectConfig", () => {
+  test("the globalOnly class goes by default, and the view says how many", () => {
+    expect(globalOnlyOptionNames().has(GLOBAL_ONLY)).toBe(true);
+    const { config, view } = projectConfig(CONFIG, { scope: "package-rules" });
+    expect(Object.keys(config)).toEqual(["automerge", "groupName", "labels"]);
+    expect(view).toEqual({ scope: "package-rules", keys: 3, droppedGlobalOnly: 1 });
+  });
+
+  test("`full` keeps everything and reports nothing dropped", () => {
+    const { config, view } = projectConfig(CONFIG, { scope: "full" });
+    expect(Object.keys(config)).toEqual(Object.keys(CONFIG));
+    expect(view).toEqual({ scope: "full", keys: 4 });
+  });
+
+  test("keys selects, and names what the document does not have", () => {
+    const { config, view } = projectConfig(CONFIG, {
+      scope: "package-rules",
+      keys: ["automerge", "minimumReleaseAge"],
+    });
+    expect(config).toEqual({ automerge: true });
+    expect(view.withheld).toEqual([{ key: "minimumReleaseAge", reason: "absent" }]);
+    expect(view.keys).toBe(1);
+  });
+
+  /** The additive-only decision, pinned: `keys` may only ever narrow what
+   *  `scope` left, so one parameter never both narrows and widens. */
+  test("keys cannot resurrect a key the scope removed — it says why it is gone", () => {
+    const { config, view } = projectConfig(CONFIG, {
+      scope: "package-rules",
+      keys: [GLOBAL_ONLY],
+    });
+    expect(config).toEqual({});
+    expect(view.withheld).toEqual([{ key: GLOBAL_ONLY, reason: "global-only" }]);
+  });
+
+  test("widening is configScope's job, and it works", () => {
+    const { config, view } = projectConfig(CONFIG, { scope: "full", keys: [GLOBAL_ONLY] });
+    expect(Object.keys(config)).toEqual([GLOBAL_ONLY]);
+    expect(view.withheld).toBeUndefined();
+  });
+
+  /** The invariant every axis is composable under: whatever you ask for, you
+   *  get a SUBSET of what you would have got by asking for nothing. */
+  test("every projection is a subset of its input, and of the default answer", () => {
+    const scopes: ConfigScope[] = ["package-rules", "full"];
+    const keySets = [
+      undefined,
+      [],
+      ["automerge"],
+      [GLOBAL_ONLY],
+      ["automerge", GLOBAL_ONLY, "nope"],
+      Object.keys(CONFIG),
+    ];
+    for (const scope of scopes) {
+      const wide = projectConfig(CONFIG, { scope });
+      for (const keys of keySets) {
+        const { config, view } = projectConfig(CONFIG, {
+          scope,
+          ...(keys ? { keys } : {}),
+        });
+        for (const [key, value] of Object.entries(config)) {
+          expect(CONFIG).toHaveProperty(key, value);
+          expect(wide.config).toHaveProperty(key, value);
+        }
+        expect(view.keys).toBe(Object.keys(config).length);
+        expect(view.keys).toBeLessThanOrEqual(wide.view.keys);
+      }
+    }
+  });
+});
+
+describe("collapseDescriptionDiff", () => {
+  const before = ["Pin Docker digests.", "Separate major releases."];
+
+  test("collapses an append into exactly what it appended", () => {
+    const collapsed = collapseDescriptionDiff({
+      key: "description",
+      before,
+      after: [...before, "Group react packages."],
+    });
+    expect(collapsed).toEqual({
+      key: "description",
+      collapsed: "append",
+      beforeLength: 2,
+      afterLength: 3,
+      added: ["Group react packages."],
+    });
+  });
+
+  test("a replacement stays verbatim — both sides are the answer there", () => {
+    const diff = { key: "description", before, after: ["Something else entirely."] };
+    expect(collapseDescriptionDiff(diff)).toBe(diff);
+  });
+
+  test("a non-array value stays verbatim", () => {
+    const diff = { key: "description", before: "a string", after: "another string" };
+    expect(collapseDescriptionDiff(diff)).toBe(diff);
+  });
+
+  test("an empty before stays verbatim — collapsing would save nothing", () => {
+    const diff = { key: "description", before: [], after: ["The first sentence."] };
+    expect(collapseDescriptionDiff(diff)).toBe(diff);
+  });
+
+  test("only description collapses — a labels reader wants the list", () => {
+    const diff = { key: "labels", before: ["deps"], after: ["deps", "upstream"] };
+    expect(collapseDescriptionDiff(diff)).toBe(diff);
+  });
+
+  test("a delta's own extra fields ride through the collapse", () => {
+    const collapsed = collapseDiffs([
+      { key: "description", before, after: [...before, "And this."], inA: true, inB: true },
+    ]);
+    expect(collapsed[0]).toMatchObject({ inA: true, inB: true, collapsed: "append" });
+  });
+
+  test("collapsing an append is an order of magnitude smaller than the diff", () => {
+    // The measured shape: `mergeChildConfig` concatenates `description` on
+    // nearly every merge, so a best-practices rule re-embeds ~24 sentences
+    // twice. One sentence is what the step actually did.
+    const long = Array.from({ length: 24 }, (_, i) => `Sentence number ${i} of a preset body.`);
+    const diff = { key: "description", before: long, after: [...long, "The one this rule added."] };
+    const verbatim = JSON.stringify(diff).length;
+    const collapsed = JSON.stringify(collapseDescriptionDiff(diff)).length;
+    expect(collapsed * 10).toBeLessThan(verbatim);
+  });
+});
+
+describe("rendering", () => {
+  const collapsed = collapseDescriptionDiff({
+    key: "description",
+    before: ["One.", "Two."],
+    after: ["One.", "Two.", "Three."],
+  });
+
+  test("a collapsed diff renders what it added, not both arrays", () => {
+    expect(diffLine(collapsed)).toBe('description: 2 entries + 1 appended (now 3) — ["Three."]');
+    expect(mergedLine(collapsed)).toBe('description += 1 of 3 entries: ["Three."]');
+  });
+
+  test("an ordinary diff renders before → after", () => {
+    const diff = { key: "groupName", before: undefined, after: "react monorepo" };
+    expect(diffLine(diff)).toBe('groupName: (unset) → "react monorepo"');
+    expect(mergedLine(diff)).toBe('groupName = "react monorepo"');
+  });
+});
+
+describe("flag parsing", () => {
+  test("--keys takes --select's comma grammar", () => {
+    expect(parseKeys("automerge, labels ,")).toEqual(["automerge", "labels"]);
+    expect(parseKeys(undefined)).toBeUndefined();
+    // "no keys" is never what someone typing a flag meant.
+    expect(parseKeys(" , ")).toBeUndefined();
+  });
+
+  test("--config-scope names the values that exist", () => {
+    expect(parseConfigScope("full", "--config-scope")).toBe("full");
+    expect(() => parseConfigScope("global", "--config-scope")).toThrow(/package-rules\|full/);
+  });
+});

--- a/packages/cli/src/projections/config-view.ts
+++ b/packages/cli/src/projections/config-view.ts
@@ -1,0 +1,272 @@
+import { globalOnlyOptionNames, removeGlobalConfig } from "@renovate-config-debugger/engine";
+import { CliError } from "../io";
+import { preview } from "../output";
+
+/**
+ * Roadmap 070: the projection over a CONFIG-SHAPED document — the effective
+ * config, a per-dependency simulation result, a comparison's key delta —
+ * shared by the CLI's `--format json` and the MCP server, the way
+ * `projections/tree.ts` is shared by `rcd tree` and `get_preset_tree`.
+ *
+ * It exists because those documents are unusable as an answer at scale. A
+ * `finalDependencyConfig` is ~25 kB over 396 top-level keys, 107 of which are
+ * `globalOnly` options that no `packageRules` entry can read or write; and
+ * `description` — a mergeable array Renovate concatenates on nearly every
+ * merge — is re-embedded IN FULL on both sides of every diff that touches it
+ * (4 kB per rule at `config:best-practices` scale).
+ *
+ * Two axes, one vocabulary on both transports:
+ *
+ * - `scope` selects a CLASS of key (`package-rules` drops the globalOnly
+ *   class, `full` keeps everything);
+ * - `keys` selects NAMED keys, and only ever narrows what `scope` left.
+ *
+ * The order is the decision, not an accident: `keys` runs after the scope
+ * prune, so no combination of parameters can return a key the default answer
+ * withheld. Every answer is a subset of the default answer — which is what
+ * lets a caller reason about what it did NOT get. Widening is `scope`'s job
+ * alone, and the payload always states which scope produced it.
+ */
+
+export const CONFIG_SCOPES = ["package-rules", "full"] as const;
+export type ConfigScope = (typeof CONFIG_SCOPES)[number];
+
+export interface ConfigViewRequest {
+  /** Top-level option names to keep. Omitted: everything `scope` left. */
+  keys?: readonly string[];
+  scope: ConfigScope;
+}
+
+/**
+ * Why a requested key is not in the answer. `absent` ("this document does not
+ * carry that option") and `global-only` ("this VIEW cannot carry it") are
+ * different answers, and a silently empty result is indistinguishable from a
+ * bug, so the view names which one happened.
+ *
+ * A globalOnly name under `package-rules` always reads `global-only`, whether
+ * or not the document held it: that is the reason the caller can act on —
+ * `scope: "full"` is the parameter that changes the answer.
+ */
+export interface WithheldKey {
+  key: string;
+  reason: "absent" | "global-only";
+}
+
+/** What produced the document next to it. ~60 bytes, so a reader never has to
+ *  infer which projection an answer came out of. */
+export interface ConfigView {
+  scope: ConfigScope;
+  /** How many top-level keys the returned document has. */
+  keys: number;
+  /** `globalOnly` options the scope removed. Present only when it removed some. */
+  droppedGlobalOnly?: number;
+  /** Present only when `keys` named something the answer does not carry. */
+  withheld?: WithheldKey[];
+}
+
+export interface ProjectedConfig {
+  config: Record<string, unknown>;
+  view: ConfigView;
+}
+
+/** The key-level decision, without a document: which of `present` survive the
+ *  request, and the view that describes it. Shared by {@link projectConfig}
+ *  and the comparison delta, which is a key LIST rather than a record. */
+export function projectKeySet(
+  present: readonly string[],
+  request: ConfigViewRequest,
+): { kept: Set<string>; view: ConfigView } {
+  const globalOnly = globalOnlyOptionNames();
+  const pruned =
+    request.scope === "package-rules"
+      ? present.filter((key) => !globalOnly.has(key))
+      : [...present];
+  const droppedGlobalOnly = present.length - pruned.length;
+  if (!request.keys) {
+    return {
+      kept: new Set(pruned),
+      view: {
+        scope: request.scope,
+        keys: pruned.length,
+        ...(droppedGlobalOnly > 0 ? { droppedGlobalOnly } : {}),
+      },
+    };
+  }
+  const survivors = new Set(pruned);
+  const kept = new Set<string>();
+  const withheld: WithheldKey[] = [];
+  for (const key of request.keys) {
+    if (survivors.has(key)) {
+      kept.add(key);
+    } else {
+      // The scope, not the document, is why a globalOnly key is gone — and
+      // `keys` must never resurrect it. `scope: "full"` is the way back.
+      withheld.push({
+        key,
+        reason: request.scope === "package-rules" && globalOnly.has(key) ? "global-only" : "absent",
+      });
+    }
+  }
+  return {
+    kept,
+    view: {
+      scope: request.scope,
+      keys: kept.size,
+      ...(droppedGlobalOnly > 0 ? { droppedGlobalOnly } : {}),
+      ...(withheld.length > 0 ? { withheld } : {}),
+    },
+  };
+}
+
+/** A config document, scope-pruned and then key-selected. Strictly
+ *  subtractive: the result is always a subset of `config`. */
+export function projectConfig(
+  config: Record<string, unknown>,
+  request: ConfigViewRequest,
+): ProjectedConfig {
+  if (request.scope === "package-rules" && !request.keys) {
+    // The engine's own primitive on the whole-document path — one definition
+    // of the globalOnly class, and the pipeline's regression guard covers it.
+    const pruned = removeGlobalConfig(config, false);
+    const dropped = Object.keys(config).length - Object.keys(pruned).length;
+    return {
+      config: pruned,
+      view: {
+        scope: request.scope,
+        keys: Object.keys(pruned).length,
+        ...(dropped > 0 ? { droppedGlobalOnly: dropped } : {}),
+      },
+    };
+  }
+  const { kept, view } = projectKeySet(Object.keys(config), request);
+  const projected: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (kept.has(key)) {
+      projected[key] = value;
+    }
+  }
+  return { config: projected, view };
+}
+
+/**
+ * A before/after pair for one key. `MergedKey` (a rule's merge) and
+ * `ConfigKeyDelta` (a comparison's delta) are structurally the same thing, so
+ * the collapsing below is written once and generically — a delta's own extra
+ * fields (`inA`, `beforeInherited`, …) ride through untouched.
+ */
+export interface KeyDiff {
+  key: string;
+  before?: unknown;
+  after?: unknown;
+}
+
+/** An `append`-shaped diff, stated instead of re-embedded. */
+export interface CollapsedKeyDiff {
+  key: string;
+  /** How `after` relates to `before` — only `append` is collapsible. */
+  collapsed: "append";
+  beforeLength: number;
+  afterLength: number;
+  /** Exactly what this step appended — the answer the reader wanted. */
+  added: string[];
+}
+
+export type MaybeCollapsed<T extends KeyDiff> =
+  | T
+  | (Omit<T, "before" | "after"> & CollapsedKeyDiff);
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+/**
+ * Collapses a `description` append into what it appended.
+ *
+ * The conditions are deliberately narrow: the key is `description`, both sides
+ * are string arrays, the before side is non-empty, and `after` starts with
+ * `before` — which is precisely what `mergeChildConfig`'s array concatenation
+ * guarantees. Anything else stays verbatim: a rule that REPLACED the
+ * description must still show both sides, and collapsing an empty `before`
+ * saves nothing.
+ *
+ * `description` alone, on purpose. It is prose, it is never a matcher input,
+ * it is the only mergeable array Renovate concatenates on effectively every
+ * merge, and it is the heaviest key of a per-dependency config. `labels` and
+ * `extends` stay verbatim — a reader of a `labels` diff wants the list. This
+ * is `computeDescriptionProvenance`'s direction (attribute the contribution,
+ * never drop the key): the full array is one `get_provenance description`
+ * away.
+ */
+export function collapseDescriptionDiff<T extends KeyDiff>(diff: T): MaybeCollapsed<T> {
+  const { before, after, ...rest } = diff;
+  if (
+    diff.key !== "description" ||
+    !isStringArray(before) ||
+    !isStringArray(after) ||
+    before.length === 0 ||
+    after.length <= before.length ||
+    JSON.stringify(after.slice(0, before.length)) !== JSON.stringify(before)
+  ) {
+    return diff;
+  }
+  return {
+    ...rest,
+    collapsed: "append",
+    beforeLength: before.length,
+    afterLength: after.length,
+    added: after.slice(before.length),
+  };
+}
+
+export function collapseDiffs<T extends KeyDiff>(diffs: readonly T[]): MaybeCollapsed<T>[] {
+  return diffs.map((diff) => collapseDescriptionDiff(diff));
+}
+
+function isCollapsed(diff: KeyDiff | CollapsedKeyDiff): diff is CollapsedKeyDiff {
+  return "collapsed" in diff;
+}
+
+/** `key: before → after`, or the collapsed form. The comparison's delta line. */
+export function diffLine(diff: KeyDiff | CollapsedKeyDiff): string {
+  if (isCollapsed(diff)) {
+    return (
+      `${diff.key}: ${diff.beforeLength} entries + ${diff.added.length} appended ` +
+      `(now ${diff.afterLength}) — ${preview(diff.added)}`
+    );
+  }
+  return `${diff.key}: ${preview(diff.before)} → ${preview(diff.after)}`;
+}
+
+/** `key = value`, or the collapsed form — what one merge step DID, without a
+ *  verb, so a caller can prefix its own ("sets …", "  …"). */
+export function mergedLine(diff: KeyDiff | CollapsedKeyDiff): string {
+  if (isCollapsed(diff)) {
+    return `${diff.key} += ${diff.added.length} of ${diff.afterLength} entries: ${preview(diff.added)}`;
+  }
+  return `${diff.key} = ${preview(diff.after)}`;
+}
+
+export function parseConfigScope(raw: string | undefined, flag: string): ConfigScope | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const found = CONFIG_SCOPES.find((scope) => scope === raw);
+  if (!found) {
+    throw new CliError(`${flag} must be one of ${CONFIG_SCOPES.join("|")} (got "${raw}")`);
+  }
+  return found;
+}
+
+/** `--keys a,b,c` — `--select`'s grammar, so one comma list means one thing
+ *  everywhere. An empty list is `undefined`: "no keys" would be an answer with
+ *  nothing in it, which is never what someone typing a flag meant. */
+export function parseKeys(raw: string | undefined): string[] | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const keys = raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return keys.length > 0 ? keys : undefined;
+}

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "vitest";
+import type { SimulationComparison, SimulationResult } from "@renovate-config-debugger/engine";
+import { comparisonPayload, simulationPayload, VERDICT_DETAIL_NOTE } from "./simulate";
+
+/**
+ * Roadmap 070. Hand-built results, so the payload SHAPE is asserted without a
+ * pipeline run — the engine's golden↔shimmed suite owns what the numbers in it
+ * mean.
+ */
+
+const DESCRIPTION = ["Pin Docker digests.", "Separate major releases."];
+
+const SIM: SimulationResult = {
+  rules: [
+    {
+      index: 0,
+      verdict: "matched",
+      clauses: [],
+      notes: [],
+      merged: [
+        { key: "groupName", after: "react monorepo" },
+        { key: "description", before: DESCRIPTION, after: [...DESCRIPTION, "Group react."] },
+      ],
+    },
+  ],
+  rawFinalConfig: { groupName: "react monorepo", onboardingConfig: {} },
+  finalDependencyConfig: {
+    automerge: true,
+    groupName: "react monorepo",
+    onboardingConfig: { extends: ["config:recommended"] },
+  },
+  flattened: {
+    merged: [{ key: "description", before: DESCRIPTION, after: [...DESCRIPTION, "From minor."] }],
+    blocks: {},
+    authoredBlocks: [],
+  },
+  mergeSteps: [],
+  errors: [],
+  warnings: [],
+  notes: [],
+};
+
+describe("simulationPayload", () => {
+  test('detail "full" is the escape hatch — the result itself, not a rebuild', () => {
+    expect(simulationPayload(SIM, { detail: "full", scope: "package-rules" })).toBe(SIM);
+    expect(simulationPayload(SIM, { detail: "full", scope: "full", keys: ["automerge"] })).toBe(
+      SIM,
+    );
+  });
+
+  test("the default answer is exactly the listed members", () => {
+    const payload = simulationPayload(SIM, { detail: "verdict", scope: "package-rules" });
+    expect(Object.keys(payload)).toEqual([
+      "rules",
+      "flattened",
+      "finalDependencyConfig",
+      "configView",
+      "errors",
+      "warnings",
+      "notes",
+      "detailNote",
+    ]);
+    expect(payload).not.toHaveProperty("mergeSteps");
+    expect(payload).not.toHaveProperty("rawFinalConfig");
+    expect(payload).toHaveProperty("detailNote", VERDICT_DETAIL_NOTE);
+  });
+
+  test("the per-dependency config is scoped, keyed, and says so", () => {
+    const payload = simulationPayload(SIM, { detail: "verdict", scope: "package-rules" });
+    expect(payload).toMatchObject({
+      finalDependencyConfig: { automerge: true, groupName: "react monorepo" },
+      configView: { scope: "package-rules", keys: 2, droppedGlobalOnly: 1 },
+    });
+    const keyed = simulationPayload(SIM, {
+      detail: "verdict",
+      scope: "package-rules",
+      keys: ["automerge", "onboardingConfig"],
+    });
+    expect(keyed).toMatchObject({
+      finalDependencyConfig: { automerge: true },
+      configView: { withheld: [{ key: "onboardingConfig", reason: "global-only" }] },
+    });
+  });
+
+  test("the merged description appends are collapsed, in the rules and in flattened", () => {
+    const payload = simulationPayload(SIM, { detail: "verdict", scope: "package-rules" });
+    expect(payload).toMatchObject({
+      rules: [
+        {
+          merged: [
+            { key: "groupName", after: "react monorepo" },
+            { key: "description", collapsed: "append", added: ["Group react."] },
+          ],
+        },
+      ],
+      flattened: { merged: [{ key: "description", collapsed: "append", added: ["From minor."] }] },
+    });
+  });
+});
+
+const COMPARISON: SimulationComparison = {
+  matchedOnlyInA: [],
+  matchedOnlyInB: [],
+  matchedInBoth: [],
+  behaviorOnlyInA: [],
+  behaviorOnlyInB: [],
+  signatureChanges: [],
+  rulesChanged: false,
+  configDelta: [
+    { key: "automerge", before: false, after: true, inA: true, inB: true },
+    {
+      key: "description",
+      before: DESCRIPTION,
+      after: [...DESCRIPTION, "And this one."],
+      inA: true,
+      inB: true,
+    },
+    { key: "groupName", after: "react monorepo", inA: false, inB: true },
+  ],
+  noChange: false,
+  summary: "differs: automerge, description, groupName",
+};
+
+describe("comparisonPayload", () => {
+  test("collapsing never moves a key: same keys, same order, smaller values", () => {
+    const payload = comparisonPayload(COMPARISON, { scope: "package-rules" });
+    expect(payload.configDelta.map((delta) => delta.key)).toEqual([
+      "automerge",
+      "description",
+      "groupName",
+    ]);
+    expect(payload.configDelta[1]).toMatchObject({
+      collapsed: "append",
+      added: ["And this one."],
+      inA: true,
+      inB: true,
+    });
+    expect(JSON.stringify(payload.configDelta).length).toBeLessThan(
+      JSON.stringify(COMPARISON.configDelta).length,
+    );
+    expect(payload.configView).toEqual({ scope: "package-rules", keys: 3 });
+  });
+
+  test("keys narrows the delta, and the verdict is left alone", () => {
+    const payload = comparisonPayload(COMPARISON, {
+      scope: "package-rules",
+      keys: ["groupName", "labels"],
+    });
+    expect(payload.configDelta.map((delta) => delta.key)).toEqual(["groupName"]);
+    expect(payload.configView.withheld).toEqual([{ key: "labels", reason: "absent" }]);
+    // The comparison FOUND three changed keys; a narrowed view does not get to
+    // restate what it found.
+    expect(payload.summary).toBe(COMPARISON.summary);
+    expect(payload.noChange).toBe(false);
+  });
+});

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -1,0 +1,145 @@
+import type {
+  ConfigKeyDelta,
+  MergedKey,
+  RuleEvaluation,
+  SimulationComparison,
+  SimulationResult,
+} from "@renovate-config-debugger/engine";
+import { CliError } from "../io";
+import {
+  collapseDiffs,
+  type ConfigScope,
+  type ConfigView,
+  type MaybeCollapsed,
+  projectConfig,
+  projectKeySet,
+} from "./config-view";
+
+/**
+ * Roadmap 070: the simulate/compare payload shape, shared by `rcd simulate` /
+ * `rcd compare` and the MCP server's `simulate` / `compare_simulations`.
+ *
+ * It used to live in `mcp/server.ts`, which meant the CLI's `--format json`
+ * had no `detail` gate at all and spread the whole `SimulationResult`: 74% of
+ * a 106 kB answer was `mergeSteps` + `rawFinalConfig`, describing how the
+ * merge proceeded — a question nobody asked. The two transports are one
+ * surface, so they are now one implementation, and the projections it applies
+ * (`config-view`) are the same on both.
+ */
+
+/**
+ * H1 (roadmap 068, 6 of 9 persona sessions): what a simulate answer carries by
+ * default.
+ *
+ * Measured on `config:recommended` + a react update, the whole
+ * `SimulationResult` is 1.36 MB — of which `mergeSteps` is 797 kB (two
+ * elements, each a full config snapshot) and `rawFinalConfig` 199 kB. Those
+ * two answer "how did the merge proceed", a question nobody asked, and they
+ * drowned the one that was: the elision spent its budget on them and returned
+ * 2 of 713 rules, with the merge trace dropped whole anyway. Personas at every
+ * level asked for the same shape by hand — the matched rules, `flattened` and
+ * `finalDependencyConfig`.
+ *
+ * So the merge trace is opt-in. `full` is the whole `SimulationResult`,
+ * untouched and byte-exact, for the caller who is actually stepping through
+ * the merge — which is also what makes every other projection here safe to
+ * apply: the unprojected document is one parameter away.
+ */
+export const SIMULATE_DETAIL = ["verdict", "full"] as const;
+export type SimulateDetail = (typeof SIMULATE_DETAIL)[number];
+
+export const VERDICT_DETAIL_NOTE =
+  "`mergeSteps` and `rawFinalConfig` are omitted at this detail level — on a `config:recommended` " +
+  'run they are ~1 MB of the payload and describe how the merge proceeded. Pass detail: "full" ' +
+  "for them.";
+
+export interface SimulateProjection {
+  detail: SimulateDetail;
+  keys?: readonly string[];
+  scope: ConfigScope;
+}
+
+/** A rule with its merge diffs collapsed. Exported because the rule list is
+ *  REPLACED downstream when `verdict`/`source` scope it (`buildRuleView`), and
+ *  the replacement must carry the same shape as the default one. */
+export function collapseRuleMerges(
+  rules: readonly RuleEvaluation[],
+): (RuleEvaluation | (Omit<RuleEvaluation, "merged"> & { merged: MaybeCollapsed<MergedKey>[] }))[] {
+  return rules.map((rule) =>
+    rule.merged ? { ...rule, merged: collapseDiffs(rule.merged) } : rule,
+  );
+}
+
+/**
+ * The simulation, at the requested detail. Listed key by key rather than
+ * subtracted from the result, so the default shape is legible here and a
+ * future field has to be admitted on purpose.
+ */
+export function simulationPayload(sim: SimulationResult, options: SimulateProjection) {
+  if (options.detail === "full") {
+    return sim;
+  }
+  const projected = projectConfig(sim.finalDependencyConfig, {
+    scope: options.scope,
+    ...(options.keys ? { keys: options.keys } : {}),
+  });
+  return {
+    rules: collapseRuleMerges(sim.rules),
+    flattened: { ...sim.flattened, merged: collapseDiffs(sim.flattened.merged) },
+    finalDependencyConfig: projected.config,
+    configView: projected.view,
+    errors: sim.errors,
+    warnings: sim.warnings,
+    notes: sim.notes,
+    detailNote: VERDICT_DETAIL_NOTE,
+  };
+}
+
+export interface ComparisonProjection {
+  keys?: readonly string[];
+  scope: ConfigScope;
+}
+
+export interface ProjectedComparison extends Omit<SimulationComparison, "configDelta"> {
+  configDelta: MaybeCollapsed<ConfigKeyDelta>[];
+  configView: ConfigView;
+}
+
+/**
+ * The comparison, with its key delta scoped, key-selected and
+ * description-collapsed.
+ *
+ * `summary` and the verdict booleans are deliberately NOT projected: they
+ * state what the comparison found, over the whole delta, and a verdict that
+ * changed with the view a caller asked for would be uncitable. So `summary`
+ * may name a key this view withheld — which is exactly what `configView`
+ * (`scope`, `withheld`, `droppedGlobalOnly`) is there to say.
+ *
+ * Collapsing never moves a key: it rewrites one entry's VALUE fields, so the
+ * delta's key set is untouched by it.
+ */
+export function comparisonPayload(
+  comparison: SimulationComparison,
+  options: ComparisonProjection,
+): ProjectedComparison {
+  const { kept, view } = projectKeySet(
+    comparison.configDelta.map((delta) => delta.key),
+    { scope: options.scope, ...(options.keys ? { keys: options.keys } : {}) },
+  );
+  return {
+    ...comparison,
+    configDelta: collapseDiffs(comparison.configDelta.filter((delta) => kept.has(delta.key))),
+    configView: view,
+  };
+}
+
+export function parseDetail(raw: string | undefined): SimulateDetail | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const found = SIMULATE_DETAIL.find((detail) => detail === raw);
+  if (!found) {
+    throw new CliError(`--detail must be one of ${SIMULATE_DETAIL.join("|")} (got "${raw}")`);
+  }
+  return found;
+}

--- a/packages/cli/test/fixtures/described.json
+++ b/packages/cli/test/fixtures/described.json
@@ -1,0 +1,10 @@
+{
+  "description": ["The base config for this repository.", "Reviewed every quarter."],
+  "packageRules": [
+    {
+      "description": ["Group the react packages into one PR."],
+      "matchPackageNames": ["react"],
+      "groupName": "react monorepo"
+    }
+  ]
+}

--- a/packages/engine/src/config-scope.ts
+++ b/packages/engine/src/config-scope.ts
@@ -1,0 +1,64 @@
+import { getOptions } from "./renovate-adapter";
+
+/**
+ * Which config options a repository config may actually reach — the
+ * `globalOnly` class, named once.
+ *
+ * Renovate declares 100+ options as `globalOnly`: they are read from the
+ * self-hosted global config and are neither settable by a repo config nor
+ * reachable by a `packageRules` entry. Two consumers need that class:
+ *
+ * - the pipeline, which strips it from the inherited-config layer exactly as
+ *   Renovate's own `removeGlobalConfig` does (roadmap 008);
+ * - the CLI/MCP projections (roadmap 070), which prune it from a
+ *   PER-DEPENDENCY config document, where every one of those keys is provably
+ *   inert.
+ *
+ * It lives in its own module so the second consumer does not have to import
+ * the pipeline (and with it the whole run machinery) to ask a question about
+ * option metadata.
+ */
+
+let cachedGlobalOnly: ReadonlySet<string> | undefined;
+
+/** The names of every `globalOnly` option of the pinned Renovate. Cached —
+ *  `getOptions()` is a fixed table, and callers ask per config document. */
+export function globalOnlyOptionNames(): ReadonlySet<string> {
+  if (cachedGlobalOnly) {
+    return cachedGlobalOnly;
+  }
+  const names = new Set<string>();
+  for (const option of getOptions()) {
+    if (option.globalOnly) {
+      names.add(option.name);
+    }
+  }
+  cachedGlobalOnly = names;
+  return cachedGlobalOnly;
+}
+
+/**
+ * Renovate's `removeGlobalConfig` (dist/config/index.js) reimplemented — the
+ * upstream module also drags the full modules/manager graph (100+ Node-only
+ * manager modules) into any bundle that imports it, so the visualizer keeps
+ * this pure 7-line getOptions() loop local instead of deep-importing it.
+ *
+ * `keepInherited` is upstream's carve-out for the INHERITED layer, where the
+ * `inheritConfigSupport` options are legal; on any other document (a repo
+ * config, a per-dependency config) pass `false`.
+ */
+export function removeGlobalConfig(
+  config: Record<string, unknown>,
+  keepInherited: boolean,
+): Record<string, unknown> {
+  const outputConfig = { ...config };
+  for (const option of getOptions()) {
+    if (keepInherited && option.inheritConfigSupport) {
+      continue;
+    }
+    if (option.globalOnly) {
+      delete outputConfig[option.name];
+    }
+  }
+  return outputConfig;
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,4 +1,5 @@
 export { runPipeline } from "./pipeline";
+export { globalOnlyOptionNames, removeGlobalConfig } from "./config-scope";
 export {
   type ClauseEvaluation,
   type ClauseState,

--- a/packages/engine/src/pipeline.ts
+++ b/packages/engine/src/pipeline.ts
@@ -1,6 +1,5 @@
 import {
   getDefaultConfig,
-  getOptions,
   GlobalConfig,
   InheritConfig,
   massageConfig,
@@ -13,6 +12,7 @@ import {
   validateConfig,
 } from "./renovate-adapter";
 import { getPresetAuth, setPresetAuth } from "./auth";
+import { removeGlobalConfig } from "./config-scope";
 import {
   getUsedInjectionKeys,
   resetInjectedPresets,
@@ -63,28 +63,6 @@ function resolvePlatformContext(input: PipelineInput): PlatformContext {
     ENDPOINT_DEFAULTS[platform] ??
     "";
   return overridden ? { platform, endpoint, overridden } : { platform, endpoint };
-}
-
-/**
- * Renovate's `removeGlobalConfig` (dist/config/index.js) reimplemented — the
- * upstream module also drags the full modules/manager graph (100+ Node-only
- * manager modules) into any bundle that imports it, so the visualizer keeps
- * this pure 7-line getOptions() loop local instead of deep-importing it.
- */
-function removeGlobalConfig(
-  config: Record<string, unknown>,
-  keepInherited: boolean,
-): Record<string, unknown> {
-  const outputConfig = { ...config };
-  for (const option of getOptions()) {
-    if (keepInherited && option.inheritConfigSupport) {
-      continue;
-    }
-    if (option.globalOnly) {
-      delete outputConfig[option.name];
-    }
-  }
-  return outputConfig;
 }
 
 // Renovate's config modules hold module-level state (GlobalConfig, memCache,

--- a/roadmap/070-agent-payload-projection.md
+++ b/roadmap/070-agent-payload-projection.md
@@ -1,0 +1,136 @@
+# 070 — Agent payload projection: ask precisely, get a small answer
+
+Milestone: M19 · Status: in progress
+
+## Summary
+
+The headless surface answers three questions with a config document —
+`get_final_config` / `rcd run --select final`, `simulate`'s
+`finalDependencyConfig`, and `compare_simulations`' key delta — and until now
+it answered all three with everything it had. Measured on the CLI, compact
+JSON:
+
+| payload                                               | total   | `rawFinalConfig` | `mergeSteps` | `finalDependencyConfig` |
+| ----------------------------------------------------- | ------- | ---------------- | ------------ | ----------------------- |
+| `simulate` on `test/fixtures/mixed-rules.json`        | 106 KB  | 26 KB            | 52 KB        | 24.8 KB / 396 keys      |
+| `simulate` on `config:recommended` + a react update   | 1.39 MB | 199 KB           | 797 KB       | 26.8 KB / 396 keys      |
+| `simulate` on `config:best-practices` + `@babel/core` | 2.99 MB | 203 KB           | 2.44 MB      | 27.6 KB / 395 keys      |
+
+Three facts shaped the fix:
+
+1. **107 of those 396 keys are `globalOnly`** — options read from a self-hosted
+   global config, which no matcher can read and no rule can write. In a
+   PER-DEPENDENCY config they are provably inert. Dropping them is 27% of the
+   keys but only 12% of the bytes: it is a legibility win, not a byte win.
+2. **`keys` is the byte lever.** The same fixture asked for three named options
+   is 2.9 KB.
+3. **The CLI was the worse offender than MCP.** `rcd simulate --format json`
+   spread the whole `SimulationResult`, so the merge trace was 74% of its
+   payload — the `detail` gate existed only on the MCP side. Consistency here
+   is not a nicety; it is most of the fix.
+
+And one defect underneath all three: `description` is a `mergeable` array, so
+`mergeChildConfig` concatenates it on nearly every merge, and every merged diff
+re-embedded the whole array on BOTH sides. At `config:best-practices` scale one
+rule's `description` entry is 4,084 bytes; the collapsed form is 145.
+
+## User story
+
+As an agent debugging one option of one dependency, I want to ask for that
+option and get an answer about it, so that the tool's reply fits in the context
+I have and I can tell what it did not tell me.
+
+## The design: four orthogonal axes, one vocabulary on both transports
+
+| axis                 | parameter                 | selects                   | default                  |
+| -------------------- | ------------------------- | ------------------------- | ------------------------ |
+| `detail`             | `verdict` \| `full`       | which top-level members   | `verdict`, both surfaces |
+| `configScope`        | `package-rules` \| `full` | which CLASS of config key | per tool, below          |
+| `keys`               | `string[]`                | which NAMED config keys   | all                      |
+| `verdict` / `source` | existing                  | which rules               | existing                 |
+
+Two shared projection modules under `packages/cli/src/projections/`, following
+the `tree.ts` / `messages.ts` pattern — pure functions, no io, used by the CLI's
+`--format json` and by the MCP server so the two transports are one
+implementation:
+
+- **`config-view.ts`** — `projectConfig(config, {keys, scope})`, plus the
+  `description` collapse (`collapseDiffs`, `diffLine`, `mergedLine`).
+- **`simulate.ts`** — `SIMULATE_DETAIL`, `VERDICT_DETAIL_NOTE`,
+  `simulationPayload` (moved out of `mcp/server.ts`) and `comparisonPayload`.
+
+The engine keeps one definition of the `globalOnly` class:
+`packages/engine/src/config-scope.ts` (hoisted out of `pipeline.ts`) exports
+`removeGlobalConfig` — which the pipeline already used for the inherited layer
+— and a cached `globalOnlyOptionNames()`. `execute()`, `diffKeys`,
+`SimulationResult` and every golden↔shimmed snapshot are untouched: all of this
+is presentation.
+
+### Decision 1 — `keys` is additive-filter-only
+
+`keys` applies AFTER the scope prune, so it can only ever narrow. Asking for a
+`globalOnly` option under the default `simulate` scope returns nothing and
+reports `withheld: [{key, reason: "global-only"}]`; widening is
+`configScope: "full"`'s job alone, because one parameter that both narrows and
+widens is a parameter nobody can predict.
+
+`absent` and `global-only` are kept apart deliberately: "this document has no
+such option" and "this view cannot carry it" are different answers, and a
+silently empty result is indistinguishable from a bug.
+
+The invariant that buys: **every answer is a subset of the default answer**,
+for any combination of the four axes. That is what makes them composable, and
+what lets an agent reason about what it did not get.
+
+### Decision 2 — the same vocabulary, a different default per tool
+
+- `simulate.finalDependencyConfig` and `compare_simulations`' delta default to
+  `package-rules`. The document is by construction "what `applyPackageRules`
+  produced for one dependency"; the globalOnly class cannot participate.
+- `get_final_config` and `rcd run --select final` default to `full`. This is
+  the run's whole effective config — the surface someone debugs a self-hosted
+  `globalConfig`/`inheritedConfig` layer on, where those options ARE the
+  answer. Pruning them by default would be wrong for the tool's own question.
+
+Each answer states which view produced it (`configView.scope`,
+`droppedGlobalOnly`, `withheld`), so nobody has to infer it.
+
+### Decision 3 — collapse `description`, and only `description`
+
+The conditions are narrow: the key is `description`, both sides are string
+arrays, `before` is non-empty, and `after` starts with `before` — precisely what
+array concatenation guarantees. A rule that REPLACED the description still
+shows both sides; `labels` and `extends` stay verbatim, because a reader of a
+`labels` diff wants the list. This is 069's direction (attribute the
+contribution, never drop the key): the collapsed entry names the sentences this
+step added and states the length of the array they joined, and the full array
+is one `get_provenance description` away.
+
+## Scope
+
+- `packages/engine/src/config-scope.ts` (new) + the `index.ts` exports.
+- `packages/cli/src/projections/config-view.ts`, `projections/simulate.ts` (new,
+  with unit tests including the monotonicity invariant).
+- `rcd simulate` gains `--detail`, `--keys`, `--config-scope`; `rcd compare` and
+  `rcd run` gain `--keys` and `--config-scope`; `args.ts` carries the entries.
+- MCP `simulate`, `compare_simulations`, `get_final_config` gain `keys` and
+  `configScope`; the size hints name `keys`.
+- `packages/cli/README.md`.
+
+Out of scope: the app (it consumes `SimulationResult` directly and has its own
+UI affordances for size), `mcp/result.ts` (the byte budget stays a transport
+safety net — the reduction happens at construction), and dot-path keys.
+
+## Risks
+
+- **A published output shape changes.** `rcd simulate --format json` no longer
+  carries `mergeSteps`/`rawFinalConfig` by default and prunes the globalOnly
+  class from `finalDependencyConfig`. Mitigated by `--detail full` (byte-exact,
+  and covered by a test that asserts identity, not equality), by
+  `--config-scope full`, by the `detailNote` in the payload naming the flag,
+  and by the package being pre-1.0 and flagged experimental.
+- **`keys` does not touch `rules`.** An unfiltered `config:recommended`
+  `simulate` is still ~346 KB, because the rule list dominates at that scale,
+  and it will still elide. That is `verdict`/`source` territory; whether
+  `verdict: "notable"` should become the MCP default is a separate decision on
+  a separate axis.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -74,6 +74,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [067](067-semantic-release.md)                          | semantic-release: one version for every public package               | M16                  | done        |
 | [068](068-keyboard-ux.md)                               | Keyboard UX: ⌘⏎ to run, a bare-key jump layer, one Escape ladder     | M18                  | done        |
 | [069](069-description-provenance.md)                    | Per-string `description` provenance: who said what about this config | M19                  | in progress |
+| [070](070-agent-payload-projection.md)                  | Agent payload projection: `keys`, config scope, collapsed diffs      | M19                  | in progress |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
The study's #1 friction: `finalDependencyConfig` was the raw merged config (396 keys, 107 globalOnly) and CLI `--format json` spread the whole SimulationResult — 106 KB on a small fixture. A new shared projections layer (`config-view.ts`, `simulate.ts`) serves both transports: strictly-subtractive `keys` with withheld reasons, `configScope` (default `package-rules` on simulate/compare, `full` on get_final_config), CLI `--detail`, and collapsed description diffs. Measured: 106 KB → 24.5 KB default → 2.9 KB with `--keys`.

Part of the persona-replay fix stack.