### PR TITLE
fix(app): reset the provenance view state during render, not in an effect

### DIFF
--- a/packages/app/src/components/EffectiveConfig.tsx
+++ b/packages/app/src/components/EffectiveConfig.tsx
@@ -780,8 +780,16 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     expand === "full" && includeDefaults,
   );
 
-  // node ids and keys are per-run, so drop any stale expansion/filter state
-  useEffect(() => {
+  // node ids and keys are per-run, so drop any stale expansion/filter state.
+  // DURING RENDER, not in an effect (the `useDescriptionProvenance` idiom):
+  // effects flush after the commit, so a click landing in the gap between the
+  // commit that delivered this provenance and its passive flush would enqueue
+  // its expansion first and then be wiped by the reset — a user's first click
+  // silently undone, and the flake CI caught as "the expanded description row
+  // rendered no ledger".
+  const [resetOwner, setResetOwner] = useState(provenance);
+  if (resetOwner !== provenance) {
+    setResetOwner(provenance);
     setExpanded(new Set());
     setQuery("");
     setLayerFilter("all");
@@ -790,7 +798,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     setView("keys");
     setExpand("keep-internal");
     setIncludeDefaults(false);
-  }, [provenance]);
+  }
 
   const entries = useMemo(() => (provenance ? [...provenance.values()] : []), [provenance]);
 


### PR DESCRIPTION
## The flaky failure

[PR #208's CI run](https://github.com/secustor/renovate-config-debugger/actions/runs/32082250444/job/95548973905) failed once with `EffectiveConfig.test.tsx > expands the description row into a per-string blame ledger: the expanded description row rendered no ledger` — while every other stack layer, carrying the byte-identical component and test, passed in the same CI wave. Both the test and the code it exercises are on `main`; the stack is not involved.

## The race

`EffectiveConfig` dropped its per-run view state (expansion, filters, view mode) in a **passive effect** keyed on the async-resolved `provenance`:

```ts
useEffect(() => { setExpanded(new Set()); /* … */ }, [provenance]);
```

Effects flush after the commit. A click that lands in the gap between the commit that delivered the new provenance and that commit's passive flush enqueues its `setExpanded(add)` first — and the reset's plain `setExpanded(new Set())` then overwrites it. The row collapses again in the same flush, so the ledger never renders. The test's `waitFor` observing the committed DOM before passive effects run is exactly that gap; a slow runner widens it. It is also a (tiny) real bug: a user's first click within that window is silently undone.

## The fix

Reset during render via the owner-state idiom this codebase already documents and uses in `useDescriptionProvenance`: track the provenance identity in state and, when it changes, apply the resets in the same render pass. No commit pairs stale view state with new provenance, and no gap exists for a click to fall into.

Verified: app unit suite 619/619, lint, typecheck, format all green; the previously-flaky test passes (its synchronous post-click assertion is now guaranteed by construction).