### PR TITLE
feat(engine)!: name the comparison axes - behavior first, identity nested

### DIFF
--- a/packages/app/src/features/simulator/ComparisonPanel.tsx
+++ b/packages/app/src/features/simulator/ComparisonPanel.tsx
@@ -6,44 +6,8 @@ import type {
 } from "@renovate-config-debugger/engine";
 import { toDescriptor } from "./form";
 import { previewValue, writeMark } from "./rule-format";
-import type { PinnedRun } from "./use-ab-comparison";
+import { descriptorDiffKeys, type PinnedRun } from "./use-ab-comparison";
 import { WriteRow, type WriteValue } from "./WriteRow";
-
-/**
- * Roadmap 021: the fields two descriptors disagree on, sorted for a stable
- * warning message. Compared via JSON so array-valued fields (lockFiles,
- * registryUrls, categories) and the `isBump` flag (only present when
- * updateType is "bump") are handled the same as everywhere else in this file.
- */
-function descriptorDiffKeys(a: DependencyDescriptor, b: DependencyDescriptor): string[] {
-  const keys = new Set<string>([...Object.keys(a), ...Object.keys(b)]);
-  const diffs: string[] = [];
-  for (const key of keys) {
-    const av = (a as Record<string, unknown>)[key];
-    const bv = (b as Record<string, unknown>)[key];
-    if (JSON.stringify(av) !== JSON.stringify(bv)) {
-      diffs.push(key);
-    }
-  }
-  return diffs.toSorted();
-}
-
-/**
- * Roadmap 062: the no-change verdict is about BEHAVIOR — the resulting config
- * and what every rule did. When a selector's text moved too (the unavoidable
- * side effect of editing the array a rule matches on), the sentence says so,
- * so the reader is not left wondering whether the panel noticed their edit.
- */
-function noChangeText(comparison: SimulationComparison): string {
-  if (comparison.rulesChanged) {
-    return (
-      "No behavioral change — the final per-dependency config is identical in A and B, and every " +
-      "rule still does what it did. A rule's pattern text changed, which is expected when the " +
-      "edit is to the array that rule matches on."
-    );
-  }
-  return "No behavioral change — the matched rules and the final per-dependency config are identical in A and B.";
-}
 
 /** Roadmap 021: one column ("A (pinned)" / "B (current)") of the A/B input
  *  descriptor comparison — every field the simulator actually sent the
@@ -143,8 +107,12 @@ function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) 
               key={d.key}
               name={d.key}
               mark={writeMark(d.inA, d.inB)}
-              before={deltaSide(d.before, d.inA, d.beforeInherited, "(unset)", "A")}
-              after={deltaSide(d.after, d.inB, d.afterInherited, "(removed)", "B")}
+              before={deltaSide(d.a, d.inA, d.aInherited, "(unset)", "A")}
+              after={deltaSide(d.b, d.inB, d.bInherited, "(removed)", "B")}
+              // Prose Renovate accumulates from every matched rule: it moves
+              // whenever the matched-rule set does, and on its own it is not a
+              // behavioral difference.
+              note={d.kind === "documentation" ? "documentation text" : undefined}
             />
           ))}
         </div>
@@ -154,6 +122,45 @@ function ConfigDeltaSection({ configDelta }: { configDelta: ConfigKeyDelta[] }) 
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * The verdict, in the comparison's OWN words (`netEffect`) rather than a
+ * sentence this panel invents — the app used to assert "a rule's pattern text
+ * changed" for every behavior-preserving edit, including ones that added a
+ * clause. Three states: identical, documentation-only (prose moved, behavior
+ * did not — the delta is still shown, so the reader can see what), and differs.
+ */
+function ComparisonBody({ comparison }: { comparison: SimulationComparison }) {
+  if (comparison.verdict === "identical") {
+    return <p className="sim-compare-nochange">No behavioral change — {comparison.netEffect}.</p>;
+  }
+  if (comparison.verdict === "documentation-only") {
+    return (
+      <>
+        <p className="sim-compare-nochange">No behavioral change — {comparison.netEffect}.</p>
+        <ConfigDeltaSection configDelta={comparison.configDelta} />
+      </>
+    );
+  }
+  return (
+    <>
+      <div className="sim-compare-rules">
+        <RuleDeltaList
+          title="Only in A (stopped matching)"
+          refs={comparison.stoppedMatching}
+          kind="only-a"
+        />
+        <RuleDeltaList
+          title="Only in B (now matching)"
+          refs={comparison.startedMatching}
+          kind="only-b"
+        />
+        <RuleDeltaList title="Matched in both" refs={comparison.matchedInBoth} kind="both" />
+      </div>
+      <ConfigDeltaSection configDelta={comparison.configDelta} />
+    </>
   );
 }
 
@@ -223,25 +230,8 @@ export function ComparisonPanel({
           Pinned this result as <strong>A</strong>. Edit the config and run the pipeline again, then
           simulate to compare it against <strong>B</strong>.
         </p>
-      ) : comparison.noChange ? (
-        <p className="sim-compare-nochange">{noChangeText(comparison)}</p>
       ) : (
-        <>
-          <div className="sim-compare-rules">
-            <RuleDeltaList
-              title="Only in A (stopped matching)"
-              refs={comparison.behaviorOnlyInA}
-              kind="only-a"
-            />
-            <RuleDeltaList
-              title="Only in B (now matching)"
-              refs={comparison.behaviorOnlyInB}
-              kind="only-b"
-            />
-            <RuleDeltaList title="Matched in both" refs={comparison.matchedInBoth} kind="both" />
-          </div>
-          <ConfigDeltaSection configDelta={comparison.configDelta} />
-        </>
+        <ComparisonBody comparison={comparison} />
       )}
       <details className="sim-compare-inputs" open={diffKeys.size > 0}>
         <summary>Inputs compared</summary>

--- a/packages/app/src/features/simulator/use-ab-comparison.ts
+++ b/packages/app/src/features/simulator/use-ab-comparison.ts
@@ -7,6 +7,29 @@ import type {
 } from "@renovate-config-debugger/engine";
 import { type FormState, toDescriptor } from "./form";
 
+/**
+ * Roadmap 021: the fields two descriptors disagree on, sorted for a stable
+ * warning message. Compared via JSON so array-valued fields (lockFiles,
+ * registryUrls, categories) and the `isBump` flag (only present when
+ * updateType is "bump") are handled the same as everywhere else.
+ *
+ * Lives here, not in the panel, because it now answers two questions from one
+ * definition: what to warn about, and what the comparison's `mode` is — the
+ * axis the caller varied, which the engine cannot derive on its own.
+ */
+export function descriptorDiffKeys(a: DependencyDescriptor, b: DependencyDescriptor): string[] {
+  const keys = new Set<string>([...Object.keys(a), ...Object.keys(b)]);
+  const diffs: string[] = [];
+  for (const key of keys) {
+    const av = (a as Record<string, unknown>)[key];
+    const bv = (b as Record<string, unknown>)[key];
+    if (JSON.stringify(av) !== JSON.stringify(bv)) {
+      diffs.push(key);
+    }
+  }
+  return diffs.toSorted();
+}
+
 /** Roadmap 021: the pinned A-run plus the full form snapshot it was run
  *  against (all simulator fields, not just the ones the engine reads) — so
  *  the comparison panel can show and diff exactly what was simulated. */
@@ -55,8 +78,21 @@ export function useAbComparison({
     if (!engineModule || !pinned || !sim || pinned.sim === sim) {
       return null;
     }
-    return engineModule.compareSimulations(pinned.sim, sim);
-  }, [engineModule, pinned, sim]);
+    // The axis this panel varied: the same hypothetical dependency on both
+    // sides means the CONFIG is what moved; a different one means the config
+    // never moved at all, so no selector text can have been rewritten.
+    // Deliberately read from `simForm` — the form that actually produced `sim`
+    // — and not from the live one, which changes on every keystroke.
+    const mode = simForm
+      ? descriptorDiffKeys(
+          toDescriptor(pinned.form, pinned.effectiveUpdateType),
+          toDescriptor(simForm, simEffectiveUpdateType),
+        ).length > 0
+        ? "dependency"
+        : "config"
+      : "unspecified";
+    return engineModule.compareSimulations(pinned.sim, sim, { mode });
+  }, [engineModule, pinned, sim, simForm, simEffectiveUpdateType]);
 
   // Roadmap 021: what the comparison panel treats as "B"'s inputs — the form
   // that actually produced `sim`, or (before any run since pinning, or after

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -253,30 +253,52 @@ change you wanted:
 
 ```console
 $ rcd compare before.json after.json --dep '{"depName":"@types/react","updateType":"major"}'
-Behavior differs between A and B — minimumReleaseAge.
+Behavior differs between A and B — minimumReleaseAge (A=null by default, B="7 days"); 1 rule started matching.
 
 Matched only in B:
   matchPackageNames
 
 Config delta:
-  minimumReleaseAge: null → "7 days"
+  minimumReleaseAge: null (default in A) → "7 days"
 ```
 
 And on a dependency that already worked, nothing:
 
 ```console
 $ rcd compare before.json after.json --dep '{"depName":"react","updateType":"major"}'
-✓ No behavioral change — the same effective config results (a rule's pattern text changed), which is expected when you edit the array the rule matches on.
+✓ No behavioral change — the same effective config results (a rule's matchPackageNames list changed), which is expected when the edit touched the very selectors that rule matches on.
 
 Selector text changed, same effect (rule identity, not behavior):
-  matchPackageNames  #1 → #1
+  matchPackageNames  #1 → #1  (clause-values-changed)
 ```
 
-That second run is the point of the two axes. Behavior is the citable claim, the
+That second run is the point of the two axes. Behavior is the citable claim: the
 per-dependency config is identical and no rule started or stopped doing
 something. Rule identity goes true on edits that provably change nothing, because
 adding an entry to the array a rule matches on rewrites that rule's selector
-text.
+text — and the parenthetical says WHICH kind of rewrite it was, so
+`clause-added` never reads as a pattern replacement.
+
+### Reading the comparison JSON
+
+`--format json` and the MCP `compare_simulations` answer carry the same object.
+It is ordered so the answer comes first:
+
+| field                                     | what it says                                                                                                                                 |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `summary`                                 | the whole verdict in one line — `${verdict}: ${netEffect}`                                                                                   |
+| `verdict`                                 | `identical`, `documentation-only` (only prose such as `description` moved), or `differs`                                                     |
+| `netEffect`                               | the words after the colon, so no consumer slices the string                                                                                  |
+| `mode`                                    | which axis the caller varied: `config`, `dependency`, or `unspecified`                                                                       |
+| `stoppedMatching` / `startedMatching`     | BEHAVIOR: effects one side produced and the other did not                                                                                    |
+| `matchedInBoth`                           | rules paired by selector signature                                                                                                           |
+| `configDelta[]`                           | changed keys, behavioral first; `kind` is `behavioral` or `documentation`, `a`/`b` are the two sides, `inA`/`inB` say which side has the key |
+| `configDelta[].aInherited` / `bInherited` | that side's value reached the final config with NO merge step writing it — a Renovate default, not a setting the config carries              |
+| `identity.*`                              | bookkeeping about selector TEXT, **not** a behavior claim: `changed`, `signatureChanges[]` (each with `kind` and `keys`), `onlyInA/onlyInB`  |
+
+`summary`, `verdict` and `netEffect` always describe the WHOLE delta, so
+`--keys`/`--config-scope` narrow the view without ever moving the verdict; what
+the view withheld is in `configView`.
 
 A few things to know when you write your own `--dep`. The two name
 fields are cross-defaulted the way Renovate's fetch worker does before

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -34,13 +34,13 @@ describe("compare", () => {
       ),
     ).toBe(0);
     const comparison = io.json() as {
-      noChange: boolean;
-      matchedOnlyInB: { label: string }[];
+      verdict: string;
+      startedMatching: { label: string }[];
       configDelta: { key: string }[];
       configView: { scope: string };
     };
-    expect(comparison.noChange).toBe(false);
-    expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
+    expect(comparison.verdict).toBe("differs");
+    expect(comparison.startedMatching[0]?.label).toBe("matchPackageNames");
     expect(comparison.configDelta.map((d) => d.key)).toContain("groupName");
     // Roadmap 070: the delta is a VIEW now, and it says which one it is.
     expect(comparison.configView.scope).toBe("package-rules");
@@ -62,7 +62,7 @@ describe("compare", () => {
         io,
       ),
     ).toBe(0);
-    expect(io.json()).toMatchObject({ noChange: true });
+    expect(io.json()).toMatchObject({ verdict: "identical" });
   });
 
   test("pretty output leads with the verdict, then the evidence", async () => {
@@ -81,11 +81,34 @@ describe("compare", () => {
     ).toBe(0);
     // The headline is the comparison's own one-liner: the verdict AND what it
     // was about, so a reader never has to assemble it from the arrays below.
+    // `description` is prose, so it is filed behind the behavioral keys rather
+    // than headlining them by alphabetical accident.
     expect(io.stdout.split("\n")[0]).toBe(
-      "Behavior differs between A and B — dependencyDashboard, description, groupName.",
+      "Behavior differs between A and B — dependencyDashboard (A=true by default, B=false by " +
+        'default), groupName (A=null by default, B="react monorepo"); description also changed ' +
+        "(documentation); 1 rule started matching.",
     );
     expect(io.stdout).toContain("Matched only in B:");
     expect(io.stdout).toContain("groupName");
+  });
+
+  /** Replay-02 N8, on the CLI side: a value NO merge step wrote is a Renovate
+   *  default, and printing it bare asserts a setting the config never carried. */
+  test("the delta marks a side the config never set as a default", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "compare",
+          fixture("clean.json"),
+          fixture("grouped.json"),
+          "--dep",
+          '{"depName":"react","packageName":"react"}',
+        ],
+        io,
+      ),
+    ).toBe(0);
+    expect(io.stdout).toContain('groupName: null (default in A) → "react monorepo"');
   });
 
   test("the JSON carries the same one-liner, so no consumer re-derives it", async () => {
@@ -108,14 +131,20 @@ describe("compare", () => {
       summary: string;
       configDelta: { key: string }[];
     };
-    expect(summary).toBe("differs: dependencyDashboard, description, groupName");
+    expect(summary).toBe(
+      "differs: dependencyDashboard (A=true by default, B=false by default), groupName " +
+        '(A=null by default, B="react monorepo"); description also changed (documentation); ' +
+        "1 rule started matching",
+    );
     expect(io.stdout).toContain("summary");
     // Roadmap 070: the summary is built from the delta's KEYS, and collapsing
-    // a value is only safe because it never moves one. Pinned explicitly.
+    // a value is only safe because it never moves one. Pinned explicitly —
+    // behavioral keys first, alphabetical within group, so the array reads in
+    // the order the summary names it.
     expect(configDelta.map((d) => d.key)).toEqual([
       "dependencyDashboard",
-      "description",
       "groupName",
+      "description",
     ]);
   });
 
@@ -168,9 +197,9 @@ describe("compare", () => {
     const comparison = json.json() as {
       a: { missingInputs: { rules: number; groups: { fieldList: string }[] } };
       b: { missingInputs: { rules: number } };
-      noChange: boolean;
+      verdict: string;
     };
-    expect(comparison.noChange).toBe(true);
+    expect(comparison.verdict).toBe("identical");
     expect(comparison.a.missingInputs.rules).toBe(2);
     expect(comparison.b.missingInputs.rules).toBe(2);
     expect(comparison.a.missingInputs.groups.map((group) => group.fieldList)).toEqual([
@@ -204,7 +233,11 @@ describe("compare", () => {
     };
     expect(comparison.configDelta.map((d) => d.key)).toEqual(["groupName"]);
     // The verdict describes the whole comparison, not the view of it.
-    expect(comparison.summary).toBe("differs: dependencyDashboard, description, groupName");
+    expect(comparison.summary).toBe(
+      "differs: dependencyDashboard (A=true by default, B=false by default), groupName " +
+        '(A=null by default, B="react monorepo"); description also changed (documentation); ' +
+        "1 rule started matching",
+    );
     // The reason a caller can act on: `--config-scope full` is what would
     // make a globalOnly name answerable, whether or not the delta held it.
     expect(comparison.configView.withheld).toEqual([
@@ -231,38 +264,70 @@ function narrowingArgs(...extra: string[]): string[] {
   ];
 }
 
+interface Comparison {
+  verdict: string;
+  configDelta: unknown[];
+  stoppedMatching: unknown[];
+  startedMatching: unknown[];
+  identity: {
+    changed: boolean;
+    onlyInA: unknown[];
+    signatureChanges: { a: { label: string }; kind: string; keys: string[] }[];
+  };
+}
+
 describe("compare separates behavior from rule identity", () => {
   const args = narrowingArgs;
 
   test("narrowing the matched array around the dependency is no behavioral change", async () => {
     const io = recordingIo();
     expect(await main(args("--format", "json"), io)).toBe(0);
-    const comparison = io.json() as {
-      noChange: boolean;
-      rulesChanged: boolean;
-      configDelta: unknown[];
-      signatureChanges: { a: { label: string }; b: { label: string } }[];
-      behaviorOnlyInA: unknown[];
-      behaviorOnlyInB: unknown[];
-      matchedOnlyInA: unknown[];
-    };
-    expect(comparison.noChange).toBe(true);
+    const comparison = io.json() as Comparison;
+    expect(comparison.verdict).toBe("identical");
     expect(comparison.configDelta).toEqual([]);
-    expect(comparison.behaviorOnlyInA).toEqual([]);
-    expect(comparison.behaviorOnlyInB).toEqual([]);
-    // The identity axis still reports the churn, on its own fields.
-    expect(comparison.rulesChanged).toBe(true);
-    expect(comparison.matchedOnlyInA).toHaveLength(1);
-    expect(comparison.signatureChanges).toHaveLength(1);
-    expect(comparison.signatureChanges[0]?.a.label).toBe("matchPackageNames");
+    expect(comparison.stoppedMatching).toEqual([]);
+    expect(comparison.startedMatching).toEqual([]);
+    // The identity axis still reports the churn, on its own fields — nested,
+    // so `identity.onlyInA` cannot be misread as "stopped matching".
+    expect(comparison.identity.changed).toBe(true);
+    expect(comparison.identity.onlyInA).toHaveLength(1);
+    expect(comparison.identity.signatureChanges).toHaveLength(1);
+    expect(comparison.identity.signatureChanges[0]?.a.label).toBe("matchPackageNames");
+    expect(comparison.identity.signatureChanges[0]?.kind).toBe("clause-values-changed");
   });
 
   test("pretty output headlines on behavior and files the churn underneath", async () => {
     const io = recordingIo();
     expect(await main(args(), io)).toBe(0);
     expect(io.stdout.split("\n")[0]).toContain("✓ No behavioral change");
-    expect(io.stdout).toContain("a rule's pattern text changed");
+    expect(io.stdout).toContain("a rule's matchPackageNames list changed");
     expect(io.stdout).toContain("Selector text changed, same effect (rule identity, not behavior)");
+  });
+
+  /**
+   * The parenthetical used to be one hardcoded sentence, "a rule's pattern
+   * text changed", fired for every behavior-preserving edit — factually wrong
+   * for the ones that ADD a clause, and untested until now.
+   */
+  test("an added clause is named as an addition, not as a pattern rewrite", async () => {
+    const added = [
+      "compare",
+      fixture("narrow-before.json"),
+      fixture("clause-added-after.json"),
+      "--dep",
+      '{"depName":"react","updateType":"minor"}',
+    ];
+    const io = recordingIo();
+    expect(await main(added, io)).toBe(0);
+    expect(io.stdout).toContain("a rule gained a matchUpdateTypes clause");
+    expect(io.stdout).not.toContain("pattern text changed");
+
+    const json = recordingIo();
+    expect(await main([...added, "--format", "json"], json)).toBe(0);
+    const comparison = json.json() as Comparison;
+    expect(comparison.verdict).toBe("identical");
+    expect(comparison.identity.signatureChanges[0]?.kind).toBe("clause-added");
+    expect(comparison.identity.signatureChanges[0]?.keys).toEqual(["matchUpdateTypes"]);
   });
 });
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -5,7 +5,7 @@ import { EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
 import { INPUT_OPTIONS, refusalNote, runOne, takeInputFile, wouldRefuse } from "../run-input";
 import { readDependency } from "../dep";
-import { diffLine, parseConfigScope, parseKeys } from "../projections/config-view";
+import { deltaLine, parseConfigScope, parseKeys } from "../projections/config-view";
 import { comparisonPayload } from "../projections/simulate";
 import { missingInputsNote } from "../rule-view";
 import { simulateAgainst } from "./simulate";
@@ -21,33 +21,31 @@ import { simulateAgainst } from "./simulate";
  */
 
 /**
- * Roadmap 062: the headline states the BEHAVIOR verdict, and says so in the
- * words a reader can cite. The identity fact (a rule's pattern text moved) is
- * reported underneath, because for the commonest behavior-preserving edit —
- * dropping an entry from the very array a rule matches on — it is guaranteed
- * to be true and means nothing on its own.
+ * The headline states the BEHAVIOR verdict, in the words a reader can cite —
+ * `netEffect` is the comparison's own phrasing, so the CLI, the MCP answer and
+ * the app all headline with one sentence instead of three re-derivations of
+ * it. The identity fact (a selector's text moved) is reported underneath,
+ * because for the commonest behavior-preserving edit — dropping an entry from
+ * the very array a rule matches on — it is guaranteed true and means nothing
+ * on its own.
+ *
+ * The headline reads the VERDICT fields only, which is what lets it take a
+ * projected comparison (whose delta may be narrowed) unchanged.
  */
-/** The comparison's own one-liner without its `identical:`/`differs:` prefix —
- *  the headline states the verdict in its own words. */
-function netEffect(comparison: ComparisonVerdict): string {
-  return comparison.summary.slice(comparison.summary.indexOf(": ") + 2);
-}
+type HeadlineFields = Pick<SimulationComparison, "verdict" | "netEffect" | "identity">;
 
-/** The headline reads the VERDICT fields only — which is what lets it take a
- *  projected comparison (whose delta may be narrowed) unchanged. */
-type ComparisonVerdict = Pick<SimulationComparison, "summary" | "noChange" | "rulesChanged">;
-
-export function comparisonHeadline(comparison: ComparisonVerdict): string {
-  if (!comparison.noChange) {
-    return `Behavior differs between A and B — ${netEffect(comparison)}.`;
+export function comparisonHeadline(comparison: HeadlineFields): string {
+  switch (comparison.verdict) {
+    case "differs":
+      return `Behavior differs between A and B — ${comparison.netEffect}.`;
+    case "documentation-only":
+      return `✓ No behavioral change — ${comparison.netEffect}.`;
+    default:
+      return comparison.identity.changed
+        ? `✓ No behavioral change — ${comparison.netEffect}, which is expected when the edit ` +
+            "touched the very selectors that rule matches on."
+        : `✓ No behavioral change: ${comparison.netEffect}.`;
   }
-  if (comparison.rulesChanged) {
-    return (
-      `✓ No behavioral change — ${netEffect(comparison)}, which is expected when you edit the ` +
-      "array the rule matches on."
-    );
-  }
-  return `✓ No behavioral change: ${netEffect(comparison)}.`;
 }
 
 export const compareCommand: Command = {
@@ -58,11 +56,16 @@ export const compareCommand: Command = {
     `compare <file> --dep '{…}' --dep-b '{…}'`,
   ],
   details: [
-    "The verdict has two axes. BEHAVIOR (`noChange`) is the citable claim: the",
-    "resulting per-dependency config is identical and no rule started or stopped",
-    "doing something. IDENTITY (`rulesChanged`, `signatureChanges`) only says a",
-    "selector's text moved — unavoidable when the edit is to the matched array",
-    "itself, and not a behavior change on its own.",
+    "The verdict has two axes. BEHAVIOR (`verdict`, one of `identical`,",
+    "`documentation-only` — only prose such as `description` moved — and",
+    "`differs`) is the citable claim, with `netEffect` stating it in words and",
+    "`stoppedMatching`/`startedMatching` naming the rules behind it. IDENTITY",
+    "(`identity.*`) is NOT a behavior claim: it only says a selector's text",
+    "moved, which is unavoidable when the edit is to the matched array itself.",
+    "",
+    "A delta side flagged `aInherited`/`bInherited` is a value that reached that",
+    "run's final config without any merge step writing it — a Renovate default,",
+    "not something the config set. Pretty output marks it `(default in A)`.",
     "",
     "The key delta is reported at `--config-scope package-rules` (the globalOnly",
     "options no rule can reach are dropped) and `--keys a,b` narrows it further.",
@@ -98,7 +101,11 @@ export const compareCommand: Command = {
 
     const simA = await simulateAgainst(a.result, depA);
     const simB = await simulateAgainst(b.result, depB);
-    const comparison = comparisonPayload(compareSimulations(simA, simB), {
+    // What this invocation varied. Two files AND two dependencies is neither
+    // axis alone, and a wrong guess is how the comparison came to claim a
+    // pattern rewrite about one unchanged config file.
+    const mode = fileB && twoDeps ? "unspecified" : twoDeps ? "dependency" : "config";
+    const comparison = comparisonPayload(compareSimulations(simA, simB, { mode }), {
       scope: scope ?? "package-rules",
       ...(keys ? { keys } : {}),
     });
@@ -139,21 +146,21 @@ export const compareCommand: Command = {
         comparisonHeadline(comparison),
         ...(missingA ? ["", `A — ${missingA}`] : []),
         ...(missingB ? ["", `B — ${missingB}`] : []),
-        ...(comparison.behaviorOnlyInA.length > 0
-          ? ["", "Matched only in A:", ...comparison.behaviorOnlyInA.map((r) => `  ${r.label}`)]
+        ...(comparison.stoppedMatching.length > 0
+          ? ["", "Matched only in A:", ...comparison.stoppedMatching.map((r) => `  ${r.label}`)]
           : []),
-        ...(comparison.behaviorOnlyInB.length > 0
-          ? ["", "Matched only in B:", ...comparison.behaviorOnlyInB.map((r) => `  ${r.label}`)]
+        ...(comparison.startedMatching.length > 0
+          ? ["", "Matched only in B:", ...comparison.startedMatching.map((r) => `  ${r.label}`)]
           : []),
         ...(comparison.configDelta.length > 0
-          ? ["", "Config delta:", ...comparison.configDelta.map((d) => `  ${diffLine(d)}`)]
+          ? ["", "Config delta:", ...comparison.configDelta.map((d) => `  ${deltaLine(d)}`)]
           : []),
-        ...(comparison.signatureChanges.length > 0
+        ...(comparison.identity.signatureChanges.length > 0
           ? [
               "",
               "Selector text changed, same effect (rule identity, not behavior):",
-              ...comparison.signatureChanges.map(
-                (c) => `  ${c.a.label}  #${c.a.index + 1} → #${c.b.index + 1}`,
+              ...comparison.identity.signatureChanges.map(
+                (c) => `  ${c.a.label}  #${c.a.index + 1} → #${c.b.index + 1}  (${c.kind})`,
               ),
             ]
           : []),

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1078,9 +1078,9 @@ describe("simulate and compare", () => {
       runId: before,
       runIdB: after,
       dep,
-    })) as { noChange: boolean; summary: string; matchedOnlyInB: { label: string }[] };
-    expect(comparison.noChange).toBe(false);
-    expect(comparison.matchedOnlyInB[0]?.label).toBe("matchPackageNames");
+    })) as { verdict: string; summary: string; startedMatching: { label: string }[] };
+    expect(comparison.verdict).toBe("differs");
+    expect(comparison.startedMatching[0]?.label).toBe("matchPackageNames");
     // Roadmap 068 (4 of 9 persona sessions): the net effect, before anyone has
     // to assemble it out of six arrays.
     expect(comparison.summary).toContain("differs: ");
@@ -1092,11 +1092,14 @@ describe("simulate and compare", () => {
     const comparison = (await call("compare_simulations", {
       runId,
       dep: { depName: "react", packageName: "react" },
-    })) as { noChange: boolean; summary: string };
-    expect(comparison.noChange).toBe(true);
+    })) as { verdict: string; summary: string; mode: string };
+    expect(comparison.verdict).toBe("identical");
     expect(comparison.summary).toBe(
       "identical: the same rules matched and the same effective config results",
     );
+    // One run, one dependency: the caller varied the config (of which there is
+    // one), never the dependency — the engine cannot see which and is told.
+    expect(comparison.mode).toBe("config");
   });
 
   /** `identical:` over two sides that both went blind on the same rule is not
@@ -1110,9 +1113,9 @@ describe("simulate and compare", () => {
       a: { missingInputs: { rules: number; groups: { fieldList: string }[] } };
       b: { missingInputs: { rules: number } };
       missingInputsNote: string;
-      noChange: boolean;
+      verdict: string;
     };
-    expect(comparison.noChange).toBe(true);
+    expect(comparison.verdict).toBe("identical");
     expect(comparison.a.missingInputs.rules).toBe(2);
     expect(comparison.b.missingInputs.rules).toBe(2);
     expect(comparison.a.missingInputs.groups.map((group) => group.fieldList)).toEqual([

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -888,14 +888,20 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       title: "Did my edit change anything?",
       description:
         "The edit oracle. Run the config before your edit and the config after it, then compare " +
-        "the two runs against the same dependency — `summary` is the whole verdict in one line " +
-        "(`identical: …` / `differs: …`), with the rules that started or stopped matching and " +
-        "the key-level delta of the resulting config underneath it. Pass runIdB to compare two " +
-        "configs, or depB to compare two dependencies against the same config. `keys` narrows " +
-        "the delta to the options you care about; `summary` and the verdict booleans always " +
-        "describe the WHOLE delta, so narrowing the view never moves the verdict. A side that " +
-        "could not evaluate a rule for lack of dependency input reports it in its own " +
-        "`missingInputs`: two blind sides agree perfectly, and `identical:` over them is not an " +
+        "the two runs against the same dependency. `summary` is the whole verdict in one line " +
+        "and `verdict` is it structured: `identical`, `differs`, or `documentation-only` — only " +
+        "prose such as `description` moved, which is not a behavioral difference. " +
+        "`stoppedMatching`/`startedMatching` are the rules behind the verdict; `configDelta` is " +
+        "the key-level delta, behavioral keys first, each entry tagged `kind`. Everything under " +
+        "`identity` is bookkeeping about selector TEXT and is NOT a behavior claim — it goes " +
+        "true whenever you edit the very array a rule matches on. A delta side flagged " +
+        "`aInherited`/`bInherited` is a Renovate default that reached that run's final config " +
+        "without any merge step writing it, not a value the config set. Pass runIdB to compare " +
+        "two configs, or depB to compare two dependencies against the same config. `keys` " +
+        "narrows the delta to the options you care about; `summary`, `verdict` and `netEffect` " +
+        "always describe the WHOLE delta, so narrowing the view never moves the verdict. A side " +
+        "that could not evaluate a rule for lack of dependency input reports it in its own " +
+        "`missingInputs`: two blind sides agree perfectly, and `identical` over them is not an " +
         "answer about your edit.",
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
@@ -927,10 +933,18 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         a: { runId: a.runId, dep: toDependency(dep), missingInputs: simA.missingInputs },
         b: { runId: b.runId, dep: toDependency(depB ?? dep), missingInputs: simB.missingInputs },
         ...(combined ? { missingInputsNote: combined } : {}),
-        ...comparisonPayload(compareSimulations(simA, simB), {
-          scope: configScope ?? "package-rules",
-          ...(keys ? { keys } : {}),
-        }),
+        // What the CALLER varied — the engine cannot see it, and guessing is
+        // how the comparison came to claim a selector rewrite about one
+        // unchanged config read through two dependencies.
+        ...comparisonPayload(
+          compareSimulations(simA, simB, {
+            mode: runIdB ? "config" : depB ? "dependency" : "config",
+          }),
+          {
+            scope: configScope ?? "package-rules",
+            ...(keys ? { keys } : {}),
+          },
+        ),
       };
     }, HINTS.compare),
   );

--- a/packages/cli/src/projections/config-view.test.ts
+++ b/packages/cli/src/projections/config-view.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "vitest";
 import { globalOnlyOptionNames } from "@renovate-config-debugger/engine";
 import {
+  collapseDeltas,
+  collapseDescriptionDelta,
   collapseDescriptionDiff,
   collapseDiffs,
   type ConfigScope,
-  diffLine,
+  deltaLine,
   mergedLine,
   parseConfigScope,
   parseKeys,
@@ -137,11 +139,34 @@ describe("collapseDescriptionDiff", () => {
     expect(collapseDescriptionDiff(diff)).toBe(diff);
   });
 
-  test("a delta's own extra fields ride through the collapse", () => {
+  test("a rule's own extra fields ride through the collapse", () => {
     const collapsed = collapseDiffs([
-      { key: "description", before, after: [...before, "And this."], inA: true, inB: true },
+      { key: "description", before, after: [...before, "And this."], ruleIndex: 3 },
     ]);
-    expect(collapsed[0]).toMatchObject({ inA: true, inB: true, collapsed: "append" });
+    expect(collapsed[0]).toMatchObject({ ruleIndex: 3, collapsed: "append" });
+  });
+
+  /** The comparison names its two sides `a`/`b` — it has no chronology — so
+   *  the same append has to collapse under that spelling too, with the delta's
+   *  own fields (`kind`, `inA`, `aInherited`) riding through untouched. */
+  test("a comparison delta collapses on a/b, keeping its own fields", () => {
+    const collapsed = collapseDeltas([
+      {
+        key: "description",
+        kind: "documentation",
+        a: before,
+        b: [...before, "And this."],
+        inA: true,
+        inB: true,
+      },
+    ]);
+    expect(collapsed[0]).toMatchObject({
+      kind: "documentation",
+      inA: true,
+      inB: true,
+      collapsed: "append",
+      added: ["And this."],
+    });
   });
 
   test("collapsing an append is an order of magnitude smaller than the diff", () => {
@@ -157,21 +182,39 @@ describe("collapseDescriptionDiff", () => {
 });
 
 describe("rendering", () => {
-  const collapsed = collapseDescriptionDiff({
+  const collapsedMerge = collapseDescriptionDiff({
     key: "description",
     before: ["One.", "Two."],
     after: ["One.", "Two.", "Three."],
   });
-
-  test("a collapsed diff renders what it added, not both arrays", () => {
-    expect(diffLine(collapsed)).toBe('description: 2 entries + 1 appended (now 3) — ["Three."]');
-    expect(mergedLine(collapsed)).toBe('description += 1 of 3 entries: ["Three."]');
+  const collapsedDelta = collapseDescriptionDelta({
+    key: "description",
+    a: ["One.", "Two."],
+    b: ["One.", "Two.", "Three."],
   });
 
-  test("an ordinary diff renders before → after", () => {
-    const diff = { key: "groupName", before: undefined, after: "react monorepo" };
-    expect(diffLine(diff)).toBe('groupName: (unset) → "react monorepo"');
-    expect(mergedLine(diff)).toBe('groupName = "react monorepo"');
+  test("a collapsed diff renders what it added, not both arrays", () => {
+    expect(deltaLine(collapsedDelta)).toBe(
+      'description: 2 entries + 1 appended (now 3) — ["Three."]',
+    );
+    expect(mergedLine(collapsedMerge)).toBe('description += 1 of 3 entries: ["Three."]');
+  });
+
+  test("an ordinary delta renders a → b", () => {
+    expect(deltaLine({ key: "groupName", a: undefined, b: "react monorepo" })).toBe(
+      'groupName: (unset) → "react monorepo"',
+    );
+    expect(mergedLine({ key: "groupName", before: undefined, after: "react monorepo" })).toBe(
+      'groupName = "react monorepo"',
+    );
+  });
+
+  /** Replay-02 N8: a value NO merge step wrote is a Renovate default. Rendered
+   *  bare it asserts a setting the config never carried. */
+  test("an inherited side says so instead of asserting a value", () => {
+    expect(
+      deltaLine({ key: "automerge", a: false, b: true, inA: true, inB: true, aInherited: true }),
+    ).toBe("automerge: false (default in A) → true");
   });
 });
 

--- a/packages/cli/src/projections/config-view.ts
+++ b/packages/cli/src/projections/config-view.ts
@@ -149,15 +149,35 @@ export function projectConfig(
 }
 
 /**
- * A before/after pair for one key. `MergedKey` (a rule's merge) and
- * `ConfigKeyDelta` (a comparison's delta) are structurally the same thing, so
- * the collapsing below is written once and generically — a delta's own extra
- * fields (`inA`, `beforeInherited`, …) ride through untouched.
+ * A before/after pair for one key — `MergedKey`, a rule's merge, which IS
+ * chronological.
  */
 export interface KeyDiff {
   key: string;
   before?: unknown;
   after?: unknown;
+}
+
+/**
+ * The comparison's spelling of the same pair. `ConfigKeyDelta` names its two
+ * sides `a`/`b` because a comparison has no chronology (in `mode:
+ * "dependency"` neither side is "before"), so the collapsing below is written
+ * for both shapes over one predicate — a delta's own extra fields (`kind`,
+ * `inA`, `aInherited`, …) ride through untouched.
+ */
+export interface KeyDelta {
+  key: string;
+  a?: unknown;
+  b?: unknown;
+}
+
+/** The presence and inheritance flags a comparison delta carries alongside its
+ *  values. Optional here so the renderer takes a collapsed delta too. */
+export interface DeltaSides {
+  inA?: boolean;
+  inB?: boolean;
+  aInherited?: boolean;
+  bInherited?: boolean;
 }
 
 /** An `append`-shaped diff, stated instead of re-embedded. */
@@ -175,18 +195,21 @@ export type MaybeCollapsed<T extends KeyDiff> =
   | T
   | (Omit<T, "before" | "after"> & CollapsedKeyDiff);
 
+export type MaybeCollapsedDelta<T extends KeyDelta> = T | (Omit<T, "a" | "b"> & CollapsedKeyDiff);
+
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string");
 }
 
 /**
- * Collapses a `description` append into what it appended.
+ * The collapsed form of a `description` append, or `undefined` when the pair
+ * is not one.
  *
  * The conditions are deliberately narrow: the key is `description`, both sides
- * are string arrays, the before side is non-empty, and `after` starts with
- * `before` — which is precisely what `mergeChildConfig`'s array concatenation
+ * are string arrays, the earlier side is non-empty, and the later one starts
+ * with it — which is precisely what `mergeChildConfig`'s array concatenation
  * guarantees. Anything else stays verbatim: a rule that REPLACED the
- * description must still show both sides, and collapsing an empty `before`
+ * description must still show both sides, and collapsing an empty first side
  * saves nothing.
  *
  * `description` alone, on purpose. It is prose, it is never a matcher input,
@@ -197,20 +220,22 @@ function isStringArray(value: unknown): value is string[] {
  * never drop the key): the full array is one `get_provenance description`
  * away.
  */
-export function collapseDescriptionDiff<T extends KeyDiff>(diff: T): MaybeCollapsed<T> {
-  const { before, after, ...rest } = diff;
+function appendCollapse(
+  key: string,
+  before: unknown,
+  after: unknown,
+): Omit<CollapsedKeyDiff, "key"> | undefined {
   if (
-    diff.key !== "description" ||
+    key !== "description" ||
     !isStringArray(before) ||
     !isStringArray(after) ||
     before.length === 0 ||
     after.length <= before.length ||
     JSON.stringify(after.slice(0, before.length)) !== JSON.stringify(before)
   ) {
-    return diff;
+    return undefined;
   }
   return {
-    ...rest,
     collapsed: "append",
     beforeLength: before.length,
     afterLength: after.length,
@@ -218,23 +243,53 @@ export function collapseDescriptionDiff<T extends KeyDiff>(diff: T): MaybeCollap
   };
 }
 
+/** {@link appendCollapse} over a chronological diff (a rule's merge). */
+export function collapseDescriptionDiff<T extends KeyDiff>(diff: T): MaybeCollapsed<T> {
+  const { before, after, ...rest } = diff;
+  const collapsed = appendCollapse(diff.key, before, after);
+  return collapsed ? { ...rest, ...collapsed } : diff;
+}
+
+/** {@link appendCollapse} over a comparison delta (`a`/`b`). */
+export function collapseDescriptionDelta<T extends KeyDelta>(delta: T): MaybeCollapsedDelta<T> {
+  const { a, b, ...rest } = delta;
+  const collapsed = appendCollapse(delta.key, a, b);
+  return collapsed ? { ...rest, ...collapsed } : delta;
+}
+
 export function collapseDiffs<T extends KeyDiff>(diffs: readonly T[]): MaybeCollapsed<T>[] {
   return diffs.map((diff) => collapseDescriptionDiff(diff));
 }
 
-function isCollapsed(diff: KeyDiff | CollapsedKeyDiff): diff is CollapsedKeyDiff {
+export function collapseDeltas<T extends KeyDelta>(deltas: readonly T[]): MaybeCollapsedDelta<T>[] {
+  return deltas.map((delta) => collapseDescriptionDelta(delta));
+}
+
+function isCollapsed(diff: object): diff is CollapsedKeyDiff {
   return "collapsed" in diff;
 }
 
-/** `key: before → after`, or the collapsed form. The comparison's delta line. */
-export function diffLine(diff: KeyDiff | CollapsedKeyDiff): string {
-  if (isCollapsed(diff)) {
-    return (
-      `${diff.key}: ${diff.beforeLength} entries + ${diff.added.length} appended ` +
-      `(now ${diff.afterLength}) — ${preview(diff.added)}`
-    );
+function collapsedLine(diff: CollapsedKeyDiff): string {
+  return (
+    `${diff.key}: ${diff.beforeLength} entries + ${diff.added.length} appended ` +
+    `(now ${diff.afterLength}) — ${preview(diff.added)}`
+  );
+}
+
+/** Replay-02 N8: a value present in a run's final config that NO merge step
+ *  wrote is a Renovate default, not something the config set. Printing it bare
+ *  asserts an explicit `automerge: false` the config never contained. */
+function deltaSide(value: unknown, inherited: boolean | undefined, run: "A" | "B"): string {
+  return `${preview(value)}${inherited ? ` (default in ${run})` : ""}`;
+}
+
+/** `key: a → b`, or the collapsed form. The comparison's delta line. */
+export function deltaLine(delta: (KeyDelta & DeltaSides) | CollapsedKeyDiff): string {
+  if (isCollapsed(delta)) {
+    return collapsedLine(delta);
   }
-  return `${diff.key}: ${preview(diff.before)} → ${preview(diff.after)}`;
+  const a = deltaSide(delta.a, delta.aInherited, "A");
+  return `${delta.key}: ${a} → ${deltaSide(delta.b, delta.bInherited, "B")}`;
 }
 
 /** `key = value`, or the collapsed form — what one merge step DID, without a

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -161,27 +161,31 @@ describe("simulationPayload", () => {
   });
 });
 
+const NET_EFFECT =
+  'automerge (A=false, B=true), groupName (unset in A, B="react monorepo"); ' +
+  "description also changed (documentation)";
+
 const COMPARISON: SimulationComparison = {
-  matchedOnlyInA: [],
-  matchedOnlyInB: [],
+  summary: `differs: ${NET_EFFECT}`,
+  verdict: "differs",
+  netEffect: NET_EFFECT,
+  mode: "config",
+  stoppedMatching: [],
+  startedMatching: [],
   matchedInBoth: [],
-  behaviorOnlyInA: [],
-  behaviorOnlyInB: [],
-  signatureChanges: [],
-  rulesChanged: false,
   configDelta: [
-    { key: "automerge", before: false, after: true, inA: true, inB: true },
+    { key: "automerge", kind: "behavioral", a: false, b: true, inA: true, inB: true },
+    { key: "groupName", kind: "behavioral", b: "react monorepo", inA: false, inB: true },
     {
       key: "description",
-      before: DESCRIPTION,
-      after: [...DESCRIPTION, "And this one."],
+      kind: "documentation",
+      a: DESCRIPTION,
+      b: [...DESCRIPTION, "And this one."],
       inA: true,
       inB: true,
     },
-    { key: "groupName", after: "react monorepo", inA: false, inB: true },
   ],
-  noChange: false,
-  summary: "differs: automerge, description, groupName",
+  identity: { changed: false, signatureChanges: [], onlyInA: [], onlyInB: [] },
 };
 
 describe("comparisonPayload", () => {
@@ -189,12 +193,13 @@ describe("comparisonPayload", () => {
     const payload = comparisonPayload(COMPARISON, { scope: "package-rules" });
     expect(payload.configDelta.map((delta) => delta.key)).toEqual([
       "automerge",
-      "description",
       "groupName",
+      "description",
     ]);
-    expect(payload.configDelta[1]).toMatchObject({
+    expect(payload.configDelta[2]).toMatchObject({
       collapsed: "append",
       added: ["And this one."],
+      kind: "documentation",
       inA: true,
       inB: true,
     });
@@ -214,6 +219,7 @@ describe("comparisonPayload", () => {
     // The comparison FOUND three changed keys; a narrowed view does not get to
     // restate what it found.
     expect(payload.summary).toBe(COMPARISON.summary);
-    expect(payload.noChange).toBe(false);
+    expect(payload.verdict).toBe("differs");
+    expect(payload.netEffect).toBe(COMPARISON.netEffect);
   });
 });

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -11,10 +11,12 @@ import { CliError } from "../io";
 import { missingInputsNote } from "../rule-view";
 import type { RunTransport } from "../run-input";
 import {
+  collapseDeltas,
   collapseDiffs,
   type ConfigScope,
   type ConfigView,
   type MaybeCollapsed,
+  type MaybeCollapsedDelta,
   projectConfig,
   projectKeySet,
 } from "./config-view";
@@ -198,7 +200,7 @@ export interface ComparisonProjection {
 }
 
 export interface ProjectedComparison extends Omit<SimulationComparison, "configDelta"> {
-  configDelta: MaybeCollapsed<ConfigKeyDelta>[];
+  configDelta: MaybeCollapsedDelta<ConfigKeyDelta>[];
   configView: ConfigView;
 }
 
@@ -206,7 +208,7 @@ export interface ProjectedComparison extends Omit<SimulationComparison, "configD
  * The comparison, with its key delta scoped, key-selected and
  * description-collapsed.
  *
- * `summary` and the verdict booleans are deliberately NOT projected: they
+ * `summary`, `verdict` and `netEffect` are deliberately NOT projected: they
  * state what the comparison found, over the whole delta, and a verdict that
  * changed with the view a caller asked for would be uncitable. So `summary`
  * may name a key this view withheld — which is exactly what `configView`
@@ -225,7 +227,7 @@ export function comparisonPayload(
   );
   return {
     ...comparison,
-    configDelta: collapseDiffs(comparison.configDelta.filter((delta) => kept.has(delta.key))),
+    configDelta: collapseDeltas(comparison.configDelta.filter((delta) => kept.has(delta.key))),
     configView: view,
   };
 }

--- a/packages/cli/test/fixtures/clause-added-after.json
+++ b/packages/cli/test/fixtures/clause-added-after.json
@@ -1,0 +1,9 @@
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["react", "vue"],
+      "matchUpdateTypes": ["minor", "major"],
+      "groupName": "frontend"
+    }
+  ]
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -21,9 +21,15 @@ export {
   summarizeMissingInputs,
 } from "./simulate-missing-inputs";
 export {
+  type CompareOptions,
   compareSimulations,
+  type ComparisonMode,
+  type ComparisonVerdict,
   type ConfigKeyDelta,
+  type DeltaKind,
+  type RuleIdentityChurn,
   type RuleRef,
+  type SelectorChangeKind,
   type SignatureChange,
   type SimulationComparison,
 } from "./simulate-compare";

--- a/packages/engine/src/simulate-compare.ts
+++ b/packages/engine/src/simulate-compare.ts
@@ -1,15 +1,57 @@
 /**
  * Roadmap 018 — A/B run comparison. A pure, dependency-free diff of two
- * `SimulationResult`s (A = a pinned earlier run, B = the current run after the
- * config was edited and re-simulated): which rules matched only in A, only in
- * B, or in both, plus the key-level delta of the final per-dependency config,
- * plus an explicit "no behavioral change" verdict when both sets are equal.
+ * `SimulationResult`s (A = one run, B = the other), stated so that the FIRST
+ * thing a reader meets is the answer: what the difference amounts to, in
+ * words, followed by the fields that justify it.
+ *
+ * Two axes, and only one of them is a claim about behavior:
+ *
+ * - BEHAVIOR — `verdict`, `stoppedMatching`, `startedMatching`, `configDelta`.
+ *   This is the citable answer to "did my edit change anything?".
+ * - IDENTITY — everything under `identity`. A selector's TEXT moved. That is
+ *   unavoidable whenever the edit is to the very array a rule matches on, so
+ *   on its own it means nothing; it is nested rather than deleted because a
+ *   reader who asks "which rule did I touch?" still needs it, and a top-level
+ *   `matchedOnlyInA` was read as "stopped matching" in 6 of 9 sessions of the
+ *   2026-07 persona study.
  *
  * No Renovate imports — the `SimulationResult` reference is a `import type`,
  * erased at compile time — so this module runs (and unit-tests) with zero
  * engine/browser machinery.
  */
 import type { RuleEvaluation, SimulationResult } from "./simulate-package-rules";
+
+/**
+ * What the caller varied between A and B. The engine cannot derive it — a
+ * `SimulationResult` carries no dependency descriptor — and a wrong guess is
+ * how the comparison came to claim "a rule's pattern text changed" about two
+ * runs of one identical config file. So it is an input, and it defaults to
+ * `unspecified` rather than to the commoner case.
+ */
+export type ComparisonMode = "config" | "dependency" | "unspecified";
+
+/**
+ * The behavior verdict, as three states rather than a boolean. `identical` and
+ * `differs` are the obvious two; `documentation-only` exists because
+ * `description` is prose Renovate accumulates from every matched rule, so an
+ * edit that only re-words a rule moves a config key without moving behavior —
+ * and calling that "differs" is as wrong as hiding it.
+ */
+export type ComparisonVerdict = "identical" | "documentation-only" | "differs";
+
+/** How a paired rule's selectors differ between the two sides. */
+export type SelectorChangeKind =
+  | "clause-added"
+  | "clause-removed"
+  | "clause-values-changed"
+  | "clause-rewritten"
+  /** Only in `mode: "dependency"`: the config is the SAME file on both sides,
+   *  so nothing was rewritten — two different entries of one `packageRules`
+   *  array happened to produce the same effect for their own dependency. */
+  | "different-rule";
+
+/** Whether a changed key can change what Renovate does. */
+export type DeltaKind = "behavioral" | "documentation";
 
 /** A matched rule identified by its selector signature (stable across edits). */
 export interface RuleRef {
@@ -25,13 +67,22 @@ export interface RuleRef {
   label: string;
 }
 
-/** One key whose final per-dependency value differs between A and B. */
+/**
+ * One key whose final per-dependency value differs between A and B.
+ *
+ * `a`/`b`, not `before`/`after`: a comparison has no chronology. B is the
+ * later config in `mode: "config"`, but in `mode: "dependency"` the two sides
+ * are one config seen through two dependencies, and calling either of them
+ * "before" is a claim the data does not support.
+ */
 export interface ConfigKeyDelta {
   key: string;
+  /** Whether this key can change what Renovate does ({@link DOCUMENTATION_KEYS}). */
+  kind: DeltaKind;
   /** A's value (only meaningful when `inA`). */
-  before?: unknown;
+  a?: unknown;
   /** B's value (only meaningful when `inB`). */
-  after?: unknown;
+  b?: unknown;
   inA: boolean;
   inB: boolean;
   /**
@@ -40,78 +91,95 @@ export interface ConfigKeyDelta {
    * set. Without this the delta asserted an explicit `automerge: false` that
    * A's own field list (correctly) never showed. Present only when true.
    */
-  beforeInherited?: boolean;
+  aInherited?: boolean;
   /** Same, for B's side of the delta. */
-  afterInherited?: boolean;
+  bInherited?: boolean;
 }
 
 /**
- * Roadmap 062: a matched rule that is present on both sides by EFFECT — it
- * merged exactly the same keys to the same values — but whose selector text
- * changed, so the two sides pair on neither signature nor index.
+ * A matched rule that is present on both sides by EFFECT — it merged exactly
+ * the same keys to the same values — but that neither signature nor index
+ * pairs.
  *
- * This is the ordinary shape of a behavior-preserving edit: removing an entry
- * from `matchPackageNames` necessarily rewrites the signature of the very rule
- * that array belongs to. Naming it as identity churn is what lets the behavior
- * verdict stay `noChange: true`.
+ * In `mode: "config"` this is the ordinary shape of a behavior-preserving
+ * edit: removing an entry from `matchPackageNames` necessarily rewrites the
+ * signature of the very rule that array belongs to. Naming it as identity
+ * churn is what lets the behavior verdict stay `identical`.
  */
 export interface SignatureChange {
   /** A's rule. */
   a: RuleRef;
   /** B's rule — same effect, different selector text. */
   b: RuleRef;
+  /** WHAT differs about the selectors, computed from both rules' clauses. */
+  kind: SelectorChangeKind;
+  /** The clause keys the change is about, sorted. Empty for `different-rule`,
+   *  where no clause changed at all. */
+  keys: string[];
+}
+
+/**
+ * The identity axis, whole and in one place. Every member of it is bookkeeping
+ * about selector TEXT; none of it is a claim about behavior.
+ */
+export interface RuleIdentityChurn {
+  /** Any matched rule's selector signature differs between A and B — added,
+   *  removed, or rewritten. True is expected, and harmless, whenever the edit
+   *  touched the array a rule matches on. */
+  changed: boolean;
+  /** Same effect on both sides, different selector text. */
+  signatureChanges: SignatureChange[];
+  /** Rules whose selector signature no rule in B carries. INCLUDES the `a` of
+   *  every {@link signatureChanges} entry — this is the signature-level fact,
+   *  not "stopped matching". */
+  onlyInA: RuleRef[];
+  /** Rules whose selector signature no rule in A carries. */
+  onlyInB: RuleRef[];
 }
 
 export interface SimulationComparison {
-  /** Rules that matched in A but no rule in B carries their selector signature
-   *  (removed, or rewritten — see {@link SignatureChange}). Identity axis. */
-  matchedOnlyInA: RuleRef[];
-  /** Rules that matched in B but no rule in A carries their selector signature.
-   *  Identity axis. */
-  matchedOnlyInB: RuleRef[];
+  /** The whole verdict as one line: `${verdict}: ${netEffect}`. First, because
+   *  object-literal order is JSON order and JSON order is reading order. */
+  summary: string;
+  /** The behavior verdict, structured. */
+  verdict: ComparisonVerdict;
+  /** The words after the colon of {@link summary}, so no consumer has to slice
+   *  a string to headline the result in its own voice. */
+  netEffect: string;
+  /** What the caller varied between A and B; `unspecified` when it did not say. */
+  mode: ComparisonMode;
+  /** BEHAVIOR: rules whose effect no rule in B reproduced — what genuinely
+   *  stopped happening. A rule that merely had its pattern rewritten is not
+   *  here (it is in `identity.signatureChanges`). */
+  stoppedMatching: RuleRef[];
+  /** BEHAVIOR: effects no rule in A produced — what genuinely started. */
+  startedMatching: RuleRef[];
   /** Rules that matched in both runs, paired by selector signature. */
   matchedInBoth: RuleRef[];
-  /**
-   * Roadmap 062 — the BEHAVIOR axis of `matchedOnlyInA`: rules whose effect no
-   * rule in B reproduced. A rule that merely had its pattern rewritten is not
-   * here (it is in {@link signatureChanges}); a rule that genuinely stopped
-   * doing something is.
-   */
-  behaviorOnlyInA: RuleRef[];
-  /** The same for B: effects no rule in A produced — what genuinely started. */
-  behaviorOnlyInB: RuleRef[];
-  /** Same effect on both sides, different selector text (identity churn only). */
-  signatureChanges: SignatureChange[];
-  /** IDENTITY: any matched rule's selector signature differs between A and B —
-   *  added, removed, or rewritten. True is expected, and harmless, whenever the
-   *  edit touched the array a rule matches on. */
-  rulesChanged: boolean;
-  /** Final per-dependency config keys that changed, sorted by key. */
+  /** Final per-dependency config keys that changed: behavioral keys first,
+   *  alphabetical within each group. One ordering for the array, the summary,
+   *  the CLI list and the app's delta column. */
   configDelta: ConfigKeyDelta[];
-  /**
-   * BEHAVIOR: the resulting per-dependency config is identical AND every effect
-   * the matched rules produced in A is still produced in B (and vice versa).
-   *
-   * Roadmap 062 (2026-07 persona study, 2 of 9 sessions): this used to be the
-   * identity verdict — it went false whenever a selector signature moved, so a
-   * provably behavior-preserving edit headlined as "Behavior differs" with an
-   * EMPTY `configDelta` underneath. Both personas had to read past the
-   * headline; one called the result uncitable. The identity fact is still
-   * reported, as {@link rulesChanged} and {@link signatureChanges} — it is just
-   * no longer allowed to speak for behavior.
-   */
-  noChange: boolean;
-  /**
-   * The whole verdict as one line, starting with `identical:` or `differs:`.
-   *
-   * Roadmap 068 (2026-07 persona study, 4 of 9 sessions): every consumer of
-   * this diff — the CLI's headline, the app's panel, an agent reading the JSON
-   * — was re-deriving "so did it change?" from six arrays and two booleans,
-   * and the readings disagreed. The net effect belongs in the comparison, once
-   * and in words, next to the fields that justify it.
-   */
-  summary: string;
+  /** The identity axis. Not a behavior claim — see {@link RuleIdentityChurn}. */
+  identity: RuleIdentityChurn;
 }
+
+/** Options for {@link compareSimulations}. */
+export interface CompareOptions {
+  /** What the caller varied between A and B. Defaults to `unspecified`. */
+  mode?: ComparisonMode;
+}
+
+/**
+ * Top-level config keys that are pure prose: they can move without anything
+ * Renovate DOES moving with them.
+ *
+ * Deliberately hardcoded, and deliberately tiny. `description` is Renovate's
+ * only pure-prose top-level option — the array `mergeChildConfig` concatenates
+ * from every matched rule, which is why it moves whenever the matched-rule set
+ * moves — and this module must stay import-free.
+ */
+const DOCUMENTATION_KEYS = new Set(["description"]);
 
 function signatureOf(rule: RuleEvaluation): string {
   return JSON.stringify(rule.clauses.map((c) => [c.key, c.value]));
@@ -161,54 +229,219 @@ function inheritedIn(result: SimulationResult, key: string): boolean {
   return !result.mergeSteps.some((step) => step.merged.some((m) => m.key === key));
 }
 
+/** A rule's clauses as key → stable value text, so two rules can be compared
+ *  clause by clause without re-parsing the signature string. */
+function clauseValues(rule: RuleEvaluation): Map<string, string> {
+  return new Map(rule.clauses.map((c) => [c.key, JSON.stringify(c.value) ?? "null"]));
+}
+
+/**
+ * WHAT changed about a paired rule's selectors, from the two evaluations
+ * themselves. Computed at pairing time, where both sides are in hand — the
+ * alternative (a hardcoded sentence at summary time) is exactly the defect
+ * this replaces: it announced "a rule's pattern text changed" for edits that
+ * ADDED a clause, and for two runs of one identical config file.
+ */
+function selectorChangeOf(
+  a: RuleEvaluation,
+  b: RuleEvaluation,
+  mode: ComparisonMode,
+): Pick<SignatureChange, "kind" | "keys"> {
+  if (mode === "dependency") {
+    // One config file, two dependencies: no selector text can have changed,
+    // because there is only one copy of it. These are two different rules.
+    return { kind: "different-rule", keys: [] };
+  }
+  const ca = clauseValues(a);
+  const cb = clauseValues(b);
+  const added = [...cb.keys()].filter((key) => !ca.has(key)).toSorted();
+  const removed = [...ca.keys()].filter((key) => !cb.has(key)).toSorted();
+  const changed = [...ca.keys()].filter((key) => cb.has(key) && cb.get(key) !== ca.get(key));
+  if (added.length > 0 && removed.length === 0 && changed.length === 0) {
+    return { kind: "clause-added", keys: added };
+  }
+  if (removed.length > 0 && added.length === 0 && changed.length === 0) {
+    return { kind: "clause-removed", keys: removed };
+  }
+  if (added.length === 0 && removed.length === 0 && changed.length > 0) {
+    return { kind: "clause-values-changed", keys: changed.toSorted() };
+  }
+  return { kind: "clause-rewritten", keys: [...added, ...removed, ...changed].toSorted() };
+}
+
 /** How many changed keys the one-liner names before it starts counting. */
 const SUMMARY_KEY_LIMIT = 6;
+/** Past this, the annotated key list stops being a line and drops to bare names. */
+const SUMMARY_LINE_BUDGET = 140;
+/** A value long enough to be a document, not an annotation. */
+const SUMMARY_VALUE_BUDGET = 24;
 
 function countOf(n: number, noun: string): string {
   return `${n} ${noun}${n === 1 ? "" : "s"}`;
 }
 
-/**
- * The net effect, in one line. Ordered by what a reader actually asked: the
- * config delta is the citable answer when there is one, the rules that started
- * or stopped doing something is the answer when the config came out the same,
- * and the identity churn is a parenthetical either way — never the headline,
- * because for the commonest behavior-preserving edit it is guaranteed true.
- */
-function summaryOf(comparison: Omit<SimulationComparison, "summary">): string {
-  if (comparison.noChange) {
-    return comparison.rulesChanged
-      ? "identical: the same effective config results (a rule's pattern text changed)"
-      : "identical: the same rules matched and the same effective config results";
+function valueText(value: unknown): string {
+  return JSON.stringify(value) ?? String(value);
+}
+
+/** One selector change, named. Singular — the caller decides when to count. */
+function churnPhrase(change: SignatureChange): string {
+  const list = change.keys.join(" + ");
+  switch (change.kind) {
+    case "clause-added":
+      return change.keys.length === 1
+        ? `a rule gained a ${list} clause`
+        : `a rule gained ${list} clauses`;
+    case "clause-removed":
+      return change.keys.length === 1
+        ? `a rule dropped its ${list} clause`
+        : `a rule dropped its ${list} clauses`;
+    case "clause-values-changed":
+      return change.keys.length === 1
+        ? `a rule's ${list} list changed`
+        : `a rule's ${list} lists changed`;
+    case "different-rule":
+      return "a different rule produced the same effect for each dependency";
+    default:
+      return "a rule's selectors were rewritten";
   }
-  const keys = comparison.configDelta.map((delta) => delta.key);
-  if (keys.length > 0) {
-    const named = keys.slice(0, SUMMARY_KEY_LIMIT).join(", ");
-    const rest = keys.length - SUMMARY_KEY_LIMIT;
-    return `differs: ${named}${rest > 0 ? ` and ${rest} more` : ""}`;
+}
+
+/** The same, counted, for several changes that agree on their kind. */
+function churnPhraseOfMany(kind: SelectorChangeKind, n: number): string {
+  switch (kind) {
+    case "clause-added":
+      return `${countOf(n, "rule")} gained a selector clause`;
+    case "clause-removed":
+      return `${countOf(n, "rule")} dropped a selector clause`;
+    case "clause-values-changed":
+      return `${countOf(n, "rule")} changed a selector's values`;
+    case "different-rule":
+      return `${countOf(n, "different rule")} produced the same effects for each dependency`;
+    default:
+      return `${countOf(n, "rule")} had their selectors rewritten`;
   }
-  const changes = [
-    ...(comparison.behaviorOnlyInB.length > 0
-      ? [`${countOf(comparison.behaviorOnlyInB.length, "rule")} started matching`]
-      : []),
-    ...(comparison.behaviorOnlyInA.length > 0
-      ? [`${countOf(comparison.behaviorOnlyInA.length, "rule")} stopped matching`]
-      : []),
-  ];
-  return `differs: ${changes.join(" and ")}, with no change to the effective config`;
+}
+
+/** The parenthetical of an `identical:` verdict, derived from what actually
+ *  changed rather than asserted. */
+function churnOf(changes: readonly SignatureChange[]): string {
+  const [first] = changes;
+  if (!first) {
+    return "a rule's selectors changed";
+  }
+  if (changes.length === 1) {
+    return churnPhrase(first);
+  }
+  return changes.every((change) => change.kind === first.kind)
+    ? churnPhraseOfMany(first.kind, changes.length)
+    : `${countOf(changes.length, "rule")} changed selectors without changing what they do`;
+}
+
+/** One side of a key delta, in words: the value, whether the side has it at
+ *  all, and whether the value is a default the config never set. */
+function sideText(run: "A" | "B", value: unknown, present: boolean, inherited?: boolean): string {
+  if (!present) {
+    return `unset in ${run}`;
+  }
+  return `${run}=${valueText(value)}${inherited ? " by default" : ""}`;
+}
+
+function annotatedKey(delta: ConfigKeyDelta): string {
+  const a = sideText("A", delta.a, delta.inA, delta.aInherited);
+  const b = sideText("B", delta.b, delta.inB, delta.bInherited);
+  return `${delta.key} (${a}, ${b})`;
+}
+
+function withinValueBudget(delta: ConfigKeyDelta): boolean {
+  return (
+    (!delta.inA || valueText(delta.a).length <= SUMMARY_VALUE_BUDGET) &&
+    (!delta.inB || valueText(delta.b).length <= SUMMARY_VALUE_BUDGET)
+  );
 }
 
 /**
- * Compares a pinned run (`a`) with the current run (`b`). Matched rules are
- * paired greedily by selector signature (a multiset match, so a config with two
- * rules sharing selectors is handled), leftover A rules become `matchedOnlyInA`
- * and leftover B rules `matchedOnlyInB`.
+ * The changed keys, with direction and values while they still fit on a line.
+ * Annotation is all-or-nothing: half a list annotated reads as if the bare
+ * half had no values, which is a worse answer than a bare list.
  */
-export function compareSimulations(a: SimulationResult, b: SimulationResult): SimulationComparison {
+function keyList(deltas: readonly ConfigKeyDelta[]): string {
+  const shown = deltas.slice(0, SUMMARY_KEY_LIMIT);
+  const rest = deltas.length - shown.length;
+  const tail = rest > 0 ? ` and ${rest} more` : "";
+  const annotated = `${shown.map(annotatedKey).join(", ")}${tail}`;
+  if (shown.every(withinValueBudget) && annotated.length <= SUMMARY_LINE_BUDGET) {
+    return annotated;
+  }
+  return `${shown.map((delta) => delta.key).join(", ")}${tail}`;
+}
+
+/**
+ * The net effect, in one line, without the verdict prefix. Ordered by what a
+ * reader actually asked: the config delta is the citable answer when there is
+ * one, the rules that started or stopped doing something is the answer when
+ * the config came out the same, and the identity churn is a parenthetical
+ * either way — never the headline, because for the commonest
+ * behavior-preserving edit it is guaranteed true.
+ */
+function netEffectOf(
+  verdict: ComparisonVerdict,
+  comparison: Omit<SimulationComparison, "summary" | "verdict" | "netEffect">,
+): string {
+  const behavioral = comparison.configDelta.filter((delta) => delta.kind === "behavioral");
+  const documentation = comparison.configDelta.filter((delta) => delta.kind === "documentation");
+  if (verdict === "identical") {
+    return comparison.identity.changed
+      ? `the same effective config results (${churnOf(comparison.identity.signatureChanges)})`
+      : "the same rules matched and the same effective config results";
+  }
+  if (verdict === "documentation-only") {
+    const named = documentation.map((delta) => delta.key).join(", ");
+    return `only ${named} changed — documentation text, no behavioral difference`;
+  }
+  const ruleChanges = [
+    ...(comparison.startedMatching.length > 0
+      ? [`${countOf(comparison.startedMatching.length, "rule")} started matching`]
+      : []),
+    ...(comparison.stoppedMatching.length > 0
+      ? [`${countOf(comparison.stoppedMatching.length, "rule")} stopped matching`]
+      : []),
+  ];
+  const documentationTail =
+    documentation.length > 0
+      ? [`${documentation.map((delta) => delta.key).join(", ")} also changed (documentation)`]
+      : [];
+  if (behavioral.length > 0) {
+    return [keyList(behavioral), ...documentationTail, ...ruleChanges].join("; ");
+  }
+  if (documentationTail.length === 0) {
+    return `${ruleChanges.join(" and ")}, with no change to the effective config`;
+  }
+  return [ruleChanges.join(" and "), ...documentationTail].join("; ");
+}
+
+/**
+ * Compares run `a` with run `b`. Matched rules are paired greedily by selector
+ * signature (a multiset match, so a config with two rules sharing selectors is
+ * handled); the leftovers are paired again by what they MERGED, and whatever
+ * pairs there changed its identity without changing its behavior.
+ *
+ * `options.mode` says what the caller varied. It is the difference between "a
+ * rule's selectors were rewritten" (true only when the config text differs)
+ * and "a different rule produced the same effect for each dependency" (the
+ * only possible reading when one config file is simulated against two
+ * dependencies).
+ */
+export function compareSimulations(
+  a: SimulationResult,
+  b: SimulationResult,
+  options: CompareOptions = {},
+): SimulationComparison {
+  const mode = options.mode ?? "unspecified";
   const aMatched = matchedRules(a);
   const bRemaining = matchedRules(b);
   const matchedInBoth: RuleRef[] = [];
-  const matchedOnlyInA: RuleRef[] = [];
+  const onlyInA: RuleRef[] = [];
   const unpairedA: RuleEvaluation[] = [];
 
   for (const ra of aMatched) {
@@ -218,31 +451,35 @@ export function compareSimulations(a: SimulationResult, b: SimulationResult): Si
       matchedInBoth.push(refOf(ra));
       bRemaining.splice(i, 1);
     } else {
-      matchedOnlyInA.push(refOf(ra));
+      onlyInA.push(refOf(ra));
       unpairedA.push(ra);
     }
   }
-  const matchedOnlyInB = bRemaining.map(refOf);
+  const onlyInB = bRemaining.map(refOf);
 
-  // Roadmap 062, second pass: the rules the SIGNATURE pass left over, paired
-  // again by what they merged. Whatever pairs here changed its pattern text
-  // without changing what it did — identity churn, not behavior. Whatever is
-  // still left over is a real behavioral difference.
+  // Second pass: the rules the SIGNATURE pass left over, paired again by what
+  // they merged. Whatever pairs here did the same thing on both sides —
+  // identity churn, not behavior. Whatever is still left over is a real
+  // behavioral difference.
   const unpairedB = [...bRemaining];
   const signatureChanges: SignatureChange[] = [];
-  const behaviorOnlyInA: RuleRef[] = [];
+  const stoppedMatching: RuleRef[] = [];
   for (const ra of unpairedA) {
     const effect = effectOf(ra);
     const i = effect === undefined ? -1 : unpairedB.findIndex((rb) => effectOf(rb) === effect);
     const paired = i >= 0 ? unpairedB[i] : undefined;
     if (paired) {
-      signatureChanges.push({ a: refOf(ra), b: refOf(paired) });
+      signatureChanges.push({
+        a: refOf(ra),
+        b: refOf(paired),
+        ...selectorChangeOf(ra, paired, mode),
+      });
       unpairedB.splice(i, 1);
     } else {
-      behaviorOnlyInA.push(refOf(ra));
+      stoppedMatching.push(refOf(ra));
     }
   }
-  const behaviorOnlyInB = unpairedB.map(refOf);
+  const startedMatching = unpairedB.map(refOf);
 
   const configA = a.finalDependencyConfig;
   const configB = b.finalDependencyConfig;
@@ -256,29 +493,44 @@ export function compareSimulations(a: SimulationResult, b: SimulationResult): Si
     }
     configDelta.push({
       key,
-      ...(inA ? { before: configA[key] } : {}),
-      ...(inB ? { after: configB[key] } : {}),
+      kind: DOCUMENTATION_KEYS.has(key) ? "documentation" : "behavioral",
+      ...(inA ? { a: configA[key] } : {}),
+      ...(inB ? { b: configB[key] } : {}),
       inA,
       inB,
-      ...(inA && inheritedIn(a, key) ? { beforeInherited: true } : {}),
-      ...(inB && inheritedIn(b, key) ? { afterInherited: true } : {}),
+      ...(inA && inheritedIn(a, key) ? { aInherited: true } : {}),
+      ...(inB && inheritedIn(b, key) ? { bInherited: true } : {}),
     });
   }
+  // Behavioral first, alphabetical within group — the summary names them in
+  // this order, so the array under it must too.
+  configDelta.sort((x, y) =>
+    x.kind === y.kind ? x.key.localeCompare(y.key) : x.kind === "behavioral" ? -1 : 1,
+  );
 
-  const rulesChanged = matchedOnlyInA.length > 0 || matchedOnlyInB.length > 0;
-  const noChange =
-    behaviorOnlyInA.length === 0 && behaviorOnlyInB.length === 0 && configDelta.length === 0;
-
-  const comparison = {
-    matchedOnlyInA,
-    matchedOnlyInB,
-    matchedInBoth,
-    behaviorOnlyInA,
-    behaviorOnlyInB,
+  const identity: RuleIdentityChurn = {
+    changed: onlyInA.length > 0 || onlyInB.length > 0,
     signatureChanges,
-    rulesChanged,
-    configDelta,
-    noChange,
+    onlyInA,
+    onlyInB,
   };
-  return { ...comparison, summary: summaryOf(comparison) };
+  const behavioralKeys = configDelta.some((delta) => delta.kind === "behavioral");
+  const rulesMoved = stoppedMatching.length > 0 || startedMatching.length > 0;
+  const verdict: ComparisonVerdict =
+    rulesMoved || behavioralKeys
+      ? "differs"
+      : configDelta.length > 0
+        ? "documentation-only"
+        : "identical";
+
+  const core = {
+    mode,
+    stoppedMatching,
+    startedMatching,
+    matchedInBoth,
+    configDelta,
+    identity,
+  };
+  const netEffect = netEffectOf(verdict, core);
+  return { summary: `${verdict}: ${netEffect}`, verdict, netEffect, ...core };
 }

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -1,8 +1,8 @@
 /**
  * Roadmap 018 — unit tests for the pure A/B `compareSimulations` diff. Builds
- * `SimulationResult`-shaped fixtures by hand (the module only reads `rules` and
- * `finalDependencyConfig`), so this needs no Renovate machinery and runs as a
- * plain node test.
+ * `SimulationResult`-shaped fixtures by hand (the module only reads `rules`,
+ * `mergeSteps` and `finalDependencyConfig`), so this needs no Renovate
+ * machinery and runs as a plain node test.
  */
 import { describe, expect, it } from "vitest";
 import { compareSimulations, type RuleEvaluation, type SimulationResult } from "../src/index";
@@ -37,12 +37,33 @@ function sim(
     rawFinalConfig: {},
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
-    // Roadmap 044: the merge step-through's snapshots — the A/B comparison
-    // (021) does not read them, so a hand-built fixture leaves them empty.
+    // Roadmap 044: the merge step-through's snapshots — a fixture that leaves
+    // them empty is honestly saying NO step wrote any of its final config, so
+    // every value in it reads as an inherited default (replay-02 N8).
     mergeSteps: [],
     errors: [],
     warnings: [],
     notes: [],
+  };
+}
+
+/** The same, but with a flatten step that wrote every key of the final config
+ *  — so the delta is about values the config SET, not defaults it inherited. */
+function simWritten(
+  rules: RuleEvaluation[],
+  finalDependencyConfig: Record<string, unknown>,
+): SimulationResult {
+  return {
+    ...sim(rules, finalDependencyConfig),
+    mergeSteps: [
+      {
+        kind: "flatten",
+        updateType: "minor",
+        before: {},
+        after: finalDependencyConfig,
+        merged: Object.entries(finalDependencyConfig).map(([key, after]) => ({ key, after })),
+      },
+    ],
   };
 }
 
@@ -55,9 +76,9 @@ describe("compareSimulations", () => {
       { automerge: true },
     );
     const cmp = compareSimulations(a, b);
-    expect(cmp.noChange).toBe(true);
-    expect(cmp.matchedOnlyInA).toEqual([]);
-    expect(cmp.matchedOnlyInB).toEqual([]);
+    expect(cmp.verdict).toBe("identical");
+    expect(cmp.identity.onlyInA).toEqual([]);
+    expect(cmp.identity.onlyInB).toEqual([]);
     expect(cmp.configDelta).toEqual([]);
     expect(cmp.matchedInBoth.map((r) => r.signature)).toEqual([
       JSON.stringify([["matchPackageNames", ["react"]]]),
@@ -74,12 +95,12 @@ describe("compareSimulations", () => {
     });
     const cmp = compareSimulations(a, b);
     expect(cmp.matchedInBoth.map((r) => r.label)).toEqual(["matchDatasources"]);
-    expect(cmp.matchedOnlyInA.map((r) => r.label)).toEqual(["matchPackageNames"]);
-    expect(cmp.matchedOnlyInB.map((r) => r.label)).toEqual(["matchSourceUrls"]);
-    expect(cmp.noChange).toBe(false);
+    expect(cmp.identity.onlyInA.map((r) => r.label)).toEqual(["matchPackageNames"]);
+    expect(cmp.identity.onlyInB.map((r) => r.label)).toEqual(["matchSourceUrls"]);
+    expect(cmp.verdict).toBe("differs");
   });
 
-  it("emits key-level config deltas with before/after and presence flags", () => {
+  it("emits key-level config deltas with a/b values and presence flags", () => {
     const a = sim([matched(0, [["matchPackageNames", ["x"]]])], {
       automerge: false,
       labels: ["old"],
@@ -89,22 +110,23 @@ describe("compareSimulations", () => {
       groupName: "grp",
     });
     const cmp = compareSimulations(a, b);
-    expect(cmp.noChange).toBe(false);
+    expect(cmp.verdict).toBe("differs");
     // sorted by key: automerge (changed), groupName (added in B), labels
     // (removed from A). These fixtures have no merge steps, so every present
     // value is honestly flagged as inherited (replay-02 N8).
     expect(cmp.configDelta).toEqual([
       {
         key: "automerge",
-        before: false,
-        after: true,
+        kind: "behavioral",
+        a: false,
+        b: true,
         inA: true,
         inB: true,
-        beforeInherited: true,
-        afterInherited: true,
+        aInherited: true,
+        bInherited: true,
       },
-      { key: "groupName", after: "grp", inA: false, inB: true, afterInherited: true },
-      { key: "labels", before: ["old"], inA: true, inB: false, beforeInherited: true },
+      { key: "groupName", kind: "behavioral", b: "grp", inA: false, inB: true, bInherited: true },
+      { key: "labels", kind: "behavioral", a: ["old"], inA: true, inB: false, aInherited: true },
     ]);
   });
 
@@ -115,21 +137,18 @@ describe("compareSimulations", () => {
     // default as an explicit value: that asserts an `automerge: false` the
     // config never contains.
     const a = sim([matched(0, [["matchPackageNames", ["x"]]])], { automerge: false });
-    const b = {
-      ...sim([matched(0, [["matchPackageNames", ["x"]]])], { automerge: true }),
-      mergeSteps: [
-        {
-          kind: "flatten" as const,
-          updateType: "minor",
-          before: { automerge: false },
-          after: { automerge: true },
-          merged: [{ key: "automerge", before: false, after: true }],
-        },
-      ],
-    };
+    const b = simWritten([matched(0, [["matchPackageNames", ["x"]]])], { automerge: true });
     const cmp = compareSimulations(a, b);
     expect(cmp.configDelta).toEqual([
-      { key: "automerge", before: false, after: true, inA: true, inB: true, beforeInherited: true },
+      {
+        key: "automerge",
+        kind: "behavioral",
+        a: false,
+        b: true,
+        inA: true,
+        inB: true,
+        aInherited: true,
+      },
     ]);
   });
 
@@ -145,16 +164,16 @@ describe("compareSimulations", () => {
     const cmp = compareSimulations(a, b);
     // matchManagers matched in both (A idx0, B idx1); the no-match rules drop out.
     expect(cmp.matchedInBoth.map((r) => r.label)).toEqual(["matchManagers"]);
-    expect(cmp.matchedOnlyInA).toEqual([]);
-    expect(cmp.matchedOnlyInB).toEqual([]);
-    expect(cmp.noChange).toBe(true);
+    expect(cmp.identity.onlyInA).toEqual([]);
+    expect(cmp.identity.onlyInB).toEqual([]);
+    expect(cmp.verdict).toBe("identical");
   });
 
   /**
-   * Roadmap 062: the two axes. `merged` is what a rule DID; two matched rules
-   * that merged the same keys to the same values are the same rule wearing a
-   * different pattern, and that is identity churn — the unavoidable side effect
-   * of editing the array the rule matches on — not a behavior change.
+   * The two axes. `merged` is what a rule DID; two matched rules that merged
+   * the same keys to the same values are the same rule wearing a different
+   * pattern, and that is identity churn — the unavoidable side effect of
+   * editing the array the rule matches on — not a behavior change.
    */
   describe("behavior versus rule identity", () => {
     const effect = [{ key: "groupName", after: "frontend" }];
@@ -165,15 +184,17 @@ describe("compareSimulations", () => {
       const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
       const b = sim([{ ...narrow, merged: effect }], { groupName: "frontend" });
       const cmp = compareSimulations(a, b);
-      expect(cmp.noChange).toBe(true);
-      expect(cmp.rulesChanged).toBe(true);
-      expect(cmp.behaviorOnlyInA).toEqual([]);
-      expect(cmp.behaviorOnlyInB).toEqual([]);
-      expect(cmp.signatureChanges).toHaveLength(1);
+      expect(cmp.verdict).toBe("identical");
+      expect(cmp.identity.changed).toBe(true);
+      expect(cmp.stoppedMatching).toEqual([]);
+      expect(cmp.startedMatching).toEqual([]);
+      expect(cmp.identity.signatureChanges).toHaveLength(1);
       // The signature-level fields are unchanged — the identity claim is still
-      // exactly as reported before, it just no longer speaks for behavior.
-      expect(cmp.matchedOnlyInA).toHaveLength(1);
-      expect(cmp.matchedOnlyInB).toHaveLength(1);
+      // exactly as reported before, it just no longer speaks for behavior, and
+      // nesting it under `identity` is what says so structurally: an
+      // `identity.onlyInA` cannot be misread as "stopped matching".
+      expect(cmp.identity.onlyInA).toHaveLength(1);
+      expect(cmp.identity.onlyInB).toHaveLength(1);
     });
 
     it("a rewritten selector that changed what the rule did IS a behavior change", () => {
@@ -182,10 +203,10 @@ describe("compareSimulations", () => {
         groupName: "ui",
       });
       const cmp = compareSimulations(a, b);
-      expect(cmp.noChange).toBe(false);
-      expect(cmp.signatureChanges).toEqual([]);
-      expect(cmp.behaviorOnlyInA).toHaveLength(1);
-      expect(cmp.behaviorOnlyInB).toHaveLength(1);
+      expect(cmp.verdict).toBe("differs");
+      expect(cmp.identity.signatureChanges).toEqual([]);
+      expect(cmp.stoppedMatching).toHaveLength(1);
+      expect(cmp.startedMatching).toHaveLength(1);
     });
 
     it("an unrecorded effect never pairs — two unknowns are not the same rule", () => {
@@ -193,18 +214,147 @@ describe("compareSimulations", () => {
       const a = sim([matched(0, [["matchPackageNames", ["lodash"]]])], {});
       const b = sim([matched(0, [["matchSourceUrls", ["https://x"]]])], {});
       const cmp = compareSimulations(a, b);
-      expect(cmp.signatureChanges).toEqual([]);
-      expect(cmp.behaviorOnlyInA).toHaveLength(1);
-      expect(cmp.behaviorOnlyInB).toHaveLength(1);
-      expect(cmp.noChange).toBe(false);
+      expect(cmp.identity.signatureChanges).toEqual([]);
+      expect(cmp.stoppedMatching).toHaveLength(1);
+      expect(cmp.startedMatching).toHaveLength(1);
+      expect(cmp.verdict).toBe("differs");
     });
 
     it("identical rules on both sides change neither axis", () => {
       const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
       const cmp = compareSimulations(a, a);
-      expect(cmp.noChange).toBe(true);
-      expect(cmp.rulesChanged).toBe(false);
-      expect(cmp.signatureChanges).toEqual([]);
+      expect(cmp.verdict).toBe("identical");
+      expect(cmp.identity.changed).toBe(false);
+      expect(cmp.identity.signatureChanges).toEqual([]);
+    });
+  });
+
+  /**
+   * The churn parenthetical used to be one hardcoded sentence — "a rule's
+   * pattern text changed" — fired for every behavior-preserving edit, so it
+   * was wrong for the ones that ADDED or DROPPED a clause and impossible for
+   * two dependencies read through one unchanged file. `kind` and `keys` are
+   * computed where both rules are in hand, and the sentence follows from them.
+   */
+  describe("selector change kinds", () => {
+    const effect = [{ key: "groupName", after: "frontend" }];
+    const bare = matched(0, [["matchPackageNames", ["react"]]]);
+    const withUpdateTypes = matched(0, [
+      ["matchPackageNames", ["react"]],
+      ["matchUpdateTypes", ["minor", "major"]],
+    ]);
+
+    it("names the clause a rule gained", () => {
+      const a = sim([{ ...bare, merged: effect }], { groupName: "frontend" });
+      const b = sim([{ ...withUpdateTypes, merged: effect }], { groupName: "frontend" });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.verdict).toBe("identical");
+      expect(cmp.identity.signatureChanges[0]?.kind).toBe("clause-added");
+      expect(cmp.identity.signatureChanges[0]?.keys).toEqual(["matchUpdateTypes"]);
+      expect(cmp.summary).toBe(
+        "identical: the same effective config results (a rule gained a matchUpdateTypes clause)",
+      );
+    });
+
+    it("names the clause a rule dropped", () => {
+      const a = sim([{ ...withUpdateTypes, merged: effect }], { groupName: "frontend" });
+      const b = sim([{ ...bare, merged: effect }], { groupName: "frontend" });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.identity.signatureChanges[0]?.kind).toBe("clause-removed");
+      expect(cmp.identity.signatureChanges[0]?.keys).toEqual(["matchUpdateTypes"]);
+      expect(cmp.summary).toBe(
+        "identical: the same effective config results (a rule dropped its matchUpdateTypes clause)",
+      );
+    });
+
+    it("calls a swapped clause set a rewrite, and lists every key involved", () => {
+      const a = sim([{ ...bare, merged: effect }], { groupName: "frontend" });
+      const b = sim([{ ...matched(0, [["matchDepTypes", ["dependencies"]]]), merged: effect }], {
+        groupName: "frontend",
+      });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.identity.signatureChanges[0]?.kind).toBe("clause-rewritten");
+      expect(cmp.identity.signatureChanges[0]?.keys).toEqual([
+        "matchDepTypes",
+        "matchPackageNames",
+      ]);
+      expect(cmp.summary).toBe(
+        "identical: the same effective config results (a rule's selectors were rewritten)",
+      );
+    });
+
+    /** One config file read through two dependencies: no selector text can
+     *  have changed, because there is only one copy of it. One input flips a
+     *  sentence that used to be unconditional. */
+    it("calls the pair a different rule in dependency mode", () => {
+      const wide = matched(0, [["matchPackageNames", ["react", "vue"]]]);
+      const narrow = matched(0, [["matchPackageNames", ["react"]]]);
+      const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
+      const b = sim([{ ...narrow, merged: effect }], { groupName: "frontend" });
+      const cmp = compareSimulations(a, b, { mode: "dependency" });
+      expect(cmp.mode).toBe("dependency");
+      expect(cmp.identity.signatureChanges[0]?.kind).toBe("different-rule");
+      expect(cmp.identity.signatureChanges[0]?.keys).toEqual([]);
+      expect(cmp.summary).toBe(
+        "identical: the same effective config results " +
+          "(a different rule produced the same effect for each dependency)",
+      );
+    });
+
+    it("defaults to unspecified rather than guessing an axis", () => {
+      const a = sim([{ ...bare, merged: effect }], { groupName: "frontend" });
+      expect(compareSimulations(a, a).mode).toBe("unspecified");
+    });
+  });
+
+  /**
+   * `description` is prose Renovate accumulates from every matched rule, so it
+   * moves whenever the matched-rule set does. Calling that a behavior change
+   * is as wrong as hiding it: it gets its own verdict, and it never headlines
+   * a delta that has behavioral keys in it.
+   */
+  describe("documentation keys", () => {
+    const rule = matched(0, [["matchPackageNames", ["react"]]]);
+
+    it("gives a description-only delta its own verdict", () => {
+      const a = simWritten([rule], { description: ["Group the react packages."] });
+      const b = simWritten([rule], { description: ["Group all frontend packages."] });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.verdict).toBe("documentation-only");
+      expect(cmp.configDelta.map((delta) => delta.kind)).toEqual(["documentation"]);
+      expect(cmp.summary).toBe(
+        "documentation-only: only description changed — documentation text, " +
+          "no behavioral difference",
+      );
+    });
+
+    it("files description behind the behavioral keys when both moved", () => {
+      const a = simWritten([rule], { automerge: false, description: ["Group react."] });
+      const b = simWritten([rule], { automerge: true, description: ["Group all of frontend."] });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.verdict).toBe("differs");
+      expect(cmp.summary).toBe(
+        "differs: automerge (A=false, B=true); description also changed (documentation)",
+      );
+    });
+
+    it("orders the delta behavioral-first, alphabetical within group", () => {
+      const a = simWritten([rule], {
+        automerge: false,
+        description: ["Group react."],
+        groupName: "old",
+      });
+      const b = simWritten([rule], {
+        automerge: true,
+        description: ["Group all of frontend."],
+        groupName: "new",
+      });
+      const cmp = compareSimulations(a, b, { mode: "config" });
+      expect(cmp.configDelta.map((delta) => delta.key)).toEqual([
+        "automerge",
+        "groupName",
+        "description",
+      ]);
     });
   });
 
@@ -220,10 +370,26 @@ describe("compareSimulations", () => {
     const wide = matched(0, [["matchPackageNames", ["react", "vue"]]]);
     const narrow = matched(0, [["matchPackageNames", ["react"]]]);
 
-    it("names the changed keys when the effective config moved", () => {
-      const a = sim([matched(0, [["matchManagers", ["npm"]]])], { groupName: "old" });
-      const b = sim([matched(0, [["matchManagers", ["npm"]]])], { groupName: "new", labels: [] });
-      expect(compareSimulations(a, b).summary).toBe("differs: groupName, labels");
+    it("names the changed keys, with direction and values", () => {
+      const a = simWritten([matched(0, [["matchManagers", ["npm"]]])], { groupName: "old" });
+      const b = simWritten([matched(0, [["matchManagers", ["npm"]]])], {
+        groupName: "new",
+        labels: [],
+      });
+      expect(compareSimulations(a, b, { mode: "config" }).summary).toBe(
+        'differs: groupName (A="old", B="new"), labels (unset in A, B=[])',
+      );
+    });
+
+    /** Replay-02 N8, in the surface an agent actually reads: a side nothing
+     *  wrote is a default, and the summary says so rather than asserting a
+     *  value the config never contained. */
+    it("marks a side the config never set as a default", () => {
+      const a = sim([matched(0, [["matchManagers", ["npm"]]])], { automerge: false });
+      const b = simWritten([matched(0, [["matchManagers", ["npm"]]])], { automerge: true });
+      expect(compareSimulations(a, b, { mode: "config" }).summary).toBe(
+        "differs: automerge (A=false by default, B=true)",
+      );
     });
 
     it("counts the rules when the config came out the same", () => {
@@ -238,8 +404,8 @@ describe("compareSimulations", () => {
     it("says identical for a behavior-preserving pattern edit, and why", () => {
       const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
       const b = sim([{ ...narrow, merged: effect }], { groupName: "frontend" });
-      expect(compareSimulations(a, b).summary).toBe(
-        "identical: the same effective config results (a rule's pattern text changed)",
+      expect(compareSimulations(a, b, { mode: "config" }).summary).toBe(
+        "identical: the same effective config results (a rule's matchPackageNames list changed)",
       );
     });
 
@@ -250,11 +416,11 @@ describe("compareSimulations", () => {
       );
     });
 
-    it("stops naming keys once the list would stop being a line", () => {
+    it("stops naming keys, and stops annotating them, once it would stop being a line", () => {
       const many = Object.fromEntries(
-        Array.from({ length: 9 }, (_, i) => [`key${i}`, i]),
+        Array.from({ length: 9 }, (_, i) => [`key${i}`, `a value far too long to annotate ${i}`]),
       ) as Record<string, unknown>;
-      const cmp = compareSimulations(sim([], {}), sim([], many));
+      const cmp = compareSimulations(sim([], {}), sim([], many), { mode: "config" });
       expect(cmp.summary).toBe("differs: key0, key1, key2, key3, key4, key5 and 3 more");
     });
   });
@@ -265,7 +431,17 @@ describe("compareSimulations", () => {
     const b = sim([matched(0, clause)], {});
     const cmp = compareSimulations(a, b);
     expect(cmp.matchedInBoth).toHaveLength(1);
-    expect(cmp.matchedOnlyInA).toHaveLength(1);
-    expect(cmp.matchedOnlyInB).toHaveLength(0);
+    expect(cmp.identity.onlyInA).toHaveLength(1);
+    expect(cmp.identity.onlyInB).toHaveLength(0);
+  });
+
+  /** `summary` is `${verdict}: ${netEffect}`, and `netEffect` exists so no
+   *  consumer has to slice a string to headline the result in its own voice. */
+  it("states the net effect separately from the verdict prefix", () => {
+    const a = simWritten([matched(0, [["matchManagers", ["npm"]]])], { automerge: false });
+    const b = simWritten([matched(0, [["matchManagers", ["npm"]]])], { automerge: true });
+    const cmp = compareSimulations(a, b, { mode: "config" });
+    expect(cmp.netEffect).toBe("automerge (A=false, B=true)");
+    expect(cmp.summary).toBe(`${cmp.verdict}: ${cmp.netEffect}`);
   });
 });

--- a/roadmap/070-agent-payload-projection.md
+++ b/roadmap/070-agent-payload-projection.md
@@ -55,7 +55,9 @@ the `tree.ts` / `messages.ts` pattern — pure functions, no io, used by the CLI
 implementation:
 
 - **`config-view.ts`** — `projectConfig(config, {keys, scope})`, plus the
-  `description` collapse (`collapseDiffs`, `diffLine`, `mergedLine`).
+  `description` collapse (`collapseDiffs`/`collapseDeltas`, `deltaLine`,
+  `mergedLine` — the comparison delta names its sides `a`/`b`, a merge names
+  them `before`/`after`, and one predicate serves both).
 - **`simulate.ts`** — `SIMULATE_DETAIL`, `VERDICT_DETAIL_NOTE`,
   `simulationPayload` (moved out of `mcp/server.ts`) and `comparisonPayload`.
 


### PR DESCRIPTION
compare_simulations' raw JSON misled six of nine persona sessions: a
signature-changed rule appeared in both matchedOnlyInA and
matchedOnlyInB, noChange: true sat beside rulesChanged: true, the
hardcoded '(a rule's pattern text changed)' parenthetical was factually
wrong for added-clause edits, before/after meant different things in
dep-vs-dep and run-vs-run mode, and cosmetic description deltas
headlined the alphabetical differs: summary.

The shape now leads with the behavior axis: a verdict enum
(identical | documentation-only | differs) replaces noChange,
stoppedMatching/startedMatching mean exactly what they say, the
identity axis is nested under identity.*, deltas use mode-neutral
a/b naming with a behavioral|documentation kind and behavioral-first
ordering, SignatureChange carries the actual change kind, and the
summary derives its phrasing from that kind and states direction
(A=false, B=true; 'by default' for inherited values). mode is a caller
input - never guessed. CLI, MCP and the app move in lockstep.

BREAKING CHANGE: SimulationComparison's field names and summary
wording changed; noChange/rulesChanged/behaviorOnlyIn*/matchedOnlyIn*
and delta before/after are gone.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>