### PR TITLE
fix(digest): quote validator messages to a clause boundary and stop underselling warnings

### DIFF
--- a/packages/app/src/lib/run-digest.test.ts
+++ b/packages/app/src/lib/run-digest.test.ts
@@ -75,6 +75,42 @@ describe("verdict", () => {
     expect(ids(clauses)).toEqual(["verdict", "presets", "effective", "problems"]);
   });
 
+  test("a run with only warnings is accepted, but not with a checkmark", () => {
+    const clauses = buildRunDigest(
+      input({
+        warnings: 1,
+        firstProblem: {
+          severity: "warning",
+          topic: "Configuration Warning",
+          message: "Invalid schedule: `before 6am on monday` may never match.",
+        },
+      }),
+    );
+    const verdict = clause(clauses, "verdict");
+    expect(verdict.tone).toBe("warn");
+    expect(verdict.text).not.toContain("✓");
+    // The phrase the CLI, MCP and e2e suites substring-match — it has to
+    // survive both acceptance variants, or those assertions go vacuous.
+    expect(verdict.text).toContain("Renovate accepted this config");
+    // The two clauses stay independently composed: the verdict says there is
+    // something to look at, the tail still counts it and links to it.
+    expect(ids(clauses)).toContain("problems");
+  });
+
+  test("the warnings verdict carries no count — the problems tail owns that", () => {
+    const text = (warnings: number): string =>
+      clause(
+        buildRunDigest(
+          input({
+            warnings,
+            firstProblem: { severity: "warning", topic: "Configuration Warning", message: "M" },
+          }),
+        ),
+        "verdict",
+      ).text;
+    expect(text(3)).toBe(text(1));
+  });
+
   test("errors that are not validation errors do not claim the config was refused", () => {
     const clauses = buildRunDigest(
       input({
@@ -327,7 +363,30 @@ describe("problems tail", () => {
     expect(problems.link?.label).toBe("fix them");
   });
 
-  test("a long message is elided on a word boundary", () => {
+  test("a two-sentence message is cut at its clause boundary, keeping the diagnosis", () => {
+    const problems = clause(
+      buildRunDigest(
+        input({
+          warnings: 1,
+          firstProblem: {
+            severity: "warning",
+            topic: "Configuration Warning",
+            // Upstream's real wording, per the message shape documented in
+            // packages/engine/src/error-translations.ts (redundant-glob-star).
+            message:
+              "packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.",
+          },
+        }),
+      ),
+      "problems",
+    );
+    expect(problems.text).toContain("other patterns… —");
+    // The remedy half is what the Problems tab is for; quoting a slice of it
+    // is what produced the old mid-clause cut.
+    expect(problems.text).not.toContain("as * or…");
+  });
+
+  test("a long message with no clause break falls back to a word boundary", () => {
     const problems = clause(
       buildRunDigest(
         input({
@@ -348,8 +407,9 @@ describe("problems tail", () => {
 });
 
 describe("assembled paragraphs", () => {
-  /** The canonical shape: a clean run of the app's own default config. */
-  test("clean run with a huge expansion", () => {
+  /** The canonical shape: a run Renovate accepted with one warning, over the
+   *  app's own default config. */
+  test("accepted run with one warning and a huge expansion", () => {
     const clauses = buildRunDigest(
       input({
         warnings: 1,
@@ -371,7 +431,26 @@ describe("assembled paragraphs", () => {
       }),
     );
     expect(digestText(clauses)).toMatchInlineSnapshot(
-      `"✓ Renovate accepted this config. It rewrote \`packageNames → matchPackageNames\` and \`stabilityDays\` in your file. Your \`config:recommended\` and \`:dependencyDashboard\` entries expanded into 1,076 presets — only 14 of which set options, the rest are package-grouping rules. Everything merged into 23 effective options, 6 of them overridden along the way. 1 warning: Invalid schedule: \`before 6am on monday\` may never match — review it."`,
+      `"Renovate accepted this config, but flagged something worth reviewing. It rewrote \`packageNames → matchPackageNames\` and \`stabilityDays\` in your file. Your \`config:recommended\` and \`:dependencyDashboard\` entries expanded into 1,076 presets — only 14 of which set options, the rest are package-grouping rules. Everything merged into 23 effective options, 6 of them overridden along the way. 1 warning: Invalid schedule: \`before 6am on monday\` may never match — review it."`,
+    );
+  });
+
+  /** Both of this fix's edges in one paragraph: the warnings verdict, and a
+   *  two-sentence validator message cut at its clause boundary. */
+  test("an accepted run whose one warning is a two-sentence validator message", () => {
+    const clauses = buildRunDigest(
+      input({
+        warnings: 1,
+        firstProblem: {
+          severity: "warning",
+          topic: "Configuration Warning",
+          message:
+            "packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.",
+        },
+      }),
+    );
+    expect(digestText(clauses)).toMatchInlineSnapshot(
+      `"Renovate accepted this config, but flagged something worth reviewing. Your \`config:recommended\` entry expanded into 4 presets. Everything merged into 12 effective options. 1 warning: packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns… — review it."`,
     );
   });
 

--- a/packages/app/src/lib/run-digest.ts
+++ b/packages/app/src/lib/run-digest.ts
@@ -9,6 +9,12 @@ import type { ResultsTabId } from "@/data/results-tabs";
  * Roadmap 029: every number the digest quotes arrives in `DigestInput` and is
  * never recomputed here — the app derives each one exactly once and feeds both
  * the tab badges and this generator, so the two can never disagree.
+ *
+ * Granularity ceiling: the paragraph is built from run-level aggregates and
+ * from provenance keyed per TOP-LEVEL config key, so two configs that differ
+ * only inside a `packageRules` entry produce the same paragraph. That is by
+ * design — the digest orients, it does not detect change. Rule-level
+ * differences are visible in the simulator and in `rcd compare`.
  */
 
 const nf = new Intl.NumberFormat();
@@ -22,6 +28,10 @@ const HUGE_EXPANSION = 50;
 
 /** How much of a validator message the digest quotes before eliding it. */
 const PROBLEM_SUMMARY_MAX = 120;
+
+/** The shortest quote an elision will settle for — below this a boundary cut
+ *  amputates the message to a stub, so a word-boundary cut reads better. */
+const PROBLEM_SUMMARY_MIN = PROBLEM_SUMMARY_MAX / 2;
 
 export type DigestTone = "ok" | "warn" | "error" | "plain";
 
@@ -130,16 +140,48 @@ function unpunctuated(text: string): string {
   return text.trim().replace(/(?<![.\s])[.\s]+$/, "");
 }
 
-/** The first problem, short enough to sit inside a sentence. Elides on a word
- *  boundary so a truncated validator message never ends mid-token. */
+/** End of the last complete sentence/clause in `text` (exclusive of its
+ *  terminator), or -1 when there is none. Two word characters have to precede
+ *  the mark, so "e.g." and "packageRules[0]." are not boundaries. */
+function lastClauseBreak(text: string): number {
+  let last = -1;
+  for (const match of text.matchAll(/\w\w[.;!?](?=\s)/g)) {
+    if (match.index !== undefined) {
+      last = match.index + 2;
+    }
+  }
+  return last;
+}
+
+/**
+ * The first problem, short enough to sit inside a sentence. Prefers to end the
+ * quote at the last sentence/clause boundary that fits the budget — validator
+ * messages are typically a diagnosis followed by a remedy, and the digest only
+ * needs the diagnosis (the clause it sits in already links to the Problems tab,
+ * where the remedy and the curated translation live). Falls back to a word
+ * boundary when there is no usable break, so a truncated message never ends
+ * mid-token.
+ *
+ * Deliberately quotes the RAW validator message, not the engine's translated
+ * explanation: `ErrorTranslation.explain()` returns multi-sentence paragraphs
+ * (hundreds to ~1,300 characters) meant to render as a block beside the
+ * message, and it covers only a curated handful of message families — sourcing
+ * it here would make the paragraph read inconsistently by curation.
+ */
 function summarizeProblem(problem: DigestProblem): string {
   const raw = unpunctuated(problem.message) || unpunctuated(problem.topic);
   if (raw.length <= PROBLEM_SUMMARY_MAX) {
     return raw;
   }
+  // `+ 1` so a terminator sitting exactly on the budget edge still counts —
+  // the lookahead needs the whitespace that follows it.
+  const clauseBreak = lastClauseBreak(raw.slice(0, PROBLEM_SUMMARY_MAX + 1));
+  if (clauseBreak > PROBLEM_SUMMARY_MIN) {
+    return `${raw.slice(0, clauseBreak).trimEnd()}…`;
+  }
   const cut = raw.slice(0, PROBLEM_SUMMARY_MAX);
   const lastSpace = cut.lastIndexOf(" ");
-  return `${(lastSpace > PROBLEM_SUMMARY_MAX / 2 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+  return `${(lastSpace > PROBLEM_SUMMARY_MIN ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
 }
 
 /** "2 errors and 1 warning" — only the halves that are non-zero. */
@@ -173,6 +215,18 @@ function verdictClause(input: DigestInput): DigestClause {
       id: "verdict",
       tone: "warn",
       text: "Renovate accepted every option in this config, but the run did not complete cleanly.",
+    };
+  }
+  if (input.warnings > 0) {
+    // Roadmap 029's scope names three verdicts — errors vs. warnings vs. clean.
+    // A warning run is not clean, so it must not open with the checkmark; the
+    // phrase "Renovate accepted this config" is kept verbatim on purpose (the
+    // CLI, MCP and e2e suites substring-match it across both variants). No
+    // count here: `problemClause` owns the count and the link to it.
+    return {
+      id: "verdict",
+      tone: "warn",
+      text: "Renovate accepted this config, but flagged something worth reviewing.",
     };
   }
   return { id: "verdict", tone: "ok", text: "✓ Renovate accepted this config." };

--- a/packages/app/src/lib/run-facts.ts
+++ b/packages/app/src/lib/run-facts.ts
@@ -114,6 +114,12 @@ function migrationLabel(step: TraceEvent): string {
  * exactly the derivations that feed the tab badges. `effective` is null while
  * provenance is still being computed (the browser computes it asynchronously);
  * the digest then says so rather than quoting a number it does not have.
+ *
+ * Every signal below is a run-level aggregate or provenance keyed per
+ * TOP-LEVEL config key, so an edit confined to one `packageRules` entry moves
+ * none of them and the paragraph comes out unchanged. That ceiling is
+ * deliberate: rule-level differences belong to the simulator and to
+ * `rcd compare`, not to the orientation paragraph.
  */
 export function buildDigestInput(
   result: TraceResult,

--- a/packages/cli/src/commands/digest.ts
+++ b/packages/cli/src/commands/digest.ts
@@ -7,7 +7,9 @@ import { INPUT_OPTIONS, runFromArgs, wouldRefuse } from "../run-input";
 
 /**
  * The Overview tab's paragraph, in a terminal — the cheapest orientation
- * before deciding what to drill into.
+ * before deciding what to drill into. Not a diff oracle: it narrates run-level
+ * aggregates, so two runs differing only inside a `packageRules` entry read
+ * the same — use `compare` for that.
  */
 export const digestCommand: Command = {
   name: "digest",


### PR DESCRIPTION
The digest truncated the embedded validator message mid-clause at 120
chars ('...Please remove them, as * or...') - the most quotable line in
the output was the mangled one. summarizeProblem now cuts at the last
complete sentence/clause inside the budget, falling back byte-identically
to the word-boundary cut when no break exists.

A warnings-only run also led with the bare '✓ Renovate accepted this
config.' with the warning appended sentences later; it now reads
'Renovate accepted this config, but flagged something worth reviewing.'
- keeping the substring six external tests pin, dropping the checkmark,
carrying no count (the problems clause owns that). The top-level-key
granularity ceiling (rule-level edits produce byte-identical digests) is
now documented where the inputs are chosen.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>