### PR TITLE
chore(lint): enable react/preserve-manual-memoization

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,7 +60,6 @@
     "react/set-state-in-effect": "off",
     "react/exhaustive-effect-dependencies": "off",
     "react/immutability": "off",
-    "react/preserve-manual-memoization": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -665,19 +665,46 @@ export function App() {
   // effect runs only after its content committed. `focusResultsRef` (armed by
   // onRun below) and `resultsColRef` (the pane to measure) are handed down.
 
+  // Roadmap 007/039: the repo reference the load form (and the welcome panel's
+  // shortcut) types into. App's state rather than `useRepoLoad`'s, because BOTH
+  // clusters below read it — the load parses it, the inherited-config layer
+  // derives its probe target from it — and one of them has to be declared
+  // first. Owning it here is what lets the layer come first without the load
+  // closing over bindings this render has not created yet: a forward capture is
+  // a value React Compiler must treat as "may change later", which costs the
+  // memoization of everything downstream of the layer's parse.
+  const [repoInput, setRepoInput] = useState("");
+  // Roadmap 045/048: the inherited-config layer — its text and parse, the
+  // probe-target fields, the `inheritConfig*` policy read off the global
+  // config, and the probe the repo load calls between the repo config arriving
+  // and the run that processes it. Declared BEFORE the load, which calls into
+  // it.
+  const {
+    inheritedText,
+    inheritedParse,
+    applyInheritedText,
+    inheritAuto,
+    inheritFields,
+    inheritState,
+    onInheritAutoFieldChange,
+    onInheritRepoFieldChange,
+    onInheritFileFieldChange,
+    probeInheritedConfig,
+  } = useInheritedConfigLayer({
+    globalConfig: globalParse.config,
+    repoInput,
+    revealInheritedStage,
+  });
   // Roadmap 048: the load-from-repo cluster — the disclosure and its focus
-  // hand-back, the reference fields, the in-flight flag, the auth hint, and
-  // the load itself. Called BEFORE the inherited-config layer because that
-  // layer derives its probe target from `repoInput`, which this hook owns;
-  // everything the load acts on is either declared above or (for the run path,
-  // the layer gate and the guard) a hoisted function declaration below.
+  // hand-back, the branch/tag field, the in-flight flag, the auth hint, and the
+  // load itself. Everything the load acts on is either declared above or (for
+  // the run path, the layer gate and the guard) a hoisted function declaration
+  // below.
   const {
     repoFormOpen,
     repoToggleRef,
     toggleRepoForm,
     closeRepoForm,
-    repoInput,
-    setRepoInput,
     repoRef,
     setRepoRef,
     repoLoading,
@@ -699,10 +726,11 @@ export function App() {
     onRun: (inputs, opts) => onRun(undefined, inputs, opts),
     globalConfig: globalParse.config,
     platformOverride: platformOverride && hasGlobalContext,
+    repoInput,
     oauthConfigured: Boolean(OAUTH_CONFIG),
     // Roadmap 045: the org probe when auto-load is on, otherwise the layer as
-    // it already stands. An arrow, so it reads the inherited-config layer
-    // declared below — by the time a load calls it, that binding exists.
+    // it already stands — resolved at the one point in the load's sequence a
+    // real `inheritConfig` run resolves it.
     resolveInheritedConfig: async (args) =>
       inheritAuto ? await probeInheritedConfig(args) : inheritedParse.config,
   });
@@ -713,26 +741,6 @@ export function App() {
     signedIn,
     query: repoInput,
     onPick: setRepoInput,
-  });
-  // Roadmap 045/048: the inherited-config layer — its text and parse, the
-  // probe-target fields, the `inheritConfig*` policy read off the global
-  // config, and the probe the repo load calls between the repo config arriving
-  // and the run that processes it.
-  const {
-    inheritedText,
-    inheritedParse,
-    applyInheritedText,
-    inheritAuto,
-    inheritFields,
-    inheritState,
-    onInheritAutoFieldChange,
-    onInheritRepoFieldChange,
-    onInheritFileFieldChange,
-    probeInheritedConfig,
-  } = useInheritedConfigLayer({
-    globalConfig: globalParse.config,
-    repoInput,
-    revealInheritedStage,
   });
   // Roadmap 032/076: the inherited layer's editor lives INSIDE the memoized
   // results pane now, so its change handler has to be identity-stable or the

--- a/packages/app/src/app/use-repo-load.ts
+++ b/packages/app/src/app/use-repo-load.ts
@@ -12,7 +12,10 @@
  *
  * App.tsx keeps everything the load acts ON — the editor's content, the
  * platform context, the layer parses, the untrusted-endpoint guard and the run
- * path itself — and hands it in through {@link RepoLoadHost}.
+ * path itself — and hands it in through {@link RepoLoadHost}. It also owns the
+ * reference field's state: the inherited-config layer derives its probe target
+ * from it, so the two hooks would otherwise have to close over each other's
+ * later-declared bindings (see `repoInput` below).
  */
 import { type RefObject, useRef, useState } from "react";
 import { ESCAPE_PRIORITY } from "@/lib/escape-stack";
@@ -61,12 +64,19 @@ export interface RepoLoadHost {
   /** `platformOverride && hasGlobalContext`, as the run takes it (010). */
   platformOverride: boolean;
   /**
+   * Roadmap 007/039: the reference the user types — App's state, not this
+   * hook's, because the inherited-config layer derives its probe target from
+   * the same string and is declared BEFORE this hook (it has to be: the load
+   * calls into it). Owning it here would mean one of the two hooks closing over
+   * a binding the render has not created yet.
+   */
+  repoInput: string;
+  /**
    * Roadmap 045: the inherited config the run should use — the org probe's
    * result when auto-load is on, otherwise whatever the layer already holds.
-   * A function, not a value, because App declares the inherited-config layer
-   * AFTER this hook (that layer derives from `repoInput`, which this hook
-   * owns); the load calls it at the one point in the sequence a real
-   * `inheritConfig` run resolves the layer.
+   * A function, not a value, because the probe is a fetch: the load calls it at
+   * the one point in the sequence a real `inheritConfig` run resolves the
+   * layer — after the repo config has arrived, before the run that processes it.
    */
   resolveInheritedConfig: (args: {
     platform: RepoPlatform;
@@ -88,8 +98,6 @@ export interface RepoLoad {
   repoToggleRef: RefObject<HTMLButtonElement | null>;
   toggleRepoForm: () => void;
   closeRepoForm: () => void;
-  repoInput: string;
-  setRepoInput: (value: string) => void;
   repoRef: string;
   setRepoRef: (value: string) => void;
   repoLoading: boolean;
@@ -116,6 +124,7 @@ export function useRepoLoad(host: RepoLoadHost): RepoLoad {
     onRun,
     globalConfig,
     platformOverride,
+    repoInput,
     resolveInheritedConfig,
     oauthConfigured,
   } = host;
@@ -124,7 +133,6 @@ export function useRepoLoad(host: RepoLoadHost): RepoLoad {
   // editor card's title bar.
   const [repoFormOpen, setRepoFormOpen] = useState(false);
   const repoToggleRef = useRef<HTMLButtonElement>(null);
-  const [repoInput, setRepoInput] = useState("");
   const [repoRef, setRepoRef] = useState("");
   const [repoLoading, setRepoLoading] = useState(false);
   // When a GitHub load fails with a not-found/auth/rate-limit error, offer the
@@ -340,8 +348,6 @@ export function useRepoLoad(host: RepoLoadHost): RepoLoad {
     repoToggleRef,
     toggleRepoForm,
     closeRepoForm,
-    repoInput,
-    setRepoInput,
     repoRef,
     setRepoRef,
     repoLoading,


### PR DESCRIPTION
Both App.tsx hits traced to useRepoLoad's resolveInheritedConfig arrow
forward-referencing bindings of the later-declared inherited-config
layer, which made every memo depending on inheritedParse unpreservable.
useInheritedConfigLayer now runs first, with repoInput lifted into App
and passed down, so the closure only captures already-declared bindings.
No memo bodies changed.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>