### PR TITLE
fix(cli): close the four replay-03 friction points on both transports

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -146,8 +146,10 @@ the answer.
 
 `--keys a,b` selects top-level options by name, out of what the scope left. A
 name the scope removed is not resurrected — it comes back in
-`configView.withheld` with the reason, and `--config-scope full` is the way to
-it:
+`configView.withheld` with the reason: `global-only` (the scope, and
+`--config-scope full` is the way to it), `absent` (the document does not carry
+that option), or — on `compare`, whose delta only lists keys that differ —
+`identical` (both sides carry it and nothing changed):
 
 ```console
 $ rcd simulate renovate.json --dep '{"depName":"react"}' --format json --keys groupName,onboardingConfig
@@ -232,24 +234,24 @@ actually do for the dependency in question:
 $ rcd simulate renovate.json --dep '{"depName":"@types/react","updateType":"major"}'
 This major update gets no special handling from your matched rules — the defaults apply.
 
-1 of 2 packageRules matched.
+1 of 2 packageRules matched — rule numbers are merged packageRules[N] indexes, and `--rule <n>` takes them verbatim.
 
-  #2 matched (matchUpdateTypes=matched)
+  #1 matched (matchUpdateTypes=matched)
       sets dependencyDashboardApproval = true
 1 of 2 rule hidden by --verdict notable — `--verdict all --source all` shows every rule.
 ```
 
-Rule #1 is the missing one. `--verdict no-match` prints the clause that rejected
+Rule #0 is the missing one. `--verdict no-match` prints the clause that rejected
 it, and `--rule 0` returns that one row whatever the facets hide:
 
 ```console
 $ rcd simulate renovate.json --dep '{"depName":"@types/react","updateType":"major"}' --verdict no-match
-  #1 no-match (matchPackageNames=no-match)
+  #0 no-match (matchPackageNames=no-match)
 ```
 
 So `matchPackageNames` is the culprit, not the update type.
 
-Now suppose rule #1 had selected on something your `--dep` never mentioned —
+Now suppose rule #0 had selected on something your `--dep` never mentioned —
 `"matchSourceUrls": ["https://github.com/facebook/react"]` instead of
 `matchPackageNames`. From the outside the run looks the same: a rule that reads
 a field you left unset fails CLOSED, which Renovate reports as an ordinary
@@ -260,9 +262,9 @@ so, and it is printed whatever `--verdict` you asked for:
 $ rcd simulate sourceurl.json --dep '{"depName":"@types/react","updateType":"major"}'
 This major update gets no special handling from your matched rules — the defaults apply.
 
-1 of 2 packageRules matched.
+1 of 2 packageRules matched — rule numbers are merged packageRules[N] indexes, and `--rule <n>` takes them verbatim.
 
-  #2 matched (matchUpdateTypes=matched)
+  #1 matched (matchUpdateTypes=matched)
       sets dependencyDashboardApproval = true
 1 of 2 rule hidden by --verdict notable — `--verdict all --source all` shows every rule.
 1 of 2 rules could not match because the simulated dependency has no sourceUrl — Renovate treats a missing value as a non-match. Set sourceUrl on the dependency if you expected these rules to fire. `--verdict no-input` lists them.
@@ -301,7 +303,7 @@ $ rcd compare before.json after.json --dep '{"depName":"react","updateType":"maj
 ✓ No behavioral change — the same effective config results (a rule's matchPackageNames list changed), which is expected when the edit touched the very selectors that rule matches on.
 
 Selector text changed, same effect (rule identity, not behavior):
-  matchPackageNames  #1 → #1  (clause-values-changed)
+  matchPackageNames  #0 → #0  (clause-values-changed)
 ```
 
 That second run is the point of the two axes. Behavior is the citable claim: the

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -103,9 +103,10 @@ export const OPTIONS = {
   rule: {
     flags: "--rule <n>",
     description:
-      "one merged packageRule by index, whatever the other facets hide: its row " +
-      "(`simulate`) or its body (`provenance <file> packageRules`), with the layer " +
-      "that wrote it and its index inside that layer",
+      "one merged packageRule by zero-based index — the `#N` the output prints — " +
+      "whatever the other facets hide: its row (`simulate`) or its body " +
+      "(`provenance <file> packageRules`), with the layer that wrote it and its " +
+      "index inside that layer",
   },
   detail: {
     flags: "--detail <which>",

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -219,7 +219,7 @@ describe("compare", () => {
           "--dep",
           '{"depName":"react","packageName":"react"}',
           "--keys",
-          "groupName,onboardingConfig",
+          "groupName,onboardingConfig,labels",
           "--format",
           "json",
         ],
@@ -239,9 +239,13 @@ describe("compare", () => {
         "1 rule started matching",
     );
     // The reason a caller can act on: `--config-scope full` is what would
-    // make a globalOnly name answerable, whether or not the delta held it.
+    // make a globalOnly name answerable, whether or not the delta held it —
+    // and `labels`, identical on both sides, is `identical`, not `absent`
+    // (replay-03: "absent" read as "not in the config" about a key both
+    // configs hold).
     expect(comparison.configView.withheld).toEqual([
       { key: "onboardingConfig", reason: "global-only" },
+      { key: "labels", reason: "identical" },
     ]);
   });
 });

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -69,9 +69,9 @@ function identityLines(comparison: ProjectedComparison): string[] {
       : [
           "",
           "Selector text changed, same effect (rule identity, not behavior):",
-          ...changes.map(
-            (c) => `  ${c.a.label}  #${c.a.index + 1} → #${c.b.index + 1}  (${c.kind})`,
-          ),
+          // Zero-based, like `--rule`, `index` in JSON and the provenance
+          // citations — one index scheme on the whole surface (replay-03).
+          ...changes.map((c) => `  ${c.a.label}  #${c.a.index} → #${c.b.index}  (${c.kind})`),
         ];
   }
   const counts = comparison.identity.counts;
@@ -108,7 +108,10 @@ export const compareCommand: Command = {
     "The key delta is reported at `--config-scope package-rules` (the globalOnly",
     "options no rule can reach are dropped) and `--keys a,b` narrows it further.",
     "Neither touches the verdict: `summary` states what the comparison found",
-    "over the WHOLE delta, and `configView` says what the view withheld.",
+    "over the WHOLE delta, and `configView.withheld` names every requested key",
+    "the answer does not carry, with why — `identical` (both sides carry it,",
+    "nothing differs), `absent` (neither side's per-dependency config has it; a",
+    "rule that did not match contributes nothing), or `global-only`.",
     "",
     "`--detail verdict` (the default) answers with the claim and its evidence,",
     "and states the identity axis as counts; `--detail rules` restores the rule",
@@ -154,6 +157,12 @@ export const compareCommand: Command = {
       scope: scope ?? "package-rules",
       detail,
       transport: "cli",
+      sideKeys: [
+        ...new Set([
+          ...Object.keys(simA.finalDependencyConfig),
+          ...Object.keys(simB.finalDependencyConfig),
+        ]),
+      ],
       ...(keys ? { keys } : {}),
     });
 

--- a/packages/cli/src/commands/provenance.test.ts
+++ b/packages/cli/src/commands/provenance.test.ts
@@ -28,6 +28,39 @@ describe("provenance", () => {
     const io = recordingIo();
     expect(await main(["provenance", fixture("clean.json"), "notAnOption"], io)).toBe(1);
   });
+
+  /** Replay-03 (3 CLI sessions): "winner: defaults" on a key a packageRule
+   *  sets read as the effective value for an update the rule covers. The MCP's
+   *  get_provenance carried the pointer; the CLI did not. */
+  test("a key packageRules can also set carries the per-dependency note", async () => {
+    const io = recordingIo();
+    expect(
+      await main(["provenance", fixture("grouped.json"), "groupName", "--format", "json"], io),
+    ).toBe(0);
+    const entry = io.json() as { note?: string };
+    expect(entry.note).toContain("1 packageRule can set `groupName` per-dependency");
+    expect(entry.note).toContain("Simulate a dependency");
+
+    // Pretty output prints the same pointer…
+    const pretty = recordingIo();
+    expect(await main(["provenance", fixture("grouped.json"), "groupName"], pretty)).toBe(0);
+    expect(pretty.stdout).toContain("Simulate a dependency");
+
+    // …and a key no rule touches carries no such caveat.
+    const untouched = recordingIo();
+    expect(
+      await main(["provenance", fixture("grouped.json"), "labels", "--format", "json"], untouched),
+    ).toBe(0);
+    expect((untouched.json() as { note?: string }).note).toBeUndefined();
+  });
+
+  /** Replay-03: a second positional key used to be silently dropped, which
+   *  read as "the first key's chain is the whole answer". */
+  test("two positional keys are an error, not a silently answered first one", async () => {
+    const io = recordingIo();
+    expect(await main(["provenance", fixture("clean.json"), "labels", "automerge"], io)).toBe(1);
+    expect(io.stderr).toContain("one key per call");
+  });
 });
 
 /**

--- a/packages/cli/src/commands/provenance.ts
+++ b/packages/cli/src/commands/provenance.ts
@@ -8,7 +8,12 @@ import { outputFormat, type ParsedArgs, stringOption } from "../args";
 import type { Command } from "../command";
 import { CliError, EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, preview, writeNotes } from "../output";
-import { chainStepText, entryView, provenanceOf } from "../projections/provenance";
+import {
+  chainStepText,
+  entryView,
+  perDependencyNote,
+  provenanceOf,
+} from "../projections/provenance";
 import {
   oneRuleView,
   type RuleContribution,
@@ -104,6 +109,14 @@ export const provenanceCommand: Command = {
     const source = parseSource(args);
     const { result, rest, notes } = await runFromArgs(args, io);
     writeNotes(io, notes);
+    // One key per call, stated — a second positional used to be silently
+    // dropped, which read as "the first key's chain is the whole answer".
+    if (rest.length > 1) {
+      throw new CliError(
+        `provenance answers one key per call (got ${rest.map((k) => `"${k}"`).join(", ")}) — ` +
+          "run it once per key",
+      );
+    }
     const key = rest[0];
 
     const provenance = provenanceOf(result);
@@ -150,9 +163,14 @@ export const provenanceCommand: Command = {
         }
         return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;
       }
+      // Same note the MCP's get_provenance carries (roadmap 068): for a key a
+      // packageRule can also set, this chain is the repository-wide value, not
+      // the one an actual update would get. Replay-03: three CLI sessions read
+      // "winner: defaults" as the effective value for a rule-covered update.
+      const perDependency = perDependencyNote(key, result.finalConfig);
       const view = entryView(entry);
       if (format === "json") {
-        emitJson(io, view);
+        emitJson(io, { ...view, ...(perDependency ? { note: perDependency } : {}) });
       } else {
         emitLines(io, [
           `${view.key}${view.badge ? ` [${view.badge}]` : ""} — winner: ${view.winner ?? "?"}`,
@@ -160,6 +178,7 @@ export const provenanceCommand: Command = {
           "",
           "Override chain:",
           ...view.chain.map((step) => `  ${step.layer} ${step.action} ${chainStepText(step)}`),
+          ...(perDependency ? ["", perDependency] : []),
         ]);
       }
       return wouldRefuse(result) ? EXIT_REFUSED : EXIT_OK;

--- a/packages/cli/src/commands/simulate.test.ts
+++ b/packages/cli/src/commands/simulate.test.ts
@@ -205,7 +205,10 @@ describe("simulate errors", () => {
  * each kind against `react` — a preset rule that fails on an unset depType, a
  * matching one, one that fails on an unset sourceUrl, and a genuine mismatch.
  */
-/** The rule numbers a pretty verdict list actually printed. */
+/** The rule numbers a pretty verdict list actually printed. Zero-based merged
+ *  indexes since replay-03 — the same numbers `--rule` and JSON's `index`
+ *  take, where the old one-based `#N+1` cost two expert sessions a wasted
+ *  `--rule` call each. */
 function shown(io: { stdout: string }): number[] {
   return [...io.stdout.matchAll(/^ {2}#(\d+) /gm)].map((m) => Number(m[1]));
 }
@@ -225,7 +228,7 @@ describe("simulate --verdict / --source", () => {
   test("pretty output defaults to the notable rules and says what it hid", async () => {
     const { io, code } = await run();
     expect(code).toBe(0);
-    expect(shown(io)).toEqual([2]);
+    expect(shown(io)).toEqual([1]);
     expect(io.stdout).toContain(
       "3 of 4 rules hidden by --verdict notable — `--verdict all --source all` shows every rule.",
     );
@@ -233,19 +236,32 @@ describe("simulate --verdict / --source", () => {
 
   test("--verdict all prints every rule and hides nothing", async () => {
     const { io } = await run("--verdict", "all");
-    expect(shown(io)).toEqual([1, 2, 3, 4]);
+    expect(shown(io)).toEqual([0, 1, 2, 3]);
     expect(io.stdout).not.toContain("hidden by");
   });
 
   test("the verdict facets split no-input from a genuine mismatch", async () => {
-    expect(shown((await run("--verdict", "matched")).io)).toEqual([2]);
-    expect(shown((await run("--verdict", "no-input")).io)).toEqual([1, 3]);
-    expect(shown((await run("--verdict", "no-match")).io)).toEqual([4]);
+    expect(shown((await run("--verdict", "matched")).io)).toEqual([1]);
+    expect(shown((await run("--verdict", "no-input")).io)).toEqual([0, 2]);
+    expect(shown((await run("--verdict", "no-match")).io)).toEqual([3]);
   });
 
   test("--source separates the repo's own rules from what a preset brought in", async () => {
-    expect(shown((await run("--verdict", "all", "--source", "repo")).io)).toEqual([2, 3, 4]);
-    expect(shown((await run("--verdict", "all", "--source", "presets")).io)).toEqual([1]);
+    expect(shown((await run("--verdict", "all", "--source", "repo")).io)).toEqual([1, 2, 3]);
+    expect(shown((await run("--verdict", "all", "--source", "presets")).io)).toEqual([0]);
+  });
+
+  /** The printed number and the flag agree: `#N` in the prose is the row
+   *  `--rule N` returns. */
+  test("the pretty rule number is the index --rule takes", async () => {
+    const notable = await run();
+    const [printed] = shown(notable.io);
+    expect(printed).toBe(1);
+    expect(notable.io.stdout).toContain("`--rule <n>` takes them verbatim");
+    const one = await run("--rule", String(printed), "--format", "json");
+    const report = one.io.json() as { rules: { index: number; verdict: string }[] };
+    expect(report.rules).toHaveLength(1);
+    expect(report.rules[0]).toMatchObject({ index: printed, verdict: "matched" });
   });
 
   test("an unknown value names the ones that exist", async () => {
@@ -327,7 +343,7 @@ describe("simulate --verdict / --source", () => {
    */
   test("the rules an unset field cost are named even when their rows are hidden", async () => {
     const { io } = await run();
-    expect(shown(io)).toEqual([2]);
+    expect(shown(io)).toEqual([1]);
     expect(io.stdout).toContain("2 of 4 rules could not match");
     expect(io.stdout).toContain("sourceUrl");
     expect(io.stdout).toContain("`--verdict no-input` lists them.");
@@ -335,7 +351,7 @@ describe("simulate --verdict / --source", () => {
 
   test("the same line survives --verdict matched, and --verdict all where nothing is hidden", async () => {
     const matched = await run("--verdict", "matched");
-    expect(shown(matched.io)).toEqual([2]);
+    expect(shown(matched.io)).toEqual([1]);
     expect(matched.io.stdout).toContain("2 of 4 rules could not match");
 
     const all = await run("--verdict", "all");

--- a/packages/cli/src/commands/simulate.ts
+++ b/packages/cli/src/commands/simulate.ts
@@ -43,6 +43,11 @@ export async function simulateAgainst(
  * of my rules is this", which the merged index alone never gave. Only the
  * matched ones: the suffix on all ~727 rows would bury the handful that fired,
  * and `--format json` carries `ruleSources` for the rest.
+ *
+ * `#N` is the merged `packageRules[N]` index — the same number `--rule`,
+ * `--format json`'s `index` and the provenance citations use. Replay-03: the
+ * old one-based `#N+1` cost two expert sessions a wasted `--rule` call each,
+ * because every OTHER spelling of a rule index here is zero-based.
  */
 export function verdictLines(
   rules: readonly RuleEvaluation[],
@@ -53,7 +58,7 @@ export function verdictLines(
     const clauses = rule.clauses.map((c) => `${c.key}=${c.state}`).join(", ");
     const origin = rule.verdict === "matched" ? originOf?.(rule.index) : undefined;
     const from = origin ? ` [${origin.layer} packageRules[${origin.sourceIndex}]]` : "";
-    lines.push(`  #${rule.index + 1} ${rule.verdict}${clauses ? ` (${clauses})` : ""}${from}`);
+    lines.push(`  #${rule.index} ${rule.verdict}${clauses ? ` (${clauses})` : ""}${from}`);
     for (const merged of collapseDiffs(rule.merged ?? [])) {
       lines.push(`      sets ${mergedLine(merged)}`);
     }
@@ -158,7 +163,7 @@ export const simulateCommand: Command = {
             `  ${mergedLine(m)}` +
             (step.kind === "flatten"
               ? `  (${step.updateType} block)`
-              : `  (rule #${(step.ruleIndex ?? 0) + 1})`),
+              : `  (rule #${step.ruleIndex ?? 0})`),
         ),
       );
       const hiddenNote = hiddenRulesNote(view);
@@ -178,7 +183,8 @@ export const simulateCommand: Command = {
         verdict.text,
         ...(verdict.caveat ? [verdict.caveat] : []),
         "",
-        `${matched.length} of ${sim.rules.length} packageRules matched.`,
+        `${matched.length} of ${sim.rules.length} packageRules matched — rule numbers are ` +
+          "merged packageRules[N] indexes, and `--rule <n>` takes them verbatim.",
         "",
         ...verdictLines(view.rules, view.originOf),
         ...(hiddenNote ? [hiddenNote] : []),

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1183,6 +1183,28 @@ describe("simulate and compare", () => {
     expect(comparison.summary).toContain("groupName");
   });
 
+  /** Replay-03 (2 sessions): the delta only lists keys that DIFFER, and
+   *  `absent` for an unchanged key read as "not in the config" about an option
+   *  both configs hold. */
+  test("a requested key identical on both sides is withheld as `identical`, not `absent`", async () => {
+    const before = await runConfig(CONFIG);
+    const after = await runConfig(GROUPED);
+    const comparison = (await call("compare_simulations", {
+      runId: before,
+      runIdB: after,
+      dep: { depName: "react", packageName: "react" },
+      keys: ["groupName", "labels", "notAnOption"],
+    })) as {
+      configDelta: { key: string }[];
+      configView: { withheld?: { key: string; reason: string }[] };
+    };
+    expect(comparison.configDelta.map((d) => d.key)).toContain("groupName");
+    expect(comparison.configView.withheld).toEqual([
+      { key: "labels", reason: "identical" },
+      { key: "notAnOption", reason: "absent" },
+    ]);
+  });
+
   test("the same run twice changes nothing", async () => {
     const runId = await runConfig(GROUPED);
     const comparison = (await call("compare_simulations", {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -950,7 +950,11 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "without any merge step writing it, not a value the config set. Pass runIdB to compare " +
         "two configs, or depB to compare two dependencies against the same config. `keys` " +
         "narrows the delta to the options you care about; `summary`, `verdict` and `netEffect` " +
-        "always describe the WHOLE delta, so narrowing the view never moves the verdict. A side " +
+        "always describe the WHOLE delta, so narrowing the view never moves the verdict. A " +
+        "requested key not in the answer is named in `configView.withheld` with why: " +
+        "`identical` (both sides carry it and nothing differs), `absent` (neither side's " +
+        "per-dependency config carries it — a rule that did not match this dependency " +
+        "contributes nothing), or `global-only`. A side " +
         "that could not evaluate a rule for lack of dependency input reports it in its own " +
         "`missingInputs`, and one whose matcher threw in its own `evaluationErrors`: two blind " +
         "sides agree perfectly, and `identical` over them is not an answer about your edit. " +
@@ -1008,6 +1012,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
           scope: configScope ?? "package-rules",
           detail: detail ?? "verdict",
           transport: "mcp",
+          sideKeys: [
+            ...new Set([
+              ...Object.keys(simA.finalDependencyConfig),
+              ...Object.keys(simB.finalDependencyConfig),
+            ]),
+          ],
           ...(keys ? { keys } : {}),
         },
       );

--- a/packages/cli/src/projections/config-view.test.ts
+++ b/packages/cli/src/projections/config-view.test.ts
@@ -11,6 +11,7 @@ import {
   parseConfigScope,
   parseKeys,
   projectConfig,
+  projectKeySet,
 } from "./config-view";
 
 /**
@@ -98,6 +99,36 @@ describe("projectConfig", () => {
         expect(view.keys).toBeLessThanOrEqual(wide.view.keys);
       }
     }
+  });
+});
+
+/**
+ * Replay-03 (2 MCP sessions): a comparison delta only lists keys that DIFFER,
+ * so a requested key that is the same on both sides is not in it — and
+ * `absent` for it read as "not in the config" about an option both configs
+ * hold. `unchanged` is how the comparison names that case `identical`.
+ */
+describe("projectKeySet withheld reasons", () => {
+  test("a key the documents carry but the delta does not is `identical`, not `absent`", () => {
+    const { view } = projectKeySet(
+      ["groupName"],
+      { scope: "package-rules", keys: ["groupName", "labels", "minimumReleaseAge", GLOBAL_ONLY] },
+      new Set(["labels"]),
+    );
+    expect(view.withheld).toEqual([
+      { key: "labels", reason: "identical" },
+      { key: "minimumReleaseAge", reason: "absent" },
+      { key: GLOBAL_ONLY, reason: "global-only" },
+    ]);
+  });
+
+  test("`global-only` still wins over `identical` — the scope is why it is gone", () => {
+    const { view } = projectKeySet(
+      [],
+      { scope: "package-rules", keys: [GLOBAL_ONLY] },
+      new Set([GLOBAL_ONLY]),
+    );
+    expect(view.withheld).toEqual([{ key: GLOBAL_ONLY, reason: "global-only" }]);
   });
 });
 

--- a/packages/cli/src/projections/config-view.ts
+++ b/packages/cli/src/projections/config-view.ts
@@ -39,9 +39,15 @@ export interface ConfigViewRequest {
 
 /**
  * Why a requested key is not in the answer. `absent` ("this document does not
- * carry that option") and `global-only` ("this VIEW cannot carry it") are
- * different answers, and a silently empty result is indistinguishable from a
- * bug, so the view names which one happened.
+ * carry that option"), `identical` ("both sides carry it, nothing differs")
+ * and `global-only` ("this VIEW cannot carry it") are different answers, and a
+ * silently empty result is indistinguishable from a bug, so the view names
+ * which one happened.
+ *
+ * `identical` exists for the comparison delta (replay-03, 2 MCP sessions): a
+ * delta only lists keys that DIFFER, so a requested key that is the same on
+ * both sides is not in it — and reporting that as `absent` reads as "not in
+ * the config" about an option both configs hold.
  *
  * A globalOnly name under `package-rules` always reads `global-only`, whether
  * or not the document held it: that is the reason the caller can act on —
@@ -49,7 +55,7 @@ export interface ConfigViewRequest {
  */
 export interface WithheldKey {
   key: string;
-  reason: "absent" | "global-only";
+  reason: "absent" | "identical" | "global-only";
 }
 
 /** What produced the document next to it. ~60 bytes, so a reader never has to
@@ -75,6 +81,10 @@ export interface ProjectedConfig {
 export function projectKeySet(
   present: readonly string[],
   request: ConfigViewRequest,
+  /** Keys the underlying document(s) DO carry that `present` legitimately
+   *  lacks — for a comparison delta, the keys identical on both sides. A
+   *  requested key found here is withheld as `identical`, not `absent`. */
+  unchanged?: ReadonlySet<string>,
 ): { kept: Set<string>; view: ConfigView } {
   const globalOnly = globalOnlyOptionNames();
   const pruned =
@@ -101,10 +111,13 @@ export function projectKeySet(
     } else {
       // The scope, not the document, is why a globalOnly key is gone — and
       // `keys` must never resurrect it. `scope: "full"` is the way back.
-      withheld.push({
-        key,
-        reason: request.scope === "package-rules" && globalOnly.has(key) ? "global-only" : "absent",
-      });
+      const reason =
+        request.scope === "package-rules" && globalOnly.has(key)
+          ? "global-only"
+          : unchanged?.has(key)
+            ? "identical"
+            : "absent";
+      withheld.push({ key, reason });
     }
   }
   return {

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -269,12 +269,27 @@ describe("comparisonPayload", () => {
       keys: ["groupName", "labels"],
     });
     expect(payload.configDelta.map((delta) => delta.key)).toEqual(["groupName"]);
+    // Without `sideKeys` the projection cannot tell "unchanged" from "not
+    // there" — `absent` is the honest fallback.
     expect(payload.configView.withheld).toEqual([{ key: "labels", reason: "absent" }]);
     // The comparison FOUND three changed keys; a narrowed view does not get to
     // restate what it found.
     expect(payload.summary).toBe(COMPARISON.summary);
     expect(payload.verdict).toBe("differs");
     expect(payload.netEffect).toBe(COMPARISON.netEffect);
+  });
+
+  /** Replay-03: both call sites pass `sideKeys`, so a requested key the
+   *  documents carry but the delta does not reads `identical`. */
+  test("with sideKeys, an unchanged requested key is `identical`, not `absent`", () => {
+    const payload = comparisonPayload(COMPARISON, {
+      scope: "package-rules",
+      detail: "full",
+      keys: ["groupName", "labels"],
+      sideKeys: ["groupName", "labels"],
+    });
+    expect(payload.configDelta.map((delta) => delta.key)).toEqual(["groupName"]);
+    expect(payload.configView.withheld).toEqual([{ key: "labels", reason: "identical" }]);
   });
 });
 

--- a/packages/cli/src/projections/simulate.ts
+++ b/packages/cli/src/projections/simulate.ts
@@ -287,6 +287,15 @@ export interface ComparisonProjection {
   detail: CompareDetail;
   /** Which surface the note's `detail` spelling is for. Defaults to `mcp`'s. */
   transport?: RunTransport;
+  /**
+   * Top-level keys present in EITHER side's `finalDependencyConfig` — what
+   * tells a withheld key `identical` (both sides carry it, nothing differs)
+   * apart from `absent` (neither side's per-dependency config has it). Both
+   * call sites hold the two simulations, so both pass it; without it every
+   * unchanged key reads `absent`, which replay-03 showed being read as "not
+   * in the config" about an option both configs hold.
+   */
+  sideKeys?: readonly string[];
 }
 
 /** A {@link RuleRef} without the re-serialized selector array. */
@@ -385,9 +394,14 @@ export function comparisonPayload(
   comparison: SimulationComparison,
   options: ComparisonProjection,
 ): ProjectedComparison {
+  const deltaKeys = new Set(comparison.configDelta.map((delta) => delta.key));
+  // A key both sides carry that is not in the delta did not differ — the
+  // `identical` withheld reason, as opposed to a key neither side has.
+  const unchanged = new Set((options.sideKeys ?? []).filter((key) => !deltaKeys.has(key)));
   const { kept, view } = projectKeySet(
-    comparison.configDelta.map((delta) => delta.key),
+    [...deltaKeys],
     { scope: options.scope, ...(options.keys ? { keys: options.keys } : {}) },
+    unchanged,
   );
   const { detail } = options;
   const spell = (value: CompareDetail) =>


### PR DESCRIPTION
Persona replay 03 (18 sessions, CLI and MCP separately) surfaced four
paper cuts, fixed here on both surfaces at once:

- `rcd provenance <key>` now carries the same per-dependency note the
  MCP's get_provenance has had since roadmap 068 — three CLI sessions
  read "winner: defaults" on a rule-covered key as the effective value.
- Rule numbers in pretty output are the merged zero-based
  `packageRules[N]` indexes — the same numbers `--rule`, JSON's `index`
  and the provenance citations use. The old one-based `#N+1` cost both
  CLI expert sessions a wasted `--rule` call.
- A compare key withheld because it is the same on both sides now reads
  `withheld.reason: "identical"` instead of `"absent"`, which two MCP
  sessions read as "not in the config" about an option both configs
  hold. Both call sites pass the side documents' key sets; the reason
  vocabulary is documented on both transports.
- `rcd provenance <file> key1 key2` is now an error naming both keys —
  the second positional used to be silently dropped.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>