### PR TITLE
chore(lint): enable react/globals and fix test harness captures

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -62,7 +62,6 @@
     "react/immutability": "off",
     "react/preserve-manual-memoization": "off",
     "react/memo-dependencies": "off",
-    "react/globals": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/use-focus-landing.test.tsx
+++ b/packages/app/src/app/use-focus-landing.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { type FocusLanding, useFocusLanding } from "./use-focus-landing";
 
@@ -17,7 +18,14 @@ afterEach(cleanup);
 let landing: FocusLanding | null = null;
 
 function Harness() {
-  landing = useFocusLanding();
+  const api = useFocusLanding();
+  // Reassigning the outer binding happens in an effect, not during render —
+  // `react/globals` only permits render itself to read props/state, not write
+  // an outside variable. `render`'s act() wrapper flushes it synchronously, so
+  // `mount()` still observes it before returning.
+  useEffect(() => {
+    landing = api;
+  }, [api]);
   return null;
 }
 

--- a/packages/app/src/hooks/use-engine-derivation.test.tsx
+++ b/packages/app/src/hooks/use-engine-derivation.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
 import { afterEach, expect, it, vi } from "vitest";
 import { useEngineDerivation } from "./use-engine-derivation";
 
@@ -71,7 +72,12 @@ it("settles every consumer that mounts in the same commit", async () => {
   function TwoConsumers() {
     const first = useEngineDerivation<string>(["k"], () => Promise.resolve("first"));
     const second = useEngineDerivation<string>(["k"], () => Promise.resolve("second"));
-    states = [first, second];
+    // Reassigning the outer binding happens in an effect, not during render —
+    // `react/globals` only permits render itself to read props/state, not write
+    // an outside variable.
+    useEffect(() => {
+      states = [first, second];
+    }, [first, second]);
     return null;
   }
 

--- a/packages/app/src/hooks/use-engine-derivation.test.tsx
+++ b/packages/app/src/hooks/use-engine-derivation.test.tsx
@@ -72,9 +72,6 @@ it("settles every consumer that mounts in the same commit", async () => {
   function TwoConsumers() {
     const first = useEngineDerivation<string>(["k"], () => Promise.resolve("first"));
     const second = useEngineDerivation<string>(["k"], () => Promise.resolve("second"));
-    // Reassigning the outer binding happens in an effect, not during render —
-    // `react/globals` only permits render itself to read props/state, not write
-    // an outside variable.
     useEffect(() => {
       states = [first, second];
     }, [first, second]);


### PR DESCRIPTION
oxlint 1.79.0's react/globals forbids reassigning outer variables during
render. Both hits were vitest probe components; the captures now happen
in effects, which RTL's act() flushes synchronously.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>