### PR TITLE
fix(cli): close the replay-04 friction points on both transports

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -349,11 +349,13 @@ is a different failure from `no-match` — and a rule that lost only to unset
 input is counted in `missingInputs` on both commands, per side on `compare`
 (`a.missingInputs`/`b.missingInputs`, and an `A — …` / `B — …` line in pretty
 output). Two sides that both went blind on the same rule agree perfectly, so
-`identical:` over them says nothing about your edit. And if either input config
-would be
-refused by Renovate, both commands exit `2`, which says nothing about the
-simulation itself, so they also say so on their own output (`exitNote` in JSON, a
-trailing `note:` line in pretty).
+`identical:` over them says nothing about your edit. If the input config would
+be refused by Renovate, `simulate` exits `2` and says so on its own output
+(`exitNote` in JSON, a trailing `note:` line in pretty). `compare` exits `0`
+whenever the comparison ran — its exit code reflects the comparison, not the
+inputs' validity, so a proven "no behavioral change" over a config that
+`validate` rejects is still a `0`; the refusal stays a named fact on the output
+(`wouldRefuse` per side, the same `note:`/`exitNote`).
 
 ### Group-level answers: `rcd group`
 
@@ -468,6 +470,11 @@ re-embed all of it on both sides. An append is now stated as what it appended
 `2` is deliberate. Claude Code hooks read exit 2 as the blocking "feed stderr
 back to the model and fix it" signal, so `rcd validate` drops into a
 Stop/PreToolUse hook with no wrapper around it.
+
+One exception: `compare` exits `0` whenever the comparison itself ran, even
+over an input config Renovate would refuse — its verdict is the answer, and a
+`2` there read as "the comparison failed" (replay-04). The refusal is still
+reported on the output.
 
 ## Credentials
 

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -351,10 +351,14 @@ describe("compare separates behavior from rule identity", () => {
   });
 });
 
-/** Roadmap 062 (2 of 9 sessions): exit 2 came from an INPUT config failing
- *  validation and said nothing about the comparison it accompanied. */
+/** Roadmap 062 flagged the missing explanation; replay-04 (three sessions)
+ *  showed the exit code itself was the problem: a proven "no behavioral
+ *  change" arrived as a 2 because an INPUT config failed validation, and a
+ *  script gating an edit on compare's exit code would read a safe refactor as
+ *  a failure. The comparison is the answer, so a comparison that ran is a 0
+ *  and the refusal stays a named fact on the output. */
 describe("compare on a config Renovate would refuse", () => {
-  test("names which side caused the 2", async () => {
+  test("exits 0 — the comparison ran — and names the refused side on the output", async () => {
     const io = recordingIo();
     expect(
       await main(
@@ -367,9 +371,35 @@ describe("compare on a config Renovate would refuse", () => {
         ],
         io,
       ),
-    ).toBe(2);
+    ).toBe(0);
     expect(io.stdout).toContain("note: config A would be refused by Renovate");
-    expect(io.stdout).toContain("not this command's answer");
+    expect(io.stdout).toContain("the exit code reflects the comparison, not the refusal");
+  });
+
+  test("JSON still carries the per-side refusal facts", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "compare",
+          fixture("invalid.json"),
+          fixture("grouped.json"),
+          "--dep",
+          '{"depName":"react"}',
+          "--format",
+          "json",
+        ],
+        io,
+      ),
+    ).toBe(0);
+    const payload = io.json() as {
+      a: { wouldRefuse: boolean };
+      b: { wouldRefuse: boolean };
+      exitNote: string;
+    };
+    expect(payload.a.wouldRefuse).toBe(true);
+    expect(payload.b.wouldRefuse).toBe(false);
+    expect(payload.exitNote).toContain("config A would be refused");
   });
 });
 

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -1,9 +1,9 @@
 import { compareSimulations, type SimulationComparison } from "@renovate-config-debugger/engine";
 import { outputFormat, stringOption } from "../args";
 import type { Command } from "../command";
-import { EXIT_OK, EXIT_REFUSED } from "../io";
+import { EXIT_OK } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
-import { INPUT_OPTIONS, refusalNote, runOne, takeInputFile, wouldRefuse } from "../run-input";
+import { INPUT_OPTIONS, runOne, takeInputFile, wouldRefuse } from "../run-input";
 import { readDependency } from "../dep";
 import { deltaLine, parseConfigScope, parseKeys } from "../projections/config-view";
 import {
@@ -53,6 +53,29 @@ export function comparisonHeadline(comparison: HeadlineFields): string {
             "touched the very selectors that rule matches on."
         : `✓ No behavioral change: ${comparison.netEffect}.`;
   }
+}
+
+/**
+ * Replay-04 (three sessions, one calling it "the sharpest citability problem"):
+ * compare used to exit 2 whenever an INPUT config would be refused, so a
+ * proven "No behavioral change" arrived with the exit code of a failure — the
+ * one command whose exit code a script gates an edit on was the one whose exit
+ * code did not state its own verdict. The comparison IS the answer here, so a
+ * comparison that ran exits 0, and the refusal stays a named fact on the
+ * output (`wouldRefuse` per side, this note in pretty and `exitNote` in JSON).
+ * `validate` is the command whose exit code carries refusal.
+ */
+function compareRefusalNote(refused: readonly string[]): string | undefined {
+  if (refused.length === 0) {
+    return undefined;
+  }
+  const subject = refused.length === 1 ? refused[0] : refused.join(" and ");
+  const verb = refused.length === 1 ? "would be" : "would both be";
+  return (
+    `note: ${subject} ${verb} refused by Renovate (the parse or validate stage failed) — the ` +
+    "comparison above still ran on its resolved output and the exit code reflects the " +
+    "comparison, not the refusal. `rcd validate` lists the messages and exits 2 on them."
+  );
 }
 
 /**
@@ -117,6 +140,10 @@ export const compareCommand: Command = {
     "and states the identity axis as counts; `--detail rules` restores the rule",
     "and identity arrays (`matchedInBoth` included), `--detail full` the",
     "comparison exactly as the engine computes it, selector signatures and all.",
+    "",
+    "Exit code 0 means the comparison ran — even when an input config would be",
+    "refused by Renovate (a note names the side; `wouldRefuse` in JSON).",
+    "`rcd validate` is the command whose exit code reports refusal.",
   ],
   options: [
     ...INPUT_OPTIONS,
@@ -168,7 +195,7 @@ export const compareCommand: Command = {
 
     const refusedA = wouldRefuse(a.result);
     const refusedB = wouldRefuse(b.result);
-    const refusal = refusalNote([
+    const refusal = compareRefusalNote([
       ...(refusedA ? ["config A"] : []),
       ...(refusedB && b.result !== a.result ? ["config B"] : []),
     ]);
@@ -231,6 +258,6 @@ export const compareCommand: Command = {
         ...(refusal ? ["", refusal] : []),
       ]);
     }
-    return refusedA || refusedB ? EXIT_REFUSED : EXIT_OK;
+    return EXIT_OK;
   },
 };

--- a/packages/cli/src/commands/group.test.ts
+++ b/packages/cli/src/commands/group.test.ts
@@ -113,8 +113,55 @@ describe("group", () => {
       ),
     ).toBe(0);
     const tally = io.json() as { notes: string[] };
-    // mixed-rules has a matchSourceUrls rule neither bare descriptor can feed.
-    expect(tally.notes.join(" ")).toContain("could not match because this update leaves a field");
+    // mixed-rules has a matchSourceUrls rule neither bare descriptor can feed —
+    // and the note names the field (replay-04: "a field" sent the entry
+    // persona into trial and error that naming `sourceUrl` would have skipped).
+    expect(tally.notes.join(" ")).toContain("could not match because this update leaves");
+    expect(tally.notes.join(" ")).toContain("sourceUrl");
+    expect(tally.notes.join(" ")).toContain("`rcd simulate`");
+  });
+
+  /** Replay-04: "0 groups" over starved descriptors read as "these updates
+   *  just don't group" — the headline now says the tally may be blind. */
+  test("a tally with no groups over gap-ridden updates corrects its headline", async () => {
+    const io = recordingIo();
+    expect(
+      await main(
+        [
+          "group",
+          fixture("mixed-rules.json"),
+          "--dep",
+          '{"depName":"left-pad"}',
+          "--dep",
+          '{"depName":"is-odd"}',
+        ],
+        io,
+      ),
+    ).toBe(0);
+    // Neither dep matches a grouping rule, and both starve the matchSourceUrls
+    // rule — the pretty headline carries the correction, not just a footnote.
+    expect(io.stdout).toContain("0 groups over 2 simulated updates");
+    expect(io.stdout).toContain("this tally may be blind, not empty");
+
+    const json = recordingIo();
+    expect(
+      await main(
+        [
+          "group",
+          fixture("mixed-rules.json"),
+          "--dep",
+          '{"depName":"left-pad"}',
+          "--dep",
+          '{"depName":"is-odd"}',
+          "--format",
+          "json",
+        ],
+        json,
+      ),
+    ).toBe(0);
+    // Same claim first in the JSON notes — the transports must agree.
+    const tally = json.json() as { notes: string[] };
+    expect(tally.notes[0]).toContain("this tally may be blind, not empty");
   });
 });
 

--- a/packages/cli/src/commands/group.ts
+++ b/packages/cli/src/commands/group.ts
@@ -5,33 +5,15 @@ import { EXIT_OK, EXIT_REFUSED } from "../io";
 import { emitJson, emitLines, writeNotes } from "../output";
 import { INPUT_OPTIONS, refusalNote, runFromArgs, wouldRefuse } from "../run-input";
 import { readDependencies } from "../dep";
-import { groupTally, groupTallyLines } from "../projections/group";
+import { blindTallyNote, groupTally, groupTallyLines, inputGaps } from "../projections/group";
 import { simulateAgainst } from "./simulate";
 
 /**
  * Roadmap 074: "given these pending updates, which groups form, and would each
  * meet its `minimumGroupSize`?" — the batch-level question `simulate` cannot
- * answer one dependency at a time.
+ * answer one dependency at a time. The per-member gap notes and the
+ * blind-tally correction live in the projection, shared with `simulate_group`.
  */
-
-/** A side's input gap, stated per update: a rule that could not be evaluated
- *  for one member is a fact about that member's descriptor, and a group tally
- *  over blind simulations reads as "these updates just don't group". */
-function inputGapNotes(
-  simulated: readonly { dep: DependencyDescriptor; sim: SimulationResult }[],
-): string[] {
-  return simulated.flatMap(({ dep, sim }, index) => {
-    const count = sim.missingInputs.rules;
-    if (count === 0) {
-      return [];
-    }
-    const name = dep.depName ?? `update ${index + 1}`;
-    return [
-      `${name}: ${count} rule${count === 1 ? "" : "s"} could not match because this update ` +
-        "leaves a field they read unset — `rcd simulate` that update to see which.",
-    ];
-  });
-}
 
 export const groupCommand: Command = {
   name: "group",
@@ -64,19 +46,20 @@ export const groupCommand: Command = {
       simulated.push({ dep, sim: await simulateAgainst(result, dep) });
     }
     const tally = groupTally(simulated);
-    const gaps = inputGapNotes(simulated);
+    const gaps = inputGaps(simulated, "cli");
+    const blind = blindTallyNote(tally, gaps.length);
     const refused = wouldRefuse(result);
     const refusal = refusalNote(refused ? ["the config"] : []);
     if (format === "json") {
       emitJson(io, {
         ...tally,
-        notes: [...tally.notes, ...gaps],
+        notes: [...(blind ? [blind] : []), ...tally.notes, ...gaps],
         wouldRefuse: refused,
         ...(refusal ? { exitNote: refusal } : {}),
       });
     } else {
       emitLines(io, [
-        ...groupTallyLines(tally),
+        ...groupTallyLines(tally, gaps),
         ...gaps.map((gap) => `note: ${gap}`),
         ...(refusal ? ["", refusal] : []),
       ]);

--- a/packages/cli/src/mcp/run-store.ts
+++ b/packages/cli/src/mcp/run-store.ts
@@ -102,4 +102,16 @@ export class RunStore {
   get size(): number {
     return this.#runs.size;
   }
+
+  /** The eviction bound, so `run_config`'s answer can state it up front —
+   *  replay-04's experts each lost a runId to it and burned a call
+   *  rediscovering the policy from the `get` error. */
+  get limit(): number {
+    return this.#limit;
+  }
+
+  /** Ids currently held, oldest first — the first is the next to be evicted. */
+  heldIds(): string[] {
+    return [...this.#runs.keys()];
+  }
 }

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -248,6 +248,30 @@ describe("run_config", () => {
     expect(summary).not.toHaveProperty("finalConfig");
   });
 
+  /** Replay-04 (both MCP experts): a runId silently evicted mid-session cost a
+   *  call each — the retention policy must be visible BEFORE the eviction. */
+  test("the answer states the retention policy, and warns at capacity", async () => {
+    await close();
+    await connect({ store: new RunStore(2) });
+    const first = (await call("run_config", { fileName: "renovate.json", content: CONFIG })) as {
+      runId: string;
+      held: { runIds: string[]; limit: number; note?: string };
+    };
+    expect(first.held.limit).toBe(2);
+    expect(first.held.runIds).toEqual([first.runId]);
+    expect(first.held.note).toBeUndefined();
+
+    const second = (await call("run_config", { fileName: "renovate.json", content: CONFIG })) as {
+      runId: string;
+      held: { runIds: string[]; note?: string };
+    };
+    // At capacity: the oldest-first list names what the next run_config
+    // evicts, and the note says so in words.
+    expect(second.held.runIds).toEqual([first.runId, second.runId]);
+    expect(second.held.note).toContain(`the next run_config evicts ${first.runId}`);
+    expect(second.held.note).toContain("fresh");
+  });
+
   test("a config Renovate would refuse says so instead of failing", async () => {
     const summary = (await call("run_config", {
       fileName: "renovate.json",
@@ -1674,6 +1698,21 @@ describe("RunStore", () => {
     expect(() => store.get(b.runId)).toThrow(/no run/);
     expect(store.get(a.runId).runId).toBe(a.runId);
     expect(store.get(c.runId).runId).toBe(c.runId);
+  });
+
+  test("states its own policy: the limit, and the held ids oldest first", () => {
+    const store = new RunStore(2);
+    const fake = { events: [], errors: [], warnings: [] } as unknown as Parameters<
+      RunStore["put"]
+    >[0];
+    const input = { fileName: "renovate.json", content: "{}" };
+    expect(store.limit).toBe(2);
+    const a = store.put(fake, input);
+    const b = store.put(fake, input);
+    expect(store.heldIds()).toEqual([a.runId, b.runId]);
+    // A get refreshes recency, so the drilled-into run leaves eviction order.
+    store.get(a.runId);
+    expect(store.heldIds()).toEqual([b.runId, a.runId]);
   });
 });
 

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -53,7 +53,7 @@ import {
   previewValue,
   provenanceOf,
 } from "../projections/provenance";
-import { groupTally } from "../projections/group";
+import { blindTallyNote, groupTally, inputGaps } from "../projections/group";
 import { oneRuleView, RULE_DIGEST_PLANS, ruleProvenanceView } from "../projections/rule-provenance";
 import {
   BODIES,
@@ -384,7 +384,30 @@ const MESSAGES_NOTE =
   "`index` on each message) rather than re-typing the text; a re-typed message that does not " +
   "match the run exactly comes back with severity null.";
 
-function runSummary(run: HeldRun, notes: string[]) {
+/**
+ * The retention facts, stated on every `run_config` answer (replay-04): the
+ * store is a small LRU, and both expert sessions lost their baseline runId to
+ * it mid-comparison — the policy must be visible BEFORE the eviction, not only
+ * in the error after it. `runIds` is oldest-first, so the first listed is the
+ * next to go.
+ */
+function heldView(store: RunStore) {
+  const runIds = store.heldIds();
+  return {
+    runIds,
+    limit: store.limit,
+    ...(runIds.length >= store.limit
+      ? {
+          note:
+            `at capacity — the server holds the ${store.limit} most recently used runs, and ` +
+            `the next run_config evicts ${runIds[0]}. An evicted runId just needs a fresh ` +
+            "run_config of the same content.",
+        }
+      : {}),
+  };
+}
+
+function runSummary(run: HeldRun, notes: string[], store: RunStore) {
   const { result, facts } = run;
   const payload = digestPayload(result, facts);
   const stats = result.presetTree ? treeStatsOf(result).stats : null;
@@ -399,6 +422,7 @@ function runSummary(run: HeldRun, notes: string[]) {
     ...(result.errors.length + result.warnings.length > 0 ? { messagesNote: MESSAGES_NOTE } : {}),
     presetErrors: facts.presetErrors.map((event) => event.title),
     treeSummary: stats?.summary ?? null,
+    held: heldView(store),
     ...(notes.length > 0 ? { notes } : {}),
   };
 }
@@ -506,7 +530,10 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
         "Resolves a Renovate config exactly as the web app does — parse, migrate, massage, " +
         "validate, resolve presets, merge — and HOLDS the trace. Returns a small summary plus a " +
         "runId; every other tool takes that runId, so a whole debugging session describes ONE " +
-        "run instead of re-resolving (and re-fetching remote presets) per question. Start here.",
+        "run instead of re-resolving (and re-fetching remote presets) per question. Start here. " +
+        "Only the few most recently used runs stay held (`held` in the answer states the limit " +
+        "and what is next to be evicted) — an evicted runId is recoverable by re-running the " +
+        "same content.",
       // The one tool that reaches the network: `extends` can name a preset on
       // GitHub, GitLab, Gitea or Forgejo. Not idempotent for the same reason —
       // a remote preset can change between two runs, which is exactly why the
@@ -592,7 +619,7 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       };
       throwIfCancelled(ctx);
       const result: TraceResult = await runPipeline(input, ctx.mcpReq.signal);
-      return runSummary(store.put(result, input), notes);
+      return runSummary(store.put(result, input), notes, store);
     }),
   );
 
@@ -974,19 +1001,12 @@ export function createMcpServer(io: CliIo, options?: McpServerOptions): McpServe
       const tally = groupTally(simulated);
       // A member whose descriptor left rule inputs unset can be mis-tallied —
       // a rule that would put it in a group reported a plain `no-match`. Named
-      // per member, same reasoning as compare's per-side notes.
-      const gaps = simulated.flatMap(({ dep, sim }, index) => {
-        const count = sim.missingInputs.rules;
-        if (count === 0) {
-          return [];
-        }
-        const name = dep.depName ?? `deps[${index}]`;
-        return [
-          `${name}: ${count} rule${count === 1 ? "" : "s"} could not match because this ` +
-            "update leaves a field they read unset — simulate that update to see which.",
-        ];
-      });
-      return { ...tally, notes: [...tally.notes, ...gaps] };
+      // per member (fields included), and when the whole tally came out empty
+      // over blind members, the correction leads the notes — same text the CLI
+      // headline carries.
+      const gaps = inputGaps(simulated, "mcp");
+      const blind = blindTallyNote(tally, gaps.length);
+      return { ...tally, notes: [...(blind ? [blind] : []), ...tally.notes, ...gaps] };
     }, HINTS.simulate),
   );
 

--- a/packages/cli/src/projections/group.test.ts
+++ b/packages/cli/src/projections/group.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { groupTally, groupTallyLines } from "./group";
+import type { MissingInputSummary } from "@renovate-config-debugger/engine";
+import { blindTallyNote, groupTally, groupTallyLines, inputGaps } from "./group";
 
 /**
  * Roadmap 074. Pure — no pipeline run: the tally is arithmetic over the
@@ -99,5 +100,67 @@ describe("groupTally", () => {
     expect(text).toContain("Ungrouped — each update gets its own PR:");
     expect(text).toContain("lodash (patch)");
     expect(text).toContain("updates YOU supplied");
+  });
+});
+
+/**
+ * Replay-04: the gap notes now name the unset FIELDS, and a tally that formed
+ * no groups over gap-ridden updates says it may be blind — both shared here so
+ * the CLI and simulate_group cannot phrase the correction differently.
+ */
+const summary = (rules: number, fieldLists: string[]): MissingInputSummary => ({
+  rules,
+  groups: fieldLists.map((fieldList) => ({
+    fields: fieldList.split(" or "),
+    fieldList,
+    selectors: ["matchSourceUrls"],
+    rules,
+    sampleRuleIndexes: [1],
+  })),
+});
+
+describe("inputGaps / blindTallyNote", () => {
+  test("a gap note names the update, the count and the fields", () => {
+    const gaps = inputGaps(
+      [
+        { dep: { depName: "react" }, sim: { missingInputs: summary(2, ["sourceUrl"]) } },
+        { dep: { depName: "lodash" }, sim: { missingInputs: summary(0, []) } },
+      ],
+      "cli",
+    );
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toContain("react: 2 rules could not match");
+    expect(gaps[0]).toContain("leaves sourceUrl unset");
+    expect(gaps[0]).toContain("`rcd simulate`");
+  });
+
+  test("the MCP spelling names the tool, not the flag", () => {
+    const gaps = inputGaps(
+      [{ dep: {}, sim: { missingInputs: summary(1, ["packageFile or lockFiles"]) } }],
+      "mcp",
+    );
+    expect(gaps[0]).toContain("update 1: 1 rule could not match");
+    expect(gaps[0]).toContain("leaves packageFile or lockFiles unset");
+    expect(gaps[0]).toContain("simulate that update");
+    expect(gaps[0]).not.toContain("rcd");
+  });
+
+  test("blind only when NO group formed and gaps exist", () => {
+    const empty = groupTally([update("left-pad", "minor", {})]);
+    expect(blindTallyNote(empty, 1)).toContain("may be blind, not empty");
+    expect(blindTallyNote(empty, 0)).toBeUndefined();
+    const formed = groupTally([update("react", "minor", { groupName: "g" })]);
+    expect(blindTallyNote(formed, 1)).toBeUndefined();
+  });
+
+  test("pretty output carries the correction under the headline", () => {
+    const tally = groupTally([update("left-pad", "minor", {})]);
+    const gaps = inputGaps(
+      [{ dep: { depName: "left-pad" }, sim: { missingInputs: summary(3, ["sourceUrl"]) } }],
+      "cli",
+    );
+    const lines = groupTallyLines(tally, gaps);
+    expect(lines[0]).toBe("0 groups over 1 simulated update (1 update ungrouped).");
+    expect(lines[2]).toContain("may be blind, not empty");
   });
 });

--- a/packages/cli/src/projections/group.ts
+++ b/packages/cli/src/projections/group.ts
@@ -1,4 +1,5 @@
 import type { DependencyDescriptor, SimulationResult } from "@renovate-config-debugger/engine";
+import type { RunTransport } from "../run-input";
 
 /**
  * Roadmap 074: the group-level answer over SEVERAL simulated updates.
@@ -146,13 +147,65 @@ function plural(count: number, noun: string): string {
   return `${count} ${noun}${count === 1 ? "" : "s"}`;
 }
 
-/** The tally as pretty output prints it. */
-export function groupTallyLines(tally: GroupTally): string[] {
+/** The slice of a simulation the gap notes read — structural, like
+ *  {@link SimulatedUpdate}, so both transports hand in what they hold. */
+export interface GapInput {
+  dep: DependencyDescriptor;
+  sim: Pick<SimulationResult, "missingInputs">;
+}
+
+/**
+ * A member's input gap, per update, with the unset FIELDS named (replay-04:
+ * "a field they read unset" sent the entry persona through a trial-and-error
+ * loop that naming `sourceUrl` up front would have skipped). One shared
+ * function — the CLI's and the MCP tool's wording used to be two near-copies.
+ */
+export function inputGaps(simulated: readonly GapInput[], transport: RunTransport): string[] {
+  const spell = transport === "cli" ? "`rcd simulate`" : "simulate";
+  return simulated.flatMap(({ dep, sim }, index) => {
+    const count = sim.missingInputs.rules;
+    if (count === 0) {
+      return [];
+    }
+    const name = dep.depName ?? `update ${index + 1}`;
+    const fields = [...new Set(sim.missingInputs.groups.map((group) => group.fieldList))];
+    const named =
+      fields.length > 0 ? `leaves ${fields.slice(0, 3).join(" / ")} unset` : "leaves fields unset";
+    return [
+      `${name}: ${count} rule${count === 1 ? "" : "s"} could not match because this update ` +
+        `${named} — ${spell} that update to see which rules.`,
+    ];
+  });
+}
+
+/**
+ * The headline correction for a blind tally: "0 groups" over updates whose
+ * descriptors starved the matchers reads as "these updates just don't group",
+ * when the honest reading is "the tally could not see". Returned for BOTH
+ * transports to put first — the JSON notes array and the pretty headline must
+ * make the same claim.
+ */
+export function blindTallyNote(tally: GroupTally, gapCount: number): string | undefined {
+  if (tally.groups.length > 0 || gapCount === 0) {
+    return undefined;
+  }
+  return (
+    `No groups formed, but ${plural(gapCount, "update")} left fields unset that rules match ` +
+    "on — this tally may be blind, not empty. Fill the named fields and re-run before " +
+    "concluding these updates don't group."
+  );
+}
+
+/** The tally as pretty output prints it; `gaps` is {@link inputGaps}'s answer,
+ *  so a blind tally can correct itself right under the headline instead of in
+ *  a footnote nobody reads before concluding "these updates don't group". */
+export function groupTallyLines(tally: GroupTally, gaps: readonly string[] = []): string[] {
+  const blind = blindTallyNote(tally, gaps.length);
   const headline =
     `${plural(tally.groups.length, "group")} over ${plural(tally.updates, "simulated update")}` +
     (tally.ungrouped.length > 0 ? ` (${plural(tally.ungrouped.length, "update")} ungrouped)` : "") +
     ".";
-  const lines = [headline];
+  const lines = [headline, ...(blind ? ["", `⚠ ${blind}`] : [])];
   for (const group of tally.groups) {
     lines.push("", `  ${group.verdict}`);
     for (const member of group.members) {

--- a/packages/cli/src/projections/provenance.test.ts
+++ b/packages/cli/src/projections/provenance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import type { KeyProvenance } from "@renovate-config-debugger/engine";
-import { chainStepText, entryView } from "./provenance";
+import { chainStepText, entryView, perDependencyNote } from "./provenance";
 
 /**
  * Roadmap 071: what a step of the override chain reports for a key Renovate
@@ -87,5 +87,54 @@ describe("chainStepText", () => {
       ),
     );
     expect(view.chain.map((step) => chainStepText(step))).toEqual(['["a"]', '+1 → 2 total ["b"]']);
+  });
+});
+
+/**
+ * Replay-04 (CLI expert on 44006): `provenance automerge` carried no
+ * per-dependency note while `labels`/`autoApprove` did — `automerge` was set
+ * only INSIDE `:automergeMinor`'s update-type blocks, which the direct `key in
+ * rule` scan missed, and the absence read as "no rule touches this".
+ */
+describe("perDependencyNote", () => {
+  test("a direct rule-level setter counts as before", () => {
+    const note = perDependencyNote("labels", { packageRules: [{ labels: ["deps"] }] });
+    expect(note).toContain("1 packageRule can set `labels` per-dependency");
+    expect(note).not.toContain("update-type block");
+  });
+
+  test("a key set only inside an update-type block counts, named as conditional", () => {
+    const note = perDependencyNote("automerge", {
+      packageRules: [{ matchPackageNames: ["react"], minor: { automerge: true } }],
+    });
+    expect(note).toContain("1 packageRule can set `automerge` per-dependency");
+    expect(note).toContain("only inside an update-type block");
+    expect(note).toContain("applies only when the update's type matches");
+  });
+
+  test("mixed direct and nested setters state how many are conditional", () => {
+    const note = perDependencyNote("automerge", {
+      packageRules: [
+        { matchPackageNames: ["a"], automerge: true },
+        { matchPackageNames: ["b"], minor: { automerge: true } },
+        { matchPackageNames: ["c"], patch: { automerge: true } },
+      ],
+    });
+    expect(note).toContain("3 packageRules can set `automerge` per-dependency");
+    expect(note).toContain("2 of them only inside an update-type block");
+  });
+
+  test("a rule that sets the key both ways is counted once, as direct", () => {
+    const note = perDependencyNote("automerge", {
+      packageRules: [{ automerge: false, minor: { automerge: true } }],
+    });
+    expect(note).toContain("1 packageRule can set `automerge` per-dependency");
+    expect(note).not.toContain("update-type block");
+  });
+
+  test("no setter anywhere stays silent, and packageRules itself is exempt", () => {
+    const rules = { packageRules: [{ minor: { automerge: true } }] };
+    expect(perDependencyNote("labels", rules)).toBeUndefined();
+    expect(perDependencyNote("packageRules", rules)).toBeUndefined();
   });
 });

--- a/packages/cli/src/projections/provenance.ts
+++ b/packages/cli/src/projections/provenance.ts
@@ -3,6 +3,7 @@ import {
   type KeyProvenance,
   type ProvenanceLayer,
   type TraceResult,
+  UPDATE_TYPE_KEYS,
 } from "@renovate-config-debugger/engine";
 import { isOverridden, multiContribBadgeKind } from "@renovate-config-debugger/app/headless";
 import { CliError } from "../io";
@@ -154,7 +155,20 @@ export function indexView(entry: KeyProvenance): ProvenanceIndexEntry {
  * `packageRules`, so the count is this config's, not Renovate's option
  * metadata. The clauses of those rules are the simulator's business, which is
  * what the note points at.
+ *
+ * A rule can also set the key INSIDE an update-type block (`minor:
+ * {automerge: true}` is how `:automergeMinor` works) — replay-04's expert
+ * read the note's absence on `automerge` as "no rule touches this", exactly
+ * the misread the note exists to prevent, so nested writers count too and are
+ * named as conditional.
  */
+function setsNested(rule: Record<string, unknown>, key: string): boolean {
+  return UPDATE_TYPE_KEYS.some((block) => {
+    const nested = rule[block];
+    return nested !== null && typeof nested === "object" && key in nested;
+  });
+}
+
 export function perDependencyNote(
   key: string,
   finalConfig: Record<string, unknown> | undefined,
@@ -162,14 +176,25 @@ export function perDependencyNote(
   if (key === "packageRules" || !Array.isArray(finalConfig?.packageRules)) {
     return undefined;
   }
-  const setters = finalConfig.packageRules.filter(
-    (rule) => rule !== null && typeof rule === "object" && key in rule,
-  ).length;
+  const rules = finalConfig.packageRules.filter(
+    (rule): rule is Record<string, unknown> => rule !== null && typeof rule === "object",
+  );
+  const direct = rules.filter((rule) => key in rule).length;
+  const nested = rules.filter((rule) => !(key in rule) && setsNested(rule, key)).length;
+  const setters = direct + nested;
   if (setters === 0) {
     return undefined;
   }
+  const which =
+    nested === setters ? (setters === 1 ? "only" : "all of them only") : `${nested} of them only`;
+  const nestedClause =
+    nested === 0
+      ? ""
+      : ` (${which} inside an update-type block ` +
+        "such as `minor: {…}`, which applies only when the update's type matches)";
   return (
-    `${setters} packageRule${setters === 1 ? "" : "s"} can set \`${key}\` per-dependency — this ` +
+    `${setters} packageRule${setters === 1 ? "" : "s"} can set \`${key}\` per-dependency` +
+    `${nestedClause} — this ` +
     "chain is the repository-wide value. Simulate a dependency to see the value an actual " +
     "update would get."
   );

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -417,15 +417,17 @@ export function wouldRefuse(result: TraceResult): boolean {
 }
 
 /**
- * Roadmap 062 (2026-07 persona study): `simulate`/`compare` exit 2 whenever an
- * INPUT config would be refused — which says nothing about the simulation or
- * the comparison those commands just answered. Two personas hit the bare `2`
- * with no hint in the output; one ran a control experiment to work out where it
- * came from. So every command whose exit code can be 2 for a reason other than
- * its own answer says which input caused it, in words, on the same output.
+ * Roadmap 062 (2026-07 persona study): `simulate` (and, then, `compare`) exit
+ * 2 whenever an INPUT config would be refused — which says nothing about the
+ * answer those commands just gave. Two personas hit the bare `2` with no hint
+ * in the output; one ran a control experiment to work out where it came from.
+ * So every command whose exit code can be 2 for a reason other than its own
+ * answer says which input caused it, in words, on the same output.
  *
- * The exit-code contract itself is untouched (0/1/2 is documented and
- * hook-relied-upon) — this is the missing explanation, not a new behavior.
+ * `simulate`/`group` keep the `2` (their subject is one config, and the
+ * contract is documented and hook-relied-upon). `compare` no longer uses this
+ * note: replay-04 showed its `2` overruling its own "no behavioral change"
+ * verdict, so it exits on the comparison and carries its own wording.
  */
 export function refusalNote(refused: readonly string[]): string | undefined {
   if (refused.length === 0) {

--- a/packages/engine/src/simulate-compare.ts
+++ b/packages/engine/src/simulate-compare.ts
@@ -414,10 +414,14 @@ function netEffectOf(
   if (behavioral.length > 0) {
     return [keyList(behavioral), ...documentationTail, ...ruleChanges].join("; ");
   }
-  if (documentationTail.length === 0) {
-    return `${ruleChanges.join(" and ")}, with no change to the effective config`;
-  }
-  return [ruleChanges.join(" and "), ...documentationTail].join("; ");
+  // Stated even when documentation text moved (replay-04): "1 rule started
+  // matching; description also changed" read as a behavioral claim, and the
+  // one fact that scopes it — the effective config came out the same — was
+  // the clause this branch used to drop.
+  return [
+    `${ruleChanges.join(" and ")}, with no change to the effective config`,
+    ...documentationTail,
+  ].join("; ");
 }
 
 /**

--- a/packages/engine/test/simulate-compare.node.test.ts
+++ b/packages/engine/test/simulate-compare.node.test.ts
@@ -402,6 +402,23 @@ describe("compareSimulations", () => {
       );
     });
 
+    /** Replay-04 (CLI expert on 44529): "1 rule started matching; description
+     *  also changed" read as a behavioral claim — the clause that scopes it,
+     *  the effective config coming out the same, was dropped exactly when a
+     *  documentation key moved alongside the rule churn. */
+    it("keeps the no-config-change clause when only documentation moved with the rules", () => {
+      const a = simWritten([matched(0, [["matchPackageNames", ["lodash"]]])], {
+        description: ["Old."],
+      });
+      const b = simWritten([matched(1, [["matchSourceUrls", ["https://x"]]])], {
+        description: ["Old.", "New."],
+      });
+      expect(compareSimulations(a, b).summary).toBe(
+        "differs: 1 rule started matching and 1 rule stopped matching, " +
+          "with no change to the effective config; description also changed (documentation)",
+      );
+    });
+
     it("says identical for a behavior-preserving pattern edit, and why", () => {
       const a = sim([{ ...wide, merged: effect }], { groupName: "frontend" });
       const b = sim([{ ...narrow, merged: effect }], { groupName: "frontend" });


### PR DESCRIPTION
Persona replay 04 (18 sessions on the fix stack) confirmed the replay-03
items resolved and surfaced four new, smaller frictions plus one carried
nuance — all closed here:

- provenance: perDependencyNote now counts rules that set a key only
  inside an update-type block (minor: {automerge: true}), named as
  conditional — 'provenance automerge' no longer reads as 'no rule
  touches this' (CLI and MCP, shared projection).
- mcp: run_config answers carry 'held' (runIds oldest-first, limit, and
  an at-capacity note naming the next eviction), and the tool description
  states the retention policy — both experts lost a runId to the silent
  LRU and burned a call rediscovering it.
- compare: exits 0 whenever the comparison ran; an input config Renovate
  would refuse stays a named fact on the output (wouldRefuse per side,
  note/exitNote) instead of overruling a proven 'no behavioral change'
  with exit 2. simulate/group keep their documented 2.
- group/simulate_group: gap notes name the unset fields (sourceUrl, ...)
  and a tally that formed no groups over gap-ridden updates corrects its
  own headline ('may be blind, not empty') — shared projection, same
  wording on both transports.
- engine compare netEffect: the 'with no change to the effective config'
  clause survives when a documentation key moved alongside rule churn,
  so 'N rules started matching; description also changed' can no longer
  read as a behavioral claim.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>