### PR TITLE
feat(cli): group-level simulation — would this group actually form?

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ rcd tree renovate.json --node "config:best-practices" --body resolved
 rcd provenance renovate.json labels
 rcd simulate renovate.json --dep '{"depName":"react","currentValue":"17.0.0"}'
 rcd compare before.json after.json --dep '{"depName":"react"}'   # the edit oracle
+rcd group renovate.json --dep '{"depName":"a"}' --dep '{"depName":"b"}'  # would these updates group, and does the group form?
 rcd docs minimumReleaseAge        # option semantics for the pinned Renovate
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,7 @@ the way.
 | `resolved`   | the merged config Renovate would run with            |
 | `simulate`   | which `packageRules` match a hypothetical dependency |
 | `compare`    | did an edit change behavior                          |
+| `group`      | which groups form from several updates               |
 | `run`        | the whole trace                                      |
 | `docs`       | what an option means, and where it may go            |
 | `mcp`        | all of the above over MCP stdio                      |
@@ -51,6 +52,7 @@ $ rcd provenance renovate.json labels
 $ rcd resolved renovate.json --mode full
 $ rcd simulate renovate.json --dep '{"depName":"react","currentValue":"17.0.0","newValue":"18.0.0"}'
 $ rcd compare before.json after.json --dep '{"depName":"react"}'
+$ rcd group renovate.json --dep '{"depName":"react","updateType":"minor"}' --dep '{"depName":"react-dom","updateType":"minor"}'
 $ rcd docs minimumReleaseAge
 $ echo '{"extends":["config:recommended"]}' | rcd run --stdin --format json --select status
 ```
@@ -100,6 +102,8 @@ The rest belong to one command each.
 |              | `--detail <which>`           | `verdict` (default) \| `rules` \| `full`                                |
 |              | `--keys <a,b,…>`             | only these options of the config delta                                  |
 |              | `--config-scope <which>`     | `package-rules` (default) \| `full`                                     |
+| `group`      | `--dep <json>` (repeatable)  | one pending update per occurrence, at least two                         |
+|              | `--deps-file <file>`         | a JSON array of the same objects                                        |
 | `run`        | `--select <a,b,…>`           | `status\|errors\|warnings\|final\|events\|tree\|layers\|platform\|all`  |
 |              | `--keys <a,b,…>`             | only these options of `--select final`                                  |
 |              | `--config-scope <which>`     | `full` (default) \| `package-rules`                                     |
@@ -350,6 +354,37 @@ would be
 refused by Renovate, both commands exit `2`, which says nothing about the
 simulation itself, so they also say so on their own output (`exitNote` in JSON, a
 trailing `note:` line in pretty).
+
+### Group-level answers: `rcd group`
+
+`simulate` is one dependency at a time by construction, so "would this group
+actually reach its `minimumGroupSize`" is not a question it can answer. `group`
+takes SEVERAL updates — `--dep` repeatedly, or `--deps-file` with a JSON array
+of the same objects — runs the same evaluation for each, and tallies them by
+the `groupName` their matching rules produced:
+
+```console
+$ rcd group renovate.json \
+    --dep '{"depName":"react","updateType":"minor"}' \
+    --dep '{"depName":"react-dom","updateType":"minor"}' \
+    --dep '{"depName":"lodash","updateType":"patch"}'
+1 group over 3 simulated updates (1 update ungrouped).
+
+  "react monorepo" would WAIT: 2 updates of the 3 its minimumGroupSize requires.
+      react (minor)
+      react-dom (minor)
+
+  Ungrouped — each update gets its own PR:
+      lodash (patch)
+```
+
+Two honesty caveats travel on every answer. The tally is over the updates YOU
+supplied — Renovate evaluates `minimumGroupSize` against the repository's real
+pending updates at run time, so "would wait" here means "these updates alone
+don't reach it", never "this group can never form". And membership is by
+`groupName` as the rules resolved it: branch splitting (`separateMajorMinor`,
+custom `branchName` templates) is not modeled. The MCP `simulate_group` tool is
+the same answer over a held run.
 
 On a `config:best-practices` run the rule list runs to several hundred, so BOTH
 output formats answer with the rules that ACTED — `--verdict notable`: matched,

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -80,11 +80,17 @@ export const OPTIONS = {
   },
   dep: {
     flags: "--dep <json>",
+    multiple: true,
     description:
       'the dependency update to simulate, e.g. \'{"depName":"react","currentValue":"17.0.0",' +
-      '"newValue":"18.0.0"}\' — packageName defaults to depName, as in a real run',
+      '"newValue":"18.0.0"}\' — packageName defaults to depName, as in a real run. ' +
+      "`group` takes it repeatedly, one per pending update",
   },
   "dep-file": { flags: "--dep-file <file>", description: "--dep, read from a file" },
+  "deps-file": {
+    flags: "--deps-file <file>",
+    description: "a JSON array of `--dep` objects — `group`'s batch input",
+  },
   "dep-b": { flags: "--dep-b <json>", description: "the B-side dependency to compare" },
   "dep-b-file": { flags: "--dep-b-file <file>", description: "--dep-b, read from a file" },
   search: { flags: "--search", description: "list options whose name matches" },

--- a/packages/cli/src/commands/group.test.ts
+++ b/packages/cli/src/commands/group.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import { main } from "../main";
+import { fixture, recordingIo } from "../test-harness";
+
+/**
+ * Roadmap 074: the batch-level question both replay-03 entry sessions could
+ * only hedge on — "would this group actually reach its minimumGroupSize?" —
+ * answered from the same evaluation `simulate` runs, over several updates.
+ */
+
+const REACT = '{"depName":"react","packageName":"react","updateType":"minor"}';
+const REACT_DOM = '{"depName":"react-dom","packageName":"react-dom","updateType":"minor"}';
+const LODASH = '{"depName":"lodash","packageName":"lodash","updateType":"patch"}';
+
+describe("group", () => {
+  test("tallies groups and answers the minimumGroupSize gate", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "group",
+          fixture("group-minimum.json"),
+          "--dep",
+          REACT,
+          "--dep",
+          REACT_DOM,
+          "--dep",
+          LODASH,
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const tally = io.json() as {
+      updates: number;
+      groups: {
+        groupName: string;
+        size: number;
+        minimumGroupSize: number;
+        wouldForm: boolean;
+        verdict: string;
+        members: { depName: string }[];
+      }[];
+      ungrouped: { depName: string }[];
+      notes: string[];
+    };
+    expect(tally.updates).toBe(3);
+    const react = tally.groups.find((group) => group.groupName === "react monorepo");
+    expect(react).toMatchObject({ size: 2, minimumGroupSize: 3, wouldForm: false });
+    expect(react?.verdict).toContain("would WAIT: 2 updates of the 3");
+    expect(react?.members.map((member) => member.depName)).toEqual(["react", "react-dom"]);
+    expect(tally.ungrouped.map((member) => member.depName)).toEqual(["lodash"]);
+    // The honesty caveat is part of the answer, not optional prose.
+    expect(tally.notes.join(" ")).toContain("updates YOU supplied");
+  });
+
+  test("pretty output states the verdict per group", async () => {
+    const io = recordingIo();
+    expect(
+      await main(["group", fixture("group-minimum.json"), "--dep", REACT, "--dep", REACT_DOM], io),
+    ).toBe(0);
+    expect(io.stdout).toContain('"react monorepo" would WAIT');
+    expect(io.stdout).toContain("react (minor)");
+    expect(io.stdout).toContain("updates YOU supplied");
+  });
+
+  test("a group with no gate forms from the updates it has", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "group",
+          fixture("group-minimum.json"),
+          "--dep",
+          '{"depName":"chalk","packageName":"chalk","updateType":"patch"}',
+          "--dep",
+          LODASH,
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const tally = io.json() as { groups: { groupName: string; wouldForm: boolean }[] };
+    expect(tally.groups).toEqual([
+      expect.objectContaining({ groupName: "cosmetics", wouldForm: true }),
+    ]);
+  });
+
+  test("one update is simulate's question, and the error says so", async () => {
+    const io = recordingIo();
+    expect(await main(["group", fixture("group-minimum.json"), "--dep", REACT], io)).toBe(1);
+    expect(io.stderr).toContain("at least two updates");
+    expect(io.stderr).toContain("rcd simulate");
+  });
+
+  test("an update that leaves rule inputs unset is flagged per member", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "group",
+          fixture("mixed-rules.json"),
+          "--dep",
+          '{"depName":"react"}',
+          "--dep",
+          '{"depName":"lodash"}',
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const tally = io.json() as { notes: string[] };
+    // mixed-rules has a matchSourceUrls rule neither bare descriptor can feed.
+    expect(tally.notes.join(" ")).toContain("could not match because this update leaves a field");
+  });
+});
+
+describe("group --deps-file", () => {
+  test("reads the batch from a JSON array file", async () => {
+    const io = recordingIo();
+    const { writeFile, mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "rcd-group-"));
+    const path = join(dir, "updates.json");
+    await writeFile(path, `[${REACT},${REACT_DOM}]`, "utf8");
+    expect(
+      await main(
+        ["group", fixture("group-minimum.json"), "--deps-file", path, "--format", "json"],
+        io,
+      ),
+    ).toBe(0);
+    const tally = io.json() as { updates: number; groups: { size: number }[] };
+    expect(tally.updates).toBe(2);
+    expect(tally.groups[0]?.size).toBe(2);
+  });
+
+  test("a file that is not an array is an error naming the file", async () => {
+    const io = recordingIo();
+    const { writeFile, mkdtemp } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const dir = await mkdtemp(join(tmpdir(), "rcd-group-"));
+    const path = join(dir, "not-an-array.json");
+    await writeFile(path, "{}", "utf8");
+    expect(await main(["group", fixture("group-minimum.json"), "--deps-file", path], io)).toBe(1);
+    expect(io.stderr).toContain("JSON array");
+  });
+});
+
+describe("simulate keeps its one-dep contract", () => {
+  test("a second --dep on simulate is an error pointing at group", async () => {
+    const io = recordingIo();
+    expect(
+      await main(["simulate", fixture("grouped.json"), "--dep", REACT, "--dep", REACT_DOM], io),
+    ).toBe(1);
+    expect(io.stderr).toContain("rcd group");
+  });
+});

--- a/packages/cli/src/commands/group.ts
+++ b/packages/cli/src/commands/group.ts
@@ -1,0 +1,86 @@
+import type { DependencyDescriptor, SimulationResult } from "@renovate-config-debugger/engine";
+import { outputFormat } from "../args";
+import type { Command } from "../command";
+import { EXIT_OK, EXIT_REFUSED } from "../io";
+import { emitJson, emitLines, writeNotes } from "../output";
+import { INPUT_OPTIONS, refusalNote, runFromArgs, wouldRefuse } from "../run-input";
+import { readDependencies } from "../dep";
+import { groupTally, groupTallyLines } from "../projections/group";
+import { simulateAgainst } from "./simulate";
+
+/**
+ * Roadmap 074: "given these pending updates, which groups form, and would each
+ * meet its `minimumGroupSize`?" — the batch-level question `simulate` cannot
+ * answer one dependency at a time.
+ */
+
+/** A side's input gap, stated per update: a rule that could not be evaluated
+ *  for one member is a fact about that member's descriptor, and a group tally
+ *  over blind simulations reads as "these updates just don't group". */
+function inputGapNotes(
+  simulated: readonly { dep: DependencyDescriptor; sim: SimulationResult }[],
+): string[] {
+  return simulated.flatMap(({ dep, sim }, index) => {
+    const count = sim.missingInputs.rules;
+    if (count === 0) {
+      return [];
+    }
+    const name = dep.depName ?? `update ${index + 1}`;
+    return [
+      `${name}: ${count} rule${count === 1 ? "" : "s"} could not match because this update ` +
+        "leaves a field they read unset — `rcd simulate` that update to see which.",
+    ];
+  });
+}
+
+export const groupCommand: Command = {
+  name: "group",
+  summary: "which groups form from several updates, and does each meet its minimumGroupSize",
+  usage: [
+    `group [file] --dep '{"depName":"a","updateType":"minor"}' --dep '{"depName":"b","updateType":"minor"}'`,
+    "group [file] --deps-file updates.json",
+  ],
+  details: [
+    "Simulates every update you supply (the same evaluation `simulate` runs),",
+    "reads each one's per-dependency `groupName` and `minimumGroupSize`, and",
+    "tallies the groups: which updates land together, and whether the members",
+    "you supplied alone reach the gate. `--dep` repeats, one per update, or",
+    "`--deps-file` names a JSON array of the same objects.",
+    "",
+    "The tally is over YOUR list — Renovate evaluates minimumGroupSize against",
+    "the repository's real pending updates, so `wouldForm: false` here means",
+    '"these updates alone don\'t reach it", not "this group can never form".',
+    "Branch splitting (separateMajorMinor, custom branchName templates) is not",
+    "modeled; membership is by groupName as the rules resolved it.",
+  ],
+  options: [...INPUT_OPTIONS, "dep", "deps-file", "format"],
+  async run(args, io) {
+    const format = outputFormat(args);
+    const deps = await readDependencies(args);
+    const { result, notes } = await runFromArgs(args, io);
+    writeNotes(io, notes);
+    const simulated: { dep: DependencyDescriptor; sim: SimulationResult }[] = [];
+    for (const dep of deps) {
+      simulated.push({ dep, sim: await simulateAgainst(result, dep) });
+    }
+    const tally = groupTally(simulated);
+    const gaps = inputGapNotes(simulated);
+    const refused = wouldRefuse(result);
+    const refusal = refusalNote(refused ? ["the config"] : []);
+    if (format === "json") {
+      emitJson(io, {
+        ...tally,
+        notes: [...tally.notes, ...gaps],
+        wouldRefuse: refused,
+        ...(refusal ? { exitNote: refusal } : {}),
+      });
+    } else {
+      emitLines(io, [
+        ...groupTallyLines(tally),
+        ...gaps.map((gap) => `note: ${gap}`),
+        ...(refusal ? ["", refusal] : []),
+      ]);
+    }
+    return refused ? EXIT_REFUSED : EXIT_OK;
+  },
+};

--- a/packages/cli/src/dep.ts
+++ b/packages/cli/src/dep.ts
@@ -5,20 +5,61 @@ import {
   parseInjectedPreset,
 } from "@renovate-config-debugger/engine";
 import type { OptionName, ParsedArgs } from "./args";
-import { stringOption } from "./args";
+import { listOption, stringOption } from "./args";
 import { CliError, errorMessage } from "./io";
 
 /**
  * The hypothetical dependency update `simulate`/`compare` evaluate the rules
  * against — JSON on the command line, or a file. Same shape the simulator form
  * fills in: `{ "depName": "react", "currentValue": "17.0.0", "newValue": "18.0.0" }`.
+ *
+ * `group` (roadmap 074) takes SEVERAL: `--dep` repeatedly, or `--deps-file`
+ * with a JSON array of the same objects.
  */
+
+/** One descriptor, parsed and finished the way a real lookup would finish it. */
+function parseDescriptor(text: string, what: string): DependencyDescriptor {
+  let parsed: Record<string, unknown>;
+  try {
+    // JSON5 object parsing, the same superset the app accepts in its own
+    // paste-a-JSON fields.
+    parsed = parseInjectedPreset(text);
+  } catch (err) {
+    throw new CliError(`${what}: ${errorMessage(err)}`);
+  }
+  return finishDescriptor(parsed as DependencyDescriptor);
+}
+
+/** Every field of DependencyDescriptor is optional, so the descriptor is
+ *  whatever subset the caller supplied; the matchers themselves report which
+ *  fields they could not read (`no-input`), which is a better error than any
+ *  shape check here could give. `updateType` is the one derived field: Renovate
+ *  sets it from the version pair long before packageRules run. */
+function finishDescriptor(dep: DependencyDescriptor): DependencyDescriptor {
+  if (!dep.updateType) {
+    const derived = deriveUpdateType(dep.currentValue, dep.newValue, dep.versioning);
+    if (derived) {
+      return { ...dep, updateType: derived };
+    }
+  }
+  return dep;
+}
+
 export async function readDependency(
   args: ParsedArgs,
   inline: OptionName,
   fromFile: OptionName,
 ): Promise<DependencyDescriptor> {
-  const literal = stringOption(args, inline);
+  const inlineValues = listOption(args, inline);
+  // `--dep` is repeatable for `group`'s sake; here a second occurrence would
+  // be silently last-one-wins, which is never what the caller meant.
+  if (inlineValues.length > 1) {
+    throw new CliError(
+      `--${inline} was given ${inlineValues.length} times — this command evaluates ONE update; ` +
+        "`rcd group` is the command that takes several",
+    );
+  }
+  const literal = inlineValues[0] ?? stringOption(args, inline);
   const path = stringOption(args, fromFile);
   if (literal && path) {
     throw new CliError(`pass --${inline} or --${fromFile}, not both`);
@@ -36,26 +77,47 @@ export async function readDependency(
       `--${inline} is required, e.g. --${inline} '{"depName":"react","currentValue":"17.0.0","newValue":"18.0.0"}'`,
     );
   }
-  let parsed: Record<string, unknown>;
-  try {
-    // JSON5 object parsing, the same superset the app accepts in its own
-    // paste-a-JSON fields.
-    parsed = parseInjectedPreset(text);
-  } catch (err) {
-    throw new CliError(`--${inline}: ${errorMessage(err)}`);
-  }
-  // Every field of DependencyDescriptor is optional, so the descriptor is
-  // whatever subset the caller supplied; the matchers themselves report which
-  // fields they could not read (`no-input`), which is a better error than any
-  // shape check here could give.
-  const dep = parsed as DependencyDescriptor;
-  if (!dep.updateType) {
-    // The same derivation the simulator form performs before a run: Renovate
-    // sets `updateType` from the version pair long before packageRules run.
-    const derived = deriveUpdateType(dep.currentValue, dep.newValue, dep.versioning);
-    if (derived) {
-      return { ...dep, updateType: derived };
+  return parseDescriptor(text, `--${inline}`);
+}
+
+/**
+ * The batch input: every `--dep` occurrence, then the `--deps-file` array.
+ * At least two — one update is `simulate`'s question, and a "group" of one
+ * would answer it with a worse tool.
+ */
+export async function readDependencies(args: ParsedArgs): Promise<DependencyDescriptor[]> {
+  const deps = listOption(args, "dep").map((text, index) =>
+    parseDescriptor(text, `--dep (occurrence ${index + 1})`),
+  );
+  const path = stringOption(args, "deps-file");
+  if (path) {
+    let text: string;
+    try {
+      text = await readFile(path, "utf8");
+    } catch (err) {
+      throw new CliError(`cannot read --deps-file "${path}": ${errorMessage(err)}`);
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      throw new CliError(`--deps-file "${path}": ${errorMessage(err)}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new CliError(`--deps-file "${path}" must hold a JSON array of dependency objects`);
+    }
+    for (const [index, entry] of parsed.entries()) {
+      if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new CliError(`--deps-file "${path}" entry #${index} is not an object`);
+      }
+      deps.push(finishDescriptor(entry as DependencyDescriptor));
     }
   }
-  return dep;
+  if (deps.length < 2) {
+    throw new CliError(
+      "group needs at least two updates (`--dep` repeatedly, or `--deps-file` with a JSON " +
+        "array) — for a single update, `rcd simulate` is the question",
+    );
+  }
+  return deps;
 }

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -6,6 +6,7 @@ import type { Command } from "./command";
 import { compareCommand } from "./commands/compare";
 import { digestCommand } from "./commands/digest";
 import { docsCommand } from "./commands/docs";
+import { groupCommand } from "./commands/group";
 import { mcpCommand } from "./commands/mcp";
 import { provenanceCommand } from "./commands/provenance";
 import { resolvedCommand } from "./commands/resolved";
@@ -38,6 +39,7 @@ const COMMANDS: readonly Command[] = [
   resolvedCommand,
   simulateCommand,
   compareCommand,
+  groupCommand,
   docsCommand,
   mcpCommand,
 ];

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -167,6 +167,7 @@ describe("tool surface", () => {
       "get_resolved_config",
       "run_config",
       "simulate",
+      "simulate_group",
     ]);
     const node = tools.find((t) => t.name === "get_preset_node");
     expect(node?.description).toContain("one node at a time");
@@ -220,6 +221,7 @@ describe("tool surface", () => {
       "get_resolved_config",
       "run_config",
       "simulate",
+      "simulate_group",
     ]);
 
     // A whole drill-down, not just a handshake: the held run survives the era.
@@ -1244,6 +1246,66 @@ describe("simulate and compare", () => {
     expect(notes).toContain("A — 2 of 4 rules could not match");
     expect(notes).toContain("B — 2 of 4 rules could not match");
     expect(notes).toContain('`verdict: "no-input"` lists them.');
+  });
+});
+
+/**
+ * Roadmap 074: the batch-level question `simulate` cannot answer one
+ * dependency at a time — both replay-03 entry sessions on the 44529 scenario
+ * could only hedge "would this group actually reach its minimumGroupSize".
+ */
+describe("simulate_group", () => {
+  const MINIMUM_GROUP = JSON.stringify({
+    labels: ["deps"],
+    packageRules: [
+      {
+        matchPackageNames: ["react", "react-dom"],
+        groupName: "react monorepo",
+        minimumGroupSize: 3,
+      },
+    ],
+  });
+
+  test("tallies the groups and answers the minimumGroupSize gate", async () => {
+    const runId = await runConfig(MINIMUM_GROUP);
+    const tally = (await call("simulate_group", {
+      runId,
+      deps: [
+        { depName: "react", packageName: "react", updateType: "minor" },
+        { depName: "react-dom", packageName: "react-dom", updateType: "minor" },
+        { depName: "lodash", packageName: "lodash", updateType: "patch" },
+      ],
+    })) as {
+      updates: number;
+      groups: {
+        groupName: string;
+        size: number;
+        minimumGroupSize: number;
+        wouldForm: boolean;
+        verdict: string;
+      }[];
+      ungrouped: { depName?: string }[];
+      notes: string[];
+    };
+    expect(tally.updates).toBe(3);
+    expect(tally.groups[0]).toMatchObject({
+      groupName: "react monorepo",
+      size: 2,
+      minimumGroupSize: 3,
+      wouldForm: false,
+    });
+    expect(tally.groups[0]?.verdict).toContain("would WAIT: 2 updates of the 3");
+    expect(tally.ungrouped.map((member) => member.depName)).toEqual(["lodash"]);
+    // The scope caveat is part of the answer: this tally is over the supplied
+    // deps, never the repository's real pending updates.
+    expect(tally.notes.join(" ")).toContain("updates YOU supplied");
+  });
+
+  test("one dep is refused by the schema — simulate is that question", async () => {
+    const runId = await runConfig(MINIMUM_GROUP);
+    await expect(call("simulate_group", { runId, deps: [{ depName: "react" }] })).rejects.toThrow(
+      /deps/,
+    );
   });
 });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -53,6 +53,7 @@ import {
   previewValue,
   provenanceOf,
 } from "../projections/provenance";
+import { groupTally } from "../projections/group";
 import { oneRuleView, RULE_DIGEST_PLANS, ruleProvenanceView } from "../projections/rule-provenance";
 import {
   BODIES,
@@ -144,8 +145,9 @@ const INSTRUCTIONS =
   "get_preset_node for what `extends` expanded into (preset bodies are large — one node per " +
   "call), get_option_docs instead of recalling option semantics, which change between Renovate " +
   "releases. simulate answers in one sentence (`verdict.text`) before the evidence, scoped to the " +
-  "rules that acted; every answer states what its view withheld and the parameter that returns " +
-  "it, so read `notes` before you conclude anything is absent. " +
+  "rules that acted; simulate_group tallies SEVERAL updates into the groups they would form; " +
+  "every answer states what its view withheld and the " +
+  "parameter that returns it, so read `notes` before you conclude anything is absent. " +
   "Before you propose an edit, prove it: run_config the edited text and " +
   "compare_simulations the two runs against the same dependency. Everything here is read-only.";
 
@@ -930,6 +932,61 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         ...payload,
         ...(view.notes.length > 0 ? { filterNotes: view.notes } : {}),
       };
+    }, HINTS.simulate),
+  );
+
+  server.registerTool(
+    "simulate_group",
+    {
+      title: "Which groups form from several updates",
+      description:
+        "The batch-level question `simulate` cannot answer one dependency at a time: given " +
+        "SEVERAL pending updates, which groups form, and does each reach its " +
+        "`minimumGroupSize`? Every update in `deps` is simulated exactly as `simulate` would, " +
+        "then tallied by the `groupName` its matching rules produced; each group reports its " +
+        "members, `size`, the `minimumGroupSize` gate its members carry and `wouldForm` — " +
+        "`verdict` states the claim in one sentence. Updates no rule groups are listed in " +
+        "`ungrouped`, one PR each. The tally is over the `deps` YOU supplied — Renovate " +
+        "evaluates minimumGroupSize against the repository's real pending updates, so " +
+        '`wouldForm: false` means "these updates alone don\'t reach it", never "this group ' +
+        'can never form". Branch splitting (separateMajorMinor, custom branchName templates) ' +
+        "is not modeled; per-update rule evidence is simulate's answer, one dep at a time.",
+      annotations: HELD_RUN_ANNOTATIONS,
+      inputSchema: z.strictObject({
+        runId: RUN_ID,
+        deps: z
+          .array(DEP)
+          .min(2)
+          .describe(
+            "The pending updates to tally, at least two — for a single update, `simulate` is " +
+              "the question.",
+          ),
+      }),
+    },
+    answer(async ({ runId, deps }, ctx) => {
+      const run = store.get(runId);
+      const simulated: { dep: DependencyDescriptor; sim: SimulationResult }[] = [];
+      // Sequential on purpose: the engine serializes its queue anyway, and a
+      // cancelled call must stop enqueuing (see throwIfCancelled).
+      for (const dep of deps) {
+        simulated.push({ dep: toDependency(dep), sim: await simulateRun(run, dep, ctx) });
+      }
+      const tally = groupTally(simulated);
+      // A member whose descriptor left rule inputs unset can be mis-tallied —
+      // a rule that would put it in a group reported a plain `no-match`. Named
+      // per member, same reasoning as compare's per-side notes.
+      const gaps = simulated.flatMap(({ dep, sim }, index) => {
+        const count = sim.missingInputs.rules;
+        if (count === 0) {
+          return [];
+        }
+        const name = dep.depName ?? `deps[${index}]`;
+        return [
+          `${name}: ${count} rule${count === 1 ? "" : "s"} could not match because this ` +
+            "update leaves a field they read unset — simulate that update to see which.",
+        ];
+      });
+      return { ...tally, notes: [...tally.notes, ...gaps] };
     }, HINTS.simulate),
   );
 

--- a/packages/cli/src/projections/group.test.ts
+++ b/packages/cli/src/projections/group.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { groupTally, groupTallyLines } from "./group";
+
+/**
+ * Roadmap 074. Pure — no pipeline run: the tally is arithmetic over the
+ * per-dependency configs the simulations already produced.
+ */
+
+function update(
+  depName: string,
+  updateType: string,
+  config: Record<string, unknown>,
+): Parameters<typeof groupTally>[0][number] {
+  return { dep: { depName, updateType }, sim: { finalDependencyConfig: config } };
+}
+
+describe("groupTally", () => {
+  test("members below the gate would WAIT, and the verdict says the arithmetic", () => {
+    const tally = groupTally([
+      update("react", "minor", { groupName: "react monorepo", minimumGroupSize: 3 }),
+      update("react-dom", "minor", { groupName: "react monorepo", minimumGroupSize: 3 }),
+      update("lodash", "patch", {}),
+    ]);
+    expect(tally.updates).toBe(3);
+    expect(tally.groups).toHaveLength(1);
+    expect(tally.groups[0]).toMatchObject({
+      groupName: "react monorepo",
+      size: 2,
+      minimumGroupSize: 3,
+      wouldForm: false,
+    });
+    expect(tally.groups[0]?.verdict).toBe(
+      '"react monorepo" would WAIT: 2 updates of the 3 its minimumGroupSize requires.',
+    );
+    expect(tally.ungrouped).toEqual([{ depName: "lodash", updateType: "patch" }]);
+  });
+
+  test("a group at its gate forms, and one without a gate says so", () => {
+    const tally = groupTally([
+      update("react", "minor", { groupName: "react monorepo", minimumGroupSize: 2 }),
+      update("react-dom", "minor", { groupName: "react monorepo", minimumGroupSize: 2 }),
+      update("chalk", "patch", { groupName: "cosmetics" }),
+    ]);
+    expect(tally.groups[0]).toMatchObject({ size: 2, minimumGroupSize: 2, wouldForm: true });
+    expect(tally.groups[0]?.verdict).toContain("meets its minimumGroupSize: 2 of 2");
+    expect(tally.groups[1]).toMatchObject({
+      groupName: "cosmetics",
+      minimumGroupSize: 1,
+      wouldForm: true,
+    });
+    expect(tally.groups[1]?.verdict).toContain("no minimumGroupSize gate");
+  });
+
+  /** Rule-scoped `minimumGroupSize` can hand members of ONE group different
+   *  values; inside Renovate the effective gate is then ordering-dependent, so
+   *  the tally takes the conservative one and names the spread. */
+  test("members that disagree on the gate are tallied against the largest, and named", () => {
+    const tally = groupTally([
+      update("a", "minor", { groupName: "g", minimumGroupSize: 5 }),
+      update("b", "minor", { groupName: "g", minimumGroupSize: 2 }),
+    ]);
+    expect(tally.groups[0]).toMatchObject({
+      minimumGroupSize: 5,
+      minimumGroupSizeValues: [2, 5],
+      wouldForm: false,
+    });
+    expect(tally.notes.join(" ")).toContain("different minimumGroupSize values (2, 5)");
+  });
+
+  test("the scope caveat is on every answer — the tally is over the supplied list", () => {
+    const tally = groupTally([
+      update("a", "minor", { groupName: "g" }),
+      update("b", "minor", { groupName: "g" }),
+    ]);
+    expect(tally.notes.join(" ")).toContain("updates YOU supplied");
+    expect(tally.notes.join(" ")).toContain("separateMajorMinor");
+  });
+
+  test("groupSlug rides along when a member's config set one", () => {
+    const tally = groupTally([
+      update("a", "minor", { groupName: "g", groupSlug: "my-g" }),
+      update("b", "minor", { groupName: "g" }),
+    ]);
+    expect(tally.groups[0]?.groupSlug).toBe("my-g");
+  });
+
+  test("pretty lines carry the headline, the members and the caveats", () => {
+    const lines = groupTallyLines(
+      groupTally([
+        update("react", "minor", { groupName: "react monorepo", minimumGroupSize: 3 }),
+        update("react-dom", "minor", { groupName: "react monorepo", minimumGroupSize: 3 }),
+        update("lodash", "patch", {}),
+      ]),
+    );
+    const text = lines.join("\n");
+    expect(lines[0]).toBe("1 group over 3 simulated updates (1 update ungrouped).");
+    expect(text).toContain('"react monorepo" would WAIT');
+    expect(text).toContain("react-dom (minor)");
+    expect(text).toContain("Ungrouped — each update gets its own PR:");
+    expect(text).toContain("lodash (patch)");
+    expect(text).toContain("updates YOU supplied");
+  });
+});

--- a/packages/cli/src/projections/group.ts
+++ b/packages/cli/src/projections/group.ts
@@ -1,0 +1,176 @@
+import type { DependencyDescriptor, SimulationResult } from "@renovate-config-debugger/engine";
+
+/**
+ * Roadmap 074: the group-level answer over SEVERAL simulated updates.
+ *
+ * `simulate` is one-dependency-at-a-time by construction, so "would this group
+ * actually reach its `minimumGroupSize`" was unanswerable — both replay-03
+ * entry sessions on the 44529 scenario named exactly this gap, and their only
+ * honest option was a hedge. This module is plain arithmetic over N existing
+ * simulations: each update's per-dependency config names the group it lands in
+ * and the threshold it carries; the tally states which groups form.
+ *
+ * Deliberately NOT a branch simulator: Renovate's branchifier splits by
+ * branchName templates, `separateMajorMinor` and friends. The tally answers
+ * the grouping question the rules decide — `groupName` membership and the
+ * `minimumGroupSize` gate — and says so.
+ */
+
+/** One simulated update, as the tally identifies it back to the caller. */
+export interface GroupMember {
+  depName?: string;
+  updateType?: string;
+}
+
+export interface GroupView {
+  groupName: string;
+  /** `groupSlug` when a member's config set one — branch names build on it. */
+  groupSlug?: string;
+  members: GroupMember[];
+  size: number;
+  /** The gate the verdict is measured against — the largest value any member
+   *  carries, when they disagree (see `minimumGroupSizeValues`). */
+  minimumGroupSize: number;
+  /** Present only when members carry DIFFERENT values: rule-scoped
+   *  `minimumGroupSize` makes the effective gate ordering-dependent inside
+   *  Renovate, so the tally takes the conservative one and names the spread. */
+  minimumGroupSizeValues?: number[];
+  /** `size >= minimumGroupSize` — whether these updates alone meet the gate. */
+  wouldForm: boolean;
+  /** The claim in one citable sentence. */
+  verdict: string;
+}
+
+export interface GroupTally {
+  updates: number;
+  groups: GroupView[];
+  /** Updates no rule put in a group — each would get its own PR. */
+  ungrouped: GroupMember[];
+  notes: string[];
+}
+
+const SCOPE_NOTE =
+  "This tally is over the updates YOU supplied — Renovate evaluates minimumGroupSize against " +
+  "the repository's real pending updates at run time, so a group that would wait here can " +
+  "still form when more updates are pending.";
+
+const BRANCH_NOTE =
+  "Membership is by groupName as the rules resolved it per update. Branch splitting " +
+  "(separateMajorMinor, separateMultipleMajor, custom branchName templates) is not modeled.";
+
+function memberOf(dep: DependencyDescriptor): GroupMember {
+  return {
+    ...(dep.depName ? { depName: dep.depName } : {}),
+    ...(dep.updateType ? { updateType: dep.updateType } : {}),
+  };
+}
+
+function minimumOf(config: Record<string, unknown>): number {
+  const raw = config["minimumGroupSize"];
+  // Renovate's default: no threshold — one update is enough.
+  return typeof raw === "number" && raw >= 1 ? raw : 1;
+}
+
+function verdictOf(view: Omit<GroupView, "verdict">): string {
+  const updates = view.size === 1 ? "1 update" : `${view.size} updates`;
+  if (view.minimumGroupSize <= 1) {
+    return `"${view.groupName}" forms from ${updates} — no minimumGroupSize gate.`;
+  }
+  return view.wouldForm
+    ? `"${view.groupName}" meets its minimumGroupSize: ${view.size} of ${view.minimumGroupSize} required updates.`
+    : `"${view.groupName}" would WAIT: ${updates} of the ${view.minimumGroupSize} its minimumGroupSize requires.`;
+}
+
+/** One update plus the slice of its simulation the tally reads — structural,
+ *  so a test hands in the config without fabricating a whole result. */
+export interface SimulatedUpdate {
+  dep: DependencyDescriptor;
+  sim: Pick<SimulationResult, "finalDependencyConfig">;
+}
+
+/**
+ * The tally. Pure over what the simulations already computed: each entry is
+ * one update and the `finalDependencyConfig` its matching rules produced.
+ */
+export function groupTally(simulated: readonly SimulatedUpdate[]): GroupTally {
+  const byName = new Map<string, { members: GroupMember[]; minimums: number[]; slug?: string }>();
+  const ungrouped: GroupMember[] = [];
+  for (const { dep, sim } of simulated) {
+    const config = sim.finalDependencyConfig;
+    const groupName = config["groupName"];
+    if (typeof groupName !== "string" || groupName.length === 0) {
+      ungrouped.push(memberOf(dep));
+      continue;
+    }
+    const entry = byName.get(groupName) ?? { members: [], minimums: [] };
+    entry.members.push(memberOf(dep));
+    entry.minimums.push(minimumOf(config));
+    const slug = config["groupSlug"];
+    if (typeof slug === "string" && slug.length > 0) {
+      entry.slug = slug;
+    }
+    byName.set(groupName, entry);
+  }
+  const groups = [...byName.entries()].map(([groupName, entry]) => {
+    const distinct = [...new Set(entry.minimums)].toSorted((a, b) => a - b);
+    const minimumGroupSize = distinct.at(-1) ?? 1;
+    const base = {
+      groupName,
+      ...(entry.slug ? { groupSlug: entry.slug } : {}),
+      members: entry.members,
+      size: entry.members.length,
+      minimumGroupSize,
+      ...(distinct.length > 1 ? { minimumGroupSizeValues: distinct } : {}),
+      wouldForm: entry.members.length >= minimumGroupSize,
+    };
+    return { ...base, verdict: verdictOf(base) };
+  });
+  const disagreements = groups.filter((group) => group.minimumGroupSizeValues);
+  return {
+    updates: simulated.length,
+    groups,
+    ungrouped,
+    notes: [
+      SCOPE_NOTE,
+      BRANCH_NOTE,
+      ...disagreements.map(
+        (group) =>
+          `"${group.groupName}": its members carry different minimumGroupSize values ` +
+          `(${group.minimumGroupSizeValues?.join(", ")}) — the verdict uses the largest.`,
+      ),
+    ],
+  };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/** The tally as pretty output prints it. */
+export function groupTallyLines(tally: GroupTally): string[] {
+  const headline =
+    `${plural(tally.groups.length, "group")} over ${plural(tally.updates, "simulated update")}` +
+    (tally.ungrouped.length > 0 ? ` (${plural(tally.ungrouped.length, "update")} ungrouped)` : "") +
+    ".";
+  const lines = [headline];
+  for (const group of tally.groups) {
+    lines.push("", `  ${group.verdict}`);
+    for (const member of group.members) {
+      lines.push(
+        `      ${member.depName ?? "(unnamed dependency)"}` +
+          (member.updateType ? ` (${member.updateType})` : ""),
+      );
+    }
+  }
+  if (tally.ungrouped.length > 0) {
+    lines.push("", "  Ungrouped — each update gets its own PR:");
+    for (const member of tally.ungrouped) {
+      lines.push(
+        `      ${member.depName ?? "(unnamed dependency)"}` +
+          (member.updateType ? ` (${member.updateType})` : ""),
+      );
+    }
+  }
+  lines.push("", ...tally.notes.map((note) => note));
+  return lines;
+}

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -195,6 +195,7 @@ describe("bin/rcd-dev.mjs mcp", () => {
       "get_provenance",
       "get_resolved_config",
       "simulate",
+      "simulate_group",
       "compare_simulations",
       "explain_message",
       "get_option_docs",

--- a/packages/cli/test/fixtures/group-minimum.json
+++ b/packages/cli/test/fixtures/group-minimum.json
@@ -1,0 +1,11 @@
+{
+  "labels": ["deps"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["react", "react-dom"],
+      "groupName": "react monorepo",
+      "minimumGroupSize": 3
+    },
+    { "matchPackageNames": ["chalk"], "groupName": "cosmetics" }
+  ]
+}

--- a/roadmap/074-group-simulation.md
+++ b/roadmap/074-group-simulation.md
@@ -1,0 +1,83 @@
+# 074 — Group-level simulation: would this group actually form?
+
+Milestone: M19 · Status: in progress
+
+## Summary
+
+`simulate` evaluates the packageRules against ONE hypothetical update, by
+construction. That makes a whole class of question unanswerable: grouping is a
+property of a SET of updates, and `minimumGroupSize` is a gate over that set.
+Persona replay 03 named the gap precisely — both entry-level sessions on the
+`44529` scenario ("why does this group wait?") produced correct diagnoses of
+everything the tools could see, then had to hedge the one question the scenario
+was actually about: _"given N pending updates, would the group meet its
+minimum?"_ Their reports called it "a real gap for this bug class, not an
+inconvenience", and it was the only question in the study no tool on either
+transport could close.
+
+This layer answers it with arithmetic the engine already knows how to produce:
+`rcd group` (CLI) and `simulate_group` (MCP) take SEVERAL updates, run the
+same per-dependency evaluation `simulate` runs for each, and tally the results
+by the `groupName` each update's matching rules produced.
+
+## What it models, and what it refuses to
+
+Each supplied update is simulated exactly as `simulate` would (same
+`simulatePackageRules`, same updateType derivation, same missing-input
+accounting). From each per-dependency config the tally reads three keys:
+
+- `groupName` — membership. Unset means ungrouped: that update gets its own PR.
+- `groupSlug` — carried through when set; branch names build on it.
+- `minimumGroupSize` — the gate. Absent or non-numeric reads as Renovate's
+  default of 1 (no gate).
+
+Per group the answer is `members`, `size`, `minimumGroupSize`, `wouldForm`
+(`size >= minimumGroupSize`) and a one-sentence citable `verdict` — the same
+verdict-first shape roadmap 048 established for `simulate`.
+
+Three honesty rules, all stated in the answer's `notes` rather than assumed:
+
+1. **The tally is over the supplied list.** Renovate evaluates
+   `minimumGroupSize` against the repository's real pending updates at run
+   time. `wouldForm: false` means "these updates alone don't reach it", never
+   "this group can never form". The scope note travels on every answer.
+2. **Members that disagree on the gate are named.** `minimumGroupSize` is
+   rule-scoped, so two members of one group can carry different values; inside
+   Renovate the effective value is then ordering-dependent. The tally takes
+   the largest (the conservative reading), reports the spread in
+   `minimumGroupSizeValues`, and says so in a note.
+3. **This is not a branch simulator.** `separateMajorMinor`,
+   `separateMultipleMajor` and custom `branchName` templates can split one
+   groupName across branches; modeling that would mean reimplementing the
+   branchifier against a moving target. Membership is by `groupName` as the
+   rules resolved it, and the note says exactly that.
+
+A member whose descriptor left rule inputs unset is flagged per member (same
+reasoning as `compare`'s per-side notes): a rule that would have grouped it
+reported a plain `no-match`, so a blind tally reads as "these updates just
+don't group".
+
+## Surface
+
+- **CLI**: `rcd group <file> --dep '{…}' --dep '{…}'` (repeatable) or
+  `--deps-file updates.json` (JSON array of the same objects). At least two
+  updates — one update is `simulate`'s question, and the error says so.
+  `--dep` became repeatable in the shared option table; `simulate`/`compare`
+  reject a second occurrence with a pointer at `group` instead of silently
+  taking the last one.
+- **MCP**: `simulate_group { runId, deps: [DEP, …] }` (min 2, enforced by the
+  schema) over a held run. Same projection, same notes; the instructions
+  paragraph names it next to `simulate`.
+
+The tally lives in `projections/group.ts`, shared by both transports like every
+other projection since roadmap 070, and is pure over
+`{ dep, finalDependencyConfig }` pairs — the unit tests never run the pipeline.
+
+## Deliberately out of scope
+
+- Auto-deriving the update list from a repository (lock files, datasource
+  lookups) — the debugger simulates hypotheticals; fetching real pending
+  updates is Renovate's job.
+- Per-group schedule/branch-concurrency reasoning (`prConcurrentLimit`,
+  `schedule`) — different gates, different questions, and none of them were
+  the replay-03 gap.

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -78,6 +78,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [071](071-rule-index-provenance.md)                     | Rule indexes: per-layer ranges, and one number per rule              | M19                  | in progress |
 | [072](072-option-docs-depth.md)                         | Option docs: where an option may go, and what the table cannot know  | M19                  | in progress |
 | [073](073-focused-by-default.md)                        | Focused by default: the answer that acted, and a map of the rest     | M19                  | in progress |
+| [074](074-group-simulation.md)                          | Group-level simulation: would this group actually form?              | M19                  | in progress |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
Roadmap 074. `simulate` is one dependency at a time by construction, so
"given N pending updates, would the group reach its minimumGroupSize?"
was unanswerable — the one question in persona replay 03 no tool on
either transport could close (both 44529 entry sessions hedged exactly
here).

`rcd group` (repeatable `--dep`, or `--deps-file` with a JSON array) and
the MCP `simulate_group` tool run the same per-dependency evaluation
`simulate` runs for each update, then tally by the `groupName` the rules
produced: members, size, the `minimumGroupSize` gate, `wouldForm`, and a
one-sentence citable verdict per group; ungrouped updates are listed as
one PR each. Members that disagree on the gate are tallied against the
largest value and the spread is named. Two caveats travel on every
answer: the tally is over the supplied list (Renovate evaluates the gate
against the repository's real pending updates), and branch splitting
(separateMajorMinor, branchName templates) is not modeled.

The tally is a pure projection (`projections/group.ts`) shared by both
transports; `--dep` became repeatable in the shared option table, and
`simulate`/`compare` reject a second occurrence with a pointer at
`group` instead of silently taking the last one.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>