### PR TITLE
fix(cli): rule provenance as per-layer ranges with source-index cross-links

### DIFF
--- a/packages/app/src/components/RuleMessage.tsx
+++ b/packages/app/src/components/RuleMessage.tsx
@@ -1,4 +1,9 @@
 import type { RuleAttribution, ValidationMessage } from "@renovate-config-debugger/engine";
+import {
+  crossRuleIndex,
+  type RuleMessageIndexKind,
+  ruleIndexInMessage,
+} from "@/lib/rule-cross-index";
 
 /**
  * Roadmap 013: one canonical rule presentation + cross-links. A validation
@@ -8,34 +13,11 @@ import type { RuleAttribution, ValidationMessage } from "@renovate-config-debugg
  * scheme the message uses) and, when the mapping is determinable via
  * `computeRuleProvenance`, appends the OTHER index as a second clickable
  * annotation: "repo-config index 1 = merged rule 713".
+ *
+ * The index arithmetic itself lives in `lib/rule-cross-index` (roadmap 071):
+ * `rcd validate` and the MCP server annotate the same messages, and they must
+ * quote the number this component renders rather than restate it.
  */
-
-const RULE_INDEX_RE = /packageRules\[(\d+)\]/;
-
-/**
- * `"repo"` = the message came from validating the repo's own directly-authored
- * config (pre-preset-merge) — e.g. the top-level validate stage.
- * `"merged"` = the message came from validating the fully-merged
- * `finalConfig.packageRules` — e.g. the simulator's own validateConfig echo.
- */
-export type RuleMessageIndexKind = "repo" | "merged";
-
-/** The other index for a given one, only when it is attributable to the repo layer
- *  (a preset-sourced rule has no repo-config index to annotate with). */
-function crossIndex(
-  indexKind: RuleMessageIndexKind,
-  index: number,
-  ruleAttribution: RuleAttribution[] | null | undefined,
-): number | undefined {
-  if (!ruleAttribution) {
-    return undefined;
-  }
-  if (indexKind === "repo") {
-    return ruleAttribution.find((a) => a.layer.kind === "repo" && a.sourceIndex === index)?.index;
-  }
-  const entry = ruleAttribution.find((a) => a.index === index);
-  return entry?.layer.kind === "repo" ? entry.sourceIndex : undefined;
-}
 
 export function RuleMessage({
   message,
@@ -52,17 +34,15 @@ export function RuleMessage({
   /** Scrolls to / highlights the simulator's merged-index rule row. */
   onJumpToSimRule?: (mergedIndex: number) => void;
 }) {
-  const match = RULE_INDEX_RE.exec(message.message);
-  if (!match || match.index === undefined) {
+  const reference = ruleIndexInMessage(message.message);
+  if (!reference) {
     // No rule reference to linkify — the message renders as plain text.
     return message.message;
   }
-  const index = Number(match[1]);
-  const start = match.index;
-  const end = start + match[0].length;
-  const before = message.message.slice(0, start);
-  const after = message.message.slice(end);
-  const cross = crossIndex(indexKind, index, ruleAttribution);
+  const { index } = reference;
+  const before = message.message.slice(0, reference.start);
+  const after = message.message.slice(reference.end);
+  const cross = crossRuleIndex(indexKind, index, ruleAttribution);
 
   return (
     <>
@@ -77,7 +57,7 @@ export function RuleMessage({
             : "Jump to this rule in the simulator's rule list"
         }
       >
-        {match[0]}
+        {reference.text}
       </button>
       {after}
       {cross !== undefined ? (

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -8,7 +8,9 @@
  * parse of the 008 config layers, (roadmap 062) the simulator's rule
  * filters, which `rcd simulate --verdict/--source` is, and (roadmap 069) the
  * description digest behind the Overview's "What this config does" card — the
- * grouping and counts, not the attribution, which is the engine's. The CLI must quote the
+ * grouping and counts, not the attribution, which is the engine's; and
+ * (roadmap 071) the one-line rule summaries and the `packageRules[N]`
+ * cross-index behind `RuleMessage`. The CLI must quote the
  * SAME numbers the web
  * app renders, so it imports them rather than restating them; this barrel is
  * the seam that makes that an import instead of a copy.
@@ -48,6 +50,12 @@ export {
 } from "./effective-tally";
 export { type LayerParseResult, parseLayerJson } from "./input-schemas";
 export {
+  crossRuleIndex,
+  type RuleIndexReference,
+  ruleIndexInMessage,
+  type RuleMessageIndexKind,
+} from "./rule-cross-index";
+export {
   ALL_PRESETS,
   DEFAULT_RULE_FILTERS,
   type FilterOption,
@@ -68,6 +76,7 @@ export {
   type VerdictFilter,
   verdictFilterOptions,
 } from "./rule-filters";
+export { ruleWrittenKeys, summarizeRuleSelectors } from "./rule-selectors";
 export { isNoInputNoMatch } from "./rule-verdict";
 export {
   buildRunDigest,

--- a/packages/app/src/lib/rule-cross-index.test.ts
+++ b/packages/app/src/lib/rule-cross-index.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import type { RuleAttribution } from "@renovate-config-debugger/engine";
+import { crossRuleIndex, ruleIndexInMessage } from "./rule-cross-index";
+
+/**
+ * Roadmap 071: the cases `RuleMessage` used to own inline, now that both the
+ * app and `rcd validate`/MCP quote this mapping.
+ */
+
+/** A preset rule first, then two the repo authored — the `mixed-rules` shape. */
+const ATTRIBUTION: RuleAttribution[] = [
+  {
+    index: 0,
+    layer: { kind: "preset", nodeId: "n1", name: ":disablePeerDependencies" },
+    sourceIndex: 0,
+  },
+  { index: 1, layer: { kind: "repo" }, sourceIndex: 0 },
+  { index: 2, layer: { kind: "repo" }, sourceIndex: 1 },
+];
+
+describe("ruleIndexInMessage", () => {
+  test("finds the reference and where it sits in the prose", () => {
+    const found = ruleIndexInMessage(
+      "packageRules[1].matchPackageNames: Your input contains * but it is not the only element",
+    );
+    expect(found).toMatchObject({ index: 1, text: "packageRules[1]", start: 0 });
+    expect(found?.end).toBe("packageRules[1]".length);
+  });
+
+  test("a nested reference resolves to the TOP-LEVEL index", () => {
+    // `exec`'s first match wins, which is the index both schemes are defined
+    // against — a nested rule has no index of its own in either array.
+    expect(ruleIndexInMessage("packageRules[0].packageRules[2]: invalid")?.index).toBe(0);
+  });
+
+  test("a message with no rule reference matches nothing", () => {
+    expect(ruleIndexInMessage("Invalid configuration option: foo")).toBeUndefined();
+  });
+});
+
+describe("crossRuleIndex", () => {
+  test("a repo-config index maps to its merged index", () => {
+    expect(crossRuleIndex("repo", 1, ATTRIBUTION)).toBe(2);
+  });
+
+  test("a merged index maps back to the repo-config index", () => {
+    expect(crossRuleIndex("merged", 2, ATTRIBUTION)).toBe(1);
+  });
+
+  test("a preset-sourced merged rule has no repo index to annotate with", () => {
+    expect(crossRuleIndex("merged", 0, ATTRIBUTION)).toBeUndefined();
+  });
+
+  test("no attribution links nothing — a wrong link is worse than none", () => {
+    expect(crossRuleIndex("repo", 0, undefined)).toBeUndefined();
+    expect(crossRuleIndex("merged", 0, null)).toBeUndefined();
+  });
+
+  test("an index no layer claims is left unannotated", () => {
+    expect(crossRuleIndex("repo", 9, ATTRIBUTION)).toBeUndefined();
+    expect(crossRuleIndex("merged", 9, ATTRIBUTION)).toBeUndefined();
+  });
+});

--- a/packages/app/src/lib/rule-cross-index.ts
+++ b/packages/app/src/lib/rule-cross-index.ts
@@ -1,0 +1,74 @@
+import type { RuleAttribution } from "@renovate-config-debugger/engine";
+
+/**
+ * The two `packageRules[N]` index schemes, and the map between them.
+ *
+ * Renovate's validator writes an index into its message text (`packageRules[1]:
+ * …`) and which array that index addresses depends on WHAT was validated: the
+ * repo's own directly-authored config, or the fully merged one. Roadmap 013
+ * made that reference clickable in `RuleMessage`; roadmap 071 hoisted the
+ * index arithmetic out of the component, because `rcd validate` and the MCP
+ * server have to quote the SAME number the app renders — a second spelling of
+ * this mapping would be a second answer to the same question.
+ *
+ * Pure and DOM-free, hence `lib/`, and exported through `lib/headless.ts`.
+ */
+
+/**
+ * A `packageRules[N]` reference inside a message, kept as a REGEX rather than
+ * `parseConfigPath`: the message is prose CONTAINING a path, not a path. The
+ * first match is deliberately the one that wins — for a nested reference like
+ * `packageRules[0].packageRules[2]` the top-level index is the one both
+ * schemes below are defined against. (`parseConfigPath` stays the right tool
+ * for `suggestFix`, which is handed a bare path.)
+ */
+const RULE_INDEX_RE = /packageRules\[(\d+)\]/;
+
+/**
+ * `"repo"` = the message came from validating the repo's own directly-authored
+ * config (pre-preset-merge) — e.g. the top-level validate stage.
+ * `"merged"` = the message came from validating the fully-merged
+ * `finalConfig.packageRules` — e.g. the simulator's own validateConfig echo.
+ */
+export type RuleMessageIndexKind = "repo" | "merged";
+
+/** Where a message's `packageRules[N]` reference sits, and which N it names. */
+export interface RuleIndexReference {
+  index: number;
+  /** The matched text, e.g. `packageRules[1]` — what a caller linkifies. */
+  text: string;
+  /** Offsets of `text` in the message, for splitting it around the link. */
+  start: number;
+  end: number;
+}
+
+export function ruleIndexInMessage(message: string): RuleIndexReference | undefined {
+  const match = RULE_INDEX_RE.exec(message);
+  if (!match || match.index === undefined) {
+    return undefined;
+  }
+  const text = match[0];
+  return {
+    index: Number(match[1]),
+    text,
+    start: match.index,
+    end: match.index + text.length,
+  };
+}
+
+/** The other index for a given one, only when it is attributable to the repo layer
+ *  (a preset-sourced rule has no repo-config index to annotate with). */
+export function crossRuleIndex(
+  indexKind: RuleMessageIndexKind,
+  index: number,
+  ruleAttribution: readonly RuleAttribution[] | null | undefined,
+): number | undefined {
+  if (!ruleAttribution) {
+    return undefined;
+  }
+  if (indexKind === "repo") {
+    return ruleAttribution.find((a) => a.layer.kind === "repo" && a.sourceIndex === index)?.index;
+  }
+  const entry = ruleAttribution.find((a) => a.index === index);
+  return entry?.layer.kind === "repo" ? entry.sourceIndex : undefined;
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,27 +79,29 @@ is a positional file path unless one of these replaces it.
 
 The rest belong to one command each.
 
-| command    | flag                         | effect                                                                     |
-| ---------- | ---------------------------- | -------------------------------------------------------------------------- |
-| `tree`     | `--node <name>`              | one preset node, by name or identity                                       |
-|            | `--body <which>`             | `fetched\|afterParams\|input\|resolved` (needs `--node`)                   |
-|            | `--depth <n\|all>`           | tree depth to print (default `2`)                                          |
-| `resolved` | `--mode <m>`                 | `full\|keep-internal` (default `keep-internal`)                            |
-|            | `--include-defaults`         | write out Renovate's defaults too (`--mode full` only)                     |
-| `simulate` | `--dep <json>`, `--dep-file` | the dependency update to simulate                                          |
-|            | `--verdict <which>`          | `notable\|all\|matched\|no-input\|no-match` (pretty `notable`, JSON `all`) |
-|            | `--source <which>`           | which config level contributed the rule: `repo\|presets\|all`              |
-|            | `--detail <which>`           | `verdict` (default) \| `full` — `full` adds the merge trace                |
-|            | `--keys <a,b,…>`             | only these options of `finalDependencyConfig`                              |
-|            | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
-| `compare`  | `--dep`/`--dep-file`         | the A-side dependency                                                      |
-|            | `--dep-b`/`--dep-b-file`     | the B-side dependency                                                      |
-|            | `--keys <a,b,…>`             | only these options of the config delta                                     |
-|            | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
-| `run`      | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`     |
-|            | `--keys <a,b,…>`             | only these options of `--select final`                                     |
-|            | `--config-scope <which>`     | `full` (default) \| `package-rules`                                        |
-| `docs`     | `--search`                   | list options whose name matches                                            |
+| command      | flag                         | effect                                                                     |
+| ------------ | ---------------------------- | -------------------------------------------------------------------------- |
+| `provenance` | `--rule <n>`                 | one merged `packageRule`: its body, its layer, its index in that layer     |
+|              | `--source <which>`           | scope the `packageRules` ranges: `repo\|presets\|all`                      |
+| `tree`       | `--node <name>`              | one preset node, by name or identity                                       |
+|              | `--body <which>`             | `fetched\|afterParams\|input\|resolved` (needs `--node`)                   |
+|              | `--depth <n\|all>`           | tree depth to print (default `2`)                                          |
+| `resolved`   | `--mode <m>`                 | `full\|keep-internal` (default `keep-internal`)                            |
+|              | `--include-defaults`         | write out Renovate's defaults too (`--mode full` only)                     |
+| `simulate`   | `--dep <json>`, `--dep-file` | the dependency update to simulate                                          |
+|              | `--verdict <which>`          | `notable\|all\|matched\|no-input\|no-match` (pretty `notable`, JSON `all`) |
+|              | `--source <which>`           | which config level contributed the rule: `repo\|presets\|all`              |
+|              | `--detail <which>`           | `verdict` (default) \| `full` — `full` adds the merge trace                |
+|              | `--keys <a,b,…>`             | only these options of `finalDependencyConfig`                              |
+|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
+| `compare`    | `--dep`/`--dep-file`         | the A-side dependency                                                      |
+|              | `--dep-b`/`--dep-b-file`     | the B-side dependency                                                      |
+|              | `--keys <a,b,…>`             | only these options of the config delta                                     |
+|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
+| `run`        | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`     |
+|              | `--keys <a,b,…>`             | only these options of `--select final`                                     |
+|              | `--config-scope <which>`     | `full` (default) \| `package-rules`                                        |
+| `docs`       | `--search`                   | list options whose name matches                                            |
 
 ### Narrowing a config answer
 
@@ -136,6 +138,41 @@ $ rcd simulate renovate.json --dep '{"depName":"react"}' --format json --keys gr
 
 On the fixture measured for this feature that call is 2.9 kB, against 24.5 kB
 for the default answer and 106 kB for `--detail full`.
+
+### Which layer wrote which rule
+
+`packageRules` is the one key Renovate CONCATENATES: every layer appends its own
+rules and none overrides another, so "who won" is the wrong question for it.
+`rcd provenance <file> packageRules` answers with one contiguous merged-index
+range per contributing layer, plus a one-line digest of each rule:
+
+```console
+$ rcd provenance renovate.json packageRules
+packageRules [appended] — 714 merged rules, concatenated: every layer appends, none overrides
+
+  preset config:recommended — merged packageRules[0]–[712] (its own packageRules[0]–[712])
+    0 matchPackageNames: ["*"] → semanticCommitType
+    …
+  repo — merged packageRules[713]–[713] (your packageRules[0]–[0])
+    713 matchPackageNames: ["react"] → groupName
+```
+
+That is the arithmetic the other commands' indexes need: a rule's index inside
+its own layer is `index - from`, and for the `repo` range that is the
+`packageRules[N]` you wrote. `--source repo` keeps just your own ranges (the
+indexes do not move), and `--rule <n>` prints one merged rule's body with the
+layer that wrote it.
+
+The same numbers travel with the answers that quote an index:
+
+- `rcd simulate --format json` carries `ruleSources` (the same ranges) and, on
+  every rule that MATCHED, an inline `origin: {layer, sourceIndex}`; pretty
+  output appends ` [repo packageRules[0]]` to the matched lines.
+- `rcd validate` adds a line under any message whose `packageRules[N]` it can
+  cross-link — the validator cites the config as WRITTEN, the simulator the
+  merged array, and for a config with presets those are different numbers.
+  Nothing is annotated when the run cannot be attributed, or when the message
+  came from a global/inherited layer's own validation.
 
 ## A debugging session
 

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -99,6 +99,12 @@ export const OPTIONS = {
     flags: "--source <which>",
     description: "which config level contributed the rule: repo|presets|all (default: all)",
   },
+  rule: {
+    flags: "--rule <n>",
+    description:
+      "one merged packageRule by index: its body, its layer and its index inside " +
+      "that layer (`provenance <file> packageRules` only)",
+  },
   detail: {
     flags: "--detail <which>",
     description:

--- a/packages/cli/src/commands/provenance.test.ts
+++ b/packages/cli/src/commands/provenance.test.ts
@@ -29,3 +29,95 @@ describe("provenance", () => {
     expect(await main(["provenance", fixture("clean.json"), "notAnOption"], io)).toBe(1);
   });
 });
+
+/**
+ * Roadmap 071: `packageRules` is the key Renovate CONCATENATES, so "who
+ * overrode whom" is the wrong question for it. It answers with one contiguous
+ * merged-index range per contributing layer — the `#N layer` list it replaced
+ * carried one line per rule and no way to tell which of YOUR rules that was.
+ */
+describe("provenance packageRules", () => {
+  interface RuleReport {
+    total: number;
+    mergeSemantics: string;
+    note: string;
+    source?: string;
+    contributions: { layer: string; kind: string; from: number; to: number; rules?: string[] }[];
+  }
+
+  async function report(args: string[]): Promise<RuleReport> {
+    const io = recordingIo();
+    expect(
+      await main(
+        ["provenance", fixture("mixed-rules.json"), "packageRules", "--format", "json", ...args],
+        io,
+      ),
+    ).toBe(0);
+    return io.json() as RuleReport;
+  }
+
+  test("ranges per layer, digest lines carrying the merged index", async () => {
+    const answer = await report([]);
+    expect(answer.mergeSemantics).toBe("concat");
+    expect(answer.total).toBe(4);
+    expect(answer.contributions.map((c) => [c.layer, c.from, c.to])).toEqual([
+      ["preset :disablePeerDependencies", 0, 0],
+      ["repo", 1, 3],
+    ]);
+    const repo = answer.contributions[1];
+    expect(repo?.rules?.[0]).toBe('1 matchPackageNames: ["react"] → groupName');
+    expect(answer.note).toContain("index - from");
+  });
+
+  test("--source repo answers with just the rules you wrote", async () => {
+    const answer = await report(["--source", "repo"]);
+    expect(answer.source).toBe("repo");
+    expect(answer.contributions).toHaveLength(1);
+    expect(answer.contributions[0]?.kind).toBe("repo");
+    // Still the merged indexes — the scope narrows the view, not the array.
+    expect(answer.contributions[0]?.from).toBe(1);
+  });
+
+  test("--rule prints one merged rule's body, cited in both index schemes", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "provenance",
+          fixture("mixed-rules.json"),
+          "packageRules",
+          "--rule",
+          "1",
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const one = io.json() as {
+      layer: string;
+      sourceIndex: number;
+      citation: string;
+      rule: unknown;
+    };
+    expect(one).toMatchObject({ layer: "repo", sourceIndex: 0 });
+    expect(one.citation).toContain("merged packageRules[1]");
+    expect(one.rule).toEqual({ matchPackageNames: ["react"], groupName: "react monorepo" });
+  });
+
+  test("--rule and --source belong to the rule array, and say so elsewhere", async () => {
+    const io = recordingIo();
+    expect(
+      await main(["provenance", fixture("mixed-rules.json"), "labels", "--rule", "0"], io),
+    ).toBe(1);
+    expect(io.stderr).toContain("--rule/--source");
+  });
+
+  test("pretty output is one header per layer, not one line per rule", async () => {
+    const io = recordingIo();
+    expect(await main(["provenance", fixture("mixed-rules.json"), "packageRules"], io)).toBe(0);
+    expect(io.stdout).toContain("4 merged rules, concatenated");
+    expect(io.stdout).toContain("repo — merged packageRules[1]–[3] (your packageRules[0]–[2])");
+    expect(io.stdout).toContain('1 matchPackageNames: ["react"] → groupName');
+  });
+});

--- a/packages/cli/src/commands/provenance.ts
+++ b/packages/cli/src/commands/provenance.ts
@@ -1,29 +1,107 @@
 import { computeRuleProvenance } from "@renovate-config-debugger/engine";
-import { effectiveTally } from "@renovate-config-debugger/app/headless";
-import { outputFormat } from "../args";
+import {
+  effectiveTally,
+  SOURCE_FILTERS,
+  type SourceFilter,
+} from "@renovate-config-debugger/app/headless";
+import { outputFormat, type ParsedArgs, stringOption } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, preview, writeNotes } from "../output";
-import { entryView, layerLabel, provenanceOf } from "../projections/provenance";
+import { chainStepText, entryView, provenanceOf } from "../projections/provenance";
+import {
+  oneRuleView,
+  type RuleContribution,
+  RULE_DIGEST_PLANS,
+  type RuleProvenanceView,
+  ruleProvenanceView,
+} from "../projections/rule-provenance";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
  * "Who set this key, and who overrode whom?" — the question behind most real
  * debugging sessions, and the one the web app answers with its effective-config
  * ledger.
+ *
+ * `packageRules` is answered by its own projection (roadmap 071): Renovate
+ * concatenates that key, so "who overrode whom" is the wrong question for it
+ * and the honest answer is which contiguous slice of the merged array each
+ * layer contributed.
  */
+
+function parseRuleIndex(args: ParsedArgs): number | undefined {
+  const raw = stringOption(args, "rule");
+  if (raw === undefined) {
+    return undefined;
+  }
+  const index = Number(raw);
+  if (!Number.isInteger(index) || index < 0) {
+    throw new CliError(`--rule takes a merged rule index, 0 or greater (got "${raw}")`);
+  }
+  return index;
+}
+
+function parseSource(args: ParsedArgs): SourceFilter | undefined {
+  const raw = stringOption(args, "source");
+  if (raw === undefined) {
+    return undefined;
+  }
+  const found = SOURCE_FILTERS.find((value) => value === raw);
+  if (!found) {
+    throw new CliError(`--source must be one of ${SOURCE_FILTERS.join("|")} (got "${raw}")`);
+  }
+  return found;
+}
+
+/** `repo — merged packageRules[1]–[3] (its own packageRules[0]–[2])`. */
+function contributionHeader(contribution: RuleContribution): string {
+  const own = `${contribution.layer === "repo" ? "your" : "its own"} packageRules[0]–[${
+    contribution.count - 1
+  }]`;
+  return (
+    `  ${contribution.layer} — merged packageRules[${contribution.from}]–` +
+    `[${contribution.to}] (${own})`
+  );
+}
+
+function rulePrettyLines(view: RuleProvenanceView): string[] {
+  const lines = [
+    `packageRules${view.badge ? ` [${view.badge}]` : ""} — ${view.total} merged rules, ` +
+      "concatenated: every layer appends, none overrides",
+    "",
+  ];
+  for (const contribution of view.contributions ?? []) {
+    lines.push(contributionHeader(contribution));
+    for (const rule of contribution.rules ?? []) {
+      lines.push(`    ${rule}`);
+    }
+  }
+  if (view.attributionNote) {
+    lines.push(`  ${view.attributionNote}`);
+  }
+  lines.push("", view.note);
+  return lines;
+}
+
 export const provenanceCommand: Command = {
   name: "provenance",
   summary: "per-key provenance: which layer set each option, and who overrode whom",
   usage: ["provenance [file] [key]"],
   details: [
     "Without a key: every option some layer beyond the defaults set.",
-    "With a key: that option's full override chain, plus — for",
-    "`packageRules` — which layer contributed each merged rule.",
+    "With a key: that option's full override chain.",
+    "",
+    "`packageRules` answers with one merged-index RANGE per contributing",
+    "layer plus a one-line digest of each rule — Renovate concatenates that",
+    "key, so no layer overrides another. `--source repo|presets` scopes the",
+    "ranges and `--rule <n>` prints one merged rule's body, its layer and its",
+    "index inside that layer.",
   ],
-  options: [...INPUT_OPTIONS, "format"],
+  options: [...INPUT_OPTIONS, "rule", "source", "format"],
   async run(args, io) {
     const format = outputFormat(args);
+    const ruleIndex = parseRuleIndex(args);
+    const source = parseSource(args);
     const { result, rest, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
     const key = rest[0];
@@ -37,32 +115,52 @@ export const provenanceCommand: Command = {
       if (!entry) {
         throw new CliError(`no key "${key}" in the effective config`);
       }
-      const rules =
-        key === "packageRules"
-          ? (computeRuleProvenance(result) ?? []).map((attr) => ({
-              index: attr.index,
-              layer: layerLabel(attr.layer),
-            }))
+      if (key !== "packageRules" && (ruleIndex !== undefined || source !== undefined)) {
+        throw new CliError(
+          `--rule/--source scope the merged packageRules; "${key}" is not an array of rules`,
+        );
+      }
+      if (key === "packageRules") {
+        const attribution = computeRuleProvenance(result);
+        const rules = Array.isArray(result.finalConfig?.packageRules)
+          ? result.finalConfig.packageRules
           : [];
+        if (ruleIndex !== undefined) {
+          const one = oneRuleView(ruleIndex, attribution, rules);
+          if (format === "json") {
+            emitJson(io, one);
+          } else {
+            emitLines(io, [one.citation, "", preview(one.rule, 2_000)]);
+          }
+          return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;
+        }
+        // Always the richest digest here: a terminal scrolls and a script
+        // indexes, and neither pays the MCP transport's byte budget.
+        const view = ruleProvenanceView(
+          entry,
+          attribution,
+          rules,
+          RULE_DIGEST_PLANS[0],
+          source ? { source } : {},
+        );
+        if (format === "json") {
+          emitJson(io, view);
+        } else {
+          emitLines(io, rulePrettyLines(view));
+        }
+        return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;
+      }
+      const view = entryView(entry);
       if (format === "json") {
-        emitJson(io, { ...entryView(entry), ...(rules.length > 0 ? { rules } : {}) });
+        emitJson(io, view);
       } else {
-        const view = entryView(entry);
-        const lines = [
+        emitLines(io, [
           `${view.key}${view.badge ? ` [${view.badge}]` : ""} — winner: ${view.winner ?? "?"}`,
           `  final: ${preview(view.finalValue, 400)}`,
           "",
           "Override chain:",
-          ...view.chain.map((step) => `  ${step.layer} ${step.action} ${preview(step.after)}`),
-        ];
-        if (rules.length > 0) {
-          lines.push(
-            "",
-            "packageRules by layer:",
-            ...rules.map((r) => `  #${r.index + 1} ${r.layer}`),
-          );
-        }
-        emitLines(io, lines);
+          ...view.chain.map((step) => `  ${step.layer} ${step.action} ${chainStepText(step)}`),
+        ]);
       }
       return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;
     }

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -18,7 +18,12 @@ import {
   ruleFilterSelection,
 } from "../rule-view";
 import { collapseDiffs, mergedLine, parseConfigScope, parseKeys } from "../projections/config-view";
-import { collapseRuleMerges, parseDetail, simulationPayload } from "../projections/simulate";
+import {
+  collapseRuleMerges,
+  parseDetail,
+  simulationPayload,
+  withRuleOrigins,
+} from "../projections/simulate";
 
 /**
  * "Would this PR be grouped/labeled/blocked here?" — every packageRule
@@ -36,11 +41,23 @@ export async function simulateAgainst(
   return simulatePackageRules({ config: result.finalConfig, dep });
 }
 
-export function verdictLines(rules: readonly RuleEvaluation[]): string[] {
+/**
+ * The rule list, one line each. A MATCHED line names the layer that wrote the
+ * rule and its index there (`[repo packageRules[0]]`) — the answer to "which
+ * of my rules is this", which the merged index alone never gave. Only the
+ * matched ones: the suffix on all ~727 rows would bury the handful that fired,
+ * and `--format json` carries `ruleSources` for the rest.
+ */
+export function verdictLines(
+  rules: readonly RuleEvaluation[],
+  originOf?: (index: number) => { layer: string; sourceIndex: number } | undefined,
+): string[] {
   const lines: string[] = [];
   for (const rule of rules) {
     const clauses = rule.clauses.map((c) => `${c.key}=${c.state}`).join(", ");
-    lines.push(`  #${rule.index + 1} ${rule.verdict}${clauses ? ` (${clauses})` : ""}`);
+    const origin = rule.verdict === "matched" ? originOf?.(rule.index) : undefined;
+    const from = origin ? ` [${origin.layer} packageRules[${origin.sourceIndex}]]` : "";
+    lines.push(`  #${rule.index + 1} ${rule.verdict}${clauses ? ` (${clauses})` : ""}${from}`);
     for (const merged of collapseDiffs(rule.merged ?? [])) {
       lines.push(`      sets ${mergedLine(merged)}`);
     }
@@ -114,9 +131,13 @@ export const simulateCommand: Command = {
           detail,
           scope: scope ?? "package-rules",
           transport: selection.transport,
+          attribution: view.attribution,
           ...(keys ? { keys } : {}),
         }),
-        rules: detail === "full" ? view.rules : collapseRuleMerges(view.rules),
+        rules:
+          detail === "full"
+            ? view.rules
+            : withRuleOrigins(collapseRuleMerges(view.rules), view.attribution),
         ...(selection.explicit ? ruleFilterPayload(view) : {}),
         wouldRefuse: refused,
         ...(refusal ? { exitNote: refusal } : {}),
@@ -144,7 +165,7 @@ export const simulateCommand: Command = {
       emitLines(io, [
         `${matched.length} of ${sim.rules.length} packageRules matched.`,
         "",
-        ...verdictLines(view.rules),
+        ...verdictLines(view.rules, view.originOf),
         ...(hiddenNote ? [hiddenNote] : []),
         ...(missingNote ? [missingNote] : []),
         "",

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -1,9 +1,16 @@
+import { computeRuleProvenance, type ValidationMessage } from "@renovate-config-debugger/engine";
 import { validatedConfigOf } from "@renovate-config-debugger/app/headless";
 import { outputFormat } from "../args";
 import type { Command } from "../command";
 import { EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
-import { describeMessage, type ReportedMessage } from "../projections/messages";
+import {
+  describeMessage,
+  type MessageSeverity,
+  type ReportedMessage,
+  repoStageMessage,
+  ruleCrossLink,
+} from "../projections/messages";
 import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
@@ -35,9 +42,22 @@ export const validateCommand: Command = {
     // The snapshot the validator's messages were produced from, so a fix's
     // path resolves against the same document (`packageRules[N]` included).
     const validated = validatedConfigOf(result);
+    // The `packageRules[N]` in a validator message is the index in the config
+    // as WRITTEN; `simulate` and `provenance` cite the merged one. Only for
+    // messages the validate stage produced — the global and inherited layers
+    // file theirs in the same arrays, against a different document.
+    const attribution = computeRuleProvenance(result);
+    const describe = (m: ValidationMessage, severity: MessageSeverity): ReportedMessage =>
+      describeMessage(
+        m,
+        severity,
+        validated,
+        input.content,
+        repoStageMessage(result, m) ? ruleCrossLink(m, "repo", attribution) : undefined,
+      );
     const messages: ReportedMessage[] = [
-      ...result.errors.map((m) => describeMessage(m, "error", validated, input.content)),
-      ...result.warnings.map((m) => describeMessage(m, "warning", validated, input.content)),
+      ...result.errors.map((m) => describe(m, "error")),
+      ...result.warnings.map((m) => describe(m, "warning")),
     ];
     const presetErrors = result.events.filter((e) => e.kind === "preset-error").map((e) => e.title);
     const refused = wouldRefuse(result);
@@ -60,6 +80,9 @@ export const validateCommand: Command = {
       ];
       for (const m of messages) {
         lines.push("", `${m.severity === "error" ? "✗" : "!"} ${m.topic}: ${m.message}`);
+        if (m.rule) {
+          lines.push(`    ${m.rule.note}`);
+        }
         if (m.explanation) {
           lines.push(`    ${m.explanation}`);
         }

--- a/packages/cli/src/mcp/result.test.ts
+++ b/packages/cli/src/mcp/result.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { RESULT_BUDGET_BYTES, serializeResult } from "./result";
+import { fitsBudget, RESULT_BUDGET_BYTES, serializeResult } from "./result";
 
 /** The size budget, on its own — the tool-level assertions live in
  *  `server.test.ts`, where a real `config:recommended` run supplies the
@@ -158,5 +158,37 @@ describe("serializeResult", () => {
     expect(trunk).toBeDefined();
     expect(trunk?.body?.truncated).toBe(true);
     expect(parsed.children).toHaveLength(13);
+  });
+});
+
+/**
+ * Roadmap 071: the measurement a projection takes BEFORE it answers, so it can
+ * degrade semantically (shorter digest lines, complete attribution) instead of
+ * being collapsed to first-and-last by the pass above.
+ */
+describe("fitsBudget", () => {
+  /** `{"pad":"…"}` — the payload's bytes, minus the padding itself. */
+  const WRAPPER = '{"pad":""}'.length;
+  const padded = (bytes: number) => ({ pad: "x".repeat(bytes - WRAPPER) });
+
+  test("true exactly up to the elision target, false past it", () => {
+    // The target is the budget minus the room the elision wrapper needs, so
+    // "fits" has to be strictly stricter than "under the hard cap".
+    const target = RESULT_BUDGET_BYTES - 2_000;
+    expect(fitsBudget(padded(target))).toBe(true);
+    expect(fitsBudget(padded(target + 1))).toBe(false);
+    expect(fitsBudget(padded(RESULT_BUDGET_BYTES))).toBe(false);
+  });
+
+  test("what fits comes back whole — same predicate, same threshold", () => {
+    const payload = { rules: Array.from({ length: 200 }, (_, i) => ({ i, pad: "y".repeat(60) })) };
+    expect(fitsBudget(payload)).toBe(true);
+    expect(JSON.parse(serializeResult(payload))).toEqual(payload);
+  });
+
+  test("multi-byte characters count as bytes, not as characters", () => {
+    const text = { pad: "é".repeat(RESULT_BUDGET_BYTES - 2_000) };
+    expect(text.pad.length).toBeLessThan(RESULT_BUDGET_BYTES);
+    expect(fitsBudget(text)).toBe(false);
   });
 });

--- a/packages/cli/src/mcp/result.ts
+++ b/packages/cli/src/mcp/result.ts
@@ -278,6 +278,19 @@ function elideToBudget(compact: string, hint: string | undefined): Record<string
 }
 
 /**
+ * Whether a payload survives {@link serializeResult} whole.
+ *
+ * For projections that would rather degrade SEMANTICALLY than be collapsed to
+ * first-and-last: `get_provenance` on `packageRules` measures its own answer
+ * and drops to shorter digest lines, keeping the attribution complete, instead
+ * of handing the elider an array of 727 large objects it can only cut to two.
+ * Purely additive — the elision itself is untouched.
+ */
+export function fitsBudget(payload: unknown): boolean {
+  return byteLength(stringify(payload)) <= ELISION_TARGET_BYTES;
+}
+
+/**
  * `hint` is the narrowing a caller should apply if this particular tool's
  * answer had to be elided — naming the parameter beats "output truncated".
  */

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -35,6 +35,24 @@ const GROUPED =
   '{"labels":["deps"],"packageRules":[{"matchPackageNames":["react"],"groupName":"react"}]}';
 /** The big one — every size assertion in this file is measured against it. */
 const RECOMMENDED = '{"extends":["config:recommended"],"labels":["deps"]}';
+/** The same at scale, plus ONE rule of the caller's own — the shape the
+ *  packageRules provenance answer is about: 713 preset rules, then yours. */
+const RECOMMENDED_PLUS_RULE = JSON.stringify({
+  extends: ["config:recommended"],
+  packageRules: [{ matchPackageNames: ["react"], groupName: "react" }],
+});
+/**
+ * A rule-scoped validator ERROR, with a preset ahead of it so the two index
+ * schemes differ: `:disablePeerDependencies` contributes merged rule 0, so the
+ * `packageRules[1]` the validator names is merged rule 2.
+ */
+const BAD_SECOND_RULE = JSON.stringify({
+  extends: [":disablePeerDependencies"],
+  packageRules: [
+    { matchPackageNames: ["react"], groupName: "react" },
+    { matchPackageNames: ["*", "lodash"], groupName: "everything" },
+  ],
+});
 /** One rule of each kind against `react`: a preset rule that fails on an unset
  *  depType, a matching one, one that fails on an unset sourceUrl, and a genuine
  *  mismatch — the CLI's `mixed-rules.json` fixture, inline. */
@@ -405,6 +423,69 @@ describe("drill-down", () => {
     expect(labels.note).toBeUndefined();
   });
 
+  /**
+   * Roadmap 071: the two narrowings the ranges point at. The ranges answer
+   * "which layer", `rule` answers "what does rule N say" without shipping 714
+   * bodies, and `source` answers "just mine".
+   */
+  test("`rule` returns one merged rule's body, its layer and its index there", async () => {
+    const runId = await runConfig(RECOMMENDED_PLUS_RULE);
+    const mid = (await call("get_provenance", { runId, key: "packageRules", rule: 300 })) as {
+      index: number;
+      layer: string;
+      sourceIndex: number;
+      citation: string;
+      rule: Record<string, unknown>;
+    };
+    expect(mid.index).toBe(300);
+    expect(mid.layer).toContain("preset config:recommended");
+    expect(mid.sourceIndex).toBe(300);
+    expect(mid.rule).toBeTypeOf("object");
+
+    // The caller's own rule, cited in the index scheme they wrote it in.
+    const total = (
+      (await call("get_provenance", { runId, key: "packageRules" })) as { total: number }
+    ).total;
+    const own = (await call("get_provenance", {
+      runId,
+      key: "packageRules",
+      rule: total - 1,
+    })) as { layer: string; sourceIndex: number; citation: string; rule: unknown };
+    expect(own).toMatchObject({ layer: "repo", sourceIndex: 0 });
+    expect(own.citation).toContain("packageRules[0]");
+    expect(own.rule).toEqual({ matchPackageNames: ["react"], groupName: "react" });
+  });
+
+  test("`rule` on a key that is not the rule array names the parameter", async () => {
+    const runId = await runConfig(GROUPED);
+    await expect(call("get_provenance", { runId, key: "labels", rule: 0 })).rejects.toThrow(
+      /`rule`/,
+    );
+    await expect(call("get_provenance", { runId, key: "labels", source: "repo" })).rejects.toThrow(
+      /`source`/,
+    );
+  });
+
+  test("`source` scopes the ranges to one class of layer, indexes unchanged", async () => {
+    const runId = await runConfig(RECOMMENDED_PLUS_RULE);
+    const scoped = (await call("get_provenance", {
+      runId,
+      key: "packageRules",
+      source: "repo",
+    })) as {
+      total: number;
+      source: string;
+      contributions: { layer: string; from: number; rules?: string[] }[];
+    };
+    expect(scoped.source).toBe("repo");
+    expect(scoped.contributions).toHaveLength(1);
+    expect(scoped.contributions[0]?.layer).toBe("repo");
+    // The merged index is still the merged index — scoping the view never
+    // renumbers the array.
+    expect(scoped.contributions[0]?.from).toBe(scoped.total - 1);
+    expect(scoped.contributions[0]?.rules?.[0]).toContain(`${scoped.total - 1} matchPackageNames`);
+  });
+
   test("the resolved document keeps internal presets by default", async () => {
     const runId = await runConfig(CONFIG);
     const output = (await call("get_resolved_config", { runId })) as {
@@ -516,14 +597,80 @@ describe("size budget", () => {
     expect(JSON.stringify(tree?.inputSchema)).toContain("max 6");
   });
 
-  test("an answer over the budget is elided structurally, and says how to narrow", async () => {
-    const runId = await runConfig(RECOMMENDED);
+  /**
+   * Roadmap 071. This assertion used to be `truncated: true` plus the hint —
+   * which passed on an answer holding 2 of 714 rules, because a chain over a
+   * CONCATENATED key restates the whole merged array once per layer (733 kB)
+   * and the elider could only collapse it to first-and-last.
+   *
+   * The projection now measures itself and degrades semantically instead, so
+   * what is worth pinning is that the answer is COMPLETE: contiguous ranges
+   * covering every merged index, and a mid-array rule that is findable by
+   * reading rather than by counting.
+   */
+  test("provenance answers the packageRules question, whole", async () => {
+    const runId = await runConfig(RECOMMENDED_PLUS_RULE);
     const text = await callText("get_provenance", { runId, key: "packageRules" });
     expect(text.length).toBeLessThanOrEqual(RESULT_BUDGET_BYTES);
-    // Never cut mid-JSON.
-    const payload = JSON.parse(text) as { truncated?: boolean; hint?: string };
-    expect(payload.truncated).toBe(true);
-    expect(payload.hint).toContain("get_preset_node");
+    const payload = JSON.parse(text) as {
+      truncated?: boolean;
+      total: number;
+      mergeSemantics: string;
+      note: string;
+      contributions: { layer: string; from: number; to: number; count: number; rules?: string[] }[];
+    };
+    // Not elided at all: the answer fits because of its shape, not its luck.
+    expect(payload.truncated).toBeUndefined();
+    expect(payload.mergeSemantics).toBe("concat");
+    expect(payload.total).toBeGreaterThan(700);
+
+    // Contiguous, from 0, and every merged rule accounted for.
+    let next = 0;
+    for (const contribution of payload.contributions) {
+      expect(contribution.from).toBe(next);
+      expect(contribution.count).toBe(contribution.to - contribution.from + 1);
+      next = contribution.to + 1;
+    }
+    expect(next).toBe(payload.total);
+    expect(payload.contributions.reduce((sum, c) => sum + c.count, 0)).toBe(payload.total);
+
+    // The rule the caller WROTE is the last one, and it is named as theirs.
+    const last = payload.contributions.at(-1);
+    expect(last?.layer).toBe("repo");
+    expect(last?.from).toBe(payload.total - 1);
+
+    // A mid-array rule is findable by its merged index — no positional
+    // counting, which is what the old `{index, layer}` list demanded.
+    const lines = payload.contributions.flatMap((c) => c.rules ?? []);
+    expect(lines.some((line) => line.startsWith("300 "))).toBe(true);
+    expect(lines).toHaveLength(payload.total);
+
+    // The bodies are omitted, and the note names both ways back to them.
+    expect(text).not.toContain("semanticCommitType:");
+    expect(payload.note).toContain("rule:");
+    expect(payload.note).toContain("get_final_config");
+  });
+
+  /**
+   * The other half of roadmap 071's guard. A key whose FINAL VALUE alone blows
+   * the budget is not a `packageRules` case — there is no attribution to
+   * compress — but losing the CHAIN to `dropLargestKeys` would drop this
+   * tool's actual answer. So the value is previewed and named, and the chain
+   * survives.
+   */
+  test("a key with an enormous value keeps its chain and previews the value", async () => {
+    const runId = await runConfig(
+      JSON.stringify({ labels: Array.from({ length: 8_000 }, (_, i) => `label-${i}`) }),
+    );
+    const payload = (await call("get_provenance", { runId, key: "labels" })) as {
+      finalValue: string;
+      finalValueNote?: string;
+      chain?: unknown[];
+    };
+    expect(typeof payload.finalValue).toBe("string");
+    expect(payload.finalValue).toContain("chars)");
+    expect(payload.finalValueNote).toContain("get_final_config");
+    expect(payload.chain).toBeDefined();
   });
 
   test("the elision marks what it dropped, in place", async () => {
@@ -899,6 +1046,109 @@ describe("simulate and compare", () => {
     expect(comparison.missingInputsNote).toContain("A — 2 of 4 rules could not match");
     expect(comparison.missingInputsNote).toContain("B — 2 of 4 rules could not match");
     expect(comparison.missingInputsNote).toContain('`verdict: "no-input"` lists them.');
+  });
+});
+
+/**
+ * Roadmap 071. Every tool that quotes a rule INDEX has to say which array the
+ * index is in: `simulate` and `get_provenance` cite the merged array,
+ * Renovate's validator cites the config as written, and for a config with a
+ * preset ahead of its own rules those are different numbers for the same rule.
+ * Two personas reported the wrong rule because nothing said so.
+ */
+describe("rule indexes are cross-linked", () => {
+  interface SimRules {
+    ruleSources: { layer: string; kind: string; from: number; to: number; count: number }[];
+    ruleSourcesNote: string;
+    rules: { index: number; verdict: string; origin?: { layer: string; sourceIndex: number } }[];
+  }
+
+  test("simulate carries the legend, and the layer inline on matched rows only", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const sim = (await call("simulate", {
+      runId,
+      dep: { depName: "react", packageName: "react" },
+    })) as SimRules;
+    // The legend covers every rule index, contiguously.
+    expect(sim.ruleSources.map((s) => [s.layer, s.from, s.to])).toEqual([
+      ["preset :disablePeerDependencies", 0, 0],
+      ["repo", 1, 3],
+    ]);
+    expect(sim.ruleSourcesNote).toContain("index - from");
+
+    const matched = sim.rules.filter((rule) => rule.verdict === "matched");
+    expect(matched.length).toBeGreaterThan(0);
+    for (const rule of matched) {
+      expect(rule.origin).toBeDefined();
+    }
+    // Not on the other ~700: the legend covers them, and annotating every row
+    // costs 15 % of a payload the rule list already dominates.
+    for (const rule of sim.rules.filter((r) => r.verdict !== "matched")) {
+      expect(rule.origin).toBeUndefined();
+    }
+    // The one that matched is the reader's own first rule.
+    expect(matched[0]?.origin).toEqual({ layer: "repo", sourceIndex: 0 });
+  });
+
+  test("a scoped rule list keeps the origin the unscoped one had", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const sim = (await call("simulate", {
+      runId,
+      dep: { depName: "react", packageName: "react" },
+      verdict: "matched",
+    })) as SimRules;
+    expect(sim.rules[0]?.origin).toEqual({ layer: "repo", sourceIndex: 0 });
+    expect(sim.ruleSources).toHaveLength(2);
+  });
+
+  test("run_config links a validator message to the merged rule it names", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: BAD_SECOND_RULE,
+    })) as {
+      errors: {
+        message: string;
+        rule?: { repoIndex: number; mergedIndex: number; note: string };
+      }[];
+    };
+    const error = summary.errors.find((e) => e.message.includes("packageRules[1]"));
+    // The preset ahead of it contributes merged rule 0, so the reader's
+    // `packageRules[1]` is merged rule 2 — the index simulate would report.
+    expect(error?.rule).toMatchObject({ repoIndex: 1, mergedIndex: 2 });
+    expect(error?.rule?.note).toContain("merged rule `packageRules[2]`");
+  });
+
+  test("a config with no presets still links — 0 to 0 is an answer, not a guess", async () => {
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: JSON.stringify({
+        packageRules: [{ matchPackageNames: ["*", "lodash"], groupName: "everything" }],
+      }),
+    })) as { errors: { rule?: { repoIndex: number; mergedIndex: number } }[] };
+    expect(summary.errors[0]?.rule).toMatchObject({ repoIndex: 0, mergedIndex: 0 });
+  });
+
+  test("explain_message carries the same link, by position", async () => {
+    const runId = await runConfig(BAD_SECOND_RULE);
+    const explained = (await call("explain_message", { runId, errorIndex: 0 })) as {
+      rule?: { repoIndex: number; mergedIndex: number };
+    };
+    expect(explained.rule).toMatchObject({ repoIndex: 1, mergedIndex: 2 });
+  });
+
+  test("a run that cannot be attributed carries no link at all", async () => {
+    // The preset never resolves, so no layer's rule count is known — and a
+    // wrong cross-link is worse than none.
+    const summary = (await call("run_config", {
+      fileName: "renovate.json",
+      content: JSON.stringify({
+        extends: [":thisPresetDoesNotExist"],
+        packageRules: [{ matchPackageNames: ["*", "lodash"], groupName: "everything" }],
+      }),
+    })) as { errors: { message: string; rule?: unknown }[] };
+    const error = summary.errors.find((e) => e.message.includes("packageRules[0]"));
+    expect(error).toBeDefined();
+    expect(error?.rule).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -27,20 +27,28 @@ import { errorMessage, type CliIo } from "../io";
 import { buildRuleView, missingInputsNote, ruleFilterPayload } from "../rule-view";
 import { digestPayload } from "../projections/digest";
 import { CONFIG_SCOPES, projectConfig } from "../projections/config-view";
-import { describeMessage, type MessageSeverity } from "../projections/messages";
+import {
+  describeMessage,
+  type MessageSeverity,
+  type RuleCrossLink,
+  ruleCrossLink,
+  repoStageMessage,
+} from "../projections/messages";
 import {
   collapseRuleMerges,
   comparisonPayload,
   SIMULATE_DETAIL,
   simulationPayload,
+  withRuleOrigins,
 } from "../projections/simulate";
 import {
   entryView,
   indexView,
-  layerLabel,
   perDependencyNote,
+  previewValue,
   provenanceOf,
 } from "../projections/provenance";
+import { oneRuleView, RULE_DIGEST_PLANS, ruleProvenanceView } from "../projections/rule-provenance";
 import {
   BODIES,
   type BodyKind,
@@ -52,7 +60,7 @@ import {
   viewOf,
 } from "../projections/tree";
 import { resolveRunAuth } from "../run-input";
-import { textResult } from "./result";
+import { fitsBudget, textResult } from "./result";
 import { type HeldRun, RunStore } from "./run-store";
 import { installZodLocale } from "./zod-locale";
 
@@ -325,11 +333,29 @@ const CONFIG_SCOPE = z
       "one produced it, in `configView`.",
   );
 
+/**
+ * The `packageRules[N]` cross-link for one of a run's own messages, or nothing.
+ *
+ * Two guards, both roadmap 071: the message must come from the `validate`
+ * stage — the global and inherited layers validate their own documents into
+ * the same `errors`/`warnings` arrays, and their indexes address a different
+ * array — and the run must be attributable at all.
+ */
+function ruleLinkOf(run: HeldRun, message: ValidationMessage): RuleCrossLink | undefined {
+  if (!repoStageMessage(run.result, message)) {
+    return undefined;
+  }
+  return ruleCrossLink(message, "repo", computeRuleProvenance(run.result));
+}
+
 /** Each validator message with the position `explain_message` addresses it by.
  *  The array's own index is NOT that position: a large answer is elided
  *  structurally (see ./result), which drops elements out of the middle. */
-function withIndex(messages: readonly ValidationMessage[]) {
-  return messages.map((message, index) => ({ index, ...message }));
+function withIndex(run: HeldRun, messages: readonly ValidationMessage[]) {
+  return messages.map((message, index) => {
+    const rule = ruleLinkOf(run, message);
+    return { index, ...message, ...(rule ? { rule } : {}) };
+  });
 }
 
 const MESSAGES_NOTE =
@@ -347,8 +373,8 @@ function runSummary(run: HeldRun, notes: string[]) {
     accepted: payload.accepted,
     digest: payload.digest,
     stageStatus: result.stageStatus,
-    errors: withIndex(result.errors),
-    warnings: withIndex(result.warnings),
+    errors: withIndex(run, result.errors),
+    warnings: withIndex(run, result.warnings),
     ...(result.errors.length + result.warnings.length > 0 ? { messagesNote: MESSAGES_NOTE } : {}),
     presetErrors: facts.presetErrors.map((event) => event.title),
     treeSummary: stats?.summary ?? null,
@@ -646,9 +672,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "Per-key provenance: which layer (defaults / global / inherited / each preset / the repo " +
         "config) set each option, and who overrode whom. Without a key: a compact INDEX — every " +
         "option some layer beyond the defaults set, with its winning layer and a short value " +
-        "preview. With a key: the full override chain, every layer's before/after — and for " +
-        "`packageRules`, which layer contributed each merged rule. This is the tool for 'why is " +
-        "this value what it is': read the index, then ask for the one key.",
+        "preview. With a key: the full override chain, every layer's before/after. " +
+        '`key: "packageRules"` answers differently, because Renovate CONCATENATES that key: you ' +
+        "get one contiguous merged-index RANGE per contributing layer plus a one-line digest of " +
+        "each rule, never the bodies — `rule: <index>` returns one body, `source` scopes the " +
+        "ranges to `repo` or `presets`. This is the tool for 'why is this value what it is': " +
+        "read the index, then ask for the one key.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
@@ -656,9 +685,18 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           .string()
           .optional()
           .describe("A top-level config option, e.g. `labels`. Omit for the index."),
+        rule: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            'One merged rule by index: its body, its layer and its index inside that layer. `key: "packageRules"` only.',
+          ),
+        source: RULE_SOURCE,
       }),
     },
-    answer(({ runId, key }) => {
+    answer(({ runId, key, rule, source }) => {
       const { result } = store.get(runId);
       const provenance = provenanceOf(result);
       if (!key) {
@@ -671,19 +709,56 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       if (!entry) {
         throw new Error(`no key "${key}" in the effective config`);
       }
-      const rules =
-        key === "packageRules"
-          ? (computeRuleProvenance(result) ?? []).map((attr) => ({
-              index: attr.index,
-              layer: layerLabel(attr.layer),
-            }))
-          : [];
-      const perDependency = perDependencyNote(key, result.finalConfig);
-      return {
-        ...entryView(entry),
-        ...(perDependency ? { note: perDependency } : {}),
-        ...(rules.length > 0 ? { rules } : {}),
-      };
+      if (key !== "packageRules") {
+        for (const [name, value] of [
+          ["rule", rule],
+          ["source", source],
+        ] as const) {
+          if (value !== undefined) {
+            throw new Error(
+              `\`${name}\` scopes the merged packageRules; key "${key}" is not an array of rules. ` +
+                'Drop it, or ask for key: "packageRules".',
+            );
+          }
+        }
+        const perDependency = perDependencyNote(key, result.finalConfig);
+        const view = {
+          ...entryView(entry),
+          ...(perDependency ? { note: perDependency } : {}),
+        };
+        // Last resort before the generic elider gets it: an override chain
+        // whose FINAL value alone blows the budget keeps the chain — which is
+        // this tool's answer — and previews the value.
+        return fitsBudget(view)
+          ? view
+          : {
+              ...view,
+              finalValue: previewValue(entry.finalValue, 200),
+              finalValueNote:
+                "`finalValue` is a preview — the whole value did not fit this answer's budget. " +
+                `get_final_config with \`keys: ["${key}"]\` returns it in full.`,
+            };
+      }
+      const attribution = computeRuleProvenance(result);
+      const rules = Array.isArray(result.finalConfig?.packageRules)
+        ? result.finalConfig.packageRules
+        : [];
+      if (rule !== undefined) {
+        return oneRuleView(rule, attribution, rules);
+      }
+      // The richest digest that survives the budget WHOLE. Degrading here is
+      // semantic (shorter lines, complete ranges); leaving it to the generic
+      // elider is structural (2 rules of 727), which is no answer at all.
+      const scoped = source ? { source } : {};
+      const [richest, ...leaner] = RULE_DIGEST_PLANS;
+      let view = ruleProvenanceView(entry, attribution, rules, richest, scoped);
+      for (const plan of leaner) {
+        if (fitsBudget(view)) {
+          break;
+        }
+        view = ruleProvenanceView(entry, attribution, rules, plan, scoped);
+      }
+      return view;
     }, HINTS.provenance),
   );
 
@@ -729,7 +804,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "(`finalDependencyConfig`) and how they got there (`flattened`). " +
         "A `config:recommended` run has ~700 rules — `verdict` and `source` scope the list " +
         '(`source: "repo"` is "just my own config\'s rules"), and `keys` narrows ' +
-        "`finalDependencyConfig` to the options you asked about. Rules that failed ONLY because " +
+        "`finalDependencyConfig` to the options you asked about. " +
+        "`ruleSources` is the legend for the rule indexes — one merged-index range per " +
+        "contributing layer — and every MATCHED rule carries its own `origin` inline. " +
+        "Rules that failed ONLY because " +
         "your `dep` left a field they read unset are summarized in `missingInputs`, whatever " +
         "`verdict` you asked for: they report a plain `no-match`, so every scoped view hides them " +
         'and the answer reads as "nothing matched". The step-by-step merge trace is ' +
@@ -757,6 +835,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const run = store.get(runId);
       const sim = await simulateRun(run, dep, ctx);
       const resolvedDetail = detail ?? "verdict";
+      const view = buildRuleView(sim, run.result, {
+        verdict: verdict ?? "all",
+        source: source ?? "all",
+        explicit: true,
+        transport: "mcp",
+      });
       // `finalDependencyConfig` is by construction "what applyPackageRules
       // produced for ONE dependency", so the globalOnly class is provably
       // inert here and goes by default — the opposite of get_final_config's
@@ -765,21 +849,21 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         detail: resolvedDetail,
         scope: configScope ?? "package-rules",
         transport: "mcp",
+        attribution: view.attribution,
         ...(keys ? { keys } : {}),
       });
       if (verdict === undefined && source === undefined) {
         return { dep: toDependency(dep), ...payload };
       }
-      const view = buildRuleView(sim, run.result, {
-        verdict: verdict ?? "all",
-        source: source ?? "all",
-        explicit: true,
-        transport: "mcp",
-      });
       return {
         dep: toDependency(dep),
         ...payload,
-        rules: resolvedDetail === "full" ? view.rules : collapseRuleMerges(view.rules),
+        // The scoped list REPLACES the payload's, so it has to carry the same
+        // per-rule `origin` — the legend stays either way.
+        rules:
+          resolvedDetail === "full"
+            ? view.rules
+            : withRuleOrigins(collapseRuleMerges(view.rules), view.attribution),
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
         ...ruleFilterPayload(view),
       };
@@ -903,24 +987,23 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           "`topic` describes a `message`; an indexed message carries the run's own topic.",
         );
       }
+      // The cross-link needs the run the message came from — a re-typed
+      // message with no runId is exactly the case that cannot have one.
+      const linkOf = (picked: ValidationMessage) => (run ? ruleLinkOf(run, picked) : undefined);
       if (errorIndex !== undefined) {
         const picked = pickMessage(run, "errors", "errorIndex", errorIndex);
-        return describeMessage(picked, "error", config, text);
+        return describeMessage(picked, "error", config, text, linkOf(picked));
       }
       if (warningIndex !== undefined) {
         const picked = pickMessage(run, "warnings", "warningIndex", warningIndex);
-        return describeMessage(picked, "warning", config, text);
+        return describeMessage(picked, "warning", config, text, linkOf(picked));
       }
       if (message === undefined) {
         // Unreachable after the count check; keeps `message` narrowed to string.
         throw new Error("`message` is required when no index selects one.");
       }
-      return describeMessage(
-        { topic: topic ?? "Configuration Error", message },
-        severityOf(run, message, topic),
-        config,
-        text,
-      );
+      const quoted: ValidationMessage = { topic: topic ?? "Configuration Error", message };
+      return describeMessage(quoted, severityOf(run, message, topic), config, text, linkOf(quoted));
     }),
   );
 

--- a/packages/cli/src/projections/messages.ts
+++ b/packages/cli/src/projections/messages.ts
@@ -1,9 +1,16 @@
 import {
   applyFixToText,
   findMentionedOption,
+  type RuleAttribution,
+  type TraceResult,
   translateMessage,
   type ValidationMessage,
 } from "@renovate-config-debugger/engine";
+import {
+  crossRuleIndex,
+  type RuleMessageIndexKind,
+  ruleIndexInMessage,
+} from "@renovate-config-debugger/app/headless";
 
 /**
  * A validator message with everything roadmap 014 knows about it — shared by
@@ -21,6 +28,76 @@ import {
  */
 export type MessageSeverity = "error" | "warning";
 
+/**
+ * Roadmap 071: the merged index a validator message's `packageRules[N]` refers
+ * to, and the repo-config index it was written as.
+ *
+ * The two are different arrays and the personas conflated them: Renovate's
+ * validator cites the index in the config you WROTE, while `simulate` and
+ * `get_provenance` cite the index in the merged array — for a config extending
+ * `config:best-practices` those are 1 and 714 for the same rule. The app has
+ * cross-linked them since roadmap 013; this quotes the app's arithmetic
+ * (`crossRuleIndex`) rather than restating it.
+ */
+export interface RuleCrossLink {
+  repoIndex: number;
+  mergedIndex: number;
+  note: string;
+}
+
+function crossLinkNote(kind: RuleMessageIndexKind, repo: number, merged: number): string {
+  return kind === "repo"
+    ? `\`packageRules[${repo}]\` in your config is merged rule \`packageRules[${merged}]\` — ` +
+        "the index `simulate` and `get_provenance` cite."
+    : `merged rule \`packageRules[${merged}]\` is \`packageRules[${repo}]\` in your config — ` +
+        "the index Renovate's validator and your editor use.";
+}
+
+/**
+ * The other index for the `packageRules[N]` a message names, or `undefined`
+ * when there is none to give: no reference in the text, no attribution for
+ * this run, or a rule no repo-authored config wrote (a preset's rule has no
+ * repo-config index to annotate with).
+ */
+export function ruleCrossLink(
+  message: ValidationMessage,
+  kind: RuleMessageIndexKind,
+  attribution: readonly RuleAttribution[] | null | undefined,
+): RuleCrossLink | undefined {
+  const reference = ruleIndexInMessage(message.message);
+  if (!reference) {
+    return undefined;
+  }
+  const cross = crossRuleIndex(kind, reference.index, attribution);
+  if (cross === undefined) {
+    return undefined;
+  }
+  const repoIndex = kind === "repo" ? reference.index : cross;
+  const mergedIndex = kind === "repo" ? cross : reference.index;
+  return { repoIndex, mergedIndex, note: crossLinkNote(kind, repoIndex, mergedIndex) };
+}
+
+/**
+ * Whether this message came from validating the REPO's own config — the only
+ * stage whose `packageRules[N]` is the index in the file the user wrote.
+ *
+ * `result.errors`/`warnings` mix stages: the global and inherited layers
+ * validate their own documents into the same two arrays, and their indexes are
+ * a different array's. So the events decide, and only unanimously: a message
+ * whose exact text also appears in a `global`/`inherit` event is left
+ * unannotated rather than annotated with a plausible index.
+ */
+export function repoStageMessage(result: TraceResult, message: ValidationMessage): boolean {
+  const emitted = result.events.filter(
+    (event) =>
+      event.kind === "validation-message" &&
+      (event.messages ?? []).some(
+        (m) => m.message === message.message && m.topic === message.topic,
+      ),
+  );
+  return emitted.length > 0 && emitted.every((event) => event.stage === "validate");
+}
+
 export interface ReportedMessage {
   /** The list the RUN put this message in — `null` when nothing decided that:
    *  no run was given, or the run holds no message with this exact text. */
@@ -37,6 +114,9 @@ export interface ReportedMessage {
   note?: string;
   /** Present exactly when `severity` is null — why it could not be decided. */
   severityNote?: string;
+  /** The merged index of the `packageRules[N]` this message names, when the run
+   *  can attribute it. Absent means "not determinable", never "index 0". */
+  rule?: RuleCrossLink;
   fix?: {
     summary: string;
     path: (string | number)[];
@@ -79,13 +159,15 @@ const NO_SAFE_FIX_NOTE =
  * (`validatedConfigOf`) so a fix's path resolves against the same document;
  * `text` is the original file, for the formatting-preserving text fix. Pass
  * `null`/`undefined` for either when they are not available — the translation
- * and the docs link still work.
+ * and the docs link still work. `rule` is the cross-link {@link ruleCrossLink}
+ * computed for this message, when the caller holds the run it came from.
  */
 export function describeMessage(
   message: ValidationMessage,
   severity: MessageSeverity | null,
   config: Record<string, unknown> | null,
   text: string | null,
+  rule?: RuleCrossLink,
 ): ReportedMessage {
   const translated = translateMessage(message, config);
   const mentioned = translated ? undefined : findMentionedOption(message);
@@ -95,6 +177,7 @@ export function describeMessage(
     ...(severity === null ? { severityNote: UNKNOWN_SEVERITY_NOTE } : {}),
     topic: message.topic,
     message: message.message,
+    ...(rule ? { rule } : {}),
     translationKnown: translated !== null,
     ...(translated ? { explanation: translated.explanation } : {}),
     ...(translated?.docsUrl

--- a/packages/cli/src/projections/provenance.test.ts
+++ b/packages/cli/src/projections/provenance.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import type { KeyProvenance } from "@renovate-config-debugger/engine";
+import { chainStepText, entryView } from "./provenance";
+
+/**
+ * Roadmap 071: what a step of the override chain reports for a key Renovate
+ * CONCATENATES. Every such step's `before`/`after` is a cumulative snapshot of
+ * the whole array, so the chain restated it once per layer — the contribution
+ * is the slice, and the totals say where it sits.
+ */
+
+function entry(chain: KeyProvenance["chain"], finalValue: unknown): KeyProvenance {
+  return { key: "labels", finalValue, isDefaultOnly: false, chain };
+}
+
+describe("entryView", () => {
+  test("an appending layer reports what it appended, not the whole array", () => {
+    const view = entryView(
+      entry(
+        [
+          { layer: { kind: "global" }, action: "set", before: undefined, after: ["a"] },
+          { layer: { kind: "repo" }, action: "concat", before: ["a"], after: ["a", "b", "c"] },
+        ],
+        ["a", "b", "c"],
+      ),
+    );
+    expect(view.chain[1]).toEqual({
+      layer: "repo",
+      action: "concat",
+      addedCount: 2,
+      added: ["b", "c"],
+      totalCount: 3,
+    });
+    // The establishing step is not an append and keeps both sides.
+    expect(view.chain[0]).toMatchObject({ action: "set", after: ["a"] });
+  });
+
+  test("a concat that did NOT append keeps the snapshots — honest over clever", () => {
+    // Renovate's nested-`extends` pass can rewrite `after` wholesale, and a
+    // "slice" of an array that is not a prefix would be an invented one.
+    const view = entryView(
+      entry(
+        [
+          {
+            layer: { kind: "repo" },
+            action: "concat",
+            before: ["a"],
+            after: ["x", "y"],
+            expandedNested: true,
+          },
+        ],
+        ["x", "y"],
+      ),
+    );
+    expect(view.chain[0]).toEqual({
+      layer: "repo",
+      action: "concat",
+      before: ["a"],
+      after: ["x", "y"],
+      expandedNested: true,
+    });
+  });
+
+  test("noop steps stay out of the chain", () => {
+    const view = entryView(
+      entry(
+        [
+          { layer: { kind: "defaults" }, action: "set", before: undefined, after: [], noop: true },
+          { layer: { kind: "repo" }, action: "concat", before: [], after: ["a"] },
+        ],
+        ["a"],
+      ),
+    );
+    expect(view.chain).toHaveLength(1);
+  });
+});
+
+describe("chainStepText", () => {
+  test("an append reads as an append, a replacement as the value", () => {
+    const view = entryView(
+      entry(
+        [
+          { layer: { kind: "global" }, action: "set", before: undefined, after: ["a"] },
+          { layer: { kind: "repo" }, action: "concat", before: ["a"], after: ["a", "b"] },
+        ],
+        ["a", "b"],
+      ),
+    );
+    expect(view.chain.map((step) => chainStepText(step))).toEqual(['["a"]', '+1 → 2 total ["b"]']);
+  });
+});

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -21,19 +21,69 @@ export function layerLabel(layer: ProvenanceLayer): string {
   return layer.kind === "preset" ? `preset ${layer.name}` : layer.kind;
 }
 
+interface ChainStepBase {
+  layer: string;
+  action: string;
+  expandedNested?: true;
+}
+
+/** A layer that replaced, merged into, or established the value: both sides. */
+export interface SnapshotStep extends ChainStepBase {
+  before: unknown;
+  after: unknown;
+}
+
+/**
+ * A layer that APPENDED to an array: what it added, not another copy of the
+ * whole array.
+ *
+ * Roadmap 071. For a concatenating key every step's `before`/`after` is a
+ * cumulative snapshot, so a chain over `packageRules` restated the merged array
+ * once per layer — 733 kB on a `config:best-practices` run, of which the
+ * transport's elider kept the first rule and the last. The slice is the
+ * contribution; the totals say where it sits.
+ */
+export interface ConcatStep extends ChainStepBase {
+  addedCount: number;
+  added: unknown[];
+  /** Length of the array after this step — the slice starts at
+   *  `totalCount - addedCount`. */
+  totalCount: number;
+}
+
+export type ProvenanceChainStep = SnapshotStep | ConcatStep;
+
 export interface ProvenanceView {
   key: string;
   finalValue: unknown;
   isDefaultOnly: boolean;
   winner: string | null;
   badge: string | null;
-  chain: {
-    layer: string;
-    action: string;
-    before: unknown;
-    after: unknown;
-    expandedNested?: true;
-  }[];
+  chain: ProvenanceChainStep[];
+}
+
+/** Whether `after` is `before` with elements appended — the property a concat
+ *  step normally has, and the one an `expandedNested` rewrite can break. */
+function appendsTo(before: unknown, after: unknown): before is unknown[] {
+  if (!Array.isArray(before) || !Array.isArray(after) || after.length < before.length) {
+    return false;
+  }
+  return JSON.stringify(after.slice(0, before.length)) === JSON.stringify(before);
+}
+
+function stepView(step: KeyProvenance["chain"][number]): ProvenanceChainStep {
+  const base: ChainStepBase = {
+    layer: layerLabel(step.layer),
+    action: step.action,
+    ...(step.expandedNested ? { expandedNested: true as const } : {}),
+  };
+  if (step.action === "concat" && appendsTo(step.before, step.after) && Array.isArray(step.after)) {
+    const added = step.after.slice(step.before.length);
+    return { ...base, addedCount: added.length, added, totalCount: step.after.length };
+  }
+  // The prefix property failed (a nested-`extends` pass can rewrite `after`
+  // wholesale) — the snapshots are then the only honest report.
+  return { ...base, before: step.before, after: step.after };
 }
 
 export function entryView(entry: KeyProvenance): ProvenanceView {
@@ -44,16 +94,16 @@ export function entryView(entry: KeyProvenance): ProvenanceView {
     isDefaultOnly: entry.isDefaultOnly,
     winner: winner ? layerLabel(winner.layer) : null,
     badge: isOverridden(entry) ? multiContribBadgeKind(entry) : null,
-    chain: entry.chain
-      .filter((step) => !step.noop)
-      .map((step) => ({
-        layer: layerLabel(step.layer),
-        action: step.action,
-        before: step.before,
-        after: step.after,
-        ...(step.expandedNested ? { expandedNested: true as const } : {}),
-      })),
+    chain: entry.chain.filter((step) => !step.noop).map(stepView),
   };
+}
+
+/** One chain step, as pretty output prints it — an appending layer states what
+ *  it appended, everything else the value it left behind. */
+export function chainStepText(step: ProvenanceChainStep, max = 80): string {
+  return "added" in step
+    ? `+${step.addedCount} → ${step.totalCount} total ${previewValue(step.added, max)}`
+    : previewValue(step.after, max);
 }
 
 export interface ProvenanceIndexEntry {

--- a/packages/cli/src/projections/rule-provenance.test.ts
+++ b/packages/cli/src/projections/rule-provenance.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "vitest";
+import type { KeyProvenance, RuleAttribution } from "@renovate-config-debugger/engine";
+import {
+  oneRuleView,
+  RULE_DIGEST_PLANS,
+  ruleOrigin,
+  ruleProvenanceView,
+  ruleSourceRanges,
+} from "./rule-provenance";
+
+/**
+ * Roadmap 071. No engine run here on purpose: what this module owns is the
+ * compression of a complete per-rule attribution into ranges, and the digest
+ * lines that degrade under a byte budget while the ranges never do. The
+ * attribution itself is the engine's, covered by its own suites.
+ */
+
+const PRESET_A = { kind: "preset", nodeId: "n1", name: "config:recommended" } as const;
+const PRESET_B = { kind: "preset", nodeId: "n2", name: "config:recommended" } as const;
+
+function attr(
+  index: number,
+  layer: RuleAttribution["layer"],
+  sourceIndex: number,
+): RuleAttribution {
+  return { index, layer, sourceIndex };
+}
+
+/** One preset, the SAME preset a second time, then two repo-authored rules. */
+const ATTRIBUTION: RuleAttribution[] = [
+  attr(0, PRESET_A, 0),
+  attr(1, PRESET_A, 1),
+  attr(2, PRESET_B, 0),
+  attr(3, { kind: "repo" }, 0),
+  attr(4, { kind: "repo" }, 1),
+];
+
+const RULES: unknown[] = [
+  { matchPackageNames: ["react"], groupName: "react" },
+  { matchDepTypes: ["devDependencies"], matchUpdateTypes: ["major"], automerge: true },
+  { matchManagers: ["npm"], description: "prose", labels: ["npm"] },
+  { matchSourceUrls: ["https://github.com/facebook/react"], minimumReleaseAge: "7 days" },
+  { description: "no selectors at all" },
+];
+
+const ENTRY: KeyProvenance = {
+  key: "packageRules",
+  finalValue: RULES,
+  isDefaultOnly: false,
+  chain: [
+    { layer: PRESET_A, action: "set", before: undefined, after: RULES.slice(0, 2) },
+    { layer: PRESET_B, action: "concat", before: RULES.slice(0, 2), after: RULES.slice(0, 3) },
+    { layer: { kind: "repo" }, action: "concat", before: RULES.slice(0, 3), after: RULES },
+  ],
+};
+
+const [RICHEST, SHAPED, COUNTED] = RULE_DIGEST_PLANS;
+
+describe("ruleSourceRanges", () => {
+  test("one contiguous range per contributing layer", () => {
+    expect(ruleSourceRanges(ATTRIBUTION)).toEqual([
+      {
+        layer: "preset config:recommended",
+        kind: "preset",
+        node: "config:recommended",
+        from: 0,
+        to: 1,
+        count: 2,
+      },
+      {
+        layer: "preset config:recommended",
+        kind: "preset",
+        node: "config:recommended",
+        from: 2,
+        to: 2,
+        count: 1,
+      },
+      { layer: "repo", kind: "repo", from: 3, to: 4, count: 2 },
+    ]);
+  });
+
+  test("the same preset extended twice stays two ranges", () => {
+    // Keyed on the NODE, not the name: merging them would invent a contiguity
+    // the merge does not have, and `index - from` would then be wrong for the
+    // second block.
+    const ranges = ruleSourceRanges(ATTRIBUTION).filter((r) => r.kind === "preset");
+    expect(ranges).toHaveLength(2);
+  });
+
+  test("no attribution is no ranges, not an empty guess", () => {
+    expect(ruleSourceRanges(undefined)).toEqual([]);
+  });
+});
+
+describe("ruleOrigin", () => {
+  test("a merged index maps to its layer and its index inside that layer", () => {
+    expect(ruleOrigin(4, ATTRIBUTION)).toEqual({ layer: "repo", sourceIndex: 1 });
+    expect(ruleOrigin(2, ATTRIBUTION)).toEqual({
+      layer: "preset config:recommended",
+      sourceIndex: 0,
+    });
+  });
+
+  test("an unattributable run links nothing", () => {
+    expect(ruleOrigin(0, undefined)).toBeUndefined();
+    expect(ruleOrigin(99, ATTRIBUTION)).toBeUndefined();
+  });
+});
+
+describe("ruleProvenanceView", () => {
+  test("the ranges cover every merged rule, and say the key concatenates", () => {
+    const view = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, RICHEST);
+    expect(view.mergeSemantics).toBe("concat");
+    expect(view.total).toBe(5);
+    expect(view.badge).toBe("appended");
+    const counted = (view.contributions ?? []).reduce((sum, c) => sum + c.count, 0);
+    expect(counted).toBe(view.total);
+    expect(view.note).toContain("rule:");
+    expect(view.note).toContain("get_final_config");
+    expect(view.attributionNote).toBeUndefined();
+  });
+
+  test("`values` prefixes each line with the MERGED index and previews the first selector", () => {
+    const view = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, RICHEST);
+    const repo = view.contributions?.find((c) => c.kind === "repo");
+    expect(repo?.rules?.[0]).toBe(
+      '3 matchSourceUrls: ["https://github.com/facebook/react"] → minimumReleaseAge',
+    );
+    // A rule with no selectors says so rather than reading as an empty one.
+    expect(repo?.rules?.[1]).toBe("4 (no match*/exclude* selectors) → (sets nothing)");
+    const preset = view.contributions?.[0];
+    expect(preset?.rules?.[1]).toContain("+1 → automerge");
+  });
+
+  test("`shape` drops the values but keeps every line, `counts` drops the lines", () => {
+    const shaped = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, SHAPED);
+    expect(shaped.contributions?.[0]?.rules?.[1]).toBe(
+      "1 matchDepTypes + matchUpdateTypes → automerge",
+    );
+    // The authored layers keep their values at every level — they are a
+    // handful of rules at any scale, and they are the ones the reader wrote.
+    expect(shaped.contributions?.at(-1)?.rules?.[0]).toContain('matchSourceUrls: ["https');
+    expect(shaped.detailNote).toContain("size budget");
+
+    const counted = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, COUNTED);
+    expect(counted.contributions?.[0]?.rules).toBeUndefined();
+    expect(counted.contributions?.[0]?.count).toBe(2);
+    expect(counted.contributions?.at(-1)?.rules).toHaveLength(2);
+  });
+
+  test("`source` scopes the ranges without moving the indexes", () => {
+    const view = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, RICHEST, { source: "repo" });
+    expect(view.source).toBe("repo");
+    expect(view.contributions).toHaveLength(1);
+    expect(view.contributions?.[0]).toMatchObject({ layer: "repo", from: 3, to: 4 });
+    // `total` still counts every merged rule: a scoped view is a smaller
+    // answer to the same question, not a different array.
+    expect(view.total).toBe(5);
+  });
+
+  test("an unattributable run reports nothing rather than a wrong link", () => {
+    const view = ruleProvenanceView(ENTRY, undefined, RULES, RICHEST);
+    expect(view.contributions).toBeUndefined();
+    expect(view.attributionNote).toContain("could not be attributed");
+    expect(view.total).toBe(5);
+  });
+});
+
+describe("oneRuleView", () => {
+  test("one rule's body, with the citation in both index schemes", () => {
+    const one = oneRuleView(3, ATTRIBUTION, RULES);
+    expect(one).toMatchObject({ index: 3, layer: "repo", sourceIndex: 0 });
+    expect(one.citation).toContain("merged packageRules[3]");
+    expect(one.citation).toContain("packageRules[0]");
+    expect(one.rule).toBe(RULES[3]);
+  });
+
+  test("a preset rule cites the preset it came from", () => {
+    expect(oneRuleView(2, ATTRIBUTION, RULES).citation).toContain("preset config:recommended");
+  });
+
+  test("an index past the end is an error naming the count", () => {
+    expect(() => oneRuleView(9, ATTRIBUTION, RULES)).toThrow(/5 merged packageRules/);
+  });
+
+  test("without attribution the body is still returned, the layer is not guessed", () => {
+    const one = oneRuleView(3, undefined, RULES);
+    expect(one.layer).toBeNull();
+    expect(one.sourceIndex).toBeNull();
+    expect(one.rule).toBe(RULES[3]);
+  });
+});

--- a/packages/cli/src/projections/rule-provenance.ts
+++ b/packages/cli/src/projections/rule-provenance.ts
@@ -1,0 +1,315 @@
+import type {
+  KeyProvenance,
+  ProvenanceLayer,
+  RuleAttribution,
+} from "@renovate-config-debugger/engine";
+import {
+  isOverridden,
+  multiContribBadgeKind,
+  ruleWrittenKeys,
+  type SourceFilter,
+  summarizeRuleSelectors,
+} from "@renovate-config-debugger/app/headless";
+import { CliError } from "../io";
+import { layerLabel, previewValue } from "./provenance";
+
+/**
+ * Roadmap 071: `packageRules` provenance as per-layer RANGES, shared by
+ * `rcd provenance <file> packageRules` and the MCP server's `get_provenance`.
+ *
+ * Why this key gets its own projection: it is the one key Renovate CONCATENATES
+ * rather than overrides, so the generic chain view (`entryView`) states each
+ * layer's cumulative snapshot of the whole merged array — 733 kB of answer on a
+ * `config:best-practices` run, of which the transport's elider then kept the
+ * first rule and the last. An answer worth nothing, from a tool whose whole
+ * job is "which layer contributed this".
+ *
+ * The shape here is built on the property `computeRuleProvenance` guarantees:
+ * every layer's own rules land as one CONTIGUOUS block of the merged array, in
+ * merge order. So the attribution — complete, for every one of the ~727 rules —
+ * compresses to a handful of ranges under a kilobyte, and only the
+ * human-readable digest lines have to degrade under the byte budget. Attribution
+ * is never approximated: when the engine reports none, this says so instead of
+ * guessing.
+ */
+
+export interface RuleSourceRange {
+  /** `layerLabel` of the contributing layer, e.g. `repo`, `preset config:recommended`. */
+  layer: string;
+  kind: ProvenanceLayer["kind"];
+  /** The preset's name, for a get_preset_node drill-down. Presets only. */
+  node?: string;
+  /** First merged index this layer contributed (inclusive). */
+  from: number;
+  /** Last merged index this layer contributed (inclusive). */
+  to: number;
+  count: number;
+}
+
+/** How much of each rule the digest lines carry. Only this degrades under the
+ *  byte budget — the ranges above are always complete. */
+export type RuleDigestDetail = "values" | "shape" | "counts";
+
+/** Which detail each CLASS of layer gets. The authored layers (repo, global,
+ *  inherited) are a handful of rules at any scale, so they keep their values
+ *  while a 726-rule preset contribution degrades. */
+export interface RuleDigestPlan {
+  authored: RuleDigestDetail;
+  presets: RuleDigestDetail;
+}
+
+/**
+ * The plans a budget-limited caller walks, richest first (measured on
+ * `config:best-practices` + one own rule, 727 merged rules: 61 kB, 47 kB,
+ * <2 kB). The sentence a reader needs — "your `packageRules[0]` is merged rule
+ * 726, matching `matchSourceUrls: […]`" — survives all three.
+ */
+export const RULE_DIGEST_PLANS = [
+  { authored: "values", presets: "values" },
+  { authored: "values", presets: "shape" },
+  { authored: "values", presets: "counts" },
+] as const satisfies readonly RuleDigestPlan[];
+
+export interface RuleContribution extends RuleSourceRange {
+  /** One line per rule, `<merged index> <selectors> → <writes>`. Absent at
+   *  `counts` detail. */
+  rules?: string[];
+}
+
+export interface RuleProvenanceView {
+  key: "packageRules";
+  /** Renovate appends here; no layer overrides another. */
+  mergeSemantics: "concat";
+  /** Rules in the merged array — the count every index below is against. */
+  total: number;
+  winner: string | null;
+  badge: string | null;
+  isDefaultOnly: boolean;
+  /** Absent exactly when `attributionNote` is present. */
+  contributions?: RuleContribution[];
+  /** Renovate's nested-`extends` pass rewrote the array on some layer. */
+  expandedNested?: true;
+  /** Present when `source` scoped the contributions below. */
+  source?: SourceFilter;
+  note: string;
+  /** Present when the digest lines were reduced to fit the answer's budget. */
+  detailNote?: string;
+  /** Present exactly when attribution is unavailable. */
+  attributionNote?: string;
+}
+
+export interface RuleOrigin {
+  layer: string;
+  /** This rule's index inside its OWN layer's `packageRules` — for the repo
+   *  layer, the `packageRules[N]` in the config as written. */
+  sourceIndex: number;
+}
+
+export interface OneRuleView {
+  index: number;
+  layer: string | null;
+  sourceIndex: number | null;
+  /** The sentence that places this rule in both index schemes. */
+  citation: string;
+  rule: unknown;
+}
+
+const ATTRIBUTION_NOTE =
+  "this run's merged rules could not be attributed to layers (a `packageRules[n].extends` " +
+  "reshaped the array); nothing is reported rather than a wrong link.";
+
+const NOTE =
+  "`packageRules` CONCATENATES: every layer appends its own rules in merge order and no layer " +
+  "overrides another, so a rule's merged index is its position in one array built end to end — " +
+  "the index `simulate` and Renovate's own validator messages cite. A rule's index inside its " +
+  "own layer is `index - from`; for the `repo` contribution that is the `packageRules[N]` you " +
+  "wrote. Rule BODIES are not included here: ask for one with `rule: <index>` (`--rule <n>` on " +
+  'the CLI), or for all of them with get_final_config `keys: ["packageRules"]`.';
+
+const DEGRADED_NOTE =
+  "the per-rule digest lines were reduced to fit this answer's size budget — the ranges above " +
+  'are complete regardless. Narrow with `source: "repo"` for the rules you wrote, or ask for ' +
+  "one rule's body with `rule: <index>`.";
+
+/** Layer identity, not layer KIND: the same preset extended twice contributes
+ *  two separate blocks, and reporting them as one range would invent a
+ *  contiguity the merge does not have. */
+function layerKey(layer: ProvenanceLayer): string {
+  return layer.kind === "preset" ? `preset:${layer.nodeId}` : layer.kind;
+}
+
+function rangeOf(attr: RuleAttribution): RuleSourceRange {
+  return {
+    layer: layerLabel(attr.layer),
+    kind: attr.layer.kind,
+    ...(attr.layer.kind === "preset" ? { node: attr.layer.name } : {}),
+    from: attr.index,
+    to: attr.index,
+    count: 1,
+  };
+}
+
+/**
+ * The attribution, compressed to one range per contributing layer.
+ *
+ * `computeRuleProvenance` emits the merged indexes in order, one contiguous
+ * block per layer, so a new range starts exactly where the layer identity
+ * changes — the ranges are exact, not inferred.
+ */
+export function ruleSourceRanges(
+  attribution: readonly RuleAttribution[] | null | undefined,
+): RuleSourceRange[] {
+  const ranges: RuleSourceRange[] = [];
+  let currentKey: string | null = null;
+  for (const attr of attribution ?? []) {
+    const key = layerKey(attr.layer);
+    const current = ranges.at(-1);
+    if (current && key === currentKey && attr.index === current.to + 1) {
+      current.to = attr.index;
+      current.count += 1;
+      continue;
+    }
+    ranges.push(rangeOf(attr));
+    currentKey = key;
+  }
+  return ranges;
+}
+
+/** Which layer contributed one merged rule, and its index inside that layer. */
+export function ruleOrigin(
+  index: number,
+  attribution: readonly RuleAttribution[] | null | undefined,
+): RuleOrigin | undefined {
+  const found = attribution?.find((attr) => attr.index === index);
+  return found ? { layer: layerLabel(found.layer), sourceIndex: found.sourceIndex } : undefined;
+}
+
+/** The selector keys of a rule, read off the app's own one-line summary so
+ *  there is exactly one answer to "what does this rule select on". */
+function selectorKeys(rule: unknown): string[] {
+  const summary = summarizeRuleSelectors(rule);
+  // The two fallbacks are parenthesized prose; a selector key never is.
+  return summary.startsWith("(") ? [] : summary.split(" + ");
+}
+
+function digestLine(index: number, rule: unknown, detail: RuleDigestDetail): string {
+  const writes = ruleWrittenKeys(rule);
+  const written = writes.length > 0 ? writes.join(", ") : "(sets nothing)";
+  const selectors = selectorKeys(rule);
+  const first = selectors[0];
+  if (detail === "shape" || first === undefined) {
+    return `${index} ${summarizeRuleSelectors(rule)} → ${written}`;
+  }
+  const value = previewValue((rule as Record<string, unknown>)[first], 48);
+  const more = selectors.length - 1;
+  return `${index} ${first}: ${value}${more > 0 ? ` +${more}` : ""} → ${written}`;
+}
+
+/** Global, inherited and the repo's own config — the layers a person WROTE,
+ *  and a handful of rules at any scale. */
+function isAuthored(kind: ProvenanceLayer["kind"]): boolean {
+  return kind === "repo" || kind === "global" || kind === "inherited";
+}
+
+function detailFor(kind: ProvenanceLayer["kind"], plan: RuleDigestPlan): RuleDigestDetail {
+  return isAuthored(kind) ? plan.authored : plan.presets;
+}
+
+function keepRange(kind: ProvenanceLayer["kind"], source: SourceFilter): boolean {
+  if (source === "all") {
+    return true;
+  }
+  return source === "repo" ? kind === "repo" : kind === "preset";
+}
+
+export interface RuleProvenanceOptions {
+  /** Report only the ranges of this class of layer. `total` still counts every
+   *  merged rule — scoping the view never moves the indexes. */
+  source?: SourceFilter;
+}
+
+/**
+ * The whole answer for `packageRules`: the layer ranges, the digest lines the
+ * requested plan affords, and the semantics two persona sessions got wrong
+ * (that a later layer had "overridden" the earlier ones).
+ */
+export function ruleProvenanceView(
+  entry: KeyProvenance,
+  attribution: readonly RuleAttribution[] | null | undefined,
+  rules: readonly unknown[],
+  plan: RuleDigestPlan,
+  options?: RuleProvenanceOptions,
+): RuleProvenanceView {
+  const winner = entry.chain.findLast((step) => !step.noop) ?? entry.chain.at(-1);
+  const source = options?.source ?? "all";
+  const base: RuleProvenanceView = {
+    key: "packageRules",
+    mergeSemantics: "concat",
+    total: rules.length,
+    winner: winner ? layerLabel(winner.layer) : null,
+    // Roadmap 016's word for it — an appended array is not an overridden one.
+    badge: isOverridden(entry) ? multiContribBadgeKind(entry) : null,
+    isDefaultOnly: entry.isDefaultOnly,
+    ...(entry.chain.some((step) => step.expandedNested) ? { expandedNested: true as const } : {}),
+    ...(source !== "all" ? { source } : {}),
+    note: NOTE,
+  };
+  if (!attribution) {
+    return { ...base, attributionNote: ATTRIBUTION_NOTE };
+  }
+  const contributions = ruleSourceRanges(attribution)
+    .filter((range) => keepRange(range.kind, source))
+    .map((range) => {
+      const detail = detailFor(range.kind, plan);
+      if (detail === "counts") {
+        return range;
+      }
+      const lines: string[] = [];
+      for (let index = range.from; index <= range.to; index += 1) {
+        lines.push(digestLine(index, rules[index], detail));
+      }
+      return { ...range, rules: lines };
+    });
+  const degraded = contributions.some(
+    (range) => detailFor(range.kind, plan) !== "values" && range.count > 0,
+  );
+  return {
+    ...base,
+    contributions,
+    ...(degraded ? { detailNote: DEGRADED_NOTE } : {}),
+  };
+}
+
+/** The `packageRules[N]` citation for one merged rule, in both index schemes. */
+function citationOf(index: number, origin: RuleOrigin | undefined): string {
+  if (!origin) {
+    return (
+      `merged packageRules[${index}] — no layer could be attributed to it, so which config ` +
+      "wrote it is not reported."
+    );
+  }
+  return origin.layer === "repo"
+    ? `merged packageRules[${index}] is the \`packageRules[${origin.sourceIndex}]\` of your own config.`
+    : `merged packageRules[${index}] is packageRules[${origin.sourceIndex}] of ${origin.layer}.`;
+}
+
+/** One merged rule, body included — the drill-down the ranges point at. */
+export function oneRuleView(
+  index: number,
+  attribution: readonly RuleAttribution[] | null | undefined,
+  rules: readonly unknown[],
+): OneRuleView {
+  if (index >= rules.length) {
+    throw new CliError(
+      `this run has ${rules.length} merged packageRules; there is no packageRules[${index}].`,
+    );
+  }
+  const origin = ruleOrigin(index, attribution);
+  return {
+    index,
+    layer: origin?.layer ?? null,
+    sourceIndex: origin?.sourceIndex ?? null,
+    citation: citationOf(index, origin),
+    rule: rules[index],
+  };
+}

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -1,9 +1,11 @@
 import type {
   ConfigKeyDelta,
   MergedKey,
+  RuleAttribution,
   RuleEvaluation,
   SimulationComparison,
   SimulationResult,
+  ValidationMessage,
 } from "@renovate-config-debugger/engine";
 import { CliError } from "../io";
 import { missingInputsNote } from "../rule-view";
@@ -16,6 +18,13 @@ import {
   projectConfig,
   projectKeySet,
 } from "./config-view";
+import { type RuleCrossLink, ruleCrossLink } from "./messages";
+import {
+  type RuleOrigin,
+  ruleOrigin,
+  type RuleSourceRange,
+  ruleSourceRanges,
+} from "./rule-provenance";
 
 /**
  * Roadmap 070: the simulate/compare payload shape, shared by `rcd simulate` /
@@ -65,6 +74,51 @@ export interface SimulateProjection {
    * point at can omit it; both transports pass it.
    */
   transport?: RunTransport;
+  /**
+   * Per-rule attribution for the run this simulation came from (roadmap 071) —
+   * `buildRuleView`'s `attribution`. Omitted, or `undefined` because the run
+   * could not be attributed, means no `ruleSources`, no `origin` and no
+   * message cross-links: a wrong layer is worse than none.
+   */
+  attribution?: readonly RuleAttribution[] | undefined;
+}
+
+export const RULE_SOURCES_NOTE =
+  "`ruleSources` is the whole rule list's legend: each entry is the CONTIGUOUS range of merged " +
+  "indexes one layer contributed. A rule's index inside its own layer is `index - from` — for " +
+  "the `repo` entry that is the `packageRules[N]` you wrote. Matched rules carry it inline as " +
+  "`origin`.";
+
+/** Matched rules, with the layer that contributed them. Only the matched ones:
+ *  annotating all ~727 rows costs 15 % of the payload to answer a question
+ *  about the handful that fired, and `ruleSources` already covers the rest. */
+export function withRuleOrigins<T extends { index: number; verdict: RuleEvaluation["verdict"] }>(
+  rules: readonly T[],
+  attribution: readonly RuleAttribution[] | undefined,
+): (T | (T & { origin: RuleOrigin }))[] {
+  if (!attribution || attribution.length === 0) {
+    return [...rules];
+  }
+  return rules.map((rule) => {
+    if (rule.verdict !== "matched") {
+      return rule;
+    }
+    const origin = ruleOrigin(rule.index, attribution);
+    return origin ? { ...rule, origin } : rule;
+  });
+}
+
+/** A message with `rule` — its merged index cross-linked to the one the reader
+ *  wrote. These come from validating the MERGED array, so the link runs the
+ *  other way round from the repo-stage messages `run_config` reports. */
+export function withRuleLinks(
+  messages: readonly ValidationMessage[],
+  attribution: readonly RuleAttribution[] | undefined,
+): (ValidationMessage | (ValidationMessage & { rule: RuleCrossLink }))[] {
+  return messages.map((message) => {
+    const rule = ruleCrossLink(message, "merged", attribution);
+    return rule ? { ...message, rule } : message;
+  });
 }
 
 /** A rule with its merge diffs collapsed. Exported because the rule list is
@@ -96,8 +150,13 @@ export function simulationPayload(sim: SimulationResult, options: SimulateProjec
   const missingNote = options.transport
     ? missingInputsNote(sim.missingInputs, options.transport)
     : undefined;
+  const sources: RuleSourceRange[] = ruleSourceRanges(options.attribution);
   return {
-    rules: collapseRuleMerges(sim.rules),
+    rules: withRuleOrigins(collapseRuleMerges(sim.rules), options.attribution),
+    // ~200 bytes for the whole attribution, and immune to the elision (the
+    // largest-array pass never picks it) — so "which layer wrote this rule"
+    // survives an answer whose rule list did not.
+    ...(sources.length > 0 ? { ruleSources: sources, ruleSourcesNote: RULE_SOURCES_NOTE } : {}),
     // Admitted on purpose, and NOT next to the rows it describes: `rules` is
     // replaced downstream by a `verdict`/`source` view and is the first array
     // the MCP elision shrinks, and the rules this counts are exactly the ones
@@ -108,8 +167,11 @@ export function simulationPayload(sim: SimulationResult, options: SimulateProjec
     flattened: { ...sim.flattened, merged: collapseDiffs(sim.flattened.merged) },
     finalDependencyConfig: projected.config,
     configView: projected.view,
-    errors: sim.errors,
-    warnings: sim.warnings,
+    // The simulator validates the MERGED array (`validateConfig("repo", {
+    // packageRules })`), so a `packageRules[N]` here is a merged index — the
+    // link says which rule of the reader's own config that is.
+    errors: withRuleLinks(sim.errors, options.attribution),
+    warnings: withRuleLinks(sim.warnings, options.attribution),
     notes: sim.notes,
     detailNote: VERDICT_DETAIL_NOTE,
   };

--- a/packages/cli/src/rule-view.test.ts
+++ b/packages/cli/src/rule-view.test.ts
@@ -42,6 +42,24 @@ const UNATTRIBUTABLE = {
   presetTree: undefined,
 } as unknown as TraceResult;
 
+/** A run whose repo layer wrote both rules — enough for the replay in
+ *  `computeRuleProvenance` to attribute them. */
+const REPO_RULES = [{ groupName: "a" }, { groupName: "b" }];
+const ATTRIBUTED = {
+  events: [],
+  errors: [],
+  warnings: [],
+  finalConfig: { packageRules: REPO_RULES },
+  presetTree: {
+    id: "root",
+    name: "renovate.json",
+    state: "resolved",
+    children: [],
+    input: { packageRules: REPO_RULES },
+    resolved: { packageRules: REPO_RULES },
+  },
+} as unknown as TraceResult;
+
 describe("buildRuleView", () => {
   test("`--source` with no provenance is dropped, and the CLI note says so in flags", () => {
     const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
@@ -66,6 +84,37 @@ describe("buildRuleView", () => {
     });
     expect(view.notes[0]).toContain('source: "presets" ignored');
     expect(view.notes[0]).not.toContain("--source");
+  });
+
+  /**
+   * Roadmap 071: the attribution is computed whatever `--source` says, because
+   * it also answers "which layer wrote this MATCHED rule" — a question the
+   * filter never asks and every caller has.
+   */
+  test("the sources legend and the per-rule origin come back unasked", () => {
+    const view = buildRuleView(sim([rule(0, "matched"), rule(1, "no-match")]), ATTRIBUTED, {
+      verdict: "all",
+      // No `--source`: the attribution is not the filter's private business.
+      source: "all",
+      explicit: false,
+      transport: "cli",
+    });
+    expect(view.sources).toEqual([{ layer: "repo", kind: "repo", from: 0, to: 1, count: 2 }]);
+    expect(view.originOf(1)).toEqual({ layer: "repo", sourceIndex: 1 });
+  });
+
+  test("an unattributable run has no sources, and links nothing", () => {
+    const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
+      verdict: "all",
+      source: "all",
+      explicit: false,
+      transport: "cli",
+    });
+    expect(view.sources).toEqual([]);
+    expect(view.originOf(0)).toBeUndefined();
+    // …and the existing behavior is untouched: nothing was filtered, so
+    // nothing is reported.
+    expect(view.notes).toEqual([]);
   });
 
   test("the verdict facet counts what it hid", () => {

--- a/packages/cli/src/rule-view.ts
+++ b/packages/cli/src/rule-view.ts
@@ -1,6 +1,7 @@
 import {
   computeRuleProvenance,
   type MissingInputSummary,
+  type RuleAttribution,
   type RuleEvaluation,
   type SimulationResult,
   type TraceResult,
@@ -16,6 +17,12 @@ import {
 } from "@renovate-config-debugger/app/headless";
 import { type OutputFormat, type ParsedArgs, stringOption } from "./args";
 import { CliError } from "./io";
+import {
+  type RuleOrigin,
+  ruleOrigin,
+  type RuleSourceRange,
+  ruleSourceRanges,
+} from "./projections/rule-provenance";
 import type { RunTransport } from "./run-input";
 
 /**
@@ -98,6 +105,18 @@ export interface RuleView {
   source: SourceFilter;
   /** Diagnostics for stderr — e.g. `--source` asked for with no provenance. */
   notes: string[];
+  /**
+   * Per-rule attribution for the run behind this simulation (roadmap 071), or
+   * undefined when it is not determinable. Carried whatever `--source` did,
+   * because it is also what tells a caller which layer a MATCHED rule came
+   * from — a question the filter does not ask.
+   */
+  attribution: readonly RuleAttribution[] | undefined;
+  /** {@link attribution} as one range per contributing layer — the legend a
+   *  payload can afford next to a 727-row rule list. */
+  sources: RuleSourceRange[];
+  /** Which layer contributed one merged rule, by its `RuleEvaluation.index`. */
+  originOf: (index: number) => RuleOrigin | undefined;
 }
 
 /**
@@ -116,8 +135,12 @@ export function buildRuleView(
   const notes: string[] = [];
   let rules = sim.rules.filter((rule) => matchesVerdictFilter(rule, selection.verdict));
   let source = selection.source;
+  // Unconditionally, not just for `--source`: the attribution is also what
+  // says which layer a matched rule came from, which every caller wants and
+  // no filter asks for.
+  const attribution = computeRuleProvenance(result);
   if (source !== "all") {
-    const layerByIndex = ruleLayerIndex(computeRuleProvenance(result));
+    const layerByIndex = ruleLayerIndex(attribution);
     if (layerByIndex.size === 0) {
       notes.push(
         `${facetText(selection.transport, "source", source)} ignored: this run has no per-rule ` +
@@ -136,6 +159,9 @@ export function buildRuleView(
     verdict: selection.verdict,
     source,
     notes,
+    attribution,
+    sources: ruleSourceRanges(attribution),
+    originOf: (index) => ruleOrigin(index, attribution),
   };
 }
 

--- a/roadmap/071-rule-index-provenance.md
+++ b/roadmap/071-rule-index-provenance.md
@@ -1,0 +1,59 @@
+# 071 — Rule indexes: ranges instead of snapshots, and one number per rule
+
+Milestone: M19 · Status: in progress
+
+## Summary
+
+Two defects, one subject: which `packageRules` entry an index refers to.
+
+**The answer was unusable.** `get_provenance{key: "packageRules"}` on a
+`config:best-practices` run was 733 kB, because a CONCATENATED key's chain
+carries each layer's cumulative snapshot of the whole merged array. The
+transport's generic elider (`mcp/result.ts`) could only collapse an array of
+727 large objects to its first and last element, so the tool answered "two of
+727 rules" while its test asserted nothing but `truncated: true`.
+
+**The index was ambiguous.** Renovate's validator cites `packageRules[1]` in
+the config as WRITTEN; `simulate` and `get_provenance` cite the merged array.
+For a config extending one preset those are 1 and 2 for the same rule — and at
+`config:best-practices` scale, 1 and 714. The engine has known the mapping
+since roadmap 013 (`computeRuleProvenance`'s `sourceIndex`, which the app's
+`RuleMessage` already cross-links); every headless surface dropped it.
+
+## What changed
+
+- `packages/cli/src/projections/rule-provenance.ts` (new) — the merged array as
+  one contiguous RANGE per contributing layer (ranges are exact: the engine
+  builds the attribution block by block, in merge order), plus a one-line digest
+  per rule carrying its merged index. Bodies are never embedded; `rule: <index>`
+  returns one. Attribution unavailable ⇒ `attributionNote` and no
+  `contributions`, never a guess.
+- `mcp/result.ts` gains `fitsBudget` (purely additive). `get_provenance` picks
+  the richest digest that survives whole — values everywhere (61 kB), then
+  shape for preset ranges (47 kB), then counts (<2 kB). The authored layers keep
+  their values at every level, so "your `packageRules[0]` is merged rule 713"
+  survives the worst case. **The degradation is semantic, not structural.**
+- `projections/provenance.ts` — a `concat` step whose `after` starts with its
+  `before` reports `{addedCount, added, totalCount}` instead of two snapshots
+  (falling back to the snapshots when the prefix property fails, as an
+  `expandedNested` rewrite can make it).
+- `simulate` (both transports) carries `ruleSources` — the same ranges, ~200
+  bytes — and an inline `origin` on MATCHED rows only; annotating all 727 rows
+  costs 15% of the payload to answer a question about the six that fired.
+- Validator messages cross-link: `run_config`, `explain_message`, `rcd validate`
+  and the simulator's own merged-array messages. Two guards, because
+  `result.errors` MIXES stages: only messages emitted in the `validate` stage
+  are annotated (checked against `result.events`, ambiguity ⇒ no annotation),
+  and only when the run is attributable at all.
+- `packages/app/src/lib/rule-cross-index.ts` (new) — the arithmetic hoisted out
+  of `RuleMessage.tsx` and exported through `headless.ts`, so the CLI quotes the
+  number the app renders instead of restating it.
+
+## Non-goals
+
+The engine is untouched — `RuleAttribution` already had everything, and the app
+renders chains straight off the engine types. The elider stays payload-agnostic:
+a module documented as the last resort must not start knowing about
+`packageRules`. `get_final_config`, `get_resolved_config`, `get_preset_node
+--body` and `simulate detail: "full"` remain legitimately elidable; they are the
+declared "large body" tools, each with a named narrowing.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -75,6 +75,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [068](068-keyboard-ux.md)                               | Keyboard UX: ⌘⏎ to run, a bare-key jump layer, one Escape ladder     | M18                  | done        |
 | [069](069-description-provenance.md)                    | Per-string `description` provenance: who said what about this config | M19                  | in progress |
 | [070](070-agent-payload-projection.md)                  | Agent payload projection: `keys`, config scope, collapsed diffs      | M19                  | in progress |
+| [071](071-rule-index-provenance.md)                     | Rule indexes: per-layer ranges, and one number per rule              | M19                  | in progress |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
`get_provenance packageRules` embedded cumulative array snapshots (733 KB measured) and got elided to first+last — mid-array rules were unfindable. Now: per-layer contiguous ranges + digest lines that degrade semantically under the byte budget, `rule:`/`source:` params, concat chain slices, `ruleSources` + per-matched-row `origin` on simulate, and validate-stage messages annotated `{repoIndex, mergedIndex}` — the error's `packageRules[1]`, the simulator's rule index and provenance now speak one language. Attribution unavailable → nothing reported, never a wrong link.

Part of the persona-replay fix stack.