### PR TITLE
chore(lint): enable react/immutability

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -59,7 +59,6 @@
     "react/refs": "off",
     "react/set-state-in-effect": "off",
     "react/exhaustive-effect-dependencies": "off",
-    "react/immutability": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -412,6 +412,12 @@ export function App() {
   // result (identities → node ids need the resolved tree). A ref, not state, so
   // consuming it does not trigger a render.
   const pendingViewRef = useRef<ShareView | null>(null);
+  // …and the one way the share cluster arms it. A callback rather than the ref
+  // itself: the ref is App's, and a hook writing through an object handed to it
+  // is a hook mutating its own argument (`react/immutability`).
+  const setPendingView = useCallback((view: ShareView | null) => {
+    pendingViewRef.current = view;
+  }, []);
   // Roadmap 017: mirrors of `content`/`loadedContent` for the hashchange
   // listener (inside `useShareLink`), which is registered once (empty deps)
   // and would otherwise close over the state from that first render.
@@ -449,7 +455,7 @@ export function App() {
       // Roadmap 075 (iteration 6): the link's pins, with ids minted by the
       // cluster that owns them.
       setPins: setPinsFromShare,
-      pendingViewRef,
+      setPendingView,
       contentRef,
       loadedContentRef,
       buildShareState,
@@ -517,6 +523,20 @@ export function App() {
     requestDescriptionLedger();
   }, [jumpToTab, requestDescriptionLedger]);
 
+  /**
+   * A forward handle to the keyboard-landing cluster's preset landing. The
+   * cluster itself cannot be declared until `resultsTabs` exists (it is the run
+   * summary's, ~800 lines down), while `selectPresetNode` below has to be
+   * declared up here for `presetHover` — so the binding is reached through a
+   * ref rather than read out of a `const` that is still in its temporal dead
+   * zone at this point in the body (`react/immutability`).
+   *
+   * Same rule as the 032 latest-ref idiom: written on every render, read only
+   * from an event handler, i.e. always after the commit that filled it in. The
+   * no-op placeholder is never the one that runs — nothing can activate a
+   * cross-link before the first commit.
+   */
+  const landOnPresetNodeRef = useRef<() => void>(() => undefined);
   // Roadmap 028: selecting a preset node from anywhere else (a provenance
   // chip, a simulator rule, an editor preset hover) also switches to the
   // Presets tab. Identity-stable, so the preset-hover context — memoized on
@@ -531,7 +551,7 @@ export function App() {
     // landing the user's next Tab restarts at the top of the document. The
     // editor's preset hover is the third and keeps its caret — see
     // `jumpDisplacedFocus`.
-    landOnPresetNode();
+    landOnPresetNodeRef.current();
   });
   // The dependency is the REF, not the callback it holds: a ref object's
   // identity never changes, so this wrapper is still declared once for the
@@ -1169,19 +1189,8 @@ export function App() {
     }
   }
 
-  // Roadmap 032: `applyErrorFix` reads `content` and `errorLib`, so the
-  // memoized MessagesPanel gets this stable wrapper (latest-ref idiom) — an
-  // "Apply fix" click must patch the text as it is NOW, not as it was when
-  // the panel last rendered.
-  // The dependency is the REF, not the function it holds — its identity never
-  // changes, so the wrapper stays declared once (see `selectPresetNode`).
-  const applyErrorFixRef = useLatestRef(applyErrorFix);
-  const onApplyFix = useCallback(
-    (fix: ErrorFixResult) => {
-      void applyErrorFixRef.current(fix);
-    },
-    [applyErrorFixRef],
-  );
+  // The stable `onApplyFix` wrapper this function is reached through is
+  // registered after the keyboard-landing cluster below — see it for why.
 
   const authState: AuthState = !OAUTH_CONFIG
     ? "unconfigured"
@@ -1315,6 +1324,33 @@ export function App() {
     resultsColRef,
     configEditorRef,
   });
+  // …and the forward handle `selectPresetNode` (declared far above, because
+  // `presetHover` needs it) lands through. See its declaration.
+  landOnPresetNodeRef.current = landOnPresetNode;
+
+  /**
+   * Roadmap 032: `applyErrorFix` reads `content` and `errorLib`, so the
+   * memoized MessagesPanel gets this stable wrapper (latest-ref idiom) — an
+   * "Apply fix" click must patch the text as it is NOW, not as it was when
+   * the panel last rendered.
+   *
+   * The dependency is the REF, not the function it holds — its identity never
+   * changes, so the wrapper stays declared once (see `selectPresetNode`).
+   *
+   * Registered HERE rather than beside `applyErrorFix` itself: that function
+   * arms and lands through `landing`/`focusTab`, which the destructure above
+   * declares, and handing it to a hook any earlier reads those bindings while
+   * they are still in their temporal dead zone (`react/immutability`). The
+   * function declaration is hoisted, so only the registration had to move, and
+   * `onApplyFix` is consumed by the panel props memos further below.
+   */
+  const applyErrorFixRef = useLatestRef(applyErrorFix);
+  const onApplyFix = useCallback(
+    (fix: ErrorFixResult) => {
+      void applyErrorFixRef.current(fix);
+    },
+    [applyErrorFixRef],
+  );
 
   /**
    * Roadmap 068: what "the user asked for a run" means, in the one place its

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -13,7 +13,6 @@ import { PresetListPane } from "./PresetListPane";
 import { buildTableRows, flattenTree, type SortColumn, sortTableRows } from "./rows";
 import { SummaryHeader } from "./SummaryHeader";
 import { nf } from "@/lib/format";
-import { ROW_HEIGHT } from "./tree-shared";
 import { useEngineHelpers } from "./use-engine-helpers";
 import { useWindow } from "./use-window";
 
@@ -194,23 +193,22 @@ export const PresetTree = memo(function PresetTree({
   }, [selectedId, stats, expandAll]);
 
   // …then scroll the selected row into view once it is in the flattened list.
+  // The scroll itself is `useWindow`'s: the container is the element IT owns,
+  // and a caller writing to a value a hook handed back is what
+  // `react/immutability` forbids. `win.el` stays in the list as the signal it
+  // always was — the container (re)mounting is what makes a scroll that had no
+  // element to act on happen after all.
+  const { scrollRowIntoView } = win;
   useEffect(() => {
     if (!selectedId || view !== "tree") {
       return;
     }
     const idx = flatRows.findIndex((r) => r.node.id === selectedId);
-    const el = win.el;
-    if (idx < 0 || !el) {
+    if (idx < 0) {
       return;
     }
-    const top = idx * ROW_HEIGHT;
-    const bottom = top + ROW_HEIGHT;
-    if (top < el.scrollTop) {
-      el.scrollTop = top;
-    } else if (bottom > el.scrollTop + el.clientHeight) {
-      el.scrollTop = bottom - el.clientHeight;
-    }
-  }, [selectedId, flatRows, view, win.el]);
+    scrollRowIntoView(idx);
+  }, [selectedId, flatRows, view, win.el, scrollRowIntoView]);
 
   if (!root || root.children.length === 0 || !stats) {
     return null;

--- a/packages/app/src/features/presets/use-window.ts
+++ b/packages/app/src/features/presets/use-window.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { OVERSCAN, ROW_HEIGHT } from "./tree-shared";
 
 /**
@@ -8,6 +8,16 @@ import { OVERSCAN, ROW_HEIGHT } from "./tree-shared";
  */
 export function useWindow(count: number) {
   const [el, setEl] = useState<HTMLDivElement | null>(null);
+  // The same element, in the mutable half of the pair: `scrollRowIntoView`
+  // below WRITES to the container, and a state value is the one thing that may
+  // not be written to (`react/immutability`). The state stays what it always
+  // was — the render-visible "which element is mounted", which re-attaches the
+  // listeners below and tells the caller's effect to try its scroll again.
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const attach = useCallback((node: HTMLDivElement | null) => {
+    elRef.current = node;
+    setEl(node);
+  }, []);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewport, setViewport] = useState(400);
 
@@ -37,11 +47,36 @@ export function useWindow(count: number) {
     };
   }, [el]);
 
+  /**
+   * Scroll the row at `index` just far enough to be inside the viewport — the
+   * minimum move, so a row already visible is left exactly where it is.
+   *
+   * Lives here rather than at the call site because the container element is
+   * this hook's: adjusting the scroll position of a value a hook handed back is
+   * what `react/immutability` forbids, and the hook that constructed it is
+   * where the modification belongs. A no-op before the container mounts, which
+   * is the early return the caller used to make.
+   */
+  const scrollRowIntoView = useCallback((index: number) => {
+    const box = elRef.current;
+    if (!box) {
+      return;
+    }
+    const top = index * ROW_HEIGHT;
+    const bottom = top + ROW_HEIGHT;
+    if (top < box.scrollTop) {
+      box.scrollTop = top;
+    } else if (bottom > box.scrollTop + box.clientHeight) {
+      box.scrollTop = bottom - box.clientHeight;
+    }
+  }, []);
+
   const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
   const end = Math.min(count, Math.ceil((scrollTop + viewport) / ROW_HEIGHT) + OVERSCAN);
   return {
-    ref: setEl,
+    ref: attach,
     el,
+    scrollRowIntoView,
     start,
     end,
     padTop: start * ROW_HEIGHT,

--- a/packages/app/src/hooks/use-share-link.test.tsx
+++ b/packages/app/src/hooks/use-share-link.test.tsx
@@ -115,7 +115,7 @@ function makeHost(onRun: ShareLinkHost["onRun"]): ShareLinkHost {
     setAuthUser: noop,
     applyUntrustedGuard: noop,
     setPins: noop,
-    pendingViewRef: { current: null },
+    setPendingView: noop,
     // Equal, so a hashchange never has unsaved edits to confirm away.
     contentRef: { current: "" },
     loadedContentRef: { current: "" },
@@ -130,11 +130,19 @@ function makeHost(onRun: ShareLinkHost["onRun"]): ShareLinkHost {
   };
 }
 
-function Harness({ host, seen }: { host: ShareLinkHost; seen: { current: SimRequest | null } }) {
+/**
+ * The newest `simRequest` the hook produced, hoisted out of the render so a
+ * test can read it. A module binding rather than a ref-shaped prop: mutating a
+ * prop is what `react/immutability` forbids, in an effect as much as in the
+ * render.
+ */
+let seen: SimRequest | null = null;
+
+function Harness({ host }: { host: ShareLinkHost }) {
   const { simRequest } = useShareLink(null, host);
   useEffect(() => {
-    seen.current = simRequest;
-  }, [simRequest, seen]);
+    seen = simRequest;
+  }, [simRequest]);
   return null;
 }
 
@@ -151,8 +159,12 @@ async function openLink(token: string) {
 }
 
 function mount(onRun: ShareLinkHost["onRun"], overrides: Partial<ShareLinkHost> = {}) {
-  const seen: { current: SimRequest | null } = { current: null };
-  render(<Harness host={{ ...makeHost(onRun), ...overrides }} seen={seen} />);
+  seen = null;
+  render(<Harness host={{ ...makeHost(onRun), ...overrides }} />);
+}
+
+/** The newest request the mounted harness has observed. */
+function lastRequest(): SimRequest | null {
   return seen;
 }
 
@@ -163,11 +175,11 @@ describe("useShareLink", () => {
     const onRun = vi.fn<ShareLinkHost["onRun"]>().mockResolvedValue(ran);
     history.replaceState(null, "", "/#config=A");
 
-    const seen = mount(onRun);
-    await waitFor(() => expect(seen.current).not.toBeNull());
+    mount(onRun);
+    await waitFor(() => expect(lastRequest()).not.toBeNull());
 
-    expect(seen.current?.ranResult).toBe(ran);
-    expect(seen.current?.autoSimulate).toBe(true);
+    expect(lastRequest()?.ranResult).toBe(ran);
+    expect(lastRequest()?.autoSimulate).toBe(true);
   });
 
   it("attributes nothing to a run that produced no effective config", async () => {
@@ -182,11 +194,11 @@ describe("useShareLink", () => {
     const onRun = vi.fn<ShareLinkHost["onRun"]>().mockResolvedValue(parseErrorResult());
     history.replaceState(null, "", "/#config=A");
 
-    const seen = mount(onRun);
-    await waitFor(() => expect(seen.current).not.toBeNull());
+    mount(onRun);
+    await waitFor(() => expect(lastRequest()).not.toBeNull());
 
-    expect(seen.current?.ranResult).toBeNull();
-    expect(seen.current?.autoSimulate).toBe(true);
+    expect(lastRequest()?.ranResult).toBeNull();
+    expect(lastRequest()?.autoSimulate).toBe(true);
   });
 
   it("never leaves a failed link's request standing for the next link's run", async () => {
@@ -203,14 +215,14 @@ describe("useShareLink", () => {
       .mockResolvedValueOnce(traceResult());
     history.replaceState(null, "", "/#config=A");
 
-    const seen = mount(onRun);
+    mount(onRun);
     await waitFor(() => expect(onRun).toHaveBeenCalledTimes(1));
 
     await openLink("B");
     await waitFor(() => expect(onRun).toHaveBeenCalledTimes(2));
     await act(async () => undefined);
 
-    expect(seen.current).toBeNull();
+    expect(lastRequest()).toBeNull();
   });
 
   it("keeps autoSimulate alive when a link's own run fails over a running session", async () => {
@@ -226,15 +238,15 @@ describe("useShareLink", () => {
       .mockResolvedValueOnce(null);
     history.replaceState(null, "", "/#config=A");
 
-    const seen = mount(onRun);
+    mount(onRun);
     await waitFor(() => expect(onRun).toHaveBeenCalledTimes(1));
 
     await openLink("C");
-    await waitFor(() => expect(seen.current).not.toBeNull());
+    await waitFor(() => expect(lastRequest()).not.toBeNull());
 
     expect(onRun).toHaveBeenCalledTimes(2);
-    expect(seen.current?.autoSimulate).toBe(true);
-    expect(seen.current?.ranResult).toBeNull();
+    expect(lastRequest()?.autoSimulate).toBe(true);
+    expect(lastRequest()?.ranResult).toBeNull();
   });
 
   it("leaves the advanced drawer alone for a link that merely carries 008 layers", async () => {

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -122,8 +122,11 @@ export interface ShareLinkHost {
    *  previous one are not part of it. */
   setPins: (pins: Record<string, string>[]) => void;
   /** View state pending from a decoded link, applied by App once the run
-   *  produces a result (identities → node ids need the resolved tree). */
-  pendingViewRef: { current: ShareView | null };
+   *  produces a result (identities → node ids need the resolved tree). App
+   *  holds it in a ref (consuming it must not render); this hook only ARMS it,
+   *  through a callback rather than the ref, because writing into an object
+   *  handed in here would be this hook mutating its own argument. */
+  setPendingView: (view: ShareView | null) => void;
   /** Roadmap 017: mirrors of `content`/`loadedContent` for the hashchange
    *  listener, which is registered once (empty deps) and would otherwise
    *  close over the state from that first render. */
@@ -274,7 +277,7 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
     if (policy.suppressTokens) {
       host.openHostCredentials();
     }
-    host.pendingViewRef.current = payload.view ?? null;
+    host.setPendingView(payload.view ?? null);
     // Roadmap 075 (iteration 6): the pins ride in BEFORE the run below, so the
     // result that run commits is the first thing they are checked against —
     // which is the whole promise of the tab that lists them.

--- a/packages/app/src/hooks/use-transient-flag.test.tsx
+++ b/packages/app/src/hooks/use-transient-flag.test.tsx
@@ -11,26 +11,44 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-function Probe({
-  onRender,
-  fire,
-}: {
-  onRender: (flag: boolean) => void;
-  fire: { current: (() => void) | null };
-}) {
-  const [flag, flash] = useTransientFlag(1500);
-  fire.current = flash;
+/**
+ * The hook's flash trigger, hoisted out of the render so a test can pull it.
+ * A module binding rather than a ref-shaped prop: mutating a prop is what
+ * `react/immutability` forbids, in an effect as much as in the render.
+ */
+let flash: (() => void) | null = null;
+
+function Probe({ onRender }: { onRender: (flag: boolean) => void }) {
+  const [flag, flashNow] = useTransientFlag(1500);
+  // Published from an effect, which `render`/`act` flush synchronously — so
+  // every `mountProbe()` below still returns with the trigger in hand.
+  useEffect(() => {
+    flash = flashNow;
+  }, [flashNow]);
   onRender(flag);
   return null;
 }
 
+function mountProbe(onRender: (flag: boolean) => void) {
+  flash = null;
+  const view = render(<Probe onRender={onRender} />);
+  if (!flash) {
+    throw new Error("the probe did not render");
+  }
+  return view;
+}
+
+/** The flash, inside `act` — every caller wants the resulting render flushed. */
+function fireFlash() {
+  act(() => {
+    flash?.();
+  });
+}
+
 test("flashes on, turns itself off after the window", () => {
   const seen: boolean[] = [];
-  const fire: { current: (() => void) | null } = { current: null };
-  render(<Probe onRender={(flag) => seen.push(flag)} fire={fire} />);
-  act(() => {
-    fire.current?.();
-  });
+  mountProbe((flag) => seen.push(flag));
+  fireFlash();
   expect(seen.at(-1)).toBe(true);
   act(() => {
     vi.advanceTimersByTime(1500);
@@ -40,17 +58,12 @@ test("flashes on, turns itself off after the window", () => {
 
 test("a second flash restarts the window instead of ending it early", () => {
   const seen: boolean[] = [];
-  const fire: { current: (() => void) | null } = { current: null };
-  render(<Probe onRender={(flag) => seen.push(flag)} fire={fire} />);
-  act(() => {
-    fire.current?.();
-  });
+  mountProbe((flag) => seen.push(flag));
+  fireFlash();
   act(() => {
     vi.advanceTimersByTime(1000);
   });
-  act(() => {
-    fire.current?.();
-  });
+  fireFlash();
   act(() => {
     vi.advanceTimersByTime(1000);
   });
@@ -66,11 +79,8 @@ test("unmount inside the window clears the timer — no dead setState", () => {
   const errors: unknown[] = [];
   const onError = (event: ErrorEvent) => errors.push(event.error);
   window.addEventListener("error", onError);
-  const fire: { current: (() => void) | null } = { current: null };
-  const view = render(<Probe onRender={() => undefined} fire={fire} />);
-  act(() => {
-    fire.current?.();
-  });
+  const view = mountProbe(() => undefined);
+  fireFlash();
   view.unmount();
   expect(vi.getTimerCount()).toBe(0);
   act(() => {
@@ -84,10 +94,10 @@ test("unmount inside the window clears the timer — no dead setState", () => {
  *  with the timer still pending. This pins that the cleanup is the unmount's,
  *  not the flash's. */
 function Mounter() {
-  const [, flash] = useTransientFlag(1500);
+  const [, flashNow] = useTransientFlag(1500);
   useEffect(() => {
-    flash();
-  }, [flash]);
+    flashNow();
+  }, [flashNow]);
   return null;
 }
 


### PR DESCRIPTION
use-share-link no longer writes through its host's pendingViewRef (the
host now hands in a setter it owns); useWindow exposes scrollRowIntoView
so PresetTree stops mutating the hook-returned element; the two test
harnesses publish captures from effects instead of mutating props during
render; and App.tsx's latest-ref registrations moved below the bindings
they capture so nothing is read inside its own TDZ.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>