### PR TITLE
fix(cli): point repository metadata at the renamed repository

### DIFF
--- a/.claude/skills/persona-test/SKILL.md
+++ b/.claude/skills/persona-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: persona-test
-description: Replays the 2026-07 persona usability study (all scenarios, or a scenario/persona subset) against the live app — spawns entry/advanced/expert subagents that drive a real Chrome browser through the Renovate Config Visualizer, ground-truth withheld, and synthesizes their structured reports. Use when asked to run a persona test, replay the persona study, or evaluate a UX change against the benchmark scenarios.
+description: Replays the 2026-07 persona usability study (all scenarios, or a scenario/persona subset) against the live app — spawns entry/advanced/expert subagents that drive a real Chrome browser through the Renovate Config Debugger, ground-truth withheld, and synthesizes their structured reports. Use when asked to run a persona test, replay the persona study, or evaluate a UX change against the benchmark scenarios.
 ---
 
 # Persona-test replay

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-How the visualizer runs Renovate's own code in the browser.
+How the app runs Renovate's own code in the browser.
 
 - `packages/engine` deep-imports the `renovate` package
   (`renovate/dist/config/**`, all in one adapter module) and records the trace;

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -290,5 +290,5 @@ it — no hand writes either, and nothing is committed, so nothing can go stale.
 
 ## License
 
-[AGPL-3.0-only](https://github.com/secustor/renovate-config-visualizer/blob/main/LICENSE),
+[AGPL-3.0-only](https://github.com/secustor/renovate-config-debugger/blob/main/LICENSE),
 like the rest of this project.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,12 +13,12 @@
     "renovatebot"
   ],
   "homepage": "https://renovate.secustor.dev",
-  "bugs": "https://github.com/secustor/renovate-config-visualizer/issues",
+  "bugs": "https://github.com/secustor/renovate-config-debugger/issues",
   "license": "AGPL-3.0-only",
   "author": "secustor",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/secustor/renovate-config-visualizer.git",
+    "url": "git+https://github.com/secustor/renovate-config-debugger.git",
     "directory": "packages/cli"
   },
   "bin": {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -411,7 +411,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
     {
       title: "Run a Renovate config",
       description:
-        "Resolves a Renovate config exactly as the visualizer does — parse, migrate, massage, " +
+        "Resolves a Renovate config exactly as the web app does — parse, migrate, massage, " +
         "validate, resolve presets, merge — and HOLDS the trace. Returns a small summary plus a " +
         "runId; every other tool takes that runId, so a whole debugging session describes ONE " +
         "run instead of re-resolving (and re-fetching remote presets) per question. Start here.",

--- a/packages/oauth-worker/wrangler.jsonc
+++ b/packages/oauth-worker/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   // Cloudflare Worker: GitHub OAuth token-exchange proxy for the Renovate
-  // Config Visualizer SPA. It does nothing but turn an OAuth `code` (or a
+  // Config Debugger SPA. It does nothing but turn an OAuth `code` (or a
   // `refresh_token`) into a GitHub user token — it never sees a config, a
   // preset, or an API request. Stateless, no persistence, no body logging.
   //

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-Planned features for the Renovate Config Visualizer, in intended build order.
+Planned features for the Renovate Config Debugger, in intended build order.
 Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 
 | #                                                       | Feature                                                              | Milestone            | Status      |


### PR DESCRIPTION
The repository was renamed `renovate-config-visualizer` → `renovate-config-debugger`, but the CLI manifest still carried the old `repository.url` and `bugs` links. Trusted publishing verifies the sigstore provenance bundle against `repository.url`, so the publish died with **E422: Error verifying sigstore provenance bundle** — the attested repository did not match the manifest. Also fixes the README's license link (the other remaining mentions of the old name are comments/fixtures that legitimately reference it).

Note for the next release: the failed run had already pushed the `v0.1.0` tag before the publish step died, so semantic-release will derive **0.1.1** from this `fix:` commit — `0.1.0` will simply never exist on the registry, and the registry-rendered compat table will honestly not list it.