### PR TITLE
feat(cli)!: focused by default — answer with the rules that acted, drill down by name

### DIFF
--- a/packages/app/src/features/simulator/rule-evidence.test.ts
+++ b/packages/app/src/features/simulator/rule-evidence.test.ts
@@ -53,6 +53,7 @@ function simFixture(rules: RuleEvaluation[]): SimulationResult {
     finalDependencyConfig: {},
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/features/simulator/verdict-threads.test.ts
+++ b/packages/app/src/features/simulator/verdict-threads.test.ts
@@ -72,6 +72,7 @@ function simFixture(
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/lib/consumed-blocks.test.ts
+++ b/packages/app/src/lib/consumed-blocks.test.ts
@@ -16,6 +16,7 @@ function simFixture(flattened: Partial<SimulationResult["flattened"]> = {}): Sim
     finalDependencyConfig: {},
     flattened: { merged: [], blocks: {}, authoredBlocks: [], ...flattened },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -85,7 +85,7 @@ export {
   verdictFilterOptions,
 } from "./rule-filters";
 export { ruleWrittenKeys, summarizeRuleSelectors } from "./rule-selectors";
-export { isNoInputNoMatch } from "./rule-verdict";
+export { hasEvaluationError, isNoInputNoMatch } from "./rule-verdict";
 export { changedDependencyKeys } from "./simulation-changes";
 export {
   buildRunDigest,

--- a/packages/app/src/lib/rule-filters.test.ts
+++ b/packages/app/src/lib/rule-filters.test.ts
@@ -1,9 +1,11 @@
 /**
  * The rules drawer's two filter facets. The verdict facet has to split a
  * fail-closed "no match — input not set" from a genuine mismatch exactly the
- * way the badge does (Replay-02 R3/R4 — one predicate, `isNoInputNoMatch`),
- * and `ruleVisible` has to be the SAME predicate the cross-link focus uses to
- * decide whether a row is hidden. Both are locked here.
+ * way the badge does (Replay-02 R3/R4 — one predicate, `isNoInputNoMatch`) and
+ * keep a rule the tool could not evaluate at all out of that bucket (roadmap
+ * 073 — `hasEvaluationError`), and `ruleVisible` has to be the SAME predicate
+ * the cross-link focus uses to decide whether a row is hidden. All are locked
+ * here.
  */
 import type {
   ClauseEvaluation,
@@ -45,34 +47,47 @@ function rule(
 const REPO_LAYER: ProvenanceLayer = { kind: "repo" };
 const PRESET_LAYER: ProvenanceLayer = { kind: "preset", name: "config:recommended", nodeId: "n1" };
 
-// 0 matched (repo) · 1 no-input (preset) · 2 no-match (preset) · 3 not-simulated (preset)
+// 0 matched (repo) · 1 no-input (preset) · 2 no-match (preset) · 3 not-simulated
+// (preset) · 4 error (repo — a matcher threw, so the rule wears `no-match` too)
 const RULES = [
   rule(0, "matched", [clause("matched")]),
   rule(1, "no-match", [clause("no-input")]),
   rule(2, "no-match", [clause("no-match")]),
   rule(3, "not-simulated"),
+  rule(4, "no-match", [clause("error")]),
 ];
 const LAYERS = new Map<number, ProvenanceLayer>([
   [0, REPO_LAYER],
   [1, PRESET_LAYER],
   [2, PRESET_LAYER],
   [3, PRESET_LAYER],
+  [4, REPO_LAYER],
 ]);
 
 const indices = (rules: RuleEvaluation[]) => rules.map((r) => r.index);
 
 describe("the verdict facet", () => {
+  /**
+   * Roadmap 073's blocker: a clause whose matcher threw fails its rule to a
+   * plain `no-match`, so the old `notable` (`verdict !== "no-match"`) hid "the
+   * tool could not evaluate this rule" — and a focused default built on it
+   * would have hidden it silently. Rule 4 is that row, and it is in the default
+   * view.
+   */
   test("the default view keeps everything that is not a plain no-match", () => {
-    expect(indices(filterRules(RULES, DEFAULT_RULE_FILTERS, LAYERS))).toEqual([0, 3]);
+    expect(indices(filterRules(RULES, DEFAULT_RULE_FILTERS, LAYERS))).toEqual([0, 3, 4]);
   });
 
-  test("no-input and no-match are separate facets, split like the badge", () => {
-    const at = (verdict: "all" | "matched" | "no-input" | "no-match") =>
+  test("no-input, no-match and error are separate facets, split like the badge", () => {
+    const at = (verdict: "all" | "matched" | "no-input" | "no-match" | "error") =>
       indices(filterRules(RULES, { verdict, preset: ALL_PRESETS }, LAYERS));
-    expect(at("all")).toEqual([0, 1, 2, 3]);
+    expect(at("all")).toEqual([0, 1, 2, 3, 4]);
     expect(at("matched")).toEqual([0]);
     expect(at("no-input")).toEqual([1]);
+    // A GENUINE mismatch: the facet excludes the no-input row and, now that
+    // `error` names them, the un-evaluated one too.
     expect(at("no-match")).toEqual([2]);
+    expect(at("error")).toEqual([4]);
   });
 });
 
@@ -80,7 +95,7 @@ describe("the provenance facet", () => {
   test("narrowing to the repo layer is the old 'my rules only'", () => {
     // Note the verdict facet stays at its default: the two facets compose.
     expect(indices(filterRules(RULES, { verdict: "all", preset: REPO_RULES }, LAYERS))).toEqual([
-      0,
+      0, 4,
     ]);
   });
 
@@ -93,7 +108,7 @@ describe("the provenance facet", () => {
   test("options carry their counts, most-contributing first", () => {
     expect(presetFilterOptions(RULES, LAYERS, ALL_PRESETS)).toEqual([
       { value: "preset:config:recommended", label: "config:recommended", count: 3 },
-      { value: "repo", label: "repo config", count: 1 },
+      { value: "repo", label: "repo config", count: 2 },
     ]);
   });
 
@@ -109,8 +124,8 @@ describe("the provenance facet", () => {
 
 describe("the source facet (rcd --source)", () => {
   test("repo and presets are the two halves a CLI flag can name", () => {
-    expect(indices(filterRulesBySource(RULES, "all", LAYERS))).toEqual([0, 1, 2, 3]);
-    expect(indices(filterRulesBySource(RULES, "repo", LAYERS))).toEqual([0]);
+    expect(indices(filterRulesBySource(RULES, "all", LAYERS))).toEqual([0, 1, 2, 3, 4]);
+    expect(indices(filterRulesBySource(RULES, "repo", LAYERS))).toEqual([0, 4]);
     expect(indices(filterRulesBySource(RULES, "presets", LAYERS))).toEqual([1, 2, 3]);
   });
 
@@ -136,10 +151,11 @@ test("ruleLayerIndex turns the engine's attribution into the map the filters tak
 
 test("the verdict options state what each would leave", () => {
   expect(verdictFilterOptions(RULES).map((o) => [o.value, o.count])).toEqual([
-    ["notable", 2],
-    ["all", 4],
+    ["notable", 3],
+    ["all", 5],
     ["matched", 1],
     ["no-input", 1],
     ["no-match", 1],
+    ["error", 1],
   ]);
 });

--- a/packages/app/src/lib/rule-filters.ts
+++ b/packages/app/src/lib/rule-filters.ts
@@ -4,7 +4,7 @@ import type {
   RuleEvaluation,
 } from "@renovate-config-debugger/engine";
 import { type LayerId, layerId, layerLabel } from "@/components/provenance-layer";
-import { isNoInputNoMatch } from "./rule-verdict";
+import { hasEvaluationError, isNoInputNoMatch } from "./rule-verdict";
 
 /**
  * The rules drawer's filter facets — verdict and provenance — as one value,
@@ -31,12 +31,12 @@ import { isNoInputNoMatch } from "./rule-verdict";
  * counts rather than a second implementation that drifts.
  */
 
-/** The verdict facet. `notable` is the default view (matched + unresolved,
- *  i.e. everything except a plain no-match) — roadmap 012/047's finding that a
+/** The verdict facet. `notable` is the default view (matched + unresolved +
+ *  the rows the tool could not evaluate) — roadmap 012/047's finding that a
  *  first screen of 700 "no match" rows buries the handful that did something.
- *  The other three are the verdicts a rule row can wear, split the way the
- *  badge splits them (see {@link isNoInputNoMatch}). */
-export type VerdictFilter = "notable" | "all" | "matched" | "no-input" | "no-match";
+ *  The others are the verdicts a rule row can wear, split the way the badge
+ *  splits them (see {@link isNoInputNoMatch}, {@link hasEvaluationError}). */
+export type VerdictFilter = "notable" | "all" | "matched" | "no-input" | "no-match" | "error";
 
 /** Every {@link VerdictFilter}, for a CLI flag's parse + help text. */
 export const VERDICT_FILTERS: readonly VerdictFilter[] = [
@@ -45,6 +45,7 @@ export const VERDICT_FILTERS: readonly VerdictFilter[] = [
   "matched",
   "no-input",
   "no-match",
+  "error",
 ];
 
 /** The provenance facet: a layer id present in the run, or {@link ALL_PRESETS}.
@@ -75,12 +76,25 @@ export function isDefaultView(filters: RuleFilters): boolean {
   );
 }
 
+/**
+ * Roadmap 073, the blocker found while auditing the focused default: a clause
+ * whose matcher threw is recorded `state: "error"` and pushes its rule to
+ * `verdict: "no-match"`, so the old `notable` (`verdict !== "no-match"`) hid
+ * "the tool could not evaluate this rule" — the documented `conda`
+ * `matchCurrentVersion` case. `notable` therefore reads the error predicate
+ * too, and `no-match` keeps meaning a GENUINE mismatch: it now excludes the
+ * error rows the way it already excluded the no-input ones, because `error`
+ * names them.
+ *
+ * A filter change, not a verdict change — `execute()` still reports exactly
+ * what upstream's `applyPackageRules` would.
+ */
 export function matchesVerdictFilter(rule: RuleEvaluation, filter: VerdictFilter): boolean {
   if (filter === "all") {
     return true;
   }
   if (filter === "notable") {
-    return rule.verdict !== "no-match";
+    return rule.verdict !== "no-match" || hasEvaluationError(rule);
   }
   if (filter === "matched") {
     return rule.verdict === "matched";
@@ -88,7 +102,10 @@ export function matchesVerdictFilter(rule: RuleEvaluation, filter: VerdictFilter
   if (filter === "no-input") {
     return isNoInputNoMatch(rule);
   }
-  return rule.verdict === "no-match" && !isNoInputNoMatch(rule);
+  if (filter === "error") {
+    return hasEvaluationError(rule);
+  }
+  return rule.verdict === "no-match" && !isNoInputNoMatch(rule) && !hasEvaluationError(rule);
 }
 
 function matchesPresetFilter(
@@ -199,6 +216,7 @@ export function verdictFilterOptions(rules: RuleEvaluation[]): FilterOption[] {
     { value: "matched", label: "only matched", count: count("matched") },
     { value: "no-input", label: "only no input", count: count("no-input") },
     { value: "no-match", label: "only no match", count: count("no-match") },
+    { value: "error", label: "only not evaluated", count: count("error") },
   ];
 }
 

--- a/packages/app/src/lib/rule-verdict.ts
+++ b/packages/app/src/lib/rule-verdict.ts
@@ -1,12 +1,13 @@
 /**
  * How a rule's verdict is CLASSIFIED, as opposed to how it is rendered.
  *
- * The predicate itself now lives in the engine
- * (`src/simulate-missing-inputs.ts`), which is where its raw material is: the
- * matcher table's `readFields` and the fail-closed branch that produces a
- * `no-input` clause. The engine also aggregates it into
- * `SimulationResult.missingInputs`, and one predicate has to decide both, or
- * the summary stops counting what the filter shows.
+ * The predicates themselves now live in the engine
+ * (`src/simulate-missing-inputs.ts`), which is where their raw material is: the
+ * matcher table's `readFields`, the fail-closed branch that produces a
+ * `no-input` clause, and the `catch` that produces an `error` one. The engine
+ * also aggregates them into `SimulationResult.missingInputs` /
+ * `evaluationErrors`, and one predicate has to decide both, or the summary
+ * stops counting what the filter shows.
  *
  * The seam stays because the import path is load-bearing on this side: the
  * rules-drawer badge, the drawer's verdict filter (`rule-filters.ts`) and the
@@ -14,4 +15,4 @@
  * predicate through here. A row filtered as "no input" that then says "no
  * match" is the exact confusion Replay-02 R3/R4 was about.
  */
-export { isNoInputNoMatch } from "@renovate-config-debugger/engine";
+export { hasEvaluationError, isNoInputNoMatch } from "@renovate-config-debugger/engine";

--- a/packages/app/src/lib/simulation-changes.test.ts
+++ b/packages/app/src/lib/simulation-changes.test.ts
@@ -16,6 +16,7 @@ function simFixture(finalDependencyConfig: Record<string, unknown>): SimulationR
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/app/src/lib/verdict-sentence.test.ts
+++ b/packages/app/src/lib/verdict-sentence.test.ts
@@ -30,6 +30,7 @@ function simFixture(
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,29 +79,31 @@ is a positional file path unless one of these replaces it.
 
 The rest belong to one command each.
 
-| command      | flag                         | effect                                                                     |
-| ------------ | ---------------------------- | -------------------------------------------------------------------------- |
-| `provenance` | `--rule <n>`                 | one merged `packageRule`: its body, its layer, its index in that layer     |
-|              | `--source <which>`           | scope the `packageRules` ranges: `repo\|presets\|all`                      |
-| `tree`       | `--node <name>`              | one preset node, by name or identity                                       |
-|              | `--body <which>`             | `fetched\|afterParams\|input\|resolved` (needs `--node`)                   |
-|              | `--depth <n\|all>`           | tree depth to print (default `2`)                                          |
-| `resolved`   | `--mode <m>`                 | `full\|keep-internal` (default `keep-internal`)                            |
-|              | `--include-defaults`         | write out Renovate's defaults too (`--mode full` only)                     |
-| `simulate`   | `--dep <json>`, `--dep-file` | the dependency update to simulate                                          |
-|              | `--verdict <which>`          | `notable\|all\|matched\|no-input\|no-match` (pretty `notable`, JSON `all`) |
-|              | `--source <which>`           | which config level contributed the rule: `repo\|presets\|all`              |
-|              | `--detail <which>`           | `verdict` (default) \| `full` — `full` adds the merge trace                |
-|              | `--keys <a,b,…>`             | only these options of `finalDependencyConfig`                              |
-|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
-| `compare`    | `--dep`/`--dep-file`         | the A-side dependency                                                      |
-|              | `--dep-b`/`--dep-b-file`     | the B-side dependency                                                      |
-|              | `--keys <a,b,…>`             | only these options of the config delta                                     |
-|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                        |
-| `run`        | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`     |
-|              | `--keys <a,b,…>`             | only these options of `--select final`                                     |
-|              | `--config-scope <which>`     | `full` (default) \| `package-rules`                                        |
-| `docs`       | `--search`                   | list options whose name matches                                            |
+| command      | flag                         | effect                                                                  |
+| ------------ | ---------------------------- | ----------------------------------------------------------------------- |
+| `provenance` | `--rule <n>`                 | one merged `packageRule`: its body, its layer, its index in that layer  |
+|              | `--source <which>`           | scope the `packageRules` ranges: `repo\|presets\|all`                   |
+| `tree`       | `--node <name>`              | one preset node, by name or identity                                    |
+|              | `--body <which>`             | `fetched\|afterParams\|input\|resolved` (needs `--node`)                |
+|              | `--depth <n\|all>`           | tree depth to print (default `2`)                                       |
+| `resolved`   | `--mode <m>`                 | `full\|keep-internal` (default `keep-internal`)                         |
+|              | `--include-defaults`         | write out Renovate's defaults too (`--mode full` only)                  |
+| `simulate`   | `--dep <json>`, `--dep-file` | the dependency update to simulate                                       |
+|              | `--verdict <which>`          | `notable` (default) \|`all`\|`matched`\|`no-input`\|`no-match`\|`error` |
+|              | `--source <which>`           | which config level contributed the rule: `repo\|presets\|all`           |
+|              | `--rule <n>`                 | one merged rule's whole row, whatever the facets hide                   |
+|              | `--detail <which>`           | `verdict` (default) \| `full` — `full` adds the merge trace             |
+|              | `--keys <a,b,…>`             | only these options of `finalDependencyConfig`                           |
+|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                     |
+| `compare`    | `--dep`/`--dep-file`         | the A-side dependency                                                   |
+|              | `--dep-b`/`--dep-b-file`     | the B-side dependency                                                   |
+|              | `--detail <which>`           | `verdict` (default) \| `rules` \| `full`                                |
+|              | `--keys <a,b,…>`             | only these options of the config delta                                  |
+|              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                     |
+| `run`        | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`  |
+|              | `--keys <a,b,…>`             | only these options of `--select final`                                  |
+|              | `--config-scope <which>`     | `full` (default) \| `package-rules`                                     |
+| `docs`       | `--search`                   | list options whose name matches                                         |
 
 ### What `docs` answers
 
@@ -238,7 +240,7 @@ This major update gets no special handling from your matched rules — the defau
 ```
 
 Rule #1 is the missing one. `--verdict no-match` prints the clause that rejected
-it:
+it, and `--rule 0` returns that one row whatever the facets hide:
 
 ```console
 $ rcd simulate renovate.json --dep '{"depName":"@types/react","updateType":"major"}' --verdict no-match
@@ -268,9 +270,15 @@ This major update gets no special handling from your matched rules — the defau
 
 `--format json` carries the same fact as `missingInputs` (`rules`, and one group
 per unset field set with its `selectors`, its rule count and up to five
-`sampleRuleIndexes`) plus the sentence as `missingInputsNote`. Both survive
-`--verdict`/`--source` and the MCP answer's size elision, because the rules they
-count are exactly the rows a filter removes. Add `@types/react`
+`sampleRuleIndexes`) plus the sentence in `notes`. It survives
+`--verdict`/`--source` and the MCP answer's size elision, because the rules it
+counts are exactly the rows a filter removes — and `--rule <n>` takes one of
+those `sampleRuleIndexes` and returns that row. Its sibling `evaluationErrors`
+counts the rules whose matcher THREW (the `conda` versioning scheme is the
+documented case: its ~3 MB WASM parser is excluded from the browser build, so
+`matchCurrentVersion` cannot be evaluated). Those rules also report a plain
+`no-match`, so they are kept in the default view on purpose — an answer the tool
+could not compute is not a verdict about your config. Add `@types/react`
 to that list, keep the original as `before.json`, and use `compare` as the oracle
 for the edit. On the dependency you were fixing it should report exactly the
 change you wanted:
@@ -308,17 +316,18 @@ text — and the parenthetical says WHICH kind of rewrite it was, so
 `--format json` and the MCP `compare_simulations` answer carry the same object.
 It is ordered so the answer comes first:
 
-| field                                     | what it says                                                                                                                                 |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `summary`                                 | the whole verdict in one line — `${verdict}: ${netEffect}`                                                                                   |
-| `verdict`                                 | `identical`, `documentation-only` (only prose such as `description` moved), or `differs`                                                     |
-| `netEffect`                               | the words after the colon, so no consumer slices the string                                                                                  |
-| `mode`                                    | which axis the caller varied: `config`, `dependency`, or `unspecified`                                                                       |
-| `stoppedMatching` / `startedMatching`     | BEHAVIOR: effects one side produced and the other did not                                                                                    |
-| `matchedInBoth`                           | rules paired by selector signature                                                                                                           |
-| `configDelta[]`                           | changed keys, behavioral first; `kind` is `behavioral` or `documentation`, `a`/`b` are the two sides, `inA`/`inB` say which side has the key |
-| `configDelta[].aInherited` / `bInherited` | that side's value reached the final config with NO merge step writing it — a Renovate default, not a setting the config carries              |
-| `identity.*`                              | bookkeeping about selector TEXT, **not** a behavior claim: `changed`, `signatureChanges[]` (each with `kind` and `keys`), `onlyInA/onlyInB`  |
+| field                                     | what it says                                                                                                                                                                                                 |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `summary`                                 | the whole verdict in one line — `${verdict}: ${netEffect}`                                                                                                                                                   |
+| `verdict`                                 | `identical`, `documentation-only` (only prose such as `description` moved), or `differs`                                                                                                                     |
+| `netEffect`                               | the words after the colon, so no consumer slices the string                                                                                                                                                  |
+| `mode`                                    | which axis the caller varied: `config`, `dependency`, or `unspecified`                                                                                                                                       |
+| `stoppedMatching` / `startedMatching`     | BEHAVIOR: effects one side produced and the other did not                                                                                                                                                    |
+| `matchedInBoth`                           | rules paired by selector signature — `--detail rules` and up only                                                                                                                                            |
+| `configDelta[]`                           | changed keys, behavioral first; `kind` is `behavioral` or `documentation`, `a`/`b` are the two sides, `inA`/`inB` say which side has the key                                                                 |
+| `configDelta[].aInherited` / `bInherited` | that side's value reached the final config with NO merge step writing it — a Renovate default, not a setting the config carries                                                                              |
+| `identity.*`                              | bookkeeping about selector TEXT, **not** a behavior claim: `changed` always, `counts` at `--detail verdict`, `signatureChanges[]` (each with `kind` and `keys`) plus `onlyInA/onlyInB` from `--detail rules` |
+| `notes[]`                                 | every pointer about the answer: what the detail level withheld, and each side's own missing-input / evaluation-error line                                                                                    |
 
 `summary`, `verdict` and `netEffect` always describe the WHOLE delta, so
 `--keys`/`--config-scope` narrow the view without ever moving the verdict; what
@@ -340,11 +349,26 @@ refused by Renovate, both commands exit `2`, which says nothing about the
 simulation itself, so they also say so on their own output (`exitNote` in JSON, a
 trailing `note:` line in pretty).
 
-On a `config:best-practices` run the rule list runs to several hundred, which is
-what `--verdict` and `--source` are for. A filtered list always ends by saying
-how many rules it hid. `--format json` keeps the full `rules` array unless you
-pass one of those two flags, and adds a `ruleFilter` object with
-`total`/`shown`/`hidden` when you do.
+On a `config:best-practices` run the rule list runs to several hundred, so BOTH
+output formats answer with the rules that ACTED — `--verdict notable`: matched,
+not-simulated, and the rows the tool could not evaluate. Measured on a
+`config:recommended` config plus a react major, that is 2,550 bytes of rule rows
+against 340,843 for the whole array, which no MCP answer can carry anyway (the
+transport would elide it into a first/last window chosen by byte arithmetic).
+Nothing is withheld silently:
+
+- `--format json` and the MCP answer always carry `ruleFilter` with
+  `verdict`/`source`/`total`/`shown`/`hidden`, and a `notes` entry naming the
+  parameters that widen the view;
+- pretty output ends a narrowed list with how many rules it hid;
+- `--verdict all` returns every row, `--verdict matched|no-input|no-match|error`
+  one class, and `--rule <n>` one merged rule's whole row (its clauses, what it
+  merged, and the `origin` the list carries only on matched rows) whatever the
+  facets hide. `ruleSources` is the legend for those indexes.
+
+`matched` is a subset of `notable`, so
+`rcd simulate --format json | jq '.rules[] | select(.verdict=="matched")'`
+returns exactly what it always did.
 
 Both output formats lead with the outcome in one sentence — `verdict.text` in
 JSON, the first line of pretty output. It is the same string the web app's
@@ -367,8 +391,25 @@ which of those four happened, in one sentence.
 `rawFinalConfig` describe how the merge proceeded — ~1 MB on a
 `config:recommended` run — and are opt-in through `--detail full`, which returns
 the whole simulation result unprojected, exactly as it comes out of the engine.
-The same flag exists as `detail` on the MCP `simulate` tool; the two transports
-are one implementation.
+The one thing `--detail full` does not widen is the rule LIST: which rows you
+asked for is `--verdict`'s question, at every detail level. The same flag exists
+as `detail` on the MCP `simulate` tool; the two transports are one
+implementation.
+
+`compare` has its own `--detail`, same vocabulary on both transports. At the
+default `verdict` it answers with the claim and its evidence and states the
+identity axis as counts (`identity.counts.onlyInA/onlyInB/signatureChanges`); it
+omits `matchedInBoth` — every rule that behaved the same on both sides, in a diff
+— and the per-rule `signature` strings, each a whole selector array
+re-serialized next to the `label` that already names the rule. `--detail rules`
+restores the arrays, `--detail full` the comparison exactly as the engine
+computes it. Every level carries the same `summary`/`verdict`/`netEffect`.
+
+One note-shaped field, not five: each aggregate keeps its own `note` inside its
+object (`missingInputs.note`, `evaluationErrors.note`, `flattened.note`), and
+every pointer about the answer itself — the detail level, the rule filter, the
+`ruleSources` legend, the per-side input gaps on `compare` — is an entry in the
+single top-level `notes` array.
 
 One more shape both commands share: `description` is a mergeable array, so
 Renovate concatenates it on nearly every merge, and a merged diff used to

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -91,9 +91,10 @@ export const OPTIONS = {
   verdict: {
     flags: "--verdict <which>",
     description:
-      "which rule verdicts to print: notable|all|matched|no-input|no-match " +
-      "(pretty default: notable; --format json defaults to all). The " +
-      "missing-input summary is reported whatever you pass",
+      "which rule verdicts to answer with: notable|all|matched|no-input|no-match|error " +
+      "(default: notable — matched, not-simulated and the rules the tool could not " +
+      "evaluate). The missing-input and evaluation-error summaries are reported " +
+      "whatever you pass",
   },
   source: {
     flags: "--source <which>",
@@ -102,14 +103,16 @@ export const OPTIONS = {
   rule: {
     flags: "--rule <n>",
     description:
-      "one merged packageRule by index: its body, its layer and its index inside " +
-      "that layer (`provenance <file> packageRules` only)",
+      "one merged packageRule by index, whatever the other facets hide: its row " +
+      "(`simulate`) or its body (`provenance <file> packageRules`), with the layer " +
+      "that wrote it and its index inside that layer",
   },
   detail: {
     flags: "--detail <which>",
     description:
-      "verdict|full — `full` adds the merge trace (mergeSteps, rawFinalConfig) " +
-      "(default: verdict)",
+      "how much to answer with: `simulate` verdict|full (`full` adds the merge trace — " +
+      "mergeSteps, rawFinalConfig); `compare` verdict|rules|full (`rules` restores the " +
+      "rule and identity arrays) (default: verdict)",
   },
   keys: {
     flags: "--keys <a,b,…>",

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -266,11 +266,14 @@ function narrowingArgs(...extra: string[]): string[] {
 
 interface Comparison {
   verdict: string;
+  matchedInBoth?: unknown[];
+  notes?: string[];
   configDelta: unknown[];
   stoppedMatching: unknown[];
   startedMatching: unknown[];
   identity: {
     changed: boolean;
+    counts?: { onlyInA: number; onlyInB: number; signatureChanges: number };
     onlyInA: unknown[];
     signatureChanges: { a: { label: string }; kind: string; keys: string[] }[];
   };
@@ -281,7 +284,9 @@ describe("compare separates behavior from rule identity", () => {
 
   test("narrowing the matched array around the dependency is no behavioral change", async () => {
     const io = recordingIo();
-    expect(await main(args("--format", "json"), io)).toBe(0);
+    // Roadmap 073: the identity ARRAYS are one detail level down — the default
+    // answer states the churn as counts (asserted below).
+    expect(await main(args("--format", "json", "--detail", "rules"), io)).toBe(0);
     const comparison = io.json() as Comparison;
     expect(comparison.verdict).toBe("identical");
     expect(comparison.configDelta).toEqual([]);
@@ -301,7 +306,18 @@ describe("compare separates behavior from rule identity", () => {
     expect(await main(args(), io)).toBe(0);
     expect(io.stdout.split("\n")[0]).toContain("✓ No behavioral change");
     expect(io.stdout).toContain("a rule's matchPackageNames list changed");
-    expect(io.stdout).toContain("Selector text changed, same effect (rule identity, not behavior)");
+    // Roadmap 073: at the default detail the churn is a count plus the flag
+    // that lists it; the list itself is `--detail rules`.
+    expect(io.stdout).toContain(
+      "Selector text changed on 1 rule, same effect (rule identity, not behavior) — " +
+        "`--detail rules` lists them.",
+    );
+
+    const listed = recordingIo();
+    expect(await main(args("--detail", "rules"), listed)).toBe(0);
+    expect(listed.stdout).toContain(
+      "Selector text changed, same effect (rule identity, not behavior)",
+    );
   });
 
   /**
@@ -323,7 +339,7 @@ describe("compare separates behavior from rule identity", () => {
     expect(io.stdout).not.toContain("pattern text changed");
 
     const json = recordingIo();
-    expect(await main([...added, "--format", "json"], json)).toBe(0);
+    expect(await main([...added, "--format", "json", "--detail", "rules"], json)).toBe(0);
     const comparison = json.json() as Comparison;
     expect(comparison.verdict).toBe("identical");
     expect(comparison.identity.signatureChanges[0]?.kind).toBe("clause-added");
@@ -350,5 +366,48 @@ describe("compare on a config Renovate would refuse", () => {
     ).toBe(2);
     expect(io.stdout).toContain("note: config A would be refused by Renovate");
     expect(io.stdout).toContain("not this command's answer");
+  });
+});
+
+/**
+ * Roadmap 073: `--detail` on the comparison, same vocabulary as the MCP tool's.
+ * The default is the claim plus its evidence; what it withholds is the
+ * bookkeeping — and it says which level returns it.
+ */
+describe("compare --detail", () => {
+  async function comparisonAt(...extra: string[]): Promise<Comparison> {
+    const io = recordingIo();
+    expect(await main(narrowingArgs("--format", "json", ...extra), io)).toBe(0);
+    return io.json() as Comparison;
+  }
+
+  test("the default answers with counts, and names the level that lists them", async () => {
+    const payload = await comparisonAt();
+    expect(payload.matchedInBoth).toBeUndefined();
+    expect(payload.identity).toEqual({
+      changed: true,
+      counts: { onlyInA: 1, onlyInB: 1, signatureChanges: 1 },
+    });
+    expect(payload.notes?.join(" ")).toContain("`--detail rules`");
+    // No selector signature at this level — it is a whole matched array,
+    // restated as a string next to the `label` that already names the rule.
+    expect(JSON.stringify(payload)).not.toContain('"signature":');
+  });
+
+  test("--detail rules restores the arrays, --detail full the signatures", async () => {
+    const rules = await comparisonAt("--detail", "rules");
+    expect(rules.matchedInBoth).toBeDefined();
+    expect(rules.identity.signatureChanges).toHaveLength(1);
+    expect(JSON.stringify(rules)).not.toContain('"signature":');
+
+    const full = await comparisonAt("--detail", "full");
+    expect(JSON.stringify(full)).toContain('"signature":');
+    expect(full.notes?.join(" ") ?? "").not.toContain("--detail");
+  });
+
+  test("an unknown value names the ones that exist", async () => {
+    const io = recordingIo();
+    expect(await main(narrowingArgs("--detail", "nope"), io)).toBe(1);
+    expect(io.stderr).toContain("verdict|rules|full");
   });
 });

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -6,8 +6,12 @@ import { emitJson, emitLines, writeNotes } from "../output";
 import { INPUT_OPTIONS, refusalNote, runOne, takeInputFile, wouldRefuse } from "../run-input";
 import { readDependency } from "../dep";
 import { deltaLine, parseConfigScope, parseKeys } from "../projections/config-view";
-import { comparisonPayload } from "../projections/simulate";
-import { missingInputsNote } from "../rule-view";
+import {
+  comparisonPayload,
+  parseCompareDetail,
+  type ProjectedComparison,
+} from "../projections/simulate";
+import { evaluationErrorsNote, missingInputsNote } from "../rule-view";
 import { simulateAgainst } from "./simulate";
 
 /**
@@ -32,7 +36,10 @@ import { simulateAgainst } from "./simulate";
  * The headline reads the VERDICT fields only, which is what lets it take a
  * projected comparison (whose delta may be narrowed) unchanged.
  */
-type HeadlineFields = Pick<SimulationComparison, "verdict" | "netEffect" | "identity">;
+type HeadlineFields = Pick<SimulationComparison, "verdict" | "netEffect"> & {
+  /** `changed` alone — the one identity field every detail level carries. */
+  identity: { changed: boolean };
+};
 
 export function comparisonHeadline(comparison: HeadlineFields): string {
   switch (comparison.verdict) {
@@ -46,6 +53,37 @@ export function comparisonHeadline(comparison: HeadlineFields): string {
             "touched the very selectors that rule matches on."
         : `✓ No behavioral change: ${comparison.netEffect}.`;
   }
+}
+
+/**
+ * The identity axis, as the requested detail level carries it: the list of
+ * selector rewrites at `--detail rules`/`full`, and at the default a single
+ * line with the count and the flag that lists them. Never nothing when the
+ * churn is non-zero — a fact that vanishes with a detail level reads as a bug.
+ */
+function identityLines(comparison: ProjectedComparison): string[] {
+  const changes = comparison.identity.signatureChanges;
+  if (changes) {
+    return changes.length === 0
+      ? []
+      : [
+          "",
+          "Selector text changed, same effect (rule identity, not behavior):",
+          ...changes.map(
+            (c) => `  ${c.a.label}  #${c.a.index + 1} → #${c.b.index + 1}  (${c.kind})`,
+          ),
+        ];
+  }
+  const counts = comparison.identity.counts;
+  if (!counts || counts.signatureChanges === 0) {
+    return [];
+  }
+  const noun = counts.signatureChanges === 1 ? "rule" : "rules";
+  return [
+    "",
+    `Selector text changed on ${counts.signatureChanges} ${noun}, same effect (rule identity, ` +
+      "not behavior) — `--detail rules` lists them.",
+  ];
 }
 
 export const compareCommand: Command = {
@@ -71,6 +109,11 @@ export const compareCommand: Command = {
     "options no rule can reach are dropped) and `--keys a,b` narrows it further.",
     "Neither touches the verdict: `summary` states what the comparison found",
     "over the WHOLE delta, and `configView` says what the view withheld.",
+    "",
+    "`--detail verdict` (the default) answers with the claim and its evidence,",
+    "and states the identity axis as counts; `--detail rules` restores the rule",
+    "and identity arrays (`matchedInBoth` included), `--detail full` the",
+    "comparison exactly as the engine computes it, selector signatures and all.",
   ],
   options: [
     ...INPUT_OPTIONS,
@@ -78,12 +121,14 @@ export const compareCommand: Command = {
     "dep-file",
     "dep-b",
     "dep-b-file",
+    "detail",
     "keys",
     "config-scope",
     "format",
   ],
   async run(args, io) {
     const format = outputFormat(args);
+    const detail = parseCompareDetail(stringOption(args, "detail")) ?? "verdict";
     const keys = parseKeys(stringOption(args, "keys"));
     const scope = parseConfigScope(stringOption(args, "config-scope"), "--config-scope");
     const { file, rest } = takeInputFile(args);
@@ -107,6 +152,8 @@ export const compareCommand: Command = {
     const mode = fileB && twoDeps ? "unspecified" : twoDeps ? "dependency" : "config";
     const comparison = comparisonPayload(compareSimulations(simA, simB, { mode }), {
       scope: scope ?? "package-rules",
+      detail,
+      transport: "cli",
       ...(keys ? { keys } : {}),
     });
 
@@ -123,6 +170,16 @@ export const compareCommand: Command = {
     // two blind runs.
     const missingA = missingInputsNote(simA.missingInputs, "cli");
     const missingB = missingInputsNote(simB.missingInputs, "cli");
+    // Same reasoning, one step more serious: a side that could not EVALUATE a
+    // rule is not a side that disagreed with the other one.
+    const erroredA = evaluationErrorsNote(simA.evaluationErrors, "cli");
+    const erroredB = evaluationErrorsNote(simB.evaluationErrors, "cli");
+    const sideNotes = [
+      ...(erroredA ? [`A — ${erroredA}`] : []),
+      ...(erroredB ? [`B — ${erroredB}`] : []),
+      ...(missingA ? [`A — ${missingA}`] : []),
+      ...(missingB ? [`B — ${missingB}`] : []),
+    ];
 
     if (format === "json") {
       emitJson(io, {
@@ -131,21 +188,27 @@ export const compareCommand: Command = {
           dep: depA,
           wouldRefuse: refusedA,
           missingInputs: simA.missingInputs,
+          evaluationErrors: simA.evaluationErrors,
         },
         b: {
           config: fileB ?? file ?? "(stdin/repo)",
           dep: depB,
           wouldRefuse: refusedB,
           missingInputs: simB.missingInputs,
+          evaluationErrors: simB.evaluationErrors,
         },
         ...comparison,
+        // ONE notes array (roadmap 073): the per-side pointers and the
+        // detail-level pointer read the same way, so they live in one place.
+        ...(sideNotes.length + (comparison.notes?.length ?? 0) > 0
+          ? { notes: [...sideNotes, ...(comparison.notes ?? [])] }
+          : {}),
         ...(refusal ? { exitNote: refusal } : {}),
       });
     } else {
       emitLines(io, [
         comparisonHeadline(comparison),
-        ...(missingA ? ["", `A — ${missingA}`] : []),
-        ...(missingB ? ["", `B — ${missingB}`] : []),
+        ...sideNotes.flatMap((note) => ["", note]),
         ...(comparison.stoppedMatching.length > 0
           ? ["", "Matched only in A:", ...comparison.stoppedMatching.map((r) => `  ${r.label}`)]
           : []),
@@ -155,15 +218,7 @@ export const compareCommand: Command = {
         ...(comparison.configDelta.length > 0
           ? ["", "Config delta:", ...comparison.configDelta.map((d) => `  ${deltaLine(d)}`)]
           : []),
-        ...(comparison.identity.signatureChanges.length > 0
-          ? [
-              "",
-              "Selector text changed, same effect (rule identity, not behavior):",
-              ...comparison.identity.signatureChanges.map(
-                (c) => `  ${c.a.label}  #${c.a.index + 1} → #${c.b.index + 1}  (${c.kind})`,
-              ),
-            ]
-          : []),
+        ...identityLines(comparison),
         ...(refusal ? ["", refusal] : []),
       ]);
     }

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -39,6 +39,10 @@ describe("simulate", () => {
           '{"depName":"lodash","packageName":"lodash","currentValue":"4.17.20","newValue":"4.17.21"}',
           "--format",
           "json",
+          // Roadmap 073: the default answer is the rules that ACTED, so a
+          // genuine mismatch is one facet away.
+          "--verdict",
+          "all",
         ],
         io,
       ),
@@ -93,7 +97,7 @@ describe("simulate --detail / --keys / --config-scope", () => {
     expect(payload).not.toHaveProperty("mergeSteps");
     expect(payload).not.toHaveProperty("rawFinalConfig");
     // The omission is stated, with the flag that undoes it.
-    expect(payload.detailNote).toContain('detail: "full"');
+    expect((payload.notes as string[]).join(" ")).toContain('detail: "full"');
     expect(payload.rules).toBeDefined();
     expect(payload.flattened).toBeDefined();
   });
@@ -102,7 +106,7 @@ describe("simulate --detail / --keys / --config-scope", () => {
     const { payload } = await simulateJson("--detail", "full");
     expect(payload.mergeSteps).toBeDefined();
     expect(payload.rawFinalConfig).toBeDefined();
-    expect(payload.detailNote).toBeUndefined();
+    expect((payload.notes as string[]).join(" ")).not.toContain('detail: "full"');
     expect(payload.configView).toBeUndefined();
     // Nothing collapsed, nothing pruned — the escape hatch is the raw shape.
     const rules = payload.rules as { merged?: { key: string }[] }[];
@@ -250,12 +254,69 @@ describe("simulate --verdict / --source", () => {
     expect(io.stderr).toContain("notable|all|matched|no-input|no-match");
   });
 
-  test("--format json keeps the full array until a filter is asked for", async () => {
+  /**
+   * Roadmap 073, the flip. `--format json` used to answer with the whole array
+   * "for scripts", which on a `config:recommended` run is 340 kB the MCP
+   * transport then cut to a byte-arithmetic window anyway. Both formats now
+   * answer with the rules that acted, and `matched ⊂ notable` keeps the common
+   * `jq '.rules[] | select(.verdict=="matched")'` pipeline returning the same
+   * rows. What is new is that the payload SAYS what it withheld.
+   */
+  test("--format json answers with the notable rules and states what it withheld", async () => {
     const { io } = await run("--format", "json");
-    const sim = io.json() as { rules: unknown[]; ruleFilter?: unknown };
+    const sim = io.json() as {
+      rules: { verdict: string }[];
+      ruleFilter: Record<string, unknown>;
+      notes: string[];
+    };
+    expect(sim.rules.map((rule) => rule.verdict)).toEqual(["matched"]);
+    expect(sim.ruleFilter).toEqual({
+      verdict: "notable",
+      source: "all",
+      total: 4,
+      shown: 1,
+      hidden: 3,
+    });
+    const note = sim.notes.join(" ");
+    expect(note).toContain("1 of 4 rules");
+    expect(note).toContain("`--verdict all` returns every row");
+    expect(note).toContain("`--rule N`");
+  });
+
+  test("--verdict all is the way back, and it says nothing was withheld", async () => {
+    const { io } = await run("--format", "json", "--verdict", "all");
+    const sim = io.json() as { rules: unknown[]; ruleFilter: { hidden: number } };
     expect(sim.rules).toHaveLength(4);
-    // Scripts already index into this array — an unflagged run must not shrink it.
-    expect(sim.ruleFilter).toBeUndefined();
+    expect(sim.ruleFilter.hidden).toBe(0);
+  });
+
+  /**
+   * Roadmap 073's drill-down, and the round-trip that pins it: `--rule N`
+   * returns the row `--verdict all` shows at index N — including the rows every
+   * facet hides, which is the only reason to ask.
+   */
+  test("--rule returns one row by index, the same row --verdict all holds there", async () => {
+    const all = (await run("--format", "json", "--verdict", "all")).io.json() as {
+      rules: Record<string, unknown>[];
+    };
+    for (const index of [0, 2, 3]) {
+      const one = (await run("--format", "json", "--rule", String(index))).io.json() as {
+        rules: Record<string, unknown>[];
+        ruleFilter: Record<string, unknown>;
+      };
+      expect(one.rules).toHaveLength(1);
+      // The origin rides along on a row that did NOT match, too: the list omits
+      // it to save 15 % of the payload, one row cannot afford to.
+      const { origin: _origin, ...row } = one.rules[0] ?? {};
+      expect(row).toEqual(all.rules[index]);
+      expect(one.ruleFilter).toMatchObject({ rule: index, shown: 1, hidden: 3 });
+    }
+  });
+
+  test("--rule out of range names the total", async () => {
+    const { io, code } = await run("--rule", "9");
+    expect(code).toBe(1);
+    expect(io.stderr).toContain("evaluated 4 merged packageRules; there is no rule 9");
   });
 
   /**
@@ -287,7 +348,7 @@ describe("simulate --verdict / --source", () => {
     const sim = io.json() as {
       rules: unknown[];
       missingInputs: { rules: number; groups: { fieldList: string; rules: number }[] };
-      missingInputsNote: string;
+      notes: string[];
     };
     expect(sim.rules).toHaveLength(1);
     // The parity property: the number in the summary is the number of rows
@@ -298,7 +359,7 @@ describe("simulate --verdict / --source", () => {
       "depType or depTypes",
       "sourceUrl",
     ]);
-    expect(sim.missingInputsNote).toContain("`--verdict no-input` lists them.");
+    expect(sim.notes.join(" ")).toContain("`--verdict no-input` lists them.");
   });
 
   test("a filtered json payload states what it left out", async () => {
@@ -349,6 +410,8 @@ describe("simulate --dep defaulting", () => {
         '{"depName":"react","packageName":"lodash"}',
         "--format",
         "json",
+        "--verdict",
+        "all",
       ],
       io,
     );
@@ -469,5 +532,85 @@ describe("simulate answers in one sentence", () => {
     expect(payload.mergeSteps.length).toBeGreaterThan(0);
     expect(payload.verdict.text).toContain("WOULD automerge");
     expect(payload.flattened.note).toContain("merged up and set");
+  });
+});
+
+/**
+ * Roadmap 073's blocker, end to end. `conda` versioning is the documented
+ * honest-error case: its parser is a ~3 MB WASM module the browser build
+ * excludes, so `matchCurrentVersion` THROWS and the simulator records a clause
+ * error — while upstream treats a throwing matcher as a non-match, which put
+ * the rule in the one bucket the old `notable` filter dropped. "The tool could
+ * not evaluate this rule" is the last thing that may go missing, so the
+ * conclusion-preserving gate is asserted on the default answer.
+ */
+async function simulateConda(...flags: string[]) {
+  const io = recordingIo();
+  const code = await main(
+    [
+      "simulate",
+      fixture("conda-version.json"),
+      "--dep",
+      '{"depName":"react","versioning":"conda","currentValue":"1.2.3"}',
+      ...flags,
+    ],
+    io,
+  );
+  return { io, code };
+}
+
+describe("simulate on a rule the tool cannot evaluate", () => {
+  test("the default answer keeps the error row AND counts it", async () => {
+    const { io, code } = await simulateConda("--format", "json");
+    expect(code).toBe(0);
+    const sim = io.json() as {
+      rules: { index: number; verdict: string; clauses: { state: string; note?: string }[] }[];
+      evaluationErrors: {
+        rules: number;
+        selectors: string[];
+        messages: string[];
+        sampleRuleIndexes: number[];
+        note: string;
+      };
+      ruleFilter: { verdict: string; hidden: number };
+      notes: string[];
+    };
+    // The default is `notable`, and the error row is in it — its verdict is a
+    // plain `no-match`, so only the clause predicate can keep it.
+    expect(sim.ruleFilter.verdict).toBe("notable");
+    const errored = sim.rules.find((rule) => rule.index === 0);
+    expect(errored?.verdict).toBe("no-match");
+    expect(errored?.clauses[0]?.state).toBe("error");
+    expect(errored?.clauses[0]?.note).toContain("conda versioning is not supported");
+    // …and the aggregate says it whatever the filter, in the array that cannot
+    // be filtered away.
+    expect(sim.evaluationErrors).toMatchObject({
+      rules: 1,
+      selectors: ["matchCurrentVersion"],
+      sampleRuleIndexes: [0],
+    });
+    expect(sim.notes.join(" ")).toContain("could not be EVALUATED");
+    expect(sim.notes.join(" ")).toContain("`--verdict error` lists them.");
+  });
+
+  test("--verdict error is the facet that names them, --verdict no-match is not", async () => {
+    const onlyErrors = (
+      await simulateConda("--format", "json", "--verdict", "error")
+    ).io.json() as {
+      rules: { index: number }[];
+    };
+    expect(onlyErrors.rules.map((rule) => rule.index)).toEqual([0]);
+    // A GENUINE mismatch is a different question, and now a different facet:
+    // rule 1 matched, rule 0 could not be evaluated, so neither is one.
+    const mismatches = (
+      await simulateConda("--format", "json", "--verdict", "no-match")
+    ).io.json() as { rules: unknown[] };
+    expect(mismatches.rules).toEqual([]);
+  });
+
+  test("pretty output states it too, whatever the view hid", async () => {
+    const { io } = await simulateConda();
+    expect(io.stdout).toContain("could not be EVALUATED");
+    expect(io.stdout).toContain("may not reflect a real Renovate run");
   });
 });

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -12,18 +12,13 @@ import { INPUT_OPTIONS, refusalNote, runFromArgs, wouldRefuse } from "../run-inp
 import { readDependency } from "../dep";
 import {
   buildRuleView,
+  evaluationErrorsNote,
   hiddenRulesNote,
   missingInputsNote,
-  ruleFilterPayload,
   ruleFilterSelection,
 } from "../rule-view";
 import { collapseDiffs, mergedLine, parseConfigScope, parseKeys } from "../projections/config-view";
-import {
-  collapseRuleMerges,
-  parseDetail,
-  simulationPayload,
-  withRuleOrigins,
-} from "../projections/simulate";
+import { parseDetail, simulationPayload } from "../projections/simulate";
 import { flattenedView, verdictPayload } from "../projections/verdict";
 
 /**
@@ -83,15 +78,20 @@ export const simulateCommand: Command = {
     "it, exactly as a real lookup would before the rules run — and `packageName`",
     "defaults to `depName`, the way Renovate's fetch worker fills it in.",
     "",
-    "A `config:best-practices` config resolves to hundreds of rules, so pretty",
-    "output prints the notable ones (matched + unresolved) and says how many it",
-    "hid. `--verdict`/`--source` scope it; `--format json` keeps the full array",
-    "unless you pass one of them.",
+    "A `config:best-practices` config resolves to hundreds of rules, so BOTH",
+    "output formats answer with the notable ones — matched, not-simulated, and",
+    "the rows the tool could not evaluate — and state how many that withheld.",
+    "`--verdict all` returns every row, `--verdict matched|no-input|no-match|",
+    "error` one class, `--source repo|presets` scopes by the layer that wrote",
+    "the rule, and `--rule <n>` returns ONE merged rule by index whatever the",
+    "facets hide (`ruleSources` is the legend for those indexes). `--format",
+    "json` always carries `ruleFilter` with `total`/`shown`/`hidden`.",
     "",
     "Rules that failed only because your `--dep` left a field unset are counted",
-    "in `missingInputs` and stated in one line whatever `--verdict` you asked",
-    "for — those rules report a plain `no-match`, so every scoped view would",
-    "otherwise hide them.",
+    "in `missingInputs`, and rules whose matcher THREW in `evaluationErrors`.",
+    "Both are stated in one line whatever `--verdict` you asked for — those",
+    "rules report a plain `no-match`, so every scoped view would otherwise hide",
+    "them, and an un-evaluated rule is not a verdict about your config.",
     "",
     "`--format json` answers at `--detail verdict`: the merge trace",
     "(`mergeSteps`, `rawFinalConfig`) is ~1 MB on a `config:recommended` run and",
@@ -106,6 +106,7 @@ export const simulateCommand: Command = {
     "dep-file",
     "verdict",
     "source",
+    "rule",
     "detail",
     "keys",
     "config-scope",
@@ -113,7 +114,7 @@ export const simulateCommand: Command = {
   ],
   async run(args, io) {
     const format = outputFormat(args);
-    const selection = ruleFilterSelection(args, format);
+    const selection = ruleFilterSelection(args);
     const detail = parseDetail(stringOption(args, "detail")) ?? "verdict";
     const keys = parseKeys(stringOption(args, "keys"));
     const scope = parseConfigScope(stringOption(args, "config-scope"), "--config-scope");
@@ -130,22 +131,19 @@ export const simulateCommand: Command = {
     if (format === "json") {
       emitJson(io, {
         dep,
-        // `missingInputs` (and its note) come from the projection, so they are
-        // carried whatever `--verdict`/`--source` did to the `rules` array
-        // below — the rules it counts are the ones a filter removes.
+        // The aggregates and the rule-list view both come from the projection,
+        // so `missingInputs`, `evaluationErrors`, `ruleFilter` and the notes are
+        // carried whatever `--verdict`/`--source`/`--rule` did to the rows — the
+        // rules they count are exactly the ones a filter removes.
         ...simulationPayload(sim, {
           detail,
           scope: scope ?? "package-rules",
           transport: selection.transport,
           attribution: view.attribution,
           finalConfig: result.finalConfig,
+          ruleView: view,
           ...(keys ? { keys } : {}),
         }),
-        rules:
-          detail === "full"
-            ? view.rules
-            : withRuleOrigins(collapseRuleMerges(view.rules), view.attribution),
-        ...(selection.explicit ? ruleFilterPayload(view) : {}),
         wouldRefuse: refused,
         ...(refusal ? { exitNote: refusal } : {}),
       });
@@ -164,11 +162,13 @@ export const simulateCommand: Command = {
         ),
       );
       const hiddenNote = hiddenRulesNote(view);
-      // A sibling of the hidden-rules note, not part of it: this one is printed
-      // even when the view hid nothing, because the rules it counts are
+      // Siblings of the hidden-rules note, not part of it: these are printed
+      // even when the view hid nothing, because the rules they count are
       // reported as a plain `no-match` and read as "your config just doesn't
-      // do that".
+      // do that" — or, for the error one, as a verdict about a rule the tool
+      // never managed to evaluate.
       const missingNote = missingInputsNote(sim.missingInputs, selection.transport);
+      const errorsNote = evaluationErrorsNote(sim.evaluationErrors, selection.transport);
       // Roadmap 048: the outcome in one sentence, ABOVE the counts — the same
       // string the web app's verdict card renders, so a terminal and a
       // screenshot answer the question the same way.
@@ -182,6 +182,7 @@ export const simulateCommand: Command = {
         "",
         ...verdictLines(view.rules, view.originOf),
         ...(hiddenNote ? [hiddenNote] : []),
+        ...(errorsNote ? [errorsNote] : []),
         ...(missingNote ? [missingNote] : []),
         "",
         ...(changes.length > 0

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -43,6 +43,18 @@ const AUTOMERGE_MINOR = JSON.stringify({
 });
 /** The big one — every size assertion in this file is measured against it. */
 const RECOMMENDED = '{"extends":["config:recommended"],"labels":["deps"]}';
+/** Bigger still: `config:best-practices` extends `config:recommended` and adds
+ *  its own rules — the run roadmap 073's acceptance criteria are stated over. */
+const BEST_PRACTICES = '{"extends":["config:best-practices"],"labels":["deps"]}';
+/** The documented honest-error case: `conda`'s parser is a ~3 MB WASM module
+ *  the browser build excludes, so `matchCurrentVersion` THROWS — a clause error
+ *  on a rule whose verdict is a plain `no-match`. */
+const CONDA_RULES = JSON.stringify({
+  packageRules: [
+    { matchCurrentVersion: ">=1.0", labels: ["conda"] },
+    { matchPackageNames: ["react"], groupName: "react monorepo" },
+  ],
+});
 /** The same at scale, plus ONE rule of the caller's own — the shape the
  *  packageRules provenance answer is about: 713 preset rules, then yours. */
 const RECOMMENDED_PLUS_RULE = JSON.stringify({
@@ -681,17 +693,65 @@ describe("size budget", () => {
     expect(payload.chain).toBeDefined();
   });
 
-  test("the elision marks what it dropped, in place", async () => {
+  /**
+   * Roadmap 073. This document is ~200 kB on a `config:recommended` run, and
+   * the generic elision's answer was a `packageRules` cut to first-and-last
+   * inside a document that still looked whole — neither the config nor a
+   * description of it. A key INDEX is honest at any size: every option the
+   * document has, the bytes its value costs, and the parameter that turns a
+   * name into a value.
+   */
+  test("an effective config over the budget answers with its key index", async () => {
     const runId = await runConfig(RECOMMENDED);
     const payload = (await call("get_final_config", { runId })) as {
+      truncated?: boolean;
+      configIndex: { key: string; bytes: number }[];
+      keys: number;
+      configView: { scope: string };
+      note: string;
+    };
+    // Not elided: the answer was chosen at construction, so it fits.
+    expect(payload.truncated).toBeUndefined();
+    expect(payload.keys).toBe(payload.configIndex.length);
+    expect(payload.keys).toBeGreaterThan(100);
+    // Biggest first — the reason the document does not fit is the first line of
+    // the answer.
+    expect(payload.configIndex[0]?.key).toBe("packageRules");
+    const bytes = payload.configIndex.map((entry) => entry.bytes);
+    expect(bytes).toEqual([...bytes].toSorted((a, b) => b - a));
+    // Every key is NAMED, including the ones the elision used to drop whole.
+    expect(payload.configIndex.map((entry) => entry.key)).toContain("labels");
+    expect(payload.note).toContain('`keys: ["a", "b"]`');
+    expect(payload.note).toContain("configScope");
+  });
+
+  /** …and a document that fits is still the document. */
+  test("a config that fits comes back whole, index or no index", async () => {
+    const runId = await runConfig(CONFIG);
+    const payload = (await call("get_final_config", { runId })) as {
+      finalConfig?: { labels: string[] };
+      configIndex?: unknown;
+    };
+    expect(payload.configIndex).toBeUndefined();
+    expect(payload.finalConfig?.labels).toEqual(["deps"]);
+  });
+
+  /** The elision itself is untouched — it is the transport's safety net, and
+   *  `verdict: "all"` on a 714-rule simulation is where it still fires. */
+  test("the elision marks what it dropped, in place", async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const payload = (await call("simulate", {
+      runId,
+      dep: { depName: "react", packageName: "react" },
+      verdict: "all",
+    })) as {
       truncated: boolean;
-      finalConfig: { packageRules: { truncated: boolean; shown: number; omitted: number } };
+      rules: { truncated: boolean; shown: number; omitted: number };
     };
     expect(payload.truncated).toBe(true);
-    const rules = payload.finalConfig.packageRules;
-    expect(rules.truncated).toBe(true);
-    expect(rules.omitted).toBeGreaterThan(0);
-    expect(rules.shown).toBeGreaterThan(0);
+    expect(payload.rules.truncated).toBe(true);
+    expect(payload.rules.omitted).toBeGreaterThan(0);
+    expect(payload.rules.shown).toBeGreaterThan(0);
   });
 
   /**
@@ -847,18 +907,22 @@ describe("simulate and compare", () => {
     const parsed = JSON.parse(text) as {
       truncated?: boolean;
       omittedKeys?: string[];
-      detailNote: string;
+      notes: string[];
       finalDependencyConfig: Record<string, unknown>;
       configView: { scope: string; keys: number; droppedGlobalOnly?: number };
       flattened: unknown;
       missingInputs: { rules: number; groups: unknown[] };
+      ruleFilter: { verdict: string; total: number; shown: number; hidden: number };
       rules: { truncated: boolean; shown: number; omitted: number } | unknown[];
     };
     expect(parsed).not.toHaveProperty("mergeSteps");
     expect(parsed).not.toHaveProperty("rawFinalConfig");
     // The omission is stated, with the parameter that undoes it.
-    expect(parsed.detailNote).toContain('detail: "full"');
-    // The answer itself survives WHOLE — no key was dropped to make room.
+    expect(parsed.notes.join(" ")).toContain('detail: "full"');
+    // Roadmap 073, invariant 1: the DEFAULT answer comes back whole. Nothing
+    // was elided, nothing dropped by name — the narrowing happened at
+    // construction, where it can be described, instead of in the transport.
+    expect(parsed.truncated).toBeUndefined();
     expect(parsed.omittedKeys).toBeUndefined();
     expect(parsed.flattened).toBeDefined();
     expect(Object.keys(parsed.finalDependencyConfig).length).toBeGreaterThan(10);
@@ -875,15 +939,43 @@ describe("simulate and compare", () => {
     expect(parsed.finalDependencyConfig).not.toHaveProperty("onboardingConfig");
     expect(parsed.finalDependencyConfig).not.toHaveProperty("dryRun");
     expect(parsed.configView.keys).toBe(Object.keys(parsed.finalDependencyConfig).length);
-    // The elision shrinks `rules` first — it is the largest array in the
-    // payload — so the missing-input aggregate has to outlive it, and be
-    // reported by NAME rather than dropped as a key.
+    // The aggregate outlives every view of the rows it counts.
     expect(parsed.missingInputs).toBeDefined();
     expect(parsed.missingInputs.rules).toBeGreaterThan(0);
-    // And the rule list is a real sample of 713, not a token two.
-    const rules = parsed.rules as { shown: number; omitted: number };
-    expect(rules.shown + rules.omitted).toBeGreaterThan(700);
-    expect(rules.shown).toBeGreaterThan(20);
+    // The rule list is the handful that acted, out of ~714 — stated, with the
+    // parameter that returns the rest.
+    const rules = parsed.rules as unknown[];
+    expect(Array.isArray(rules)).toBe(true);
+    expect(rules.length).toBeLessThan(20);
+    expect(parsed.ruleFilter).toMatchObject({ verdict: "notable", shown: rules.length });
+    expect(parsed.ruleFilter.total).toBeGreaterThan(700);
+    expect(parsed.ruleFilter.hidden).toBe(parsed.ruleFilter.total - rules.length);
+    expect(parsed.notes.join(" ")).toContain('`verdict: "all"` returns every row');
+    // …and the whole answer sits well inside the budget it used to blow by 5×.
+    // What is left is mostly `finalDependencyConfig` — 289 effective options,
+    // which `keys` narrows and the test below measures.
+    expect(text.length).toBeLessThan(RESULT_BUDGET_BYTES / 2);
+  });
+
+  /**
+   * The other half of the flip: asking for every row is exactly what the
+   * transport cannot deliver whole, which is why it is not the default any
+   * more. Same run, same question, `verdict: "all"` — and the elision that
+   * used to happen unasked now happens where the caller asked for it.
+   */
+  test('verdict: "all" is the way back, and pays the transport for it', async () => {
+    const runId = await runConfig(RECOMMENDED);
+    const dep = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
+    const parsed = JSON.parse(await callText("simulate", { runId, dep, verdict: "all" })) as {
+      truncated?: boolean;
+      ruleFilter: { verdict: string; hidden: number; total: number };
+      rules: { truncated: boolean; shown: number; omitted: number };
+    };
+    expect(parsed.ruleFilter).toMatchObject({ verdict: "all", hidden: 0 });
+    expect(parsed.truncated).toBe(true);
+    // The elided array is the rule list, and it says so in place.
+    expect(parsed.rules.truncated).toBe(true);
+    expect(parsed.rules.shown + parsed.rules.omitted).toBeGreaterThan(700);
   });
 
   /**
@@ -899,9 +991,9 @@ describe("simulate and compare", () => {
     const full = (await call("simulate", { runId, dep, detail: "full" })) as {
       truncated?: boolean;
       omittedKeys?: string[];
-      detailNote?: string;
+      notes?: string[];
     };
-    expect(full.detailNote).toBeUndefined();
+    expect(full.notes?.join(" ") ?? "").not.toContain('detail: "full"');
     expect(full.truncated).toBe(true);
     expect(full.omittedKeys).toContain("mergeSteps");
     // The default answer for the same question never got that big.
@@ -953,7 +1045,9 @@ describe("simulate and compare", () => {
   test("the sentence survives the elision that takes the rules", async () => {
     const runId = await runConfig(RECOMMENDED);
     const dep = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
-    const parsed = JSON.parse(await callText("simulate", { runId, dep })) as {
+    // At `verdict: "all"` — the view that still cannot fit, which is the whole
+    // reason it is no longer the default (roadmap 073).
+    const parsed = JSON.parse(await callText("simulate", { runId, dep, verdict: "all" })) as {
       verdict: { text: string };
       flattened: { note: string };
       rules: { shown: number; omitted: number } | unknown[];
@@ -1022,22 +1116,24 @@ describe("simulate and compare", () => {
   });
 
   test("verdict/source scope the rule list and say what they hid", async () => {
-    const runId = await runConfig(GROUPED);
-    const dep = { depName: "react", currentValue: "17.0.0", newValue: "18.0.0" };
-    const full = (await call("simulate", { runId, dep })) as { rules: unknown[] };
-    // GROUPED's rules all match this dep, so `no-match` is the facet that
-    // provably hides something.
+    const runId = await runConfig(MIXED_RULES);
+    const dep = { depName: "react", packageName: "react" };
+    const all = (await call("simulate", { runId, dep, verdict: "all" })) as {
+      rules: unknown[];
+      ruleFilter: { verdict: string; hidden: number };
+    };
     const scoped = (await call("simulate", { runId, dep, verdict: "no-match" })) as {
       rules: { verdict: string }[];
       ruleFilter: { verdict: string; total: number; shown: number; hidden: number };
     };
-    // An unflagged call keeps the exact payload scripts already parse.
-    expect(full).not.toHaveProperty("ruleFilter");
-    expect(full.rules.length).toBeGreaterThan(0);
+    // Roadmap 073: `ruleFilter` is on EVERY answer, so "nothing was withheld"
+    // is a fact in the payload rather than the absence of one.
+    expect(all.ruleFilter).toMatchObject({ verdict: "all", hidden: 0 });
+    expect(all.rules.length).toBeGreaterThan(0);
     expect(scoped.rules.every((rule) => rule.verdict === "no-match")).toBe(true);
-    expect(scoped.ruleFilter.total).toBe(full.rules.length);
+    expect(scoped.ruleFilter.total).toBe(all.rules.length);
     expect(scoped.ruleFilter.shown).toBe(scoped.rules.length);
-    expect(scoped.ruleFilter.hidden).toBe(full.rules.length - scoped.rules.length);
+    expect(scoped.ruleFilter.hidden).toBe(all.rules.length - scoped.rules.length);
     expect(scoped.ruleFilter.hidden).toBeGreaterThan(0);
   });
 
@@ -1053,7 +1149,7 @@ describe("simulate and compare", () => {
     const scoped = (await call("simulate", { runId, dep, verdict: "matched" })) as {
       rules: unknown[];
       missingInputs: { rules: number; groups: { fieldList: string; selectors: string[] }[] };
-      missingInputsNote: string;
+      notes: string[];
     };
     expect(scoped.rules).toHaveLength(1);
     expect(scoped.missingInputs.rules).toBe(2);
@@ -1061,8 +1157,8 @@ describe("simulate and compare", () => {
       "depType or depTypes",
       "sourceUrl",
     ]);
-    expect(scoped.missingInputsNote).toContain('`verdict: "no-input"` lists them.');
-    expect(scoped.missingInputsNote).not.toContain("--verdict");
+    expect(scoped.notes.join(" ")).toContain('`verdict: "no-input"` lists them.');
+    expect(scoped.notes.join(" ")).not.toContain("--verdict");
     // …and it is there without asking, too.
     const unfiltered = (await call("simulate", { runId, dep })) as {
       missingInputs: { rules: number };
@@ -1112,7 +1208,7 @@ describe("simulate and compare", () => {
     })) as {
       a: { missingInputs: { rules: number; groups: { fieldList: string }[] } };
       b: { missingInputs: { rules: number } };
-      missingInputsNote: string;
+      notes: string[];
       verdict: string;
     };
     expect(comparison.verdict).toBe("identical");
@@ -1122,9 +1218,10 @@ describe("simulate and compare", () => {
       "depType or depTypes",
       "sourceUrl",
     ]);
-    expect(comparison.missingInputsNote).toContain("A — 2 of 4 rules could not match");
-    expect(comparison.missingInputsNote).toContain("B — 2 of 4 rules could not match");
-    expect(comparison.missingInputsNote).toContain('`verdict: "no-input"` lists them.');
+    const notes = comparison.notes.join(" ");
+    expect(notes).toContain("A — 2 of 4 rules could not match");
+    expect(notes).toContain("B — 2 of 4 rules could not match");
+    expect(notes).toContain('`verdict: "no-input"` lists them.');
   });
 });
 
@@ -1138,7 +1235,7 @@ describe("simulate and compare", () => {
 describe("rule indexes are cross-linked", () => {
   interface SimRules {
     ruleSources: { layer: string; kind: string; from: number; to: number; count: number }[];
-    ruleSourcesNote: string;
+    notes: string[];
     rules: { index: number; verdict: string; origin?: { layer: string; sourceIndex: number } }[];
   }
 
@@ -1147,13 +1244,16 @@ describe("rule indexes are cross-linked", () => {
     const sim = (await call("simulate", {
       runId,
       dep: { depName: "react", packageName: "react" },
+      // The origin-per-row rule is about a LIST, so it is asserted on the whole
+      // one; `rule: N` is the single-row case, below.
+      verdict: "all",
     })) as SimRules;
     // The legend covers every rule index, contiguously.
     expect(sim.ruleSources.map((s) => [s.layer, s.from, s.to])).toEqual([
       ["preset :disablePeerDependencies", 0, 0],
       ["repo", 1, 3],
     ]);
-    expect(sim.ruleSourcesNote).toContain("index - from");
+    expect(sim.notes.join(" ")).toContain("index - from");
 
     const matched = sim.rules.filter((rule) => rule.verdict === "matched");
     expect(matched.length).toBeGreaterThan(0);
@@ -1490,5 +1590,211 @@ describe("RunStore", () => {
     expect(() => store.get(b.runId)).toThrow(/no run/);
     expect(store.get(a.runId).runId).toBe(a.runId);
     expect(store.get(c.runId).runId).toBe(c.runId);
+  });
+});
+
+/**
+ * Roadmap 073's acceptance criteria, as invariants over the tool surface rather
+ * than as examples — they are what stops the payload from silently regrowing.
+ *
+ * The thesis they encode: the old default answer did not fit the transport
+ * budget, so it was ALREADY incomplete — elided into a first/last window chosen
+ * by byte arithmetic, with no relation to what was asked. The choice was never
+ * between a complete answer and a narrowed one; it was between arbitrary
+ * incompleteness and deliberate incompleteness that hands back a map.
+ */
+describe("focused by default", () => {
+  const DEP = { depName: "react", packageName: "react", currentValue: "17", newValue: "18" };
+
+  /**
+   * Invariant 1. Every tool's DEFAULT answer comes back whole on the biggest
+   * run there is. Only the named bulk surfaces may truncate — asserted below,
+   * so this test cannot pass by the elision having quietly stopped working.
+   */
+  test("no default answer is elided, on a config:best-practices run", async () => {
+    const runId = await runConfig(BEST_PRACTICES);
+    const calls: [string, Record<string, unknown>][] = [
+      ["get_final_config", { runId }],
+      ["get_preset_tree", { runId }],
+      ["get_preset_node", { runId, node: "config:best-practices" }],
+      ["get_provenance", { runId }],
+      ["get_provenance", { runId, key: "packageRules" }],
+      ["get_provenance", { runId, key: "labels" }],
+      ["simulate", { runId, dep: DEP }],
+      ["compare_simulations", { runId, dep: DEP }],
+      ["get_option_docs", { name: "minimumReleaseAge" }],
+    ];
+    for (const [name, args] of calls) {
+      const payload = (await call(name, args)) as { truncated?: boolean; hint?: string };
+      expect(payload.truncated, `${name} ${JSON.stringify(args)}`).toBeUndefined();
+    }
+  });
+
+  test("the named bulk surfaces still truncate — the test above has teeth", async () => {
+    const runId = await runConfig(BEST_PRACTICES);
+    const full = (await call("simulate", { runId, dep: DEP, detail: "full" })) as {
+      truncated?: boolean;
+    };
+    expect(full.truncated).toBe(true);
+    const body = (await call("get_preset_node", {
+      runId,
+      node: "config:best-practices",
+      body: "resolved",
+    })) as { truncated?: boolean };
+    expect(body.truncated).toBe(true);
+  });
+
+  /**
+   * Invariant 2. For every narrowing, the default payload carries both a COUNT
+   * of what was withheld and the literal parameter that returns it. A key that
+   * simply vanishes is indistinguishable from a bug.
+   */
+  test("every narrowing states its count and its own reversal", async () => {
+    const runId = await runConfig(BEST_PRACTICES);
+    const sim = (await call("simulate", { runId, dep: DEP })) as {
+      ruleFilter: { total: number; shown: number; hidden: number };
+      configView: { scope: string; droppedGlobalOnly?: number };
+      notes: string[];
+    };
+    // The rule list: counts, and the two parameters that widen it.
+    expect(sim.ruleFilter.hidden).toBe(sim.ruleFilter.total - sim.ruleFilter.shown);
+    expect(sim.ruleFilter.hidden).toBeGreaterThan(0);
+    const notes = sim.notes.join(" ");
+    expect(notes).toContain('`verdict: "all"`');
+    expect(notes).toContain("`rule: N`");
+    // The per-dependency config: the class it dropped, counted, and the scope
+    // that keeps it.
+    expect(sim.configView.droppedGlobalOnly).toBe(107);
+    expect(notes).toContain('detail: "full"');
+
+    const comparison = (await call("compare_simulations", { runId, dep: DEP })) as {
+      identity: { counts: { signatureChanges: number } };
+      notes: string[];
+    };
+    expect(comparison.identity.counts).toBeDefined();
+    expect(comparison.notes.join(" ")).toContain('`detail: "rules"`');
+
+    const config = (await call("get_final_config", { runId })) as {
+      configIndex: unknown[];
+      note: string;
+    };
+    expect(config.configIndex.length).toBeGreaterThan(0);
+    expect(config.note).toContain("keys");
+  });
+
+  /**
+   * Invariant 3, first half: a dependency without `sourceUrl` against a config
+   * whose preset rules read it. The rules lose to an unset field, report a plain
+   * `no-match`, and the DEFAULT answer still says so.
+   */
+  test("the default answer still reports the rules an unset field cost", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const sim = (await call("simulate", { runId, dep: { depName: "react" } })) as {
+      missingInputs: { rules: number; groups: { fieldList: string }[] };
+      notes: string[];
+      ruleFilter: { verdict: string; hidden: number };
+    };
+    expect(sim.ruleFilter.verdict).toBe("notable");
+    expect(sim.ruleFilter.hidden).toBeGreaterThan(0);
+    expect(sim.missingInputs.rules).toBe(2);
+    expect(sim.missingInputs.groups.map((group) => group.fieldList)).toContain("sourceUrl");
+    expect(sim.notes.join(" ")).toContain('`verdict: "no-input"` lists them.');
+  });
+
+  /**
+   * Invariant 3, second half — the BLOCKER this layer had to fix first. A clause
+   * whose matcher throws is `state: "error"` and pushes its rule to
+   * `verdict: "no-match"`, which the old `notable` predicate dropped. "The tool
+   * could not evaluate this rule" is the last thing that may go missing.
+   */
+  test("the default answer keeps a rule the tool could not evaluate, and counts it", async () => {
+    const runId = await runConfig(CONDA_RULES);
+    const sim = (await call("simulate", {
+      runId,
+      dep: { depName: "react", versioning: "conda", currentValue: "1.2.3" },
+    })) as {
+      rules: { index: number; verdict: string; clauses: { state: string }[] }[];
+      evaluationErrors: { rules: number; selectors: string[]; sampleRuleIndexes: number[] };
+      ruleFilter: { verdict: string };
+      notes: string[];
+    };
+    expect(sim.ruleFilter.verdict).toBe("notable");
+    const errored = sim.rules.find((rule) => rule.index === 0);
+    expect(errored?.verdict).toBe("no-match");
+    expect(errored?.clauses[0]?.state).toBe("error");
+    expect(sim.evaluationErrors).toMatchObject({
+      rules: 1,
+      selectors: ["matchCurrentVersion"],
+      sampleRuleIndexes: [0],
+    });
+    expect(sim.notes.join(" ")).toContain('`verdict: "error"` lists them.');
+    // And the facet that lists them is in the schema an agent reads.
+    const onlyErrors = (await call("simulate", {
+      runId,
+      dep: { depName: "react", versioning: "conda", currentValue: "1.2.3" },
+      verdict: "error",
+    })) as { rules: { index: number }[] };
+    expect(onlyErrors.rules.map((rule) => rule.index)).toEqual([0]);
+  });
+
+  /**
+   * Invariant 4: `rule: N` returns the row `verdict: "all"` shows at index N —
+   * which is what makes `missingInputs.sampleRuleIndexes` actionable, since the
+   * rows it points at are exactly the ones the default view hides.
+   */
+  test("rule: N round-trips against the row verdict: all holds there", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const dep = { depName: "react" };
+    const all = (await call("simulate", { runId, dep, verdict: "all" })) as {
+      rules: Record<string, unknown>[];
+      missingInputs: { groups: { sampleRuleIndexes: number[] }[] };
+    };
+    const sampled = all.missingInputs.groups.flatMap((group) => group.sampleRuleIndexes);
+    expect(sampled.length).toBeGreaterThan(0);
+    for (const index of sampled) {
+      const one = (await call("simulate", { runId, dep, rule: index })) as {
+        rules: Record<string, unknown>[];
+        ruleFilter: Record<string, unknown>;
+      };
+      expect(one.rules).toHaveLength(1);
+      // The single row additionally carries its `origin` — the list omits it on
+      // rows that did not match, one row can afford it.
+      const { origin: _origin, ...row } = one.rules[0] ?? {};
+      expect(row).toEqual(all.rules[index]);
+      expect(one.ruleFilter).toMatchObject({ rule: index, shown: 1 });
+    }
+  });
+
+  test("rule: N wins over the facets, and out of range names the total", async () => {
+    const runId = await runConfig(MIXED_RULES);
+    const dep = { depName: "react" };
+    // Rule 3 is a genuine mismatch — hidden by `notable` and by `matched`.
+    const one = (await call("simulate", { runId, dep, rule: 3, verdict: "matched" })) as {
+      rules: { index: number; verdict: string; origin?: unknown }[];
+      ruleFilter: { verdict: string; rule: number };
+      notes: string[];
+    };
+    expect(one.rules.map((rule) => rule.index)).toEqual([3]);
+    expect(one.rules[0]?.origin).toBeDefined();
+    // The facets report `all`: none of them produced this list, and saying
+    // `verdict: "matched"` about a row it hides would be a claim, not a fact.
+    expect(one.ruleFilter).toMatchObject({ verdict: "all", source: "all", rule: 3 });
+    expect(one.notes.join(" ")).toContain("ONLY merged rule 3");
+
+    await expect(call("simulate", { runId, dep, rule: 99 })).rejects.toThrow(
+      /evaluated 4 merged packageRules; there is no rule 99/,
+    );
+  });
+
+  test("the tool descriptions name the default and its reversals", async () => {
+    const { tools } = await client.listTools();
+    const simulate = tools.find((tool) => tool.name === "simulate");
+    expect(simulate?.description).toContain('verdict: "notable"');
+    expect(simulate?.description).toContain('`verdict: "all"`');
+    expect(simulate?.description).toContain("`rule: N`");
+    expect(simulate?.description).toContain("`evaluationErrors`");
+    const compare = tools.find((tool) => tool.name === "compare_simulations");
+    expect(compare?.description).toContain("detail: ");
+    expect(compare?.description).toContain("matchedInBoth");
   });
 });

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -25,9 +25,14 @@ import {
 } from "@renovate-config-debugger/app/headless";
 import pkg from "../../package.json";
 import { errorMessage, type CliIo } from "../io";
-import { buildRuleView, missingInputsNote, ruleFilterPayload } from "../rule-view";
+import { buildRuleView, evaluationErrorsNote, missingInputsNote } from "../rule-view";
 import { digestPayload } from "../projections/digest";
-import { CONFIG_SCOPES, projectConfig } from "../projections/config-view";
+import {
+  CONFIG_SCOPES,
+  configKeyIndex,
+  type ConfigScope,
+  projectConfig,
+} from "../projections/config-view";
 import {
   describeMessage,
   type MessageSeverity,
@@ -36,11 +41,10 @@ import {
   repoStageMessage,
 } from "../projections/messages";
 import {
-  collapseRuleMerges,
+  COMPARE_DETAIL,
   comparisonPayload,
   SIMULATE_DETAIL,
   simulationPayload,
-  withRuleOrigins,
 } from "../projections/simulate";
 import {
   entryView,
@@ -122,7 +126,7 @@ const HINTS = {
   resolved:
     'the resolved document is too large to return whole — try mode "keep-internal" without includeDefaults, or read one preset\'s contribution with get_preset_node.',
   simulate:
-    "this config has too many packageRules to report whole — the omission is marked; scope the list with `verdict`/`source`, pass `keys: [...]` for the options you care about, or narrow the dependency (a datasource, a depType) so fewer rules report `no-input`.",
+    'this config has too many packageRules to report whole — the omission is marked; drop back to the default `verdict: "notable"` (or `rule: N` for one row), pass `keys: [...]` for the options you care about, or narrow the dependency (a datasource, a depType) so fewer rules report `no-input`.',
   compare:
     "the comparison is too large to return whole — pass `keys: [...]` for the options you care about, narrow the dependency, or ask simulate for one side at a time.",
   optionDocs: "too many options matched — search for a longer substring.",
@@ -139,7 +143,9 @@ const INSTRUCTIONS =
   "at a time: get_provenance with a key for 'who set this value', get_preset_tree and " +
   "get_preset_node for what `extends` expanded into (preset bodies are large — one node per " +
   "call), get_option_docs instead of recalling option semantics, which change between Renovate " +
-  "releases. simulate answers in one sentence (`verdict.text`) before the evidence. " +
+  "releases. simulate answers in one sentence (`verdict.text`) before the evidence, scoped to the " +
+  "rules that acted; every answer states what its view withheld and the parameter that returns " +
+  "it, so read `notes` before you conclude anything is absent. " +
   "Before you propose an edit, prove it: run_config the edited text and " +
   "compare_simulations the two runs against the same dependency. Everything here is read-only.";
 
@@ -264,11 +270,22 @@ type DepInput = z.infer<typeof DEP>;
  * of the app's `VerdictFilter`/`SourceFilter` unions.
  */
 const RULE_VERDICT = z
-  .enum(["notable", "all", "matched", "no-input", "no-match"] satisfies readonly VerdictFilter[])
+  .enum([
+    "notable",
+    "all",
+    "matched",
+    "no-input",
+    "no-match",
+    "error",
+  ] satisfies readonly VerdictFilter[])
   .optional()
   .describe(
-    "Scope the returned rules by verdict: `notable` (matched + unresolved — the app's default " +
-      "view), `matched`, `no-input`, `no-match`, or `all`. Omit for the full list.",
+    "Scope the returned rules by verdict. `notable` is the DEFAULT: the rows that acted or " +
+      "could not be decided — matched, not-simulated, and the ones the tool could not evaluate. " +
+      "`all` returns every row (~700 on a `config:recommended` run, which the transport then " +
+      "elides), `matched` only what fired, `no-input` the ones your `dep` left undecidable, " +
+      "`no-match` a genuine mismatch, `error` the ones a matcher threw on. Every answer states " +
+      "what its view withheld in `ruleFilter`.",
   );
 const RULE_SOURCE = z
   .enum(["all", "repo", "presets"] satisfies readonly SourceFilter[])
@@ -592,11 +609,33 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       inputSchema: z.strictObject({ runId: RUN_ID, keys: CONFIG_KEYS, configScope: CONFIG_SCOPE }),
     },
     answer(({ runId, keys, configScope }) => {
+      const scope: ConfigScope = configScope ?? "full";
       const projected = projectConfig(finalConfigOf(store.get(runId)), {
-        scope: configScope ?? "full",
+        scope,
         ...(keys ? { keys } : {}),
       });
-      return { finalConfig: projected.config, configView: projected.view };
+      const view = { finalConfig: projected.config, configView: projected.view };
+      if (fitsBudget(view)) {
+        return view;
+      }
+      // Roadmap 073. A `config:recommended` effective config is ~200 kB, so the
+      // generic elider used to cut `packageRules` in place and hand back a
+      // document that is neither the config nor a description of it. An INDEX
+      // is an answer: every top-level option, the bytes its value costs, and
+      // the two parameters that turn a name into its value.
+      const index = configKeyIndex(projected.config);
+      return {
+        configIndex: index,
+        keys: index.length,
+        configView: projected.view,
+        note:
+          `this run's effective config is ${index.reduce((sum, entry) => sum + entry.bytes, 0)} ` +
+          "bytes at this scope — too large to return whole, so this is its key INDEX (each " +
+          "option with the bytes its value costs), not the document. Ask again with " +
+          '`keys: ["a", "b"]` for the options you care about — `configScope: "package-rules"` ' +
+          "additionally drops the ~107 globalOnly options no packageRule can read — or " +
+          "get_provenance with one `key` for who set it.",
+      };
     }, HINTS.finalConfig),
   );
 
@@ -819,17 +858,34 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "`finalDependencyConfig` to the options you asked about. " +
         "`ruleSources` is the legend for the rule indexes — one merged-index range per " +
         "contributing layer — and every MATCHED rule carries its own `origin` inline. " +
-        "Rules that failed ONLY because " +
-        "your `dep` left a field they read unset are summarized in `missingInputs`, whatever " +
-        "`verdict` you asked for: they report a plain `no-match`, so every scoped view hides them " +
-        'and the answer reads as "nothing matched". The step-by-step merge trace is ' +
-        'NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
+        'By DEFAULT the answer holds the rules that acted (`verdict: "notable"`), because the ' +
+        "whole array is ~340 kB on such a run and the transport would elide it into a window " +
+        "chosen by byte arithmetic; `ruleFilter` states `total`/`shown`/`hidden` on every answer, " +
+        '`verdict: "all"` returns every row, and `rule: N` returns ONE row by index whatever the ' +
+        "facets hide. Rules that failed ONLY because " +
+        "your `dep` left a field they read unset are summarized in `missingInputs`, and rules a " +
+        "matcher THREW on in `evaluationErrors` — both whatever `verdict` you asked for, because " +
+        'they report a plain `no-match` and would otherwise read as "nothing matched". An ' +
+        "`evaluationErrors.rules` above zero means the tool could not evaluate part of the " +
+        "config, so the verdict is incomplete rather than negative. The step-by-step merge trace " +
+        'is NOT included unless you ask for detail: "full"; it is the bulk of the payload.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
         dep: DEP,
         verdict: RULE_VERDICT,
         source: RULE_SOURCE,
+        rule: z
+          .number()
+          .int()
+          .min(0)
+          .optional()
+          .describe(
+            "One merged rule by index: its whole row — every clause, what it merged, its " +
+              '`origin` — whatever `verdict`/`source` would hide. This is how you ask "why did ' +
+              'rule N not fire", and what `missingInputs.sampleRuleIndexes` and `ruleSources` ' +
+              "hand you indexes for. Out of range names the total.",
+          ),
         keys: CONFIG_KEYS,
         configScope: CONFIG_SCOPE,
         detail: z
@@ -839,18 +895,21 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
             '`verdict` (the default) answers "what matched and what does this dependency end up ' +
               'with"; `full` adds `mergeSteps` and `rawFinalConfig` — ~1 MB on a ' +
               "`config:recommended` run, so ask for it only when you are stepping through the " +
-              "merge itself.",
+              "merge itself. It does not widen the rule list: `verdict` does that.",
           ),
       }),
     },
-    answer(async ({ runId, dep, verdict, source, keys, configScope, detail }, ctx) => {
+    answer(async ({ runId, dep, verdict, source, rule, keys, configScope, detail }, ctx) => {
       const run = store.get(runId);
       const sim = await simulateRun(run, dep, ctx);
-      const resolvedDetail = detail ?? "verdict";
+      // Roadmap 073: `notable`, not the whole array. The unfiltered answer did
+      // not fit the transport budget, so it was already incomplete — by byte
+      // arithmetic instead of on purpose. Every narrowing here is reversible by
+      // name, and `ruleFilter` says which one applied.
       const view = buildRuleView(sim, run.result, {
-        verdict: verdict ?? "all",
+        verdict: verdict ?? "notable",
         source: source ?? "all",
-        explicit: true,
+        ...(rule !== undefined ? { rule } : {}),
         transport: "mcp",
       });
       // `finalDependencyConfig` is by construction "what applyPackageRules
@@ -858,27 +917,18 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       // inert here and goes by default — the opposite of get_final_config's
       // document, and stated as such in `configView`.
       const payload = simulationPayload(sim, {
-        detail: resolvedDetail,
+        detail: detail ?? "verdict",
         scope: configScope ?? "package-rules",
         transport: "mcp",
         attribution: view.attribution,
         finalConfig: run.result.finalConfig,
+        ruleView: view,
         ...(keys ? { keys } : {}),
       });
-      if (verdict === undefined && source === undefined) {
-        return { dep: toDependency(dep), ...payload };
-      }
       return {
         dep: toDependency(dep),
         ...payload,
-        // The scoped list REPLACES the payload's, so it has to carry the same
-        // per-rule `origin` — the legend stays either way.
-        rules:
-          resolvedDetail === "full"
-            ? view.rules
-            : withRuleOrigins(collapseRuleMerges(view.rules), view.attribution),
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
-        ...ruleFilterPayload(view),
       };
     }, HINTS.simulate),
   );
@@ -902,8 +952,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "narrows the delta to the options you care about; `summary`, `verdict` and `netEffect` " +
         "always describe the WHOLE delta, so narrowing the view never moves the verdict. A side " +
         "that could not evaluate a rule for lack of dependency input reports it in its own " +
-        "`missingInputs`: two blind sides agree perfectly, and `identical` over them is not an " +
-        "answer about your edit.",
+        "`missingInputs`, and one whose matcher threw in its own `evaluationErrors`: two blind " +
+        "sides agree perfectly, and `identical` over them is not an answer about your edit. " +
+        "By default `identity` is stated as counts and `matchedInBoth` is omitted — `detail: " +
+        '"rules"` restores the arrays.',
       annotations: HELD_RUN_ANNOTATIONS,
       inputSchema: z.strictObject({
         runId: RUN_ID,
@@ -912,9 +964,20 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         depB: DEP.optional().describe("The B-side dependency. Defaults to dep."),
         keys: CONFIG_KEYS,
         configScope: CONFIG_SCOPE,
+        detail: z
+          .enum(COMPARE_DETAIL)
+          .optional()
+          .describe(
+            "`verdict` (the default) is the claim plus its evidence: the verdict, `netEffect`, " +
+              "the rules that started/stopped mattering, the key delta, and the identity axis as " +
+              "COUNTS. `rules` restores `matchedInBoth` and the identity arrays; `full` is the " +
+              "comparison exactly as the engine computes it, selector `signature` strings " +
+              "included (they are whole selector arrays re-serialized, next to the `label` that " +
+              "already names each rule).",
+          ),
       }),
     },
-    answer(async ({ runId, dep, runIdB, depB, keys, configScope }, ctx) => {
+    answer(async ({ runId, dep, runIdB, depB, keys, configScope, detail }, ctx) => {
       const a = store.get(runId);
       const b = runIdB ? store.get(runIdB) : a;
       const [simA, simB] = await Promise.all([
@@ -924,28 +987,48 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       // Per side, and outside `comparisonPayload`: the pure diff module states
       // what the two runs did, and a side that never got to evaluate a rule is
       // a fact about that side's INPUT, not about the difference.
-      const noteA = missingInputsNote(simA.missingInputs, "mcp");
-      const noteB = missingInputsNote(simB.missingInputs, "mcp");
-      const combined = [
-        ...(noteA ? [`A — ${noteA}`] : []),
-        ...(noteB ? [`B — ${noteB}`] : []),
-      ].join(" ");
+      const sideNotes = [
+        ...[simA, simB].flatMap((sim, index) => {
+          const note = evaluationErrorsNote(sim.evaluationErrors, "mcp");
+          return note ? [`${index === 0 ? "A" : "B"} — ${note}`] : [];
+        }),
+        ...[simA, simB].flatMap((sim, index) => {
+          const note = missingInputsNote(sim.missingInputs, "mcp");
+          return note ? [`${index === 0 ? "A" : "B"} — ${note}`] : [];
+        }),
+      ];
+      // What the CALLER varied — the engine cannot see it, and guessing is
+      // how the comparison came to claim a selector rewrite about one
+      // unchanged config read through two dependencies.
+      const comparison = comparisonPayload(
+        compareSimulations(simA, simB, {
+          mode: runIdB ? "config" : depB ? "dependency" : "config",
+        }),
+        {
+          scope: configScope ?? "package-rules",
+          detail: detail ?? "verdict",
+          transport: "mcp",
+          ...(keys ? { keys } : {}),
+        },
+      );
+      const notes = [...sideNotes, ...(comparison.notes ?? [])];
       return {
-        a: { runId: a.runId, dep: toDependency(dep), missingInputs: simA.missingInputs },
-        b: { runId: b.runId, dep: toDependency(depB ?? dep), missingInputs: simB.missingInputs },
-        ...(combined ? { missingInputsNote: combined } : {}),
-        // What the CALLER varied — the engine cannot see it, and guessing is
-        // how the comparison came to claim a selector rewrite about one
-        // unchanged config read through two dependencies.
-        ...comparisonPayload(
-          compareSimulations(simA, simB, {
-            mode: runIdB ? "config" : depB ? "dependency" : "config",
-          }),
-          {
-            scope: configScope ?? "package-rules",
-            ...(keys ? { keys } : {}),
-          },
-        ),
+        a: {
+          runId: a.runId,
+          dep: toDependency(dep),
+          missingInputs: simA.missingInputs,
+          evaluationErrors: simA.evaluationErrors,
+        },
+        b: {
+          runId: b.runId,
+          dep: toDependency(depB ?? dep),
+          missingInputs: simB.missingInputs,
+          evaluationErrors: simB.evaluationErrors,
+        },
+        ...comparison,
+        // ONE notes array (roadmap 073) — five note-shaped field names was four
+        // too many for an agent looking for the map.
+        ...(notes.length > 0 ? { notes } : {}),
       };
     }, HINTS.compare),
   );

--- a/packages/cli/src/projections/config-view.ts
+++ b/packages/cli/src/projections/config-view.ts
@@ -148,6 +148,32 @@ export function projectConfig(
   return { config: projected, view };
 }
 
+/** One entry of a {@link configKeyIndex}. */
+export interface ConfigKeySize {
+  key: string;
+  /** Bytes the key's VALUE costs as compact JSON — what makes the document
+   *  unanswerable, and what tells a caller which `keys` to ask for. */
+  bytes: number;
+}
+
+/**
+ * The document as a key index, biggest first (roadmap 073).
+ *
+ * The answer for a config that does not fit the transport's budget: the generic
+ * elision shrinks the largest ARRAY in place, which on an effective config means
+ * a `packageRules` cut to first-and-last inside a document that still looks
+ * whole. An index is honest at any size — it names every key the document has
+ * and states what asking for one would cost.
+ */
+export function configKeyIndex(config: Record<string, unknown>): ConfigKeySize[] {
+  return Object.entries(config)
+    .map(([key, value]) => ({
+      key,
+      bytes: new TextEncoder().encode(JSON.stringify(value) ?? "null").length,
+    }))
+    .toSorted((a, b) => b.bytes - a.bytes || a.key.localeCompare(b.key));
+}
+
 /**
  * A before/after pair for one key — `MergedKey`, a rule's merge, which IS
  * chronological.

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -35,6 +35,7 @@ const SIM: SimulationResult = {
     authoredBlocks: [],
   },
   missingInputs: { rules: 0, groups: [] },
+  evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
   mergeSteps: [],
   errors: [],
   warnings: [],
@@ -80,17 +81,21 @@ describe("simulationPayload", () => {
       "verdict",
       "rules",
       "missingInputs",
+      "evaluationErrors",
       "flattened",
       "finalDependencyConfig",
       "configView",
       "errors",
       "warnings",
+      // Roadmap 073: ONE notes array. `detailNote`, `missingInputsNote` and
+      // `ruleSourcesNote` were four field names an agent had to learn to find
+      // the same kind of sentence.
       "notes",
-      "detailNote",
     ]);
     expect(payload).not.toHaveProperty("mergeSteps");
     expect(payload).not.toHaveProperty("rawFinalConfig");
-    expect(payload).toHaveProperty("detailNote", VERDICT_DETAIL_NOTE);
+    expect(payload).not.toHaveProperty("detailNote");
+    expect(payload.notes).toContain(VERDICT_DETAIL_NOTE);
   });
 
   test("the per-dependency config is scoped, keyed, and says so", () => {
@@ -135,14 +140,44 @@ describe("simulationPayload", () => {
       scope: "package-rules",
       transport: "mcp",
     });
-    expect(payload).toMatchObject({
-      missingInputs: sim.missingInputs,
-      missingInputsNote: `${sim.missingInputs.note} \`verdict: "no-input"\` lists them.`,
+    expect(payload.missingInputs).toBe(sim.missingInputs);
+    expect(payload.notes).toContain(
+      `${sim.missingInputs.note} \`verdict: "no-input"\` lists them.`,
+    );
+    // Nothing to point at, no sentence: the array never carries an empty one.
+    const clean = simulationPayload(SIM, {
+      detail: "verdict",
+      scope: "package-rules",
+      transport: "cli",
     });
-    // Nothing to point at, no key: the shape never carries an empty sentence.
-    expect(
-      simulationPayload(SIM, { detail: "verdict", scope: "package-rules", transport: "cli" }),
-    ).not.toHaveProperty("missingInputsNote");
+    expect(clean.notes.some((note) => note.includes("could not match"))).toBe(false);
+  });
+
+  /**
+   * Roadmap 073's second aggregate. A matcher that threw fails its rule to a
+   * plain `no-match`, so this is the fact a scoped list would drop — and the
+   * one that says the answer is incomplete rather than negative.
+   */
+  test("the evaluation-error summary rides along too, with its own pointer", () => {
+    const sim: SimulationResult = {
+      ...SIM,
+      evaluationErrors: {
+        rules: 1,
+        selectors: ["matchCurrentVersion"],
+        messages: ["matcher threw: conda versioning is not supported"],
+        sampleRuleIndexes: [0],
+        note: "1 of 1 rule could not be EVALUATED: `matchCurrentVersion` threw.",
+      },
+    };
+    const payload = simulationPayload(sim, {
+      detail: "verdict",
+      scope: "package-rules",
+      transport: "mcp",
+    });
+    expect(payload.evaluationErrors).toBe(sim.evaluationErrors);
+    // Ahead of the missing-input pointer: "the tool could not evaluate this"
+    // outranks "your dep left a field unset".
+    expect(payload.notes[0]).toBe(`${sim.evaluationErrors.note} \`verdict: "error"\` lists them.`);
   });
 
   test("the merged description appends are collapsed, in the rules and in flattened", () => {
@@ -165,14 +200,20 @@ const NET_EFFECT =
   'automerge (A=false, B=true), groupName (unset in A, B="react monorepo"); ' +
   "description also changed (documentation)";
 
+const REF = (index: number, label: string) => ({
+  index,
+  label,
+  signature: JSON.stringify([[label, ["react", "react-dom", "@types/react"]]]),
+});
+
 const COMPARISON: SimulationComparison = {
   summary: `differs: ${NET_EFFECT}`,
   verdict: "differs",
   netEffect: NET_EFFECT,
   mode: "config",
-  stoppedMatching: [],
+  stoppedMatching: [REF(1, "matchPackageNames")],
   startedMatching: [],
-  matchedInBoth: [],
+  matchedInBoth: [REF(2, "matchDepTypes")],
   configDelta: [
     { key: "automerge", kind: "behavioral", a: false, b: true, inA: true, inB: true },
     { key: "groupName", kind: "behavioral", b: "react monorepo", inA: false, inB: true },
@@ -185,12 +226,24 @@ const COMPARISON: SimulationComparison = {
       inB: true,
     },
   ],
-  identity: { changed: false, signatureChanges: [], onlyInA: [], onlyInB: [] },
+  identity: {
+    changed: true,
+    signatureChanges: [
+      {
+        a: REF(3, "matchPackageNames"),
+        b: REF(3, "matchPackageNames"),
+        kind: "clause-values-changed",
+        keys: ["matchPackageNames"],
+      },
+    ],
+    onlyInA: [REF(3, "matchPackageNames")],
+    onlyInB: [REF(3, "matchPackageNames")],
+  },
 };
 
 describe("comparisonPayload", () => {
   test("collapsing never moves a key: same keys, same order, smaller values", () => {
-    const payload = comparisonPayload(COMPARISON, { scope: "package-rules" });
+    const payload = comparisonPayload(COMPARISON, { scope: "package-rules", detail: "full" });
     expect(payload.configDelta.map((delta) => delta.key)).toEqual([
       "automerge",
       "groupName",
@@ -212,6 +265,7 @@ describe("comparisonPayload", () => {
   test("keys narrows the delta, and the verdict is left alone", () => {
     const payload = comparisonPayload(COMPARISON, {
       scope: "package-rules",
+      detail: "full",
       keys: ["groupName", "labels"],
     });
     expect(payload.configDelta.map((delta) => delta.key)).toEqual(["groupName"]);
@@ -221,5 +275,74 @@ describe("comparisonPayload", () => {
     expect(payload.summary).toBe(COMPARISON.summary);
     expect(payload.verdict).toBe("differs");
     expect(payload.netEffect).toBe(COMPARISON.netEffect);
+  });
+});
+
+/**
+ * Roadmap 073: the comparison's own detail axis. The two things the default
+ * drops are the two that cost — `matchedInBoth` (every rule that behaved the
+ * same, in a diff) and the `signature` strings, each a whole selector array
+ * re-serialized next to the `label` that already names the rule — and it names
+ * the level that puts them back.
+ */
+describe("comparisonPayload detail levels", () => {
+  const at = (detail: "verdict" | "rules" | "full") =>
+    comparisonPayload(COMPARISON, { scope: "package-rules", detail, transport: "mcp" });
+
+  test("the default states identity as counts and drops matchedInBoth", () => {
+    const payload = at("verdict");
+    expect(payload).not.toHaveProperty("matchedInBoth");
+    expect(payload.identity).toEqual({
+      changed: true,
+      counts: { onlyInA: 1, onlyInB: 1, signatureChanges: 1 },
+    });
+    // The behavior arrays stay — they are the evidence for the verdict — but a
+    // rule is identified by `label` + `index`, not by a re-serialized selector.
+    expect(payload.stoppedMatching).toEqual([{ index: 1, label: "matchPackageNames" }]);
+    // …and the omission names its own reversal.
+    expect(payload.notes?.join(" ")).toContain('`detail: "rules"`');
+    expect(payload.notes?.join(" ")).toContain("`matchedInBoth`");
+  });
+
+  test('detail "rules" puts the arrays back, still without the signatures', () => {
+    const payload = at("rules");
+    expect(payload.matchedInBoth).toEqual([{ index: 2, label: "matchDepTypes" }]);
+    expect(payload.identity.counts).toBeUndefined();
+    expect(payload.identity.onlyInA).toEqual([{ index: 3, label: "matchPackageNames" }]);
+    expect(payload.identity.signatureChanges?.[0]).toMatchObject({
+      kind: "clause-values-changed",
+      a: { index: 3, label: "matchPackageNames" },
+    });
+    expect(JSON.stringify(payload)).not.toContain("@types/react");
+    expect(payload.notes?.join(" ")).toContain('`detail: "full"`');
+  });
+
+  test('detail "full" is the engine\'s comparison, signatures and all', () => {
+    const payload = at("full");
+    expect(payload.matchedInBoth).toEqual(COMPARISON.matchedInBoth);
+    expect(payload.identity).toBe(COMPARISON.identity);
+    expect(JSON.stringify(payload)).toContain("@types/react");
+    // Nothing withheld, so there is nothing to point at.
+    expect(payload.notes).toBeUndefined();
+  });
+
+  test("the note speaks the caller's own spelling", () => {
+    const cli = comparisonPayload(COMPARISON, {
+      scope: "package-rules",
+      detail: "verdict",
+      transport: "cli",
+    });
+    expect(cli.notes?.join(" ")).toContain("`--detail rules`");
+    expect(cli.notes?.join(" ")).not.toContain('detail: "rules"');
+  });
+
+  test("the verdict is never projected, at any level", () => {
+    for (const detail of ["verdict", "rules", "full"] as const) {
+      const payload = at(detail);
+      expect(payload.summary).toBe(COMPARISON.summary);
+      expect(payload.verdict).toBe("differs");
+      expect(payload.netEffect).toBe(COMPARISON.netEffect);
+      expect(payload.identity.changed).toBe(true);
+    }
   });
 });

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -3,12 +3,20 @@ import type {
   MergedKey,
   RuleAttribution,
   RuleEvaluation,
+  RuleRef,
+  SignatureChange,
   SimulationComparison,
   SimulationResult,
   ValidationMessage,
 } from "@renovate-config-debugger/engine";
 import { CliError } from "../io";
-import { missingInputsNote } from "../rule-view";
+import {
+  evaluationErrorsNote,
+  missingInputsNote,
+  ruleFilterNote,
+  ruleFilterPayload,
+  type RuleView,
+} from "../rule-view";
 import type { RunTransport } from "../run-input";
 import {
   collapseDeltas,
@@ -54,10 +62,13 @@ import { flattenedView, verdictPayload } from "./verdict";
  * level asked for the same shape by hand — the matched rules, `flattened` and
  * `finalDependencyConfig`.
  *
- * So the merge trace is opt-in. `full` is the whole `SimulationResult`,
- * untouched and byte-exact, for the caller who is actually stepping through
- * the merge — which is also what makes every other projection here safe to
- * apply: the unprojected document is one parameter away.
+ * So the merge trace is opt-in. `full` is the whole `SimulationResult` — every
+ * member verbatim, no key projection, no collapsed diffs — for the caller who
+ * is actually stepping through the merge, which is also what makes every other
+ * projection here safe to apply: the unprojected document is one parameter
+ * away. The one thing `full` does not undo is the rule-list SELECTION (roadmap
+ * 073): the facets are a question about which rows you asked for, not a
+ * projection of a row, and `verdict: "all"` is what widens them at every level.
  */
 export const SIMULATE_DETAIL = ["verdict", "full"] as const;
 export type SimulateDetail = (typeof SIMULATE_DETAIL)[number];
@@ -71,6 +82,13 @@ export interface SimulateProjection {
   detail: SimulateDetail;
   keys?: readonly string[];
   scope: ConfigScope;
+  /**
+   * Which rules to answer with, and what that view cost (roadmap 073). Omitted
+   * means the whole array unfiltered and no `ruleFilter` — the shape a
+   * hand-built test asserts on; both transports pass one, because the flipped
+   * default is only safe while the payload states what it withheld.
+   */
+  ruleView?: RuleView;
   /**
    * The transport's spelling of the missing-input pointer
    * (`missingInputsNote`). Optional only so a caller that has no rule list to
@@ -131,15 +149,36 @@ export function withRuleLinks(
   });
 }
 
-/** A rule with its merge diffs collapsed. Exported because the rule list is
- *  REPLACED downstream when `verdict`/`source` scope it (`buildRuleView`), and
- *  the replacement must carry the same shape as the default one. */
-export function collapseRuleMerges(
+/** A rule with its merge diffs collapsed. */
+function collapseRuleMerges(
   rules: readonly RuleEvaluation[],
 ): (RuleEvaluation | (Omit<RuleEvaluation, "merged"> & { merged: MaybeCollapsed<MergedKey>[] }))[] {
   return rules.map((rule) =>
     rule.merged ? { ...rule, merged: collapseDiffs(rule.merged) } : rule,
   );
+}
+
+/**
+ * The rule rows an answer carries, at this detail level — one implementation,
+ * so `rcd simulate --format json` and the MCP tool cannot disagree about the
+ * shape of a row (they did, and the whole rules array used to be re-derived at
+ * each call site after the projection had already built one).
+ *
+ * `detail: "full"` keeps the rows verbatim, the escape hatch it is meant to be.
+ * A single-rule view (`rule: N`) additionally carries `origin` on a row that
+ * did NOT match: the list omits it there because annotating ~727 rows costs 15 %
+ * of the payload, but "which layer wrote the rule I asked about" is most of the
+ * question when it is one row.
+ */
+export function ruleRows(view: RuleView, detail: SimulateDetail) {
+  const rows = detail === "full" ? [...view.rules] : collapseRuleMerges(view.rules);
+  if (view.rule === undefined) {
+    return withRuleOrigins(rows, view.attribution);
+  }
+  return rows.map((row) => {
+    const origin = ruleOrigin(row.index, view.attribution);
+    return origin ? { ...row, origin } : row;
+  });
 }
 
 /**
@@ -153,34 +192,44 @@ export function simulationPayload(sim: SimulationResult, options: SimulateProjec
   // the largest keys), and `full` must not be the level that loses it.
   const verdict = verdictPayload(sim, options.finalConfig, options.attribution);
   const flattened = flattenedView(sim, options.attribution);
+  const view = options.ruleView;
+  const rules = view ? ruleRows(view, options.detail) : collapseRuleMerges(sim.rules);
+  const filterNote = view ? ruleFilterNote(view) : undefined;
   if (options.detail === "full") {
     // The escape hatch stays the result itself — every member verbatim,
     // `mergeSteps` and `rawFinalConfig` included — plus the verdict and the
-    // flattening legend, which are additive and cost a few hundred bytes.
-    return { verdict, ...sim, flattened };
+    // flattening legend, which are additive and cost a few hundred bytes. The
+    // rule LIST is still the requested view (roadmap 073), and says so.
+    return {
+      verdict,
+      ...sim,
+      rules: view ? rules : sim.rules,
+      flattened,
+      ...(view ? ruleFilterPayload(view) : {}),
+      ...(filterNote ? { notes: [...sim.notes, filterNote] } : {}),
+    };
   }
   const projected = projectConfig(sim.finalDependencyConfig, {
     scope: options.scope,
     ...(options.keys ? { keys: options.keys } : {}),
   });
-  const missingNote = options.transport
-    ? missingInputsNote(sim.missingInputs, options.transport)
-    : undefined;
   const sources: RuleSourceRange[] = ruleSourceRanges(options.attribution);
   return {
     verdict,
-    rules: withRuleOrigins(collapseRuleMerges(sim.rules), options.attribution),
+    rules,
     // ~200 bytes for the whole attribution, and immune to the elision (the
     // largest-array pass never picks it) — so "which layer wrote this rule"
     // survives an answer whose rule list did not.
-    ...(sources.length > 0 ? { ruleSources: sources, ruleSourcesNote: RULE_SOURCES_NOTE } : {}),
-    // Admitted on purpose, and NOT next to the rows it describes: `rules` is
-    // replaced downstream by a `verdict`/`source` view and is the first array
-    // the MCP elision shrinks, and the rules this counts are exactly the ones
-    // a `notable`/`matched` filter removes. A few hundred bytes that survive
-    // both, against an answer that reads as "nothing matched".
+    ...(sources.length > 0 ? { ruleSources: sources } : {}),
+    // Admitted on purpose, and NOT next to the rows they describe: `rules` is
+    // the view a `verdict`/`source`/`rule` selection produced and the first
+    // array the MCP elision shrinks, and the rules these two count are exactly
+    // the ones a `notable`/`matched` filter removes. A few hundred bytes that
+    // survive both, against an answer that reads as "nothing matched" — or,
+    // worse, as a verdict about a rule the tool never managed to evaluate.
     missingInputs: sim.missingInputs,
-    ...(missingNote ? { missingInputsNote: missingNote } : {}),
+    evaluationErrors: sim.evaluationErrors,
+    ...(view ? ruleFilterPayload(view) : {}),
     flattened: { ...flattened, merged: collapseDiffs(sim.flattened.merged) },
     finalDependencyConfig: projected.config,
     configView: projected.view,
@@ -189,24 +238,139 @@ export function simulationPayload(sim: SimulationResult, options: SimulateProjec
     // link says which rule of the reader's own config that is.
     errors: withRuleLinks(sim.errors, options.attribution),
     warnings: withRuleLinks(sim.warnings, options.attribution),
-    notes: sim.notes,
-    detailNote: VERDICT_DETAIL_NOTE,
+    // ONE notes array (roadmap 073). The payload used to carry five
+    // note-shaped fields — `notes`, `detailNote`, `missingInputsNote`,
+    // `ruleSourcesNote` and `flattened.note` — and an agent should not have to
+    // learn five field names to find the map. Each aggregate keeps its own
+    // `note` inside its object; everything that is a pointer about the ANSWER
+    // is appended here, in the order a reader needs it.
+    notes: [
+      ...sim.notes,
+      ...(filterNote ? [filterNote] : []),
+      ...(options.transport ? notesFor(sim, options.transport) : []),
+      ...(sources.length > 0 ? [RULE_SOURCES_NOTE] : []),
+      VERDICT_DETAIL_NOTE,
+    ],
   };
 }
+
+/** The two aggregates' transport-spelled pointers, in the order that matters:
+ *  "the tool could not evaluate this" outranks "your dep left a field unset". */
+function notesFor(sim: SimulationResult, transport: RunTransport): string[] {
+  const errors = evaluationErrorsNote(sim.evaluationErrors, transport);
+  const missing = missingInputsNote(sim.missingInputs, transport);
+  return [...(errors ? [errors] : []), ...(missing ? [missing] : [])];
+}
+
+/**
+ * Roadmap 073: how much of a comparison an answer carries.
+ *
+ * `verdict` (the default) is the claim plus the evidence for it — the behavior
+ * verdict, `netEffect`, the rules that started/stopped mattering, the key delta
+ * — and states the identity axis as COUNTS. Measured on the persona-replay
+ * configs, the two things it drops are the two that cost: `matchedInBoth` is
+ * every rule that behaved the same on both sides (the answer to a question
+ * nobody asked of a diff), and a `signature` is the whole selector array of a
+ * rule re-serialized as a string, next to the `label` that already names it.
+ *
+ * `rules` puts the arrays back, still without the signature strings; `full` is
+ * the engine's `SimulationComparison` exactly as it computes it. The engine's
+ * object is complete either way — this is a projection, and the reversal is
+ * named in the answer.
+ */
+export const COMPARE_DETAIL = ["verdict", "rules", "full"] as const;
+export type CompareDetail = (typeof COMPARE_DETAIL)[number];
 
 export interface ComparisonProjection {
   keys?: readonly string[];
   scope: ConfigScope;
+  detail: CompareDetail;
+  /** Which surface the note's `detail` spelling is for. Defaults to `mcp`'s. */
+  transport?: RunTransport;
 }
 
-export interface ProjectedComparison extends Omit<SimulationComparison, "configDelta"> {
+/** A {@link RuleRef} without the re-serialized selector array. */
+type ProjectedRuleRef = Omit<RuleRef, "signature"> | RuleRef;
+
+/** The identity axis, as counts or as the arrays themselves. */
+interface ProjectedIdentity {
+  changed: boolean;
+  counts?: { onlyInA: number; onlyInB: number; signatureChanges: number };
+  signatureChanges?: (
+    | SignatureChange
+    | (Omit<SignatureChange, "a" | "b"> & {
+        a: ProjectedRuleRef;
+        b: ProjectedRuleRef;
+      })
+  )[];
+  onlyInA?: ProjectedRuleRef[];
+  onlyInB?: ProjectedRuleRef[];
+}
+
+export interface ProjectedComparison extends Omit<
+  SimulationComparison,
+  "configDelta" | "matchedInBoth" | "identity" | "stoppedMatching" | "startedMatching"
+> {
+  stoppedMatching: ProjectedRuleRef[];
+  startedMatching: ProjectedRuleRef[];
+  matchedInBoth?: ProjectedRuleRef[];
   configDelta: MaybeCollapsedDelta<ConfigKeyDelta>[];
   configView: ConfigView;
+  identity: ProjectedIdentity;
+  /** The one place a comparison's pointers live — same rule as the simulation
+   *  payload's `notes`. Absent when the answer withheld nothing. */
+  notes?: string[];
+}
+
+const IDENTITY_COUNTS_NOTE =
+  "`identity` is stated as counts at this detail level: it is bookkeeping about selector TEXT, " +
+  "never a behavior claim, and it goes true whenever you edit the very array a rule matches on. ";
+
+const MATCHED_IN_BOTH_NOTE =
+  "`matchedInBoth` (the rules that behaved the same on both sides) and the per-rule `signature` " +
+  "strings are omitted; `label` and `index` identify each rule. ";
+
+function withoutSignature(ref: RuleRef): ProjectedRuleRef {
+  const { signature: _signature, ...rest } = ref;
+  return rest;
+}
+
+function projectRefs(refs: readonly RuleRef[], detail: CompareDetail): ProjectedRuleRef[] {
+  return detail === "full" ? [...refs] : refs.map(withoutSignature);
+}
+
+function projectIdentity(
+  identity: SimulationComparison["identity"],
+  detail: CompareDetail,
+): ProjectedIdentity {
+  if (detail === "full") {
+    return identity;
+  }
+  if (detail === "verdict") {
+    return {
+      changed: identity.changed,
+      counts: {
+        onlyInA: identity.onlyInA.length,
+        onlyInB: identity.onlyInB.length,
+        signatureChanges: identity.signatureChanges.length,
+      },
+    };
+  }
+  return {
+    changed: identity.changed,
+    signatureChanges: identity.signatureChanges.map((change) => ({
+      ...change,
+      a: withoutSignature(change.a),
+      b: withoutSignature(change.b),
+    })),
+    onlyInA: projectRefs(identity.onlyInA, detail),
+    onlyInB: projectRefs(identity.onlyInB, detail),
+  };
 }
 
 /**
  * The comparison, with its key delta scoped, key-selected and
- * description-collapsed.
+ * description-collapsed, at the requested {@link CompareDetail}.
  *
  * `summary`, `verdict` and `netEffect` are deliberately NOT projected: they
  * state what the comparison found, over the whole delta, and a verdict that
@@ -225,11 +389,41 @@ export function comparisonPayload(
     comparison.configDelta.map((delta) => delta.key),
     { scope: options.scope, ...(options.keys ? { keys: options.keys } : {}) },
   );
+  const { detail } = options;
+  const spell = (value: CompareDetail) =>
+    options.transport === "cli" ? `\`--detail ${value}\`` : `\`detail: "${value}"\``;
+  const notes =
+    detail === "full"
+      ? []
+      : [
+          (detail === "verdict" ? IDENTITY_COUNTS_NOTE + MATCHED_IN_BOTH_NOTE : "") +
+            `${spell("rules")} returns the rule and identity arrays, ${spell("full")} the ` +
+            "comparison exactly as the engine computes it — every signature included.",
+        ];
+  // Destructured out rather than overwritten: at `verdict` the key is not
+  // present at all, and a spread would keep the engine's.
+  const { matchedInBoth, ...rest } = comparison;
   return {
-    ...comparison,
+    ...rest,
+    stoppedMatching: projectRefs(comparison.stoppedMatching, detail),
+    startedMatching: projectRefs(comparison.startedMatching, detail),
+    ...(detail === "verdict" ? {} : { matchedInBoth: projectRefs(matchedInBoth, detail) }),
     configDelta: collapseDeltas(comparison.configDelta.filter((delta) => kept.has(delta.key))),
     configView: view,
+    identity: projectIdentity(comparison.identity, detail),
+    ...(notes.length > 0 ? { notes } : {}),
   };
+}
+
+export function parseCompareDetail(raw: string | undefined): CompareDetail | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const found = COMPARE_DETAIL.find((detail) => detail === raw);
+  if (!found) {
+    throw new CliError(`--detail must be one of ${COMPARE_DETAIL.join("|")} (got "${raw}")`);
+  }
+  return found;
 }
 
 export function parseDetail(raw: string | undefined): SimulateDetail | undefined {

--- a/packages/cli/src/rule-view.test.ts
+++ b/packages/cli/src/rule-view.test.ts
@@ -4,7 +4,13 @@ import type {
   SimulationResult,
   TraceResult,
 } from "@renovate-config-debugger/engine";
-import { buildRuleView, missingInputsNote } from "./rule-view";
+import {
+  buildRuleView,
+  evaluationErrorsNote,
+  missingInputsNote,
+  ruleFilterNote,
+  ruleFilterPayload,
+} from "./rule-view";
 
 /**
  * The facets themselves are the app's shared predicates, covered where they
@@ -25,6 +31,7 @@ function sim(rules: RuleEvaluation[]): SimulationResult {
     finalDependencyConfig: {},
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     mergeSteps: [],
     errors: [],
     warnings: [],
@@ -65,7 +72,6 @@ describe("buildRuleView", () => {
     const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
       verdict: "all",
       source: "repo",
-      explicit: true,
       transport: "cli",
     });
     expect(view.notes[0]).toContain("--source repo ignored");
@@ -79,7 +85,6 @@ describe("buildRuleView", () => {
     const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
       verdict: "all",
       source: "presets",
-      explicit: true,
       transport: "mcp",
     });
     expect(view.notes[0]).toContain('source: "presets" ignored');
@@ -96,7 +101,6 @@ describe("buildRuleView", () => {
       verdict: "all",
       // No `--source`: the attribution is not the filter's private business.
       source: "all",
-      explicit: false,
       transport: "cli",
     });
     expect(view.sources).toEqual([{ layer: "repo", kind: "repo", from: 0, to: 1, count: 2 }]);
@@ -107,7 +111,6 @@ describe("buildRuleView", () => {
     const view = buildRuleView(sim([rule(0, "matched")]), UNATTRIBUTABLE, {
       verdict: "all",
       source: "all",
-      explicit: false,
       transport: "cli",
     });
     expect(view.sources).toEqual([]);
@@ -121,7 +124,6 @@ describe("buildRuleView", () => {
     const view = buildRuleView(sim([rule(0, "matched"), rule(1, "no-match")]), UNATTRIBUTABLE, {
       verdict: "matched",
       source: "all",
-      explicit: true,
       transport: "cli",
     });
     expect(view.rules).toHaveLength(1);
@@ -162,5 +164,114 @@ describe("missingInputsNote", () => {
 
   test("nothing to say means no line at all", () => {
     expect(missingInputsNote({ rules: 0, groups: [] }, "cli")).toBeUndefined();
+  });
+});
+
+/**
+ * Roadmap 073. The default is now `notable` on every surface, which is only
+ * safe while the answer states what it withheld and names the parameter that
+ * returns it — the reversibility invariant. `ruleFilter` carries the counts,
+ * `ruleFilterNote` the reversals, in the caller's own spelling.
+ */
+describe("the flipped default states what it withheld", () => {
+  const RULES = [rule(0, "matched"), rule(1, "no-match"), rule(2, "no-match")];
+
+  const viewAt = (verdict: "notable" | "all", transport: "cli" | "mcp") =>
+    buildRuleView(sim(RULES), ATTRIBUTED, { verdict, source: "all", transport });
+
+  test("the counts are on every payload, filtered or not", () => {
+    expect(ruleFilterPayload(viewAt("notable", "mcp")).ruleFilter).toEqual({
+      verdict: "notable",
+      source: "all",
+      total: 3,
+      shown: 1,
+      hidden: 2,
+    });
+    expect(ruleFilterPayload(viewAt("all", "mcp")).ruleFilter).toMatchObject({
+      total: 3,
+      shown: 3,
+      hidden: 0,
+    });
+  });
+
+  test("the note names the count and the exact reversals, per transport", () => {
+    const mcp = ruleFilterNote(viewAt("notable", "mcp")) ?? "";
+    expect(mcp).toContain("1 of 3 rules");
+    expect(mcp).toContain("2 withheld");
+    expect(mcp).toContain('`verdict: "all"` returns every row');
+    expect(mcp).toContain("`rule: N`");
+    expect(mcp).not.toContain("--verdict");
+
+    const cli = ruleFilterNote(viewAt("notable", "cli")) ?? "";
+    expect(cli).toContain("`--verdict all` returns every row");
+    expect(cli).toContain("`--rule N`");
+    expect(cli).not.toContain('verdict: "all"');
+  });
+
+  test("an unnarrowed view has nothing to point at", () => {
+    expect(ruleFilterNote(viewAt("all", "cli"))).toBeUndefined();
+  });
+});
+
+/** The drill-down that makes `missingInputs.sampleRuleIndexes` actionable. */
+describe("buildRuleView with a single rule", () => {
+  const RULES = [rule(0, "matched"), rule(1, "no-match")];
+
+  test("returns that row whatever the facets would hide, and says the facets did not decide", () => {
+    const view = buildRuleView(sim(RULES), ATTRIBUTED, {
+      // `notable` hides rule 1; the drill-down is about rule 1.
+      verdict: "notable",
+      source: "presets",
+      rule: 1,
+      transport: "mcp",
+    });
+    expect(view.rules.map((r) => r.index)).toEqual([1]);
+    expect(view.rule).toBe(1);
+    // The facets report `all`, because none of them produced this list.
+    expect(view.verdict).toBe("all");
+    expect(view.source).toBe("all");
+    expect(view.total).toBe(2);
+    expect(view.hidden).toBe(1);
+    expect(ruleFilterPayload(view).ruleFilter).toMatchObject({ rule: 1, shown: 1, hidden: 1 });
+    expect(ruleFilterNote(view)).toContain("ONLY merged rule 1");
+  });
+
+  test("an index the run does not have names the total", () => {
+    expect(() =>
+      buildRuleView(sim(RULES), ATTRIBUTED, {
+        verdict: "notable",
+        source: "all",
+        rule: 7,
+        transport: "cli",
+      }),
+    ).toThrow(/evaluated 2 merged packageRules; there is no rule 7/);
+  });
+});
+
+/** The engine owns the sentence; this layer owns the pointer at its end — and
+ *  "the tool could not evaluate this rule" is the last thing that may go
+ *  missing, so it gets the same treatment as the missing-input one. */
+describe("evaluationErrorsNote", () => {
+  const SUMMARY = {
+    rules: 1,
+    selectors: ["matchCurrentVersion"],
+    messages: ["matcher threw: conda versioning is not supported"],
+    sampleRuleIndexes: [0],
+    note: "1 of 4 rules could not be EVALUATED: `matchCurrentVersion` threw.",
+  };
+
+  test("each transport is told the spelling it can use", () => {
+    expect(evaluationErrorsNote(SUMMARY, "cli")).toBe(
+      `${SUMMARY.note} \`--verdict error\` lists them.`,
+    );
+    expect(evaluationErrorsNote(SUMMARY, "mcp")).toBe(
+      `${SUMMARY.note} \`verdict: "error"\` lists them.`,
+    );
+  });
+
+  test("nothing to say means no line at all", () => {
+    expect(
+      evaluationErrorsNote({ rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] }, "cli"),
+    ).toBeUndefined();
   });
 });

--- a/packages/cli/src/rule-view.ts
+++ b/packages/cli/src/rule-view.ts
@@ -1,5 +1,6 @@
 import {
   computeRuleProvenance,
+  type EvaluationErrorSummary,
   type MissingInputSummary,
   type RuleAttribution,
   type RuleEvaluation,
@@ -15,7 +16,7 @@ import {
   VERDICT_FILTERS,
   type VerdictFilter,
 } from "@renovate-config-debugger/app/headless";
-import { type OutputFormat, type ParsedArgs, stringOption } from "./args";
+import { type ParsedArgs, stringOption } from "./args";
 import { CliError } from "./io";
 import {
   type RuleOrigin,
@@ -33,21 +34,29 @@ import type { RunTransport } from "./run-input";
  * BOTH surfaces filter with one implementation, reached here through
  * `@renovate-config-debugger/app/headless`.
  *
- * The two defaults are deliberately different, because the two consumers are:
- * - pretty output defaults to `notable` (matched + unresolved — the drawer's
- *   own default view), and always states how many rows that hid, so nothing is
- *   silently truncated;
- * - `--format json` defaults to the FULL array, because scripts and the MCP
- *   drill-down already index into it; filters apply only when asked for, and
- *   then the payload carries the counts they hid.
+ * Roadmap 073 made the default ONE default: `notable` on pretty output, on
+ * `--format json` and on the MCP tool. The old json default was the full array,
+ * for scripts that index into it — but on a `config:recommended` run that array
+ * is 340 kB against a 65 kB transport budget, so the "complete" answer was
+ * already being cut to a byte-arithmetic window with no relation to the
+ * question. `matched ⊂ notable`, so the common pipeline (`jq '.rules[] |
+ * select(.verdict=="matched")'`) returns exactly what it did; what changed is
+ * that the payload now STATES what it withheld and names the parameter that
+ * returns it. That statement is the invariant — a narrowing nobody can reverse
+ * is indistinguishable from a bug.
  */
 
-/** What the flags selected, plus whether the user actually typed them. */
+/** What the flags (or the tool parameters) selected. */
 export interface RuleFilterSelection {
   verdict: VerdictFilter;
   source: SourceFilter;
-  /** Either flag was passed explicitly — the JSON payload filters only then. */
-  explicit: boolean;
+  /**
+   * One merged rule by index — the drill-down that makes
+   * `missingInputs.sampleRuleIndexes` actionable. It answers "why did rule N
+   * not fire", so it is deliberately INDEPENDENT of the facets: a row the
+   * verdict filter hides is the commonest reason to ask for it.
+   */
+  rule?: number;
   /**
    * How the caller asked. The facets are one implementation with two
    * spellings — `--source repo` on the CLI, `source: "repo"` over MCP — and a
@@ -58,8 +67,13 @@ export interface RuleFilterSelection {
 }
 
 /** The facet as the caller would have to spell it on THEIR surface. */
-function facetText(transport: RunTransport, facet: string, value: string): string {
+export function facetText(transport: RunTransport, facet: string, value: string): string {
   return transport === "mcp" ? `${facet}: "${value}"` : `--${facet} ${value}`;
+}
+
+/** `rule: 42` / `--rule 42` — the drill-down, spelled for this surface. */
+function ruleText(transport: RunTransport, index: number | "N"): string {
+  return transport === "mcp" ? `rule: ${index}` : `--rule ${index}`;
 }
 
 function parseChoice<T extends string>(
@@ -78,18 +92,25 @@ function parseChoice<T extends string>(
   return found;
 }
 
-export function ruleFilterSelection(args: ParsedArgs, format: OutputFormat): RuleFilterSelection {
-  const rawVerdict = stringOption(args, "verdict");
-  const rawSource = stringOption(args, "source");
+/** `--rule <n>`: a non-negative integer, or nothing. */
+function parseRuleIndex(raw: string | undefined): number | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  const index = Number(raw);
+  if (!Number.isInteger(index) || index < 0) {
+    throw new CliError(`--rule must be a non-negative integer (got "${raw}")`);
+  }
+  return index;
+}
+
+/** The facets, at one default for every output format (roadmap 073). */
+export function ruleFilterSelection(args: ParsedArgs): RuleFilterSelection {
+  const rule = parseRuleIndex(stringOption(args, "rule"));
   return {
-    verdict: parseChoice(
-      rawVerdict,
-      VERDICT_FILTERS,
-      "verdict",
-      format === "json" ? "all" : "notable",
-    ),
-    source: parseChoice(rawSource, SOURCE_FILTERS, "source", "all"),
-    explicit: rawVerdict !== undefined || rawSource !== undefined,
+    verdict: parseChoice(stringOption(args, "verdict"), VERDICT_FILTERS, "verdict", "notable"),
+    source: parseChoice(stringOption(args, "source"), SOURCE_FILTERS, "source", "all"),
+    ...(rule !== undefined ? { rule } : {}),
     transport: "cli",
   };
 }
@@ -103,6 +124,11 @@ export interface RuleView {
   hidden: number;
   verdict: VerdictFilter;
   source: SourceFilter;
+  /** The single rule this view was asked for, if any — the facets above then
+   *  read `all`, because none of them decided the list. */
+  rule?: number;
+  /** Which surface's spelling the notes speak. */
+  transport: RunTransport;
   /** Diagnostics for stderr — e.g. `--source` asked for with no provenance. */
   notes: string[];
   /**
@@ -120,6 +146,27 @@ export interface RuleView {
 }
 
 /**
+ * The row the drill-down asked for, or an error naming the total — an index
+ * out of range is a question about a rule that does not exist, and answering
+ * it with an empty list would read as "that rule did nothing".
+ */
+function oneRule(
+  rules: readonly RuleEvaluation[],
+  index: number,
+  transport: RunTransport,
+): RuleEvaluation {
+  const found = rules[index];
+  if (!found) {
+    throw new CliError(
+      `this simulation evaluated ${rules.length} merged packageRules; there is no rule ${index}. ` +
+        `\`${facetText(transport, "verdict", "all")}\` lists them all, and \`ruleSources\` is the ` +
+        "legend for the indexes.",
+    );
+  }
+  return found;
+}
+
+/**
  * Applies the selection to a simulation. `--source` needs per-rule provenance
  * (`computeRuleProvenance`), which a run can legitimately fail to produce (a
  * preset that would not resolve, replayed layer lengths that don't add up).
@@ -133,12 +180,30 @@ export function buildRuleView(
   selection: RuleFilterSelection,
 ): RuleView {
   const notes: string[] = [];
-  let rules = sim.rules.filter((rule) => matchesVerdictFilter(rule, selection.verdict));
-  let source = selection.source;
   // Unconditionally, not just for `--source`: the attribution is also what
   // says which layer a matched rule came from, which every caller wants and
   // no filter asks for.
   const attribution = computeRuleProvenance(result);
+  if (selection.rule !== undefined) {
+    // The drill-down answers about ONE row, so it reports the facets as `all`:
+    // saying `verdict: "notable"` about a list no facet produced would be a
+    // claim the view cannot back.
+    return {
+      rules: [oneRule(sim.rules, selection.rule, selection.transport)],
+      total: sim.rules.length,
+      hidden: Math.max(0, sim.rules.length - 1),
+      verdict: "all",
+      source: "all",
+      rule: selection.rule,
+      transport: selection.transport,
+      notes,
+      attribution,
+      sources: ruleSourceRanges(attribution),
+      originOf: (index) => ruleOrigin(index, attribution),
+    };
+  }
+  let rules = sim.rules.filter((rule) => matchesVerdictFilter(rule, selection.verdict));
+  let source = selection.source;
   if (source !== "all") {
     const layerByIndex = ruleLayerIndex(attribution);
     if (layerByIndex.size === 0) {
@@ -158,6 +223,7 @@ export function buildRuleView(
     hidden: sim.rules.length - rules.length,
     verdict: selection.verdict,
     source,
+    transport: selection.transport,
     notes,
     attribution,
     sources: ruleSourceRanges(attribution),
@@ -167,6 +233,9 @@ export function buildRuleView(
 
 /** The flags as the user would have to type them to reproduce this view. */
 function flagsOf(view: RuleView): string {
+  if (view.rule !== undefined) {
+    return `--rule ${view.rule}`;
+  }
   const flags = [`--verdict ${view.verdict}`];
   if (view.source !== "all") {
     flags.push(`--source ${view.source}`);
@@ -190,6 +259,51 @@ export function hiddenRulesNote(view: RuleView): string | undefined {
   );
 }
 
+/** What `notable` keeps, in the words the badge uses — an agent that reads
+ *  "notable" without this cannot tell whether an error row is in or out. */
+const NOTABLE_MEANS =
+  "the rows that acted or could not be decided: matched, not-simulated, and the ones the tool " +
+  "could not evaluate";
+
+/**
+ * The payload's own statement of what it withheld and how to get it back — the
+ * reversibility invariant of roadmap 073, and the reason flipping the default
+ * to `notable` is not a silent narrowing.
+ *
+ * Present whenever ANY narrowing is in effect, including the one nobody asked
+ * for (the default), and including a view that happened to hide nothing: a
+ * reader cannot tell a short list from a shortened one, and the count is what
+ * settles it.
+ */
+export function ruleFilterNote(view: RuleView): string | undefined {
+  const { transport, total } = view;
+  const allRows = `\`${facetText(transport, "verdict", "all")}\` returns every row`;
+  const oneRow = `\`${ruleText(transport, "N")}\` returns one row by index, whatever the facets hide`;
+  if (view.rule !== undefined) {
+    return (
+      `\`rules\` holds ONLY merged rule ${view.rule}, of ${total} — the drill-down ignores the ` +
+      `verdict and source facets by design. ${allRows}.`
+    );
+  }
+  if (view.verdict === "all" && view.source === "all") {
+    return undefined;
+  }
+  const facets = [
+    `\`${facetText(transport, "verdict", view.verdict)}\``,
+    ...(view.source === "all" ? [] : [`\`${facetText(transport, "source", view.source)}\``]),
+  ].join(" + ");
+  const kept = view.verdict === "notable" ? ` — ${NOTABLE_MEANS}` : "";
+  const withheld =
+    view.hidden === 0
+      ? "no row was withheld"
+      : `${view.hidden} withheld (their counts are in \`verdict\`, \`missingInputs\` and ` +
+        "`evaluationErrors`)";
+  return (
+    `\`rules\` holds the ${view.rules.length} of ${total} rules ${facets} keeps${kept}; ` +
+    `${withheld}. ${allRows}, and ${oneRow}.`
+  );
+}
+
 /**
  * The engine's transport-neutral missing-input line, with the pointer that
  * only this layer can spell: `--verdict no-input` for a person at a terminal,
@@ -210,13 +324,33 @@ export function missingInputsNote(
   return `${summary.note} \`${facetText(transport, "verdict", "no-input")}\` lists them.`;
 }
 
-/** The JSON counterpart: present only when filters were actually applied, so
- *  an unflagged `--format json` keeps the exact payload scripts already parse. */
+/**
+ * The same shape for the aggregate that must survive even harder (roadmap 073):
+ * a rule whose matcher threw is reported `no-match` by upstream, so nothing in
+ * the row's verdict says the tool failed rather than the config.
+ */
+export function evaluationErrorsNote(
+  summary: EvaluationErrorSummary,
+  transport: RunTransport,
+): string | undefined {
+  if (!summary.note) {
+    return undefined;
+  }
+  return `${summary.note} \`${facetText(transport, "verdict", "error")}\` lists them.`;
+}
+
+/**
+ * The JSON counterpart, on EVERY payload (roadmap 073) — `total`/`shown`/
+ * `hidden` are what make the flipped default auditable, and a key that appears
+ * only when a filter was passed cannot be relied on to say "nothing was
+ * withheld".
+ */
 export function ruleFilterPayload(view: RuleView): { ruleFilter: Record<string, unknown> } {
   return {
     ruleFilter: {
       verdict: view.verdict,
       source: view.source,
+      ...(view.rule !== undefined ? { rule: view.rule } : {}),
       total: view.total,
       shown: view.rules.length,
       hidden: view.hidden,

--- a/packages/cli/test/fixtures/conda-version.json
+++ b/packages/cli/test/fixtures/conda-version.json
@@ -1,0 +1,6 @@
+{
+  "packageRules": [
+    { "matchCurrentVersion": ">=1.0", "labels": ["conda"] },
+    { "matchPackageNames": ["react"], "groupName": "react monorepo" }
+  ]
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -15,9 +15,12 @@ export {
   UPDATE_TYPE_KEYS,
 } from "./simulate-package-rules";
 export {
+  type EvaluationErrorSummary,
+  hasEvaluationError,
   isNoInputNoMatch,
   type MissingInputGroup,
   type MissingInputSummary,
+  summarizeEvaluationErrors,
   summarizeMissingInputs,
 } from "./simulate-missing-inputs";
 export {

--- a/packages/engine/src/simulate-missing-inputs.ts
+++ b/packages/engine/src/simulate-missing-inputs.ts
@@ -1,7 +1,9 @@
 import type { ClauseEvaluation, RuleEvaluation } from "./simulate-package-rules";
 
 /**
- * The fail-closed no-input predicate, and the aggregate built on it.
+ * The per-clause predicates a scoped rule list would hide, and the AGGREGATES
+ * built on them — the facts that must survive every filter, every projection
+ * and the MCP transport's elision.
  *
  * The failure this exists for: a rule that read a field the simulated
  * dependency never set fails CLOSED (upstream's `if (!sourceUrl) return
@@ -12,6 +14,13 @@ import type { ClauseEvaluation, RuleEvaluation } from "./simulate-package-rules"
  * A per-row fact cannot fix that, because the rows are exactly what the filter
  * removed: the signal has to be an AGGREGATE that travels with the result,
  * outside the array anyone may filter or elide.
+ *
+ * Roadmap 073 added the second aggregate for the same reason, one step worse:
+ * a clause whose matcher THREW is recorded `state: "error"` and also pushes the
+ * rule to `verdict: "no-match"`, so a focused default would have hidden "the
+ * tool could not evaluate this rule" — the one thing that may never go missing.
+ * Every narrowing on top of this module is gated on its aggregates being
+ * unconditional, so the two live side by side.
  *
  * Type-only imports, so this module is Renovate-free and unit-testable in the
  * engine's `golden` (plain node) project.
@@ -166,4 +175,89 @@ export function summarizeMissingInputs(rules: readonly RuleEvaluation[]): Missin
     groups,
     note: buildNote(rules.length, affected.size, groups),
   };
+}
+
+/**
+ * A clause of this rule could not be evaluated at all: the matcher threw, and
+ * the simulator recorded `state: "error"` with the reason.
+ *
+ * Upstream treats a throwing matcher as a non-match, so the rule's verdict is
+ * an ordinary `no-match` — which makes this predicate, not the verdict, the
+ * only thing standing between an evaluation failure and a scoped view that
+ * drops it. `matchesVerdictFilter`'s `notable` facet reads it for exactly that
+ * reason (roadmap 073); the documented case is `matchCurrentVersion` on a
+ * `conda` dependency, whose versioning module the browser build excludes.
+ */
+export function hasEvaluationError(rule: Pick<RuleEvaluation, "clauses">): boolean {
+  return rule.clauses.some((clause) => clause.state === "error");
+}
+
+export interface EvaluationErrorSummary {
+  /** Distinct rules with at least one clause the simulator could not evaluate. */
+  rules: number;
+  /** The `match*` selectors that threw, deduped, sorted. */
+  selectors: string[];
+  /** Up to five distinct reasons, sorted — a signal, not a log. The rows
+   *  themselves carry every clause's own `note`. */
+  messages: string[];
+  /** The first five affected `RuleEvaluation.index` values, ascending — a
+   *  drill-down handle, the way {@link MissingInputGroup.sampleRuleIndexes} is. */
+  sampleRuleIndexes: number[];
+  /** The whole thing in one transport-neutral line, with the honest caveat that
+   *  a result containing one of these is not a claim about a real Renovate run.
+   *  Absent when `rules === 0`. */
+  note?: string;
+}
+
+/** Distinct clause messages kept, at most. */
+const MESSAGE_LIMIT = 5;
+
+function buildErrorNote(total: number, ruleCount: number, selectors: string[]): string {
+  const scope =
+    `${ruleCount} of ${total} ${total === 1 ? "rule" : "rules"} could not be EVALUATED: ` +
+    `${selectors.map((selector) => `\`${selector}\``).join(", ")} threw`;
+  return (
+    `${scope}. The tool could not evaluate ${ruleCount === 1 ? "this rule" : "these rules"}, so ` +
+    "this result may not reflect a real Renovate run — treat the verdict as incomplete rather " +
+    "than as a non-match."
+  );
+}
+
+/**
+ * The rules whose evaluation failed, as one aggregate. Reads the finished
+ * verdicts only — it decides nothing and changes nothing about the simulation
+ * it describes.
+ */
+export function summarizeEvaluationErrors(
+  rules: readonly RuleEvaluation[],
+): EvaluationErrorSummary {
+  const selectors = new Set<string>();
+  const messages = new Set<string>();
+  const affected: number[] = [];
+  for (const rule of rules) {
+    if (!hasEvaluationError(rule)) {
+      continue;
+    }
+    affected.push(rule.index);
+    for (const clause of rule.clauses) {
+      if (clause.state !== "error") {
+        continue;
+      }
+      selectors.add(clause.key);
+      if (clause.note) {
+        messages.add(clause.note);
+      }
+    }
+  }
+  const sortedSelectors = [...selectors].toSorted();
+  const summary: EvaluationErrorSummary = {
+    rules: affected.length,
+    selectors: sortedSelectors,
+    messages: [...messages].toSorted().slice(0, MESSAGE_LIMIT),
+    sampleRuleIndexes: affected.toSorted((a, b) => a - b).slice(0, SAMPLE_LIMIT),
+  };
+  if (summary.rules === 0) {
+    return summary;
+  }
+  return { ...summary, note: buildErrorNote(rules.length, summary.rules, sortedSelectors) };
 }

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -1,7 +1,9 @@
 import { enqueueEngineTask } from "./pipeline";
 import {
+  type EvaluationErrorSummary,
   humanFieldList,
   type MissingInputSummary,
+  summarizeEvaluationErrors,
   summarizeMissingInputs,
 } from "./simulate-missing-inputs";
 import {
@@ -232,6 +234,15 @@ export interface SimulationResult {
    * Always present — `{ rules: 0, groups: [] }` when there is nothing to say.
    */
   missingInputs: MissingInputSummary;
+  /**
+   * The rules a matcher THREW on (roadmap 073) — same reasoning as
+   * `missingInputs`, one step more serious: upstream treats a throwing matcher
+   * as a non-match, so these rules wear an ordinary `no-match` and a scoped
+   * view would drop "the tool could not evaluate this rule" without a trace.
+   * Always present — `{ rules: 0, selectors: [], messages: [],
+   * sampleRuleIndexes: [] }` when every clause was evaluated.
+   */
+  evaluationErrors: EvaluationErrorSummary;
   /** Exactly what `applyPackageRules` would return (dep fields included). */
   rawFinalConfig: Record<string, unknown>;
   /**
@@ -788,6 +799,7 @@ async function execute(input: SimulationInput): Promise<SimulationResult> {
       // Descriptive, and deliberately computed here rather than per row: the
       // views that would show it are the views that filter those rows away.
       missingInputs: summarizeMissingInputs(rules),
+      evaluationErrors: summarizeEvaluationErrors(rules),
       rawFinalConfig: config,
       finalDependencyConfig,
       flattened: { updateType, merged: flattenMerged, blocks, authoredBlocks },

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -34,6 +34,7 @@ function sim(
   return {
     rules,
     missingInputs: { rules: 0, groups: [] },
+    evaluationErrors: { rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] },
     rawFinalConfig: {},
     finalDependencyConfig,
     flattened: { merged: [], blocks: {}, authoredBlocks: [] },

--- a/packages/engine/test/simulate-missing-inputs.node.test.ts
+++ b/packages/engine/test/simulate-missing-inputs.node.test.ts
@@ -1,12 +1,20 @@
 /**
- * Unit tests for the pure missing-input reduction. Builds `RuleEvaluation`
+ * Unit tests for the pure aggregates a scoped rule list must not be able to
+ * hide — the missing-input reduction and (roadmap 073) the evaluation-error
+ * one. Builds `RuleEvaluation`
  * fixtures by hand (the module reads verdicts and clauses only), so this needs
  * no Renovate machinery and runs as a plain node test — the golden↔shimmed
  * integration case in simulate-package-rules.*.test.ts owns the question of
  * whether a real run produces these shapes.
  */
 import { describe, expect, it } from "vitest";
-import { isNoInputNoMatch, type RuleEvaluation, summarizeMissingInputs } from "../src/index";
+import {
+  hasEvaluationError,
+  isNoInputNoMatch,
+  type RuleEvaluation,
+  summarizeEvaluationErrors,
+  summarizeMissingInputs,
+} from "../src/index";
 
 type ClauseSpec = [
   key: string,
@@ -36,6 +44,13 @@ function rule(
 /** The commonest shape: one clause that fail-closed on an unset field. */
 function noInput(index: number, key: string, ...fields: string[]): RuleEvaluation {
   return rule(index, "no-match", [[key, "no-input", ...fields]]);
+}
+
+/** A rule whose matcher threw, with the note the simulator's `catch` records. */
+function errored(index: number, key: string, message: string): RuleEvaluation {
+  const base = rule(index, "no-match", [[key, "error", "currentValue"]]);
+  const clause = base.clauses[0];
+  return clause ? { ...base, clauses: [{ ...clause, note: message }] } : base;
 }
 
 describe("summarizeMissingInputs", () => {
@@ -187,5 +202,76 @@ describe("summarizeMissingInputs", () => {
     expect(summary.rules).toBe(1);
     expect(summary.groups.map((group) => group.fieldList)).toEqual(["categories", "sourceUrl"]);
     expect(summary.note).toContain("1 of 1 rule could not match");
+  });
+});
+
+/**
+ * Roadmap 073's blocker, from the other side: a throwing matcher fails its rule
+ * to a plain `no-match`, so "the tool could not evaluate this rule" needs an
+ * aggregate of its own before any view is allowed to hide the row.
+ */
+describe("summarizeEvaluationErrors", () => {
+  const CONDA = "matcher threw: conda versioning is not supported in the browser build";
+
+  it("counts the rules, names the selectors and samples the indexes", () => {
+    const summary = summarizeEvaluationErrors([
+      rule(0, "matched", [["matchPackageNames", "matched", "packageName"]]),
+      errored(1, "matchCurrentVersion", CONDA),
+      errored(2, "matchCurrentVersion", CONDA),
+    ]);
+    expect(summary).toEqual({
+      rules: 2,
+      selectors: ["matchCurrentVersion"],
+      messages: [CONDA],
+      sampleRuleIndexes: [1, 2],
+      note: expect.stringContaining("2 of 3 rules could not be EVALUATED"),
+    });
+  });
+
+  /** The honest caveat: a result holding one of these is not a claim about a
+   *  real Renovate run, and the note has to say so wherever it travels. */
+  it("says the result may not reflect a real run", () => {
+    const summary = summarizeEvaluationErrors([errored(0, "matchCurrentVersion", CONDA)]);
+    expect(summary.note).toBe(
+      "1 of 1 rule could not be EVALUATED: `matchCurrentVersion` threw. The tool could not " +
+        "evaluate this rule, so this result may not reflect a real Renovate run — treat the " +
+        "verdict as incomplete rather than as a non-match.",
+    );
+  });
+
+  it("dedupes and sorts the selectors, and keeps at most five distinct messages", () => {
+    const summary = summarizeEvaluationErrors([
+      errored(0, "matchJsonata", "matcher threw: e"),
+      errored(1, "matchCurrentVersion", "matcher threw: d"),
+      errored(2, "matchCurrentVersion", "matcher threw: c"),
+      errored(3, "matchCurrentVersion", "matcher threw: b"),
+      errored(4, "matchCurrentVersion", "matcher threw: a"),
+      errored(5, "matchCurrentVersion", "matcher threw: a"),
+      errored(6, "matchCurrentVersion", "matcher threw: f"),
+    ]);
+    expect(summary.selectors).toEqual(["matchCurrentVersion", "matchJsonata"]);
+    expect(summary.messages).toEqual([
+      "matcher threw: a",
+      "matcher threw: b",
+      "matcher threw: c",
+      "matcher threw: d",
+      "matcher threw: e",
+    ]);
+    expect(summary.sampleRuleIndexes).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("says nothing at all when every clause was evaluated", () => {
+    const summary = summarizeEvaluationErrors([
+      rule(0, "matched", [["matchPackageNames", "matched", "packageName"]]),
+      noInput(1, "matchSourceUrls", "sourceUrl"),
+    ]);
+    expect(summary).toEqual({ rules: 0, selectors: [], messages: [], sampleRuleIndexes: [] });
+    expect(summary.note).toBeUndefined();
+  });
+
+  it("hasEvaluationError reads the clauses, not the verdict", () => {
+    expect(hasEvaluationError(errored(0, "matchCurrentVersion", CONDA))).toBe(true);
+    expect(hasEvaluationError(noInput(1, "matchSourceUrls", "sourceUrl"))).toBe(false);
+    expect(hasEvaluationError(rule(2, "no-match", []))).toBe(false);
   });
 });

--- a/packages/engine/test/simulate-package-rules.shimmed.test.ts
+++ b/packages/engine/test/simulate-package-rules.shimmed.test.ts
@@ -151,6 +151,34 @@ describe("simulatePackageRules", () => {
     const clause = result.rules[0]?.clauses[0];
     expect(clause?.state).toBe("error");
     expect(clause?.note).toMatch(/conda versioning is not supported in the browser/);
+    // Roadmap 073: the rule wears an ordinary `no-match`, so the fact that it
+    // could not be EVALUATED has to leave the row — every scoped view drops
+    // the rows and none may drop this.
+    expect(result.evaluationErrors).toMatchObject({
+      rules: 1,
+      selectors: ["matchCurrentVersion"],
+      sampleRuleIndexes: [0],
+    });
+    expect(result.evaluationErrors.note).toContain("could not be EVALUATED");
+    expect(result.evaluationErrors.note).toContain("may not reflect a real Renovate run");
+    // …and it is NOT counted as a rule an unset dependency field cost: setting
+    // a field would not decide a matcher that throws.
+    expect(result.missingInputs.rules).toBe(0);
+  });
+
+  /** The other side of the aggregate: a run whose every clause was evaluated
+   *  says so with an empty summary rather than by omitting the key. */
+  it("reports no evaluation errors when every matcher answered", async () => {
+    const result = await simulatePackageRules({
+      config: { packageRules: [{ matchPackageNames: ["react"], labels: ["ui"] }] },
+      dep: npmDep,
+    });
+    expect(result.evaluationErrors).toEqual({
+      rules: 0,
+      selectors: [],
+      messages: [],
+      sampleRuleIndexes: [],
+    });
   });
 
   it("matches bump updates via matchUpdateTypes + isBump", async () => {

--- a/roadmap/073-focused-by-default.md
+++ b/roadmap/073-focused-by-default.md
@@ -1,0 +1,228 @@
+# 073 — Focused by default: the narrowest useful answer, and a map of the rest
+
+Milestone: M19 · Status: in progress
+
+## Summary
+
+The headless surface's default answer to "would this update match the rules?"
+did not fit the transport budget — so it was **already incomplete, by accident**.
+A `simulate` call on a `config:recommended` config produced 347 KB against a
+~65 KB tool-result cap, and `mcp/result.ts` elided the `rules` array
+structurally: the agent got a first/last window chosen by byte arithmetic, with
+no relation to what it asked. The choice was never between a complete answer and
+a narrowed one. It was between **arbitrary** incompleteness and **deliberate**
+incompleteness that hands back a map.
+
+This layer makes the narrowest useful answer the default on every surface, and
+gives everything it withholds a name.
+
+## Where the bytes were
+
+Same call — `config:recommended` + a react major, Renovate 44.7.4 — with the
+rules bucketed by what each contributes (compact JSON):
+
+| slice of the answer                     | rows | bytes   | what it tells you                                            |
+| --------------------------------------- | ---- | ------- | ------------------------------------------------------------ |
+| Answer tier (everything except `rules`) | —    | 4,297   | verdict sentence, dep, `flattened`, aggregates, notes        |
+| Matched rules, with clause evidence     | 3    | 2,550   | the citable "why" — what fired, on which field, what it set  |
+| Rules that failed only on unset input   | 447  | 229,446 | nothing actionable per row; `missingInputs` says it in 861 B |
+| Genuine mismatches                      | 264  | 111,104 | "these rules don't apply to this dependency"                 |
+| Rules whose matcher threw               | 0    | 2       | must never be hidden — see the blocker below                 |
+
+Two thirds of the payload is the no-input bucket, whose decision-relevant
+content roadmap 072's stack had already compressed 267× into an aggregate that
+travels unconditionally. That is the shape of this whole change: **counts and
+reasons stay, bodies go.**
+
+Those buckets sum to the answer tier plus the rules array: **347,395 B → 6,847 B**
+after the flip. Re-measured on the persona replay's `scenario-44006` config
+(`config:recommended` plus one repo rule) with `rcd simulate --format json`, the
+whole payload — `finalDependencyConfig` included, which the buckets above leave
+out — is **369,099 B at `--verdict all` and 31,172 B at the new default**,
+compact: 11.8× smaller, un-elided, and 2,550 of the surviving bytes are the rule
+rows. The remaining bulk is the per-dependency config (23,902 B / 289 effective
+options at `configScope: "package-rules"`), which `keys` narrows — see "What this
+did not do".
+
+## Three tiers, two invariants
+
+- **Answer** — always present, always small, never elided: the verdict sentence,
+  the counts, and any aggregate that could change a conclusion (`missingInputs`,
+  `evaluationErrors`, would-refuse, "a migration rewrote your config").
+- **Evidence** — default-on but scoped to what acted: the rules that matched or
+  could not be decided, with clause-level evidence and `origin`; the behavioral
+  deltas; the options the rules changed.
+- **Bulk** — opt-in by name: every rule row (`verdict: "all"`), `mergeSteps` and
+  `rawFinalConfig` (`detail: "full"`), whole config documents, preset bodies.
+
+What makes tier 3 safe to drop:
+
+1. **No silent narrowing.** Every omission is announced in tier 1 with a count,
+   a reason, and the exact parameter that reverses it. A key that simply
+   vanishes is indistinguishable from a bug.
+2. **Conclusion-preserving.** A narrowing is permitted only once the aggregates
+   covering everything it hides are unconditional. That is a testable gate, and
+   it is exactly why the missing-input summary had to land before this change
+   rather than after.
+
+## The blocker: `notable` hid evaluation errors
+
+Found while checking invariant 2, and fixed first, alone, because it is a
+correctness bug rather than a payload one.
+
+A clause whose matcher throws is recorded `state: "error"` and pushes its rule
+to `verdict: "no-match"` (`simulate-package-rules.ts`, the `catch` in
+`evaluateRule`) — while `notable` was defined as `verdict !== "no-match"`. So
+the documented honest-error case — `matchCurrentVersion` on a `conda`
+dependency, whose ~3 MB WASM versioning module the browser build deliberately
+excludes — would have vanished from a focused default. "The tool could not
+evaluate this rule" is the last thing that may go missing.
+
+The fix has three parts:
+
+- `hasEvaluationError(rule)` and `summarizeEvaluationErrors(rules)` in
+  `packages/engine/src/simulate-missing-inputs.ts` — which is now explicitly the
+  module for the aggregates that must survive filtering, projection and elision.
+  `SimulationResult.evaluationErrors` is required, computed after the rule loop
+  exactly as `missingInputs` is; its `note` states that the result may not
+  reflect a real Renovate run.
+- `notable` becomes `verdict !== "no-match" || hasEvaluationError(rule)`, and
+  `no-match` keeps meaning a GENUINE mismatch — it now excludes error rows the
+  way it already excluded no-input ones.
+- A new `error` member of the verdict vocabulary, end to end: `VerdictFilter`,
+  `matchesVerdictFilter`, `verdictFilterOptions` (so the app's drawer gets the
+  facet with its count), the MCP `RULE_VERDICT` enum, `--verdict`'s help text
+  and the `facetText` spellings.
+
+`execute()` is untouched. Widening `notable` is a FILTER change, not a verdict
+change: the oracle parity against upstream `applyPackageRules` is what the
+golden↔shimmed suite proves, and it still holds byte for byte.
+
+## The defaults that changed
+
+| surface                                        | today                                            | new default                                          | drill-down                                           |
+| ---------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------- | ---------------------------------------------------- |
+| `simulate` (MCP)                               | all ~714 rows, elided by the transport           | `verdict: "notable"` (+ error rows)                  | `verdict: all\|no-match\|no-input\|error`, `rule: N` |
+| `rcd simulate --format json`                   | `all`                                            | `notable` — one default for pretty, JSON and MCP     | `--verdict all`, `--rule N`                          |
+| `simulate` `source`                            | all                                              | **keep** `all`                                       | narrowing it would change conclusions                |
+| `simulate` `detail`                            | `verdict`                                        | **keep** — `mergeSteps`/`rawFinalConfig` stay opt-in | `detail: "full"`                                     |
+| `compare_simulations`                          | whole comparison, `matchedInBoth` + signatures   | new `detail` axis, default `verdict`                 | `detail: "rules"\|"full"`, `--detail`                |
+| `get_final_config`                             | full document, elided when over budget           | full when it fits; over budget, a **key index**      | `keys: [...]`, `configScope`                         |
+| `run_config`, `get_preset_*`, `get_provenance` | summary + handle, depth-limited, stats-then-body | **keep** — these were already the model              | unchanged                                            |
+
+### Why flipping `--format json` is safe for scripts
+
+`matched ⊂ notable`, so the common pipeline —
+`rcd simulate --format json | jq '.rules[] | select(.verdict=="matched")'` —
+returns exactly what it did before. The only queries affected are the ones
+asking for rows that did NOT match, which is the rare and explicit case. A
+default should preserve the common query and cost a flag on the rare one.
+Flipping JSON as well also keeps pretty output, JSON output and MCP giving one
+answer to one question — the defect this stack already fixed once, where the
+CLI's text renderer and its own JSON disagreed about which rules "only matched
+in A".
+
+### Completing the fetch surface: `rule: N`
+
+Focus is only safe if every hidden thing has a name, and the audit found exactly
+one gap: "why did THIS rule not fire" had no fetch. `simulate` gains `rule`
+(MCP) / `--rule <n>` (CLI): one merged rule's whole row, no elision, plus its
+`origin` — which the list omits on non-matched rows because annotating ~727 rows
+costs 15% of the payload, and which one row can afford. It is deliberately
+independent of `verdict`/`source`: a row the filter hides is the commonest
+reason to ask. It is also what finally makes `missingInputs.sampleRuleIndexes`
+actionable — that field had been handing out indexes with nothing to inspect
+them with.
+
+The drill-down reports the facets as `all` in `ruleFilter`, because none of them
+produced the list; saying `verdict: "notable"` about a row `notable` hides would
+be a claim the answer cannot back.
+
+### `compare_simulations`' own detail axis
+
+At the default `verdict` level the comparison drops the two things that cost:
+`matchedInBoth` (every rule that behaved the same on both sides — the answer to
+a question nobody asks of a diff) and the per-rule `signature` strings, each a
+whole selector array re-serialized next to the `label` that already names the
+rule. The identity axis becomes
+`identity: { changed, counts: { onlyInA, onlyInB, signatureChanges } }`, and the
+note names `detail: "rules"`. `rules` restores the arrays; `full` is the
+engine's `SimulationComparison` exactly as computed. The projection lives in
+`comparisonPayload` — `packages/engine/src/simulate-compare.ts` stays complete.
+
+Pretty output follows the same axis rather than having its own: at the default it
+prints "Selector text changed on N rules … `--detail rules` lists them", because
+a fact that disappears with a detail level reads as a bug.
+
+### `get_final_config`'s key index
+
+The run's effective config is ~200 KB on a `config:recommended` run. The generic
+elider's answer was a `packageRules` cut to first-and-last inside a document
+that still looked whole — neither the config nor a description of it. When the
+projected document does not fit (`fitsBudget`), the tool now answers with
+`{ configIndex: [{ key, bytes }], keys, configView, note }`: every top-level
+option, the bytes its value costs, biggest first, and a note naming
+`keys: [...]` and `configScope`. An index is honest at any size. A document that
+fits is still returned whole.
+
+## One notes array
+
+The simulate payload had grown five note-shaped fields — `notes`, `detailNote`,
+`missingInputsNote`, `ruleSourcesNote` and `flattened.note`. An agent should not
+have to learn five field names to find the map. Each aggregate keeps its own
+`note` inside its object (`missingInputs.note`, `evaluationErrors.note`,
+`flattened.note`); everything that is a pointer about the ANSWER is appended to
+the single top-level `notes: string[]`, in the order a reader needs it — the
+evaluation-error pointer ahead of the missing-input one, because "the tool could
+not evaluate this" outranks "your dep left a field unset". `compare` answers the
+same way.
+
+## The acceptance criteria, as tests
+
+Invariants over the tool surface, not examples — they are what stops the next
+payload from silently regrowing. All four live in
+`packages/cli/src/mcp/server.test.ts` (`describe("focused by default")`), with
+CLI-side twins in `commands/simulate.test.ts`:
+
+1. **Un-elided default.** On a `config:best-practices` run, every tool's DEFAULT
+   answer comes back with `truncated` undefined — plus a companion test proving
+   the named bulk surfaces (`detail: "full"`, `get_preset_node --body`) still do
+   truncate, so the first test cannot pass by the elision having quietly stopped
+   working.
+2. **Reversibility.** For every narrowing, the default payload carries both a
+   count of what was withheld and the literal parameter that returns it.
+3. **Conclusion-preserving.** On the group-preset config with a dependency
+   lacking `sourceUrl`, the default answer still reports `missingInputs`; on a
+   config whose matcher throws (the real `conda` case, as
+   `test/fixtures/conda-version.json`), the default answer still contains the
+   error row AND `evaluationErrors`.
+4. **Round-trip.** `rule: N` returns the row `verdict: "all"` shows at index N —
+   asserted over the indexes `missingInputs.sampleRuleIndexes` hands out.
+
+## Scope
+
+- `packages/engine/src/simulate-missing-inputs.ts` — `hasEvaluationError`,
+  `summarizeEvaluationErrors`, `EvaluationErrorSummary`; `simulate-package-rules.ts`
+  gains the required `evaluationErrors` member; `index.ts` exports.
+- `packages/app/src/lib/rule-filters.ts` — the widened `notable`, the `error`
+  facet, its count; `rule-verdict.ts` + `headless.ts` re-export the predicate.
+- `packages/cli/src/rule-view.ts` — one default for every format, the `rule`
+  selection, `ruleFilterNote`, `evaluationErrorsNote`, `ruleFilter` on every
+  payload (`explicit` is gone with the old two-defaults rule).
+- `packages/cli/src/projections/simulate.ts` — `ruleRows` (one implementation of
+  a rule row for both transports), the consolidated `notes`, `COMPARE_DETAIL` +
+  the comparison projection; `projections/config-view.ts` — `configKeyIndex`.
+- `packages/cli/src/commands/simulate.ts`, `commands/compare.ts`, `args.ts`,
+  `mcp/server.ts`; `packages/cli/README.md`.
+
+## What this did not do
+
+`finalDependencyConfig` is 23,902 B of the flipped default (289 effective
+options after `configScope: "package-rules"` drops the 107 globalOnly ones), so
+the focused payload measures 31,172 B compact rather than the 6,847 B the
+rules-and-answer tiers alone account for. It still fits the budget un-elided,
+which is what invariant 1 asks of it, and `keys: [...]` takes the same call to
+11,408 B pretty / far less compact. Making the effective-config document itself
+tiered — "the options the rules changed" by default, the whole document on
+request — is a separate decision about what a simulation's answer IS, and
+belongs with the verdict work rather than in a payload layer.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -77,6 +77,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [070](070-agent-payload-projection.md)                  | Agent payload projection: `keys`, config scope, collapsed diffs      | M19                  | in progress |
 | [071](071-rule-index-provenance.md)                     | Rule indexes: per-layer ranges, and one number per rule              | M19                  | in progress |
 | [072](072-option-docs-depth.md)                         | Option docs: where an option may go, and what the table cannot know  | M19                  | in progress |
+| [073](073-focused-by-default.md)                        | Focused by default: the answer that acted, and a map of the rest     | M19                  | in progress |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
Top of stack #211. Makes the narrowest useful answer the default on every `rcd` surface and lets an agent fetch depth by name.

**Why this is not just "smaller":** `simulate` on `config:recommended` produced 369 KB compact against a ~63 KB elision target, so the transport was *already* truncating the rules array to a first/last window chosen by byte arithmetic. The choice was never complete-vs-narrowed; it was arbitrary incompleteness vs deliberate incompleteness that hands back a map.

**Measured:** 369,099 → 31,172 B compact (11.8×); rule rows 340,843 → 2,550 B (134×); the default now fits the budget whole (never elided).

**Two invariants, enforced by tests**
1. *No silent narrowing* — every omission carries a count and the literal parameter that reverses it (`ruleFilter`, notes).
2. *Conclusion-preserving* — a narrowing is only allowed once the aggregates covering what it hides are unconditional.

Invariant 2 caught a blocker that had to land first: a clause whose matcher **throws** also sits at `verdict: "no-match"`, so `notable` would have hidden the documented conda `matchCurrentVersion` honest-error case. Fixed in the first commit (`notable` keeps error rows, `error` becomes a filter member, new `evaluationErrors` aggregate).

**Also here:** `rule: N` / `--rule N` single-rule fetch (what makes `missingInputs.sampleRuleIndexes` actionable), `compare_simulations detail: verdict|rules|full`, `get_final_config` answering over budget with a key index instead of a mangled object, and the five top-level note fields collapsed into one `notes` array.

Design note and full rationale: roadmap 073.