### PR TITLE
chore(lint): enable react/exhaustive-effect-dependencies

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -58,7 +58,6 @@
     // not an oversight.
     "react/refs": "off",
     "react/set-state-in-effect": "off",
-    "react/exhaustive-effect-dependencies": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -599,6 +599,7 @@ export function App() {
         resultsColRef.current.scrollTop = saved.results;
       }
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is the TRIGGER: the positions come from a ref captured before the run committed, and the run's commit is the layout this restore has to run against. Nothing is read out of the result, and there is nothing in it to read.
   }, [result]);
 
   // A validation message's REPO-config `packageRules[repoIndex]` → the editor
@@ -676,6 +677,8 @@ export function App() {
     // `usePanelStats` and `useResultsTab`), so listing them leaves this effect
     // firing on the result and nothing else — they are here because
     // `exhaustive-deps` cannot see that.
+    //
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is the TRIGGER: what is invalidated here belongs to the run that just ENDED, so the body reads nothing out of the new one. It cannot move into render either — `resetPanelStats` and `clearBackTab` belong to other hooks, and a cross-hook call during render is the side effect React is free to replay.
   }, [result, resetPanelStats, clearBackTab]);
 
   // Roadmap 028's post-Run scroll-into-view lives in ResultsColumn since 031:

--- a/packages/app/src/app/use-keyboard-landings.ts
+++ b/packages/app/src/app/use-keyboard-landings.ts
@@ -491,6 +491,8 @@ export function useKeyboardLandings(host: KeyboardLandingsHost): KeyboardLanding
     // ⌘⇧⏎, then a digit key or a tab while the engine was still resolving, and
     // the landing fired against the run BEFORE it and was already spent by the
     // time the one it belonged to committed.
+    //
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is the TRIGGER and nothing else: the landing is aimed by the ticket (a ref), never by the run, and what this list says is "wait for the commit the run produced". That commit is the whole point — the ticket exists precisely because there is nothing in the result to read.
   }, [result, focusResultsFnRef]);
 
   /**

--- a/packages/app/src/components/StepThrough.tsx
+++ b/packages/app/src/components/StepThrough.tsx
@@ -1,4 +1,4 @@
-import { memo, type ReactNode, useEffect, useState } from "react";
+import { memo, type ReactNode, useState } from "react";
 import { type BenignRemovals, JsonDiff } from "./JsonDiff";
 
 /** One step of a sequence: what it is, and the full config on both sides. */
@@ -81,9 +81,18 @@ export const StepThrough = memo(function StepThrough({
 
   // A re-run replaces the step list; reset to the first step. When controlled,
   // the parent owns the reset (it clears its index on new results).
-  useEffect(() => {
+  //
+  // React's "adjust state when a prop changes" idiom rather than an effect on
+  // `[steps]`: the list is the TRIGGER and nothing else — the reset does not
+  // read it — so as an effect the list was a dependency the body never touched.
+  // Done during render the trigger is the comparison itself, and the reset also
+  // lands before the paint instead of one committed frame after it, where the
+  // old index was briefly shown against the new list.
+  const [stepsOwner, setStepsOwner] = useState(steps);
+  if (steps !== stepsOwner) {
+    setStepsOwner(steps);
     setInternalIndex(0);
-  }, [steps]);
+  }
 
   if (steps.length === 0) {
     return null;

--- a/packages/app/src/features/presets/PresetTree.tsx
+++ b/packages/app/src/features/presets/PresetTree.tsx
@@ -208,6 +208,7 @@ export const PresetTree = memo(function PresetTree({
       return;
     }
     scrollRowIntoView(idx);
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `win.el` is a TRIGGER, not an input: `scrollRowIntoView` reaches the container through `useWindow`'s own ref, so the body never reads the state — but a scroll attempted before the container mounted is a no-op, and the state changing is precisely the news that there is now an element to act on. Dropping it silently loses the scroll on a (re)mount.
   }, [selectedId, flatRows, view, win.el, scrollRowIntoView]);
 
   if (!root || root.children.length === 0 || !stats) {

--- a/packages/app/src/features/simulator/use-simulation-run.ts
+++ b/packages/app/src/features/simulator/use-simulation-run.ts
@@ -95,6 +95,7 @@ export function useSimulationRun({
     setRuleFilters(DEFAULT_RULE_FILTERS);
     setFocusHint(null);
     clearGuard();
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is this effect's TRIGGER, not an input: the invalidation reads nothing from the new run, it only has to happen once per run. It cannot move into render (React's "adjust state when a prop changes" idiom) because `clearGuard` belongs to another hook, and a cross-hook call during render is the side effect React is free to replay.
   }, [result, clearGuard]);
 
   // Roadmap 016: restore the scroll position captured in `simulate` right
@@ -107,6 +108,7 @@ export function useSimulationRun({
       scrollYBeforeSimulate.current = null;
       window.scrollTo({ top: y, behavior: "auto" });
     }
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- both entries are TRIGGERS naming the layout this restore must run against: the position is read from a ref, and what the list says is "after `sim` and the verdict facet have changed TOGETHER". Dropping either would restore against an intermediate DOM — the jump this exists to prevent.
   }, [sim, ruleFilters.verdict]);
 
   /**

--- a/packages/app/src/features/simulator/use-thread-nav.ts
+++ b/packages/app/src/features/simulator/use-thread-nav.ts
@@ -73,6 +73,7 @@ export function useThreadNav(sim: SimulationResult | null): ThreadNav {
     pendingThreadRef.current = null;
     resetThreads(pending === null ? undefined : new Set([pending]));
     setReturnKey(null);
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `sim` is this effect's TRIGGER: "a new run is new evidence" is a statement about the run ARRIVING, and the reset reads nothing out of it (the only thing it consumes is the pending link request, held in a ref). It has to stay an effect too — consuming that ref is a write, which during render React is free to replay.
   }, [sim, resetThreads]);
 
   // The landing itself. One pass is enough, unlike use-rule-focus: a thread's

--- a/packages/app/src/hooks/use-engine-derivation.ts
+++ b/packages/app/src/hooks/use-engine-derivation.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react";
 import type * as EngineModule from "@renovate-config-debugger/engine";
 import { loadEngine } from "@/platform/engine-chunk";
-import { useLatestRef } from "./use-latest-ref";
+
+/** The derivation itself: everything it reads is declared in `deps` beside it. */
+type Derive<Value> = (engine: typeof EngineModule) => Value | null | PromiseLike<Value | null>;
 
 /**
  * The one shape every post-hoc trace derivation loads through: the engine
@@ -20,9 +22,14 @@ import { useLatestRef } from "./use-latest-ref";
  * wedged on `undefined` — "still loading" — forever.
  *
  * `deps` is the FULL identity of the derivation — the values `derive` reads.
- * `derive` itself is read through a latest-ref rather than being a dependency:
- * it closes over this render's props and is therefore redeclared every render,
- * so depending on it would re-run the derivation on every keystroke.
+ * `derive` itself is never a dependency: it closes over this render's props and
+ * is therefore redeclared every render, so depending on it would re-run the
+ * derivation on every keystroke. It is CAPTURED ALONGSIDE the deps instead, in
+ * the same piece of state, so the effect's one dependency carries the closure it
+ * is going to run rather than reaching outside itself for it. Which closure that
+ * is never differs from "the latest": the capture happens in the render that
+ * observed the new deps, and by the contract above the deps are the whole
+ * identity of what `derive` reads.
  *
  * The stale state is discarded DURING RENDER, not in the effect. Effects run
  * after the commit, so a reset made there paints one frame in which the new
@@ -38,21 +45,24 @@ import { useLatestRef } from "./use-latest-ref";
  */
 export function useEngineDerivation<Value>(
   deps: readonly unknown[],
-  derive: ((engine: typeof EngineModule) => Value | null | PromiseLike<Value | null>) | null,
+  derive: Derive<Value> | null,
 ): Value | null | undefined {
   const [state, setState] = useState<Value | null | undefined>(undefined);
-  const [depsOwner, setDepsOwner] = useState(deps);
-  const fresh = sameDeps(depsOwner, deps);
+  const [owner, setOwner] = useState<{ deps: readonly unknown[]; derive: Derive<Value> | null }>({
+    deps,
+    derive,
+  });
+  const fresh = sameDeps(owner.deps, deps);
   if (!fresh) {
-    setDepsOwner(deps);
+    setOwner({ deps, derive });
     setState(undefined);
   }
-  const deriveRef = useLatestRef(derive);
-  // `depsOwner` — not `deps` — is the dependency: it is the same array identity
+  // `owner` — not `deps` — is the dependency: it is the same object identity
   // until the render-time comparison above swaps it, which makes this a literal
-  // one-element list whose churn is exactly "the derivation's inputs changed".
+  // one-element list whose churn is exactly "the derivation's inputs changed",
+  // and whose one element is also where the effect reads the derivation from.
   useEffect(() => {
-    const run = deriveRef.current;
+    const run = owner.derive;
     if (!run) {
       return;
     }
@@ -71,7 +81,7 @@ export function useEngineDerivation<Value>(
     return () => {
       live = false;
     };
-  }, [depsOwner, deriveRef]);
+  }, [owner]);
   // Guarded rather than returned raw: React discards the output of the render
   // that called `setState` above, but this component's body still RAN with the
   // pre-reset `state` in hand, and a consumer that reads the return value into

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -200,11 +200,17 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
 
   /** Roadmap 017: the one path every self-initiated hash write goes through —
    *  updates the address bar and records the token (or lack of one) so the
-   *  hashchange listener can recognize its own writes. */
-  function writeHash(url: string, shareToken: string | null) {
+   *  hashchange listener can recognize its own writes.
+   *
+   *  A `useCallback([])` rather than a plain function declaration because the
+   *  two one-shot effects below call it: it reads nothing but a ref and the
+   *  `history` global, so it never goes stale, but as a per-render declaration
+   *  it was a value those effects used and did not list. Pinned here it can be
+   *  listed honestly without either effect re-registering. */
+  const writeHash = useCallback((url: string, shareToken: string | null) => {
     lastWrittenTokenRef.current = shareToken;
     history.replaceState(null, "", url);
-  }
+  }, []);
 
   /** Drops the `#config=` fragment, keeping any query string. */
   function clearShareHash() {
@@ -471,8 +477,10 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
       await loadShareTokenRef.current(shareToken, isCancelled);
     })();
     // `loadShareTokenRef` is a stable ref object, listed only because
-    // `exhaustive-deps` cannot see the `useRef()` behind `useLatestRef`.
-  }, [oauthConfig, loadShareTokenRef]);
+    // `exhaustive-deps` cannot see the `useRef()` behind `useLatestRef`;
+    // `writeHash` is pinned by its own `useCallback([])`. Neither ever changes
+    // identity, so this stays the one-shot registration described above.
+  }, [oauthConfig, loadShareTokenRef, writeHash]);
 
   // Roadmap 017: a share link opened while the app is already running is a
   // hash-only navigation — nothing reloads, so without this listener nothing
@@ -482,8 +490,9 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
   // lets a declined confirm restore exactly the hash that was showing before
   // the navigation, so the address bar never lies about what's on screen.
   // Registered once — `contentRef`/`loadedContentRef` (via `hostRef`) and
-  // `loadShareTokenRef` keep it reading current state despite that, and the
-  // one entry in its dependency list is that stable ref object.
+  // `loadShareTokenRef` keep it reading current state despite that, so the
+  // dependency list holds only identity-pinned values: that ref object and
+  // `writeHash`'s `useCallback([])`.
   useEffect(() => {
     function onHashChange(event: HashChangeEvent) {
       const decision = decideHashChangeAction(
@@ -511,7 +520,7 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
     }
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, [loadShareTokenRef]);
+  }, [loadShareTokenRef, writeHash]);
 
   // Encodes the CURRENT state (config + view, optionally simulator inputs) into
   // a link, copies it, and mirrors it into the address bar. Never continuously


### PR DESCRIPTION
Two effects were restructured so their trigger is also what the body
reads (use-engine-derivation's owner state now carries {deps, derive};
StepThrough resets via the adjust-state-during-render idiom), and
use-share-link's writeHash is pinned with useCallback and listed in its
one-shot effects' deps. The seven remaining extra deps are deliberate
re-run triggers (invalidate-on-new-run, scroll-after-commit) and carry
inline disables stating their invariants.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>