### PR TITLE
feat(cli): report the rules a dependency's unset fields cost

### DIFF
--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -52,6 +52,7 @@ function simFixture(rules: RuleEvaluation[]): SimulationResult {
     rawFinalConfig: {},
     finalDependencyConfig: {},
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    missingInputs: { rules: 0, groups: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/features/simulator/verdict-sentence.test.ts
+++ b/packages/app/src/features/simulator/verdict-sentence.test.ts
@@ -25,6 +25,7 @@ function simFixture(
     rawFinalConfig: finalDependencyConfig,
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    missingInputs: { rules: 0, groups: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/features/simulator/verdict-threads.test.ts
+++ b/packages/app/src/features/simulator/verdict-threads.test.ts
@@ -71,6 +71,7 @@ function simFixture(
     rawFinalConfig: finalDependencyConfig,
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    missingInputs: { rules: 0, groups: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/lib/rule-verdict.ts
+++ b/packages/app/src/lib/rule-verdict.ts
@@ -1,34 +1,17 @@
-import type { ClauseEvaluation, RuleEvaluation } from "@renovate-config-debugger/engine";
-
 /**
  * How a rule's verdict is CLASSIFIED, as opposed to how it is rendered.
  *
- * Hoisted out of `features/simulator/rule-format.ts` (roadmap 048's rule: the
- * shared layer must not import a feature, so a derivation both the app and
- * `packages/cli` need lives here). The rules-drawer badge, the drawer's verdict
- * filter and `rcd simulate --verdict` all have to split a fail-closed
- * "no match — input not set" from a genuine mismatch with ONE predicate — a row
- * filtered as "no input" that then says "no match" is the exact confusion
- * Replay-02 R3/R4 was about, and it would be worse across two surfaces.
+ * The predicate itself now lives in the engine
+ * (`src/simulate-missing-inputs.ts`), which is where its raw material is: the
+ * matcher table's `readFields` and the fail-closed branch that produces a
+ * `no-input` clause. The engine also aggregates it into
+ * `SimulationResult.missingInputs`, and one predicate has to decide both, or
+ * the summary stops counting what the filter shows.
+ *
+ * The seam stays because the import path is load-bearing on this side: the
+ * rules-drawer badge, the drawer's verdict filter (`rule-filters.ts`) and the
+ * headless barrel (`headless.ts`, which `packages/cli` reads) all reach the
+ * predicate through here. A row filtered as "no input" that then says "no
+ * match" is the exact confusion Replay-02 R3/R4 was about.
  */
-
-/** The clause states that fail a rule (as opposed to the neutral
- *  not-applicable / not-simulated, which decide nothing). */
-function failingClauses(clauses: ClauseEvaluation[]): ClauseEvaluation[] {
-  return clauses.filter(
-    (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
-  );
-}
-
-/**
- * Replay-02 R3/R4: a no-match decided SOLELY by fail-closed no-input clauses —
- * the rule lost to an empty simulator field (or a `--dep` that omitted the
- * field), not to real data that mismatched.
- */
-export function isNoInputNoMatch(rule: Pick<RuleEvaluation, "verdict" | "clauses">): boolean {
-  if (rule.verdict !== "no-match") {
-    return false;
-  }
-  const failing = failingClauses(rule.clauses);
-  return failing.length > 0 && failing.every((c) => c.state === "no-input");
-}
+export { isNoInputNoMatch } from "@renovate-config-debugger/engine";

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -182,7 +182,30 @@ $ rcd simulate renovate.json --dep '{"depName":"@types/react","updateType":"majo
   #1 no-match (matchPackageNames=no-match)
 ```
 
-So `matchPackageNames` is the culprit, not the update type. Add `@types/react`
+So `matchPackageNames` is the culprit, not the update type.
+
+Now suppose rule #1 had selected on something your `--dep` never mentioned —
+`"matchSourceUrls": ["https://github.com/facebook/react"]` instead of
+`matchPackageNames`. From the outside the run looks the same: a rule that reads
+a field you left unset fails CLOSED, which Renovate reports as an ordinary
+`no-match`, and every scoped view hides it. The missing-input line is what says
+so, and it is printed whatever `--verdict` you asked for:
+
+```console
+$ rcd simulate sourceurl.json --dep '{"depName":"@types/react","updateType":"major"}'
+1 of 2 packageRules matched.
+
+  #2 matched (matchUpdateTypes=matched)
+      sets dependencyDashboardApproval = true
+1 of 2 rule hidden by --verdict notable — `--verdict all --source all` shows every rule.
+1 of 2 rules could not match because the simulated dependency has no sourceUrl — Renovate treats a missing value as a non-match. Set sourceUrl on the dependency if you expected these rules to fire. `--verdict no-input` lists them.
+```
+
+`--format json` carries the same fact as `missingInputs` (`rules`, and one group
+per unset field set with its `selectors`, its rule count and up to five
+`sampleRuleIndexes`) plus the sentence as `missingInputsNote`. Both survive
+`--verdict`/`--source` and the MCP answer's size elision, because the rules they
+count are exactly the rows a filter removes. Add `@types/react`
 to that list, keep the original as `before.json`, and use `compare` as the oracle
 for the edit. On the dependency you were fixing it should report exactly the
 change you wanted:
@@ -220,7 +243,12 @@ fields are cross-defaulted the way Renovate's fetch worker does before
 `--dep '{"depName":"react"}'` matches a `matchPackageNames` rule instead of
 falling through, and the run's notes say when a field was defaulted. A clause
 reads `no-input` when the field it matches on was absent from your `--dep`, which
-is a different failure from `no-match`. And if either input config would be
+is a different failure from `no-match` — and a rule that lost only to unset
+input is counted in `missingInputs` on both commands, per side on `compare`
+(`a.missingInputs`/`b.missingInputs`, and an `A — …` / `B — …` line in pretty
+output). Two sides that both went blind on the same rule agree perfectly, so
+`identical:` over them says nothing about your edit. And if either input config
+would be
 refused by Renovate, both commands exit `2`, which says nothing about the
 simulation itself, so they also say so on their own output (`exitNote` in JSON, a
 trailing `note:` line in pretty).

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -92,7 +92,8 @@ export const OPTIONS = {
     flags: "--verdict <which>",
     description:
       "which rule verdicts to print: notable|all|matched|no-input|no-match " +
-      "(pretty default: notable; --format json defaults to all)",
+      "(pretty default: notable; --format json defaults to all). The " +
+      "missing-input summary is reported whatever you pass",
   },
   source: {
     flags: "--source <which>",

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -143,6 +143,42 @@ describe("compare", () => {
     expect(pretty.stdout).not.toContain("Reviewed every quarter.");
   });
 
+  /**
+   * The trap this closes: two sides that BOTH failed to evaluate the same rule
+   * for lack of dependency input agree perfectly, and `identical:` over two
+   * blind runs reads as "the edit does nothing".
+   */
+  test("a side that could not evaluate a rule says so, on both sides", async () => {
+    const args = [
+      "compare",
+      fixture("mixed-rules.json"),
+      fixture("mixed-rules.json"),
+      "--dep",
+      '{"depName":"react"}',
+    ];
+    const io = recordingIo();
+    expect(await main(args, io)).toBe(0);
+    expect(io.stdout).toContain("✓ No behavioral change");
+    expect(io.stdout).toContain("A — 2 of 4 rules could not match");
+    expect(io.stdout).toContain("B — 2 of 4 rules could not match");
+    expect(io.stdout).toContain("`--verdict no-input` lists them.");
+
+    const json = recordingIo();
+    expect(await main([...args, "--format", "json"], json)).toBe(0);
+    const comparison = json.json() as {
+      a: { missingInputs: { rules: number; groups: { fieldList: string }[] } };
+      b: { missingInputs: { rules: number } };
+      noChange: boolean;
+    };
+    expect(comparison.noChange).toBe(true);
+    expect(comparison.a.missingInputs.rules).toBe(2);
+    expect(comparison.b.missingInputs.rules).toBe(2);
+    expect(comparison.a.missingInputs.groups.map((group) => group.fieldList)).toEqual([
+      "depType or depTypes",
+      "sourceUrl",
+    ]);
+  });
+
   test("--keys narrows the delta without moving the verdict", async () => {
     const io = recordingIo();
     expect(

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -7,6 +7,7 @@ import { INPUT_OPTIONS, refusalNote, runOne, takeInputFile, wouldRefuse } from "
 import { readDependency } from "../dep";
 import { diffLine, parseConfigScope, parseKeys } from "../projections/config-view";
 import { comparisonPayload } from "../projections/simulate";
+import { missingInputsNote } from "../rule-view";
 import { simulateAgainst } from "./simulate";
 
 /**
@@ -109,16 +110,35 @@ export const compareCommand: Command = {
       ...(refusedB && b.result !== a.result ? ["config B"] : []),
     ]);
 
+    // Per SIDE, and reported even when the verdict is `identical:`. Two sides
+    // that both failed to evaluate the same rule for lack of input agree
+    // perfectly — and "the edit does nothing" is the wrong lesson to draw from
+    // two blind runs.
+    const missingA = missingInputsNote(simA.missingInputs, "cli");
+    const missingB = missingInputsNote(simB.missingInputs, "cli");
+
     if (format === "json") {
       emitJson(io, {
-        a: { config: file ?? "(stdin/repo)", dep: depA, wouldRefuse: refusedA },
-        b: { config: fileB ?? file ?? "(stdin/repo)", dep: depB, wouldRefuse: refusedB },
+        a: {
+          config: file ?? "(stdin/repo)",
+          dep: depA,
+          wouldRefuse: refusedA,
+          missingInputs: simA.missingInputs,
+        },
+        b: {
+          config: fileB ?? file ?? "(stdin/repo)",
+          dep: depB,
+          wouldRefuse: refusedB,
+          missingInputs: simB.missingInputs,
+        },
         ...comparison,
         ...(refusal ? { exitNote: refusal } : {}),
       });
     } else {
       emitLines(io, [
         comparisonHeadline(comparison),
+        ...(missingA ? ["", `A — ${missingA}`] : []),
+        ...(missingB ? ["", `B — ${missingB}`] : []),
         ...(comparison.behaviorOnlyInA.length > 0
           ? ["", "Matched only in A:", ...comparison.behaviorOnlyInA.map((r) => `  ${r.label}`)]
           : []),

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -258,6 +258,49 @@ describe("simulate --verdict / --source", () => {
     expect(sim.ruleFilter).toBeUndefined();
   });
 
+  /**
+   * The regression: two of these four rules lose to an unset field, both report
+   * a plain `no-match`, and every scoped view hides them — so the default
+   * output said "1 of 4 matched" and left the reader to conclude the config
+   * does not do what it plainly does.
+   */
+  test("the rules an unset field cost are named even when their rows are hidden", async () => {
+    const { io } = await run();
+    expect(shown(io)).toEqual([2]);
+    expect(io.stdout).toContain("2 of 4 rules could not match");
+    expect(io.stdout).toContain("sourceUrl");
+    expect(io.stdout).toContain("`--verdict no-input` lists them.");
+  });
+
+  test("the same line survives --verdict matched, and --verdict all where nothing is hidden", async () => {
+    const matched = await run("--verdict", "matched");
+    expect(shown(matched.io)).toEqual([2]);
+    expect(matched.io.stdout).toContain("2 of 4 rules could not match");
+
+    const all = await run("--verdict", "all");
+    expect(all.io.stdout).not.toContain("hidden by");
+    expect(all.io.stdout).toContain("2 of 4 rules could not match");
+  });
+
+  test("json carries the summary whatever the filter, and it counts the no-input rows", async () => {
+    const { io } = await run("--format", "json", "--verdict", "matched");
+    const sim = io.json() as {
+      rules: unknown[];
+      missingInputs: { rules: number; groups: { fieldList: string; rules: number }[] };
+      missingInputsNote: string;
+    };
+    expect(sim.rules).toHaveLength(1);
+    // The parity property: the number in the summary is the number of rows
+    // `--verdict no-input` prints.
+    expect(sim.missingInputs.rules).toBe(shown((await run("--verdict", "no-input")).io).length);
+    expect(sim.missingInputs.rules).toBe(2);
+    expect(sim.missingInputs.groups.map((group) => group.fieldList)).toEqual([
+      "depType or depTypes",
+      "sourceUrl",
+    ]);
+    expect(sim.missingInputsNote).toContain("`--verdict no-input` lists them.");
+  });
+
   test("a filtered json payload states what it left out", async () => {
     const { io } = await run("--format", "json", "--verdict", "matched");
     const sim = io.json() as { rules: unknown[]; ruleFilter: Record<string, unknown> };

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -13,6 +13,7 @@ import { readDependency } from "../dep";
 import {
   buildRuleView,
   hiddenRulesNote,
+  missingInputsNote,
   ruleFilterPayload,
   ruleFilterSelection,
 } from "../rule-view";
@@ -64,6 +65,11 @@ export const simulateCommand: Command = {
     "hid. `--verdict`/`--source` scope it; `--format json` keeps the full array",
     "unless you pass one of them.",
     "",
+    "Rules that failed only because your `--dep` left a field unset are counted",
+    "in `missingInputs` and stated in one line whatever `--verdict` you asked",
+    "for — those rules report a plain `no-match`, so every scoped view would",
+    "otherwise hide them.",
+    "",
     "`--format json` answers at `--detail verdict`: the merge trace",
     "(`mergeSteps`, `rawFinalConfig`) is ~1 MB on a `config:recommended` run and",
     "is opt-in through `--detail full`, which returns the whole simulation",
@@ -101,9 +107,13 @@ export const simulateCommand: Command = {
     if (format === "json") {
       emitJson(io, {
         dep,
+        // `missingInputs` (and its note) come from the projection, so they are
+        // carried whatever `--verdict`/`--source` did to the `rules` array
+        // below — the rules it counts are the ones a filter removes.
         ...simulationPayload(sim, {
           detail,
           scope: scope ?? "package-rules",
+          transport: selection.transport,
           ...(keys ? { keys } : {}),
         }),
         rules: detail === "full" ? view.rules : collapseRuleMerges(view.rules),
@@ -126,11 +136,17 @@ export const simulateCommand: Command = {
         ),
       );
       const hiddenNote = hiddenRulesNote(view);
+      // A sibling of the hidden-rules note, not part of it: this one is printed
+      // even when the view hid nothing, because the rules it counts are
+      // reported as a plain `no-match` and read as "your config just doesn't
+      // do that".
+      const missingNote = missingInputsNote(sim.missingInputs, selection.transport);
       emitLines(io, [
         `${matched.length} of ${sim.rules.length} packageRules matched.`,
         "",
         ...verdictLines(view.rules),
         ...(hiddenNote ? [hiddenNote] : []),
+        ...(missingNote ? [missingNote] : []),
         "",
         ...(changes.length > 0
           ? ["The rules changed these options for this dependency:", ...changes]

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -35,6 +35,17 @@ const GROUPED =
   '{"labels":["deps"],"packageRules":[{"matchPackageNames":["react"],"groupName":"react"}]}';
 /** The big one — every size assertion in this file is measured against it. */
 const RECOMMENDED = '{"extends":["config:recommended"],"labels":["deps"]}';
+/** One rule of each kind against `react`: a preset rule that fails on an unset
+ *  depType, a matching one, one that fails on an unset sourceUrl, and a genuine
+ *  mismatch — the CLI's `mixed-rules.json` fixture, inline. */
+const MIXED_RULES = JSON.stringify({
+  extends: [":disablePeerDependencies"],
+  packageRules: [
+    { matchPackageNames: ["react"], groupName: "react monorepo" },
+    { matchSourceUrls: ["https://github.com/facebook/react"], labels: ["upstream"] },
+    { matchPackageNames: ["lodash"], labels: ["utils"] },
+  ],
+});
 
 /** The revision the modern era negotiates. */
 const MODERN_PROTOCOL_VERSION = "2026-07-28";
@@ -685,6 +696,7 @@ describe("simulate and compare", () => {
       finalDependencyConfig: Record<string, unknown>;
       configView: { scope: string; keys: number; droppedGlobalOnly?: number };
       flattened: unknown;
+      missingInputs: { rules: number; groups: unknown[] };
       rules: { truncated: boolean; shown: number; omitted: number } | unknown[];
     };
     expect(parsed).not.toHaveProperty("mergeSteps");
@@ -708,6 +720,11 @@ describe("simulate and compare", () => {
     expect(parsed.finalDependencyConfig).not.toHaveProperty("onboardingConfig");
     expect(parsed.finalDependencyConfig).not.toHaveProperty("dryRun");
     expect(parsed.configView.keys).toBe(Object.keys(parsed.finalDependencyConfig).length);
+    // The elision shrinks `rules` first — it is the largest array in the
+    // payload — so the missing-input aggregate has to outlive it, and be
+    // reported by NAME rather than dropped as a key.
+    expect(parsed.missingInputs).toBeDefined();
+    expect(parsed.missingInputs.rules).toBeGreaterThan(0);
     // And the rule list is a real sample of 713, not a token two.
     const rules = parsed.rules as { shown: number; omitted: number };
     expect(rules.shown + rules.omitted).toBeGreaterThan(700);
@@ -801,6 +818,35 @@ describe("simulate and compare", () => {
     expect(scoped.ruleFilter.hidden).toBeGreaterThan(0);
   });
 
+  /**
+   * The agent-shaped version of the bug: `verdict: "matched"` is the natural
+   * ask, and it hides every rule that lost to an unset `dep` field — which
+   * report a plain `no-match`. The summary is a sibling of the rule array, so
+   * no filter can take it away, and it names the parameter that lists them.
+   */
+  test('verdict: "matched" still reports the rules an unset field cost', async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const dep = { depName: "react" };
+    const scoped = (await call("simulate", { runId, dep, verdict: "matched" })) as {
+      rules: unknown[];
+      missingInputs: { rules: number; groups: { fieldList: string; selectors: string[] }[] };
+      missingInputsNote: string;
+    };
+    expect(scoped.rules).toHaveLength(1);
+    expect(scoped.missingInputs.rules).toBe(2);
+    expect(scoped.missingInputs.groups.map((group) => group.fieldList)).toEqual([
+      "depType or depTypes",
+      "sourceUrl",
+    ]);
+    expect(scoped.missingInputsNote).toContain('`verdict: "no-input"` lists them.');
+    expect(scoped.missingInputsNote).not.toContain("--verdict");
+    // …and it is there without asking, too.
+    const unfiltered = (await call("simulate", { runId, dep })) as {
+      missingInputs: { rules: number };
+    };
+    expect(unfiltered.missingInputs.rules).toBe(2);
+  });
+
   test("two runs, one dependency: the edit oracle", async () => {
     const before = await runConfig(CONFIG);
     const after = await runConfig(GROUPED);
@@ -828,6 +874,31 @@ describe("simulate and compare", () => {
     expect(comparison.summary).toBe(
       "identical: the same rules matched and the same effective config results",
     );
+  });
+
+  /** `identical:` over two sides that both went blind on the same rule is not
+   *  an answer about the edit — so each side reports its own input gap. */
+  test("each side reports the rules its dependency could not decide", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const comparison = (await call("compare_simulations", {
+      runId,
+      dep: { depName: "react" },
+    })) as {
+      a: { missingInputs: { rules: number; groups: { fieldList: string }[] } };
+      b: { missingInputs: { rules: number } };
+      missingInputsNote: string;
+      noChange: boolean;
+    };
+    expect(comparison.noChange).toBe(true);
+    expect(comparison.a.missingInputs.rules).toBe(2);
+    expect(comparison.b.missingInputs.rules).toBe(2);
+    expect(comparison.a.missingInputs.groups.map((group) => group.fieldList)).toEqual([
+      "depType or depTypes",
+      "sourceUrl",
+    ]);
+    expect(comparison.missingInputsNote).toContain("A — 2 of 4 rules could not match");
+    expect(comparison.missingInputsNote).toContain("B — 2 of 4 rules could not match");
+    expect(comparison.missingInputsNote).toContain('`verdict: "no-input"` lists them.');
   });
 });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -24,7 +24,7 @@ import {
 } from "@renovate-config-debugger/app/headless";
 import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
-import { buildRuleView, ruleFilterPayload } from "../rule-view";
+import { buildRuleView, missingInputsNote, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
 import { CONFIG_SCOPES, projectConfig } from "../projections/config-view";
 import { describeMessage, type MessageSeverity } from "../projections/messages";
@@ -729,7 +729,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "(`finalDependencyConfig`) and how they got there (`flattened`). " +
         "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
         '(`source: "repo"` is "just my own config\'s rules"), and `keys` narrows ' +
-        "`finalDependencyConfig` to the options you asked about. The step-by-step merge trace is " +
+        "`finalDependencyConfig` to the options you asked about. Rules that failed ONLY because " +
+        "your `dep` left a field they read unset are summarized in `missingInputs`, whatever " +
+        "`verdict` you asked for: they report a plain `no-match`, so every scoped view hides them " +
+        'and the answer reads as "nothing matched". The step-by-step merge trace is ' +
         'NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
@@ -761,6 +764,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const payload = simulationPayload(sim, {
         detail: resolvedDetail,
         scope: configScope ?? "package-rules",
+        transport: "mcp",
         ...(keys ? { keys } : {}),
       });
       if (verdict === undefined && source === undefined) {
@@ -793,7 +797,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "the key-level delta of the resulting config underneath it. Pass runIdB to compare two " +
         "configs, or depB to compare two dependencies against the same config. `keys` narrows " +
         "the delta to the options you care about; `summary` and the verdict booleans always " +
-        "describe the WHOLE delta, so narrowing the view never moves the verdict.",
+        "describe the WHOLE delta, so narrowing the view never moves the verdict. A side that " +
+        "could not evaluate a rule for lack of dependency input reports it in its own " +
+        "`missingInputs`: two blind sides agree perfectly, and `identical:` over them is not an " +
+        "answer about your edit.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
@@ -811,9 +818,19 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         simulateRun(a, dep, ctx),
         simulateRun(b, depB ?? dep, ctx),
       ]);
+      // Per side, and outside `comparisonPayload`: the pure diff module states
+      // what the two runs did, and a side that never got to evaluate a rule is
+      // a fact about that side's INPUT, not about the difference.
+      const noteA = missingInputsNote(simA.missingInputs, "mcp");
+      const noteB = missingInputsNote(simB.missingInputs, "mcp");
+      const combined = [
+        ...(noteA ? [`A — ${noteA}`] : []),
+        ...(noteB ? [`B — ${noteB}`] : []),
+      ].join(" ");
       return {
-        a: { runId: a.runId, dep: toDependency(dep) },
-        b: { runId: b.runId, dep: toDependency(depB ?? dep) },
+        a: { runId: a.runId, dep: toDependency(dep), missingInputs: simA.missingInputs },
+        b: { runId: b.runId, dep: toDependency(depB ?? dep), missingInputs: simB.missingInputs },
+        ...(combined ? { missingInputsNote: combined } : {}),
         ...comparisonPayload(compareSimulations(simA, simB), {
           scope: configScope ?? "package-rules",
           ...(keys ? { keys } : {}),

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -34,6 +34,7 @@ const SIM: SimulationResult = {
     blocks: {},
     authoredBlocks: [],
   },
+  missingInputs: { rules: 0, groups: [] },
   mergeSteps: [],
   errors: [],
   warnings: [],
@@ -52,6 +53,7 @@ describe("simulationPayload", () => {
     const payload = simulationPayload(SIM, { detail: "verdict", scope: "package-rules" });
     expect(Object.keys(payload)).toEqual([
       "rules",
+      "missingInputs",
       "flattened",
       "finalDependencyConfig",
       "configView",
@@ -80,6 +82,41 @@ describe("simulationPayload", () => {
       finalDependencyConfig: { automerge: true },
       configView: { withheld: [{ key: "onboardingConfig", reason: "global-only" }] },
     });
+  });
+
+  /** The summary is a sibling of `rules`, not a member of it, so it is carried
+   *  by every default answer — including the ones whose rule list a filter or
+   *  the elision is about to replace. */
+  test("the missing-input summary rides along, with the transport's own pointer", () => {
+    const sim: SimulationResult = {
+      ...SIM,
+      missingInputs: {
+        rules: 1,
+        groups: [
+          {
+            fields: ["sourceUrl"],
+            fieldList: "sourceUrl",
+            selectors: ["matchSourceUrls"],
+            rules: 1,
+            sampleRuleIndexes: [3],
+          },
+        ],
+        note: "1 of 4 rules could not match because the simulated dependency has no sourceUrl.",
+      },
+    };
+    const payload = simulationPayload(sim, {
+      detail: "verdict",
+      scope: "package-rules",
+      transport: "mcp",
+    });
+    expect(payload).toMatchObject({
+      missingInputs: sim.missingInputs,
+      missingInputsNote: `${sim.missingInputs.note} \`verdict: "no-input"\` lists them.`,
+    });
+    // Nothing to point at, no key: the shape never carries an empty sentence.
+    expect(
+      simulationPayload(SIM, { detail: "verdict", scope: "package-rules", transport: "cli" }),
+    ).not.toHaveProperty("missingInputsNote");
   });
 
   test("the merged description appends are collapsed, in the rules and in flattened", () => {

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -6,6 +6,8 @@ import type {
   SimulationResult,
 } from "@renovate-config-debugger/engine";
 import { CliError } from "../io";
+import { missingInputsNote } from "../rule-view";
+import type { RunTransport } from "../run-input";
 import {
   collapseDiffs,
   type ConfigScope,
@@ -57,6 +59,12 @@ export interface SimulateProjection {
   detail: SimulateDetail;
   keys?: readonly string[];
   scope: ConfigScope;
+  /**
+   * The transport's spelling of the missing-input pointer
+   * (`missingInputsNote`). Optional only so a caller that has no rule list to
+   * point at can omit it; both transports pass it.
+   */
+  transport?: RunTransport;
 }
 
 /** A rule with its merge diffs collapsed. Exported because the rule list is
@@ -77,14 +85,26 @@ export function collapseRuleMerges(
  */
 export function simulationPayload(sim: SimulationResult, options: SimulateProjection) {
   if (options.detail === "full") {
+    // The escape hatch stays byte-exact — `missingInputs` is already a member
+    // of the result, so only the surface-specific pointer sentence is absent.
     return sim;
   }
   const projected = projectConfig(sim.finalDependencyConfig, {
     scope: options.scope,
     ...(options.keys ? { keys: options.keys } : {}),
   });
+  const missingNote = options.transport
+    ? missingInputsNote(sim.missingInputs, options.transport)
+    : undefined;
   return {
     rules: collapseRuleMerges(sim.rules),
+    // Admitted on purpose, and NOT next to the rows it describes: `rules` is
+    // replaced downstream by a `verdict`/`source` view and is the first array
+    // the MCP elision shrinks, and the rules this counts are exactly the ones
+    // a `notable`/`matched` filter removes. A few hundred bytes that survive
+    // both, against an answer that reads as "nothing matched".
+    missingInputs: sim.missingInputs,
+    ...(missingNote ? { missingInputsNote: missingNote } : {}),
     flattened: { ...sim.flattened, merged: collapseDiffs(sim.flattened.merged) },
     finalDependencyConfig: projected.config,
     configView: projected.view,

--- a/packages/cli/src/rule-view.test.ts
+++ b/packages/cli/src/rule-view.test.ts
@@ -4,7 +4,7 @@ import type {
   SimulationResult,
   TraceResult,
 } from "@renovate-config-debugger/engine";
-import { buildRuleView } from "./rule-view";
+import { buildRuleView, missingInputsNote } from "./rule-view";
 
 /**
  * The facets themselves are the app's shared predicates, covered where they
@@ -24,6 +24,7 @@ function sim(rules: RuleEvaluation[]): SimulationResult {
     rawFinalConfig: {},
     finalDependencyConfig: {},
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
+    missingInputs: { rules: 0, groups: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],
@@ -78,5 +79,39 @@ describe("buildRuleView", () => {
     expect(view.total).toBe(2);
     expect(view.hidden).toBe(1);
     expect(view.notes).toEqual([]);
+  });
+});
+
+/** The engine owns the sentence; this layer owns the pointer at its end — and
+ *  the pointer is the half that differs per surface. */
+describe("missingInputsNote", () => {
+  const SUMMARY = {
+    rules: 2,
+    groups: [
+      {
+        fields: ["sourceUrl"],
+        fieldList: "sourceUrl",
+        selectors: ["matchSourceUrls"],
+        rules: 2,
+        sampleRuleIndexes: [0, 2],
+      },
+    ],
+    note: "2 of 4 rules could not match because the simulated dependency has no sourceUrl.",
+  };
+
+  test("the CLI is told the flag it can type", () => {
+    expect(missingInputsNote(SUMMARY, "cli")).toBe(
+      `${SUMMARY.note} \`--verdict no-input\` lists them.`,
+    );
+  });
+
+  test("an agent is told the parameter instead — it cannot pass a flag", () => {
+    const note = missingInputsNote(SUMMARY, "mcp");
+    expect(note).toBe(`${SUMMARY.note} \`verdict: "no-input"\` lists them.`);
+    expect(note).not.toContain("--verdict");
+  });
+
+  test("nothing to say means no line at all", () => {
+    expect(missingInputsNote({ rules: 0, groups: [] }, "cli")).toBeUndefined();
   });
 });

--- a/packages/cli/src/rule-view.ts
+++ b/packages/cli/src/rule-view.ts
@@ -1,5 +1,6 @@
 import {
   computeRuleProvenance,
+  type MissingInputSummary,
   type RuleEvaluation,
   type SimulationResult,
   type TraceResult,
@@ -161,6 +162,26 @@ export function hiddenRulesNote(view: RuleView): string | undefined {
     `${view.hidden} of ${view.total} ${noun} hidden by ${flagsOf(view)} — ` +
     "`--verdict all --source all` shows every rule."
   );
+}
+
+/**
+ * The engine's transport-neutral missing-input line, with the pointer that
+ * only this layer can spell: `--verdict no-input` for a person at a terminal,
+ * `verdict: "no-input"` for an agent that cannot pass a flag.
+ *
+ * A SIBLING of `hiddenRulesNote`, never folded into it. That note answers
+ * "what did the filter cost" and disappears when nothing was filtered — which
+ * is precisely the view (`--verdict all`, an unfiltered MCP call) where the
+ * no-input fact is still the whole answer.
+ */
+export function missingInputsNote(
+  summary: MissingInputSummary,
+  transport: RunTransport,
+): string | undefined {
+  if (!summary.note) {
+    return undefined;
+  }
+  return `${summary.note} \`${facetText(transport, "verdict", "no-input")}\` lists them.`;
 }
 
 /** The JSON counterpart: present only when filters were actually applied, so

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,6 +15,12 @@ export {
   UPDATE_TYPE_KEYS,
 } from "./simulate-package-rules";
 export {
+  isNoInputNoMatch,
+  type MissingInputGroup,
+  type MissingInputSummary,
+  summarizeMissingInputs,
+} from "./simulate-missing-inputs";
+export {
   compareSimulations,
   type ConfigKeyDelta,
   type RuleRef,

--- a/packages/engine/src/simulate-missing-inputs.ts
+++ b/packages/engine/src/simulate-missing-inputs.ts
@@ -1,0 +1,169 @@
+import type { ClauseEvaluation, RuleEvaluation } from "./simulate-package-rules";
+
+/**
+ * The fail-closed no-input predicate, and the aggregate built on it.
+ *
+ * The failure this exists for: a rule that read a field the simulated
+ * dependency never set fails CLOSED (upstream's `if (!sourceUrl) return
+ * false`), so its rule-level verdict is a plain `no-match` — and every view
+ * that scopes the rule list (`notable`, `matched`, the app's drawer default,
+ * `rcd simulate`'s pretty default) then hides it. The reader is left with "no
+ * rule matched" and no way to learn that three rules never got the chance.
+ * A per-row fact cannot fix that, because the rows are exactly what the filter
+ * removed: the signal has to be an AGGREGATE that travels with the result,
+ * outside the array anyone may filter or elide.
+ *
+ * Type-only imports, so this module is Renovate-free and unit-testable in the
+ * engine's `golden` (plain node) project.
+ *
+ * The app has a narrower cousin, `buildNoInputCaveat`
+ * (`features/simulator/verdict-sentence.ts`), which counts only REPO-config
+ * rules via `ruleAttribution`. It is deliberately not the same number — a
+ * naive swap would fire on every `config:best-practices` run — so it keeps its
+ * scoping and is not folded in here.
+ */
+
+/** The clause states that fail a rule (as opposed to the neutral
+ *  not-applicable / not-simulated, which decide nothing). */
+function failingClauses(clauses: readonly ClauseEvaluation[]): ClauseEvaluation[] {
+  return clauses.filter(
+    (c) => c.state === "no-match" || c.state === "no-input" || c.state === "error",
+  );
+}
+
+/**
+ * Replay-02 R3/R4: a no-match decided SOLELY by fail-closed no-input clauses —
+ * the rule lost to an empty simulator field (or a `--dep` that omitted the
+ * field), not to real data that mismatched.
+ */
+export function isNoInputNoMatch(rule: Pick<RuleEvaluation, "verdict" | "clauses">): boolean {
+  if (rule.verdict !== "no-match") {
+    return false;
+  }
+  const failing = failingClauses(rule.clauses);
+  return failing.length > 0 && failing.every((c) => c.state === "no-input");
+}
+
+/** "sourceUrl" / "packageFile or lockFiles" — the fields a matcher reads,
+ *  for the fail-closed "no X set on the simulated dependency" explanation. */
+export function humanFieldList(fields: readonly string[]): string {
+  if (fields.length <= 1) {
+    return fields[0] ?? "matching input";
+  }
+  return `${fields.slice(0, -1).join(", ")} or ${fields.at(-1)}`;
+}
+
+/** One dependency field-set that decided rules against themselves. */
+export interface MissingInputGroup {
+  /** The clause's `readFields`, in matcher-registry order: `["sourceUrl"]`,
+   *  `["packageFile", "lockFiles"]`. */
+  fields: string[];
+  /** `humanFieldList(fields)` — the exact phrasing the per-clause note uses,
+   *  so the summary and the row agree word for word. */
+  fieldList: string;
+  /** The `match*` selectors that reported `no-input` on these fields, deduped,
+   *  sorted. */
+  selectors: string[];
+  /** Distinct rules that failed SOLELY on unset input and read these fields. */
+  rules: number;
+  /** The first five of those rules' `RuleEvaluation.index` values, ascending —
+   *  a drill-down handle, not the list; the `no-input` verdict facet is. */
+  sampleRuleIndexes: number[];
+}
+
+export interface MissingInputSummary {
+  /** Distinct rules across all groups — equal, by construction, to the count
+   *  the `no-input` verdict facet prints. */
+  rules: number;
+  /** Most rules first, then `fieldList` ascending. A rule with two no-input
+   *  clauses appears in two groups: the question each answers is "what would
+   *  setting THIS field buy me". */
+  groups: MissingInputGroup[];
+  /** The whole thing in one transport-neutral line — no flag or parameter
+   *  spelling, and no rule numbering, because the surfaces number rules
+   *  differently and own their own vocabulary. Absent when `rules === 0`. */
+  note?: string;
+}
+
+/** How many field groups the note names before it starts counting. */
+const NAMED_GROUPS = 3;
+
+/** Per-group `RuleEvaluation.index` samples kept, at most. */
+const SAMPLE_LIMIT = 5;
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+function buildNote(total: number, ruleCount: number, groups: MissingInputGroup[]): string {
+  const scope = `${ruleCount} of ${total} ${total === 1 ? "rule" : "rules"} could not match because `;
+  const tail =
+    " — Renovate treats a missing value as a non-match. " +
+    `Set ${groups.length === 1 ? groups[0]?.fieldList : "them"} on the dependency if you ` +
+    "expected these rules to fire.";
+  if (groups.length === 1) {
+    return `${scope}the simulated dependency has no ${groups[0]?.fieldList}${tail}`;
+  }
+  const named = groups
+    .slice(0, NAMED_GROUPS)
+    .map((group) => `${group.fieldList} (${plural(group.rules, "rule")})`)
+    .join(", ");
+  const more = groups.length - NAMED_GROUPS;
+  const list = more > 0 ? `${named}, and ${plural(more, "more field")}` : named;
+  return `${scope}the simulated dependency leaves fields they read unset: ${list}${tail}`;
+}
+
+interface GroupAccumulator {
+  fields: string[];
+  selectors: Set<string>;
+  ruleIndexes: Set<number>;
+}
+
+/**
+ * The rules a dependency's unset fields cost, grouped by the fields that were
+ * unset. Reads the finished verdicts only — it decides nothing and changes
+ * nothing about the simulation it describes.
+ */
+export function summarizeMissingInputs(rules: readonly RuleEvaluation[]): MissingInputSummary {
+  const accumulators = new Map<string, GroupAccumulator>();
+  const affected = new Set<number>();
+  for (const rule of rules) {
+    if (!isNoInputNoMatch(rule)) {
+      continue;
+    }
+    affected.add(rule.index);
+    for (const clause of rule.clauses) {
+      if (clause.state !== "no-input") {
+        continue;
+      }
+      const fields = [...clause.readFields];
+      const key = JSON.stringify(fields);
+      let accumulator = accumulators.get(key);
+      if (!accumulator) {
+        accumulator = { fields, selectors: new Set(), ruleIndexes: new Set() };
+        accumulators.set(key, accumulator);
+      }
+      accumulator.selectors.add(clause.key);
+      accumulator.ruleIndexes.add(rule.index);
+    }
+  }
+  const groups: MissingInputGroup[] = [...accumulators.values()]
+    .map((accumulator) => ({
+      fields: accumulator.fields,
+      fieldList: humanFieldList(accumulator.fields),
+      selectors: [...accumulator.selectors].toSorted(),
+      rules: accumulator.ruleIndexes.size,
+      sampleRuleIndexes: [...accumulator.ruleIndexes]
+        .toSorted((a, b) => a - b)
+        .slice(0, SAMPLE_LIMIT),
+    }))
+    .toSorted((a, b) => b.rules - a.rules || a.fieldList.localeCompare(b.fieldList));
+  if (groups.length === 0) {
+    return { rules: 0, groups: [] };
+  }
+  return {
+    rules: affected.size,
+    groups,
+    note: buildNote(rules.length, affected.size, groups),
+  };
+}

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -1,5 +1,10 @@
 import { enqueueEngineTask } from "./pipeline";
 import {
+  humanFieldList,
+  type MissingInputSummary,
+  summarizeMissingInputs,
+} from "./simulate-missing-inputs";
+import {
   GlobalConfig,
   getDefaultConfig,
   memCache,
@@ -216,6 +221,17 @@ export interface MergeStep {
 
 export interface SimulationResult {
   rules: RuleEvaluation[];
+  /**
+   * The rules that failed SOLELY because the simulated dependency left a field
+   * they read unset, grouped by that field — descriptive only, computed after
+   * the loop from the finished verdicts, read by nothing in the merge tail.
+   *
+   * It rides on the RESULT rather than on the rows because every surface that
+   * scopes the rule list (`notable`, `matched`, MCP's elision) drops exactly
+   * those rows: a fact carried inside the array is a fact the filter can hide.
+   * Always present — `{ rules: 0, groups: [] }` when there is nothing to say.
+   */
+  missingInputs: MissingInputSummary;
   /** Exactly what `applyPackageRules` would return (dep fields included). */
   rawFinalConfig: Record<string, unknown>;
   /**
@@ -397,15 +413,6 @@ function applyTemplate(value: string, field: string, notes: string[]): string {
     );
   }
   return value;
-}
-
-/** "sourceUrl" / "packageFile or lockFiles" — the fields a matcher reads,
- *  for the fail-closed "no X set on the simulated dependency" explanation. */
-function humanFieldList(fields: readonly string[]): string {
-  if (fields.length <= 1) {
-    return fields[0] ?? "matching input";
-  }
-  return `${fields.slice(0, -1).join(", ")} or ${fields.at(-1)}`;
 }
 
 async function evaluateRule(
@@ -778,6 +785,9 @@ async function execute(input: SimulationInput): Promise<SimulationResult> {
 
     return {
       rules,
+      // Descriptive, and deliberately computed here rather than per row: the
+      // views that would show it are the views that filter those rows away.
+      missingInputs: summarizeMissingInputs(rules),
       rawFinalConfig: config,
       finalDependencyConfig,
       flattened: { updateType, merged: flattenMerged, blocks, authoredBlocks },

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -33,6 +33,7 @@ function sim(
 ): SimulationResult {
   return {
     rules,
+    missingInputs: { rules: 0, groups: [] },
     rawFinalConfig: {},
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },

--- a/packages/engine/test/simulate-missing-inputs.node.test.ts
+++ b/packages/engine/test/simulate-missing-inputs.node.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the pure missing-input reduction. Builds `RuleEvaluation`
+ * fixtures by hand (the module reads verdicts and clauses only), so this needs
+ * no Renovate machinery and runs as a plain node test — the golden↔shimmed
+ * integration case in simulate-package-rules.*.test.ts owns the question of
+ * whether a real run produces these shapes.
+ */
+import { describe, expect, it } from "vitest";
+import { isNoInputNoMatch, type RuleEvaluation, summarizeMissingInputs } from "../src/index";
+
+type ClauseSpec = [
+  key: string,
+  state: RuleEvaluation["clauses"][number]["state"],
+  ...fields: string[],
+];
+
+function rule(
+  index: number,
+  verdict: RuleEvaluation["verdict"],
+  clauses: ClauseSpec[],
+): RuleEvaluation {
+  return {
+    index,
+    verdict,
+    clauses: clauses.map(([key, state, ...readFields]) => ({
+      key,
+      value: ["x"],
+      state,
+      inputValues: {},
+      readFields,
+    })),
+    notes: [],
+  };
+}
+
+/** The commonest shape: one clause that fail-closed on an unset field. */
+function noInput(index: number, key: string, ...fields: string[]): RuleEvaluation {
+  return rule(index, "no-match", [[key, "no-input", ...fields]]);
+}
+
+describe("summarizeMissingInputs", () => {
+  it("groups by the fields the clause read, and counts distinct rules", () => {
+    const summary = summarizeMissingInputs([
+      noInput(0, "matchSourceUrls", "sourceUrl"),
+      noInput(1, "matchFileNames", "packageFile", "lockFiles"),
+      noInput(2, "matchSourceUrls", "sourceUrl"),
+    ]);
+    expect(summary.rules).toBe(3);
+    expect(summary.groups).toEqual([
+      {
+        fields: ["sourceUrl"],
+        fieldList: "sourceUrl",
+        selectors: ["matchSourceUrls"],
+        rules: 2,
+        sampleRuleIndexes: [0, 2],
+      },
+      {
+        fields: ["packageFile", "lockFiles"],
+        fieldList: "packageFile or lockFiles",
+        selectors: ["matchFileNames"],
+        rules: 1,
+        sampleRuleIndexes: [1],
+      },
+    ]);
+  });
+
+  it("samples at most five rule indexes, ascending", () => {
+    const summary = summarizeMissingInputs(
+      [9, 3, 1, 7, 5, 2, 8].map((index) => noInput(index, "matchSourceUrls", "sourceUrl")),
+    );
+    expect(summary.rules).toBe(7);
+    expect(summary.groups[0]?.rules).toBe(7);
+    expect(summary.groups[0]?.sampleRuleIndexes).toEqual([1, 2, 3, 5, 7]);
+  });
+
+  it("dedupes and sorts the selectors that read the same field set", () => {
+    const summary = summarizeMissingInputs([
+      noInput(0, "matchSourceUrls", "sourceUrl"),
+      noInput(1, "excludeSourceUrls", "sourceUrl"),
+      noInput(2, "matchSourceUrls", "sourceUrl"),
+    ]);
+    expect(summary.groups[0]?.selectors).toEqual(["excludeSourceUrls", "matchSourceUrls"]);
+  });
+
+  /**
+   * The parity property that makes the number citable: it is the number of
+   * rules the `no-input` verdict facet prints. A rule that ALSO mismatched on
+   * real data would not start matching if you set the field.
+   */
+  it("excludes a rule that also lost on a genuine mismatch", () => {
+    const mixed = rule(0, "no-match", [
+      ["matchDepTypes", "no-match", "depType", "depTypes"],
+      ["matchSourceUrls", "no-input", "sourceUrl"],
+    ]);
+    expect(isNoInputNoMatch(mixed)).toBe(false);
+    expect(summarizeMissingInputs([mixed])).toEqual({ rules: 0, groups: [] });
+  });
+
+  it("ignores matched, not-simulated, clause-less and error-failed rules", () => {
+    const summary = summarizeMissingInputs([
+      rule(0, "matched", [["matchPackageNames", "matched", "packageName"]]),
+      rule(1, "not-simulated", [["matchConfidence", "not-simulated", "mergeConfidenceLevel"]]),
+      rule(2, "no-match", []),
+      // An `error` clause fails the rule too, so the rule did not lose SOLELY
+      // to unset input — setting the field would not decide it.
+      rule(3, "no-match", [
+        ["matchCurrentVersion", "error", "currentValue"],
+        ["matchSourceUrls", "no-input", "sourceUrl"],
+      ]),
+      // Neutral clauses decide nothing and must not qualify a rule on their own.
+      rule(4, "no-match", [
+        ["matchCurrentAge", "not-applicable", "currentVersionTimestamp"],
+        ["matchSourceUrls", "no-input", "sourceUrl"],
+      ]),
+    ]);
+    expect(summary.rules).toBe(1);
+    expect(summary.groups[0]?.sampleRuleIndexes).toEqual([4]);
+  });
+
+  it("says nothing at all when nothing failed on unset input", () => {
+    expect(summarizeMissingInputs([])).toEqual({ rules: 0, groups: [] });
+    const matched = summarizeMissingInputs([
+      rule(0, "matched", [["matchPackageNames", "matched", "packageName"]]),
+    ]);
+    expect(matched).toEqual({ rules: 0, groups: [] });
+    expect(matched.note).toBeUndefined();
+  });
+
+  it("names the one field in a single-group note", () => {
+    const rules = [
+      noInput(0, "matchSourceUrls", "sourceUrl"),
+      rule(1, "matched", [["matchPackageNames", "matched", "packageName"]]),
+    ];
+    expect(summarizeMissingInputs(rules).note).toBe(
+      "1 of 2 rules could not match because the simulated dependency has no sourceUrl — " +
+        "Renovate treats a missing value as a non-match. Set sourceUrl on the dependency if " +
+        "you expected these rules to fire.",
+    );
+  });
+
+  it("lists the fields, biggest first, in a multi-group note", () => {
+    const summary = summarizeMissingInputs([
+      noInput(0, "matchSourceUrls", "sourceUrl"),
+      noInput(1, "matchSourceUrls", "sourceUrl"),
+      noInput(2, "matchDepTypes", "depType", "depTypes"),
+      noInput(3, "matchCategories", "categories"),
+    ]);
+    expect(summary.rules).toBe(4);
+    expect(summary.note).toBe(
+      "4 of 4 rules could not match because the simulated dependency leaves fields they read " +
+        "unset: sourceUrl (2 rules), categories (1 rule), depType or depTypes (1 rule) — " +
+        "Renovate treats a missing value as a non-match. Set them on the dependency if you " +
+        "expected these rules to fire.",
+    );
+  });
+
+  it("names three field sets and counts the rest", () => {
+    const summary = summarizeMissingInputs([
+      noInput(0, "matchSourceUrls", "sourceUrl"),
+      noInput(1, "matchCategories", "categories"),
+      noInput(2, "matchDepTypes", "depType", "depTypes"),
+      noInput(3, "matchBaseBranches", "baseBranch"),
+      noInput(4, "matchRepositories", "repository"),
+    ]);
+    // Every group holds one rule, so the tie breaks on `fieldList` ascending.
+    expect(summary.groups.map((group) => group.fieldList)).toEqual([
+      "baseBranch",
+      "categories",
+      "depType or depTypes",
+      "repository",
+      "sourceUrl",
+    ]);
+    expect(summary.note).toContain(
+      "baseBranch (1 rule), categories (1 rule), depType or depTypes (1 rule), and 2 more fields —",
+    );
+  });
+
+  /** One rule, two unset fields: each group answers "what would setting THIS
+   *  field buy me", so the rule is in both — and counted once. */
+  it("puts a rule with two no-input clauses in two groups, counted once", () => {
+    const summary = summarizeMissingInputs([
+      rule(0, "no-match", [
+        ["matchCategories", "no-input", "categories"],
+        ["matchSourceUrls", "no-input", "sourceUrl"],
+      ]),
+    ]);
+    expect(summary.rules).toBe(1);
+    expect(summary.groups.map((group) => group.fieldList)).toEqual(["categories", "sourceUrl"]);
+    expect(summary.note).toContain("1 of 1 rule could not match");
+  });
+});

--- a/packages/engine/test/simulate-package-rules.node.test.ts
+++ b/packages/engine/test/simulate-package-rules.node.test.ts
@@ -79,6 +79,63 @@ describe("simulatePackageRules (golden)", () => {
     expect(oracle.addLabels).toEqual(["all-but-react", "via-jsonata"]);
   });
 
+  /**
+   * The golden twin of the shimmed suite's "distinguishes a real mismatch from
+   * a fail-closed missing input" case, with the same assertions on
+   * `missingInputs`: a summary computed in the browser module graph and a
+   * summary computed off untouched Renovate modules have to be the same
+   * document, or it is describing the shims rather than Renovate.
+   */
+  it("summarizes the fail-closed missing input, and only it (oracle parity)", async () => {
+    const config = {
+      packageRules: [{ matchSourceUrls: ["https://github.com/facebook/react"], labels: ["fb"] }],
+    };
+
+    // sourceUrl set but different → a genuine no-match against a named input.
+    const mismatch = await simulatePackageRules({
+      config,
+      dep: { ...npmDep, sourceUrl: "https://github.com/react/react" },
+    });
+    expect(mismatch.rules[0]?.verdict).toBe("no-match");
+    expect(mismatch.rules[0]?.clauses[0]?.state).toBe("no-match");
+    expect(mismatch.missingInputs).toEqual({ rules: 0, groups: [] });
+
+    // sourceUrl absent → upstream's `if (!sourceUrl) return false` fail-closed
+    // branch: the same rule-level verdict, summarized on the result.
+    const missing = await simulatePackageRules({ config, dep: npmDep });
+    expect(missing.rules[0]?.verdict).toBe("no-match");
+    expect(missing.rules[0]?.clauses[0]?.state).toBe("no-input");
+    expect(missing.missingInputs.rules).toBe(1);
+    expect(missing.missingInputs.groups).toEqual([
+      {
+        fields: ["sourceUrl"],
+        fieldList: "sourceUrl",
+        selectors: ["matchSourceUrls"],
+        rules: 1,
+        sampleRuleIndexes: [0],
+      },
+    ]);
+    expect(missing.missingInputs.note).toBe(
+      "1 of 1 rule could not match because the simulated dependency has no sourceUrl — " +
+        "Renovate treats a missing value as a non-match. Set sourceUrl on the dependency if " +
+        "you expected these rules to fire.",
+    );
+
+    // …and the descriptive field changed no verdict: both sides still equal
+    // what real applyPackageRules returns.
+    for (const [dep, sim] of [
+      [{ ...npmDep, sourceUrl: "https://github.com/react/react" }, mismatch],
+      [npmDep, missing],
+    ] as const) {
+      const oracle = await applyPackageRules({
+        ...config,
+        ...dep,
+        depName: dep.depName ?? dep.packageName,
+      });
+      expect(sim.rawFinalConfig).toEqual(oracle);
+    }
+  });
+
   it("flattens config[updateType] up, matching upstream (oracle parity)", async () => {
     const config = {
       packageRules: [

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -256,6 +256,27 @@ describe("simulatePackageRules", () => {
     );
     expect(missing.rules[0]?.verdict).toBe("no-match");
 
+    // Both rules end at the same rule-level verdict, so the fail-closed half is
+    // summarized on the RESULT — outside the array every scoped view filters.
+    // Asserted identically in the golden twin: the shims must not move a byte
+    // of it.
+    expect(mismatch.missingInputs).toEqual({ rules: 0, groups: [] });
+    expect(missing.missingInputs.rules).toBe(1);
+    expect(missing.missingInputs.groups).toEqual([
+      {
+        fields: ["sourceUrl"],
+        fieldList: "sourceUrl",
+        selectors: ["matchSourceUrls"],
+        rules: 1,
+        sampleRuleIndexes: [0],
+      },
+    ]);
+    expect(missing.missingInputs.note).toBe(
+      "1 of 1 rule could not match because the simulated dependency has no sourceUrl — " +
+        "Renovate treats a missing value as a non-match. Set sourceUrl on the dependency if " +
+        "you expected these rules to fire.",
+    );
+
     // oracle parity is unaffected by the finer reporting.
     for (const [dep, sim] of [
       [{ ...npmDep, sourceUrl: "https://github.com/react/react" }, mismatch],


### PR DESCRIPTION
A simulated dep missing a field the rules match on (e.g. `sourceUrl` for `matchSourceUrls`) failed silently: per-clause `no-input` existed but the rule verdict is plain `no-match`, so `matched`/`notable` filtering hid exactly those rules — two persona sessions nearly concluded 'the option doesn't work'. The engine now owns the fail-closed predicate and a required `SimulationResult.missingInputs` summary (count-parity with the `no-input` filter), reported on simulate and compare whatever the active filters.

Part of the persona-replay fix stack.