### PR TITLE
chore(lint): enable react/set-state-in-effect

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -57,7 +57,6 @@
     // matching refactor first; until then "off" is the recorded decision,
     // not an oversight.
     "react/refs": "off",
-    "react/set-state-in-effect": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -662,23 +662,37 @@ export function App() {
     setEditorKey((k) => k + 1);
   }
 
-  useEffect(() => {
+  // A new run invalidates what the previous run's views were pointing at. App's
+  // OWN half of that happens during render — React's "adjust state when a prop
+  // changes" idiom, the same one `StepThrough` uses: `result` is the trigger and
+  // the reset reads nothing out of it, and the selection and the two stepper
+  // indices are back at their starting points BEFORE the paint instead of one
+  // committed frame after it, where a stepper briefly showed the old step
+  // against the new run's sequence.
+  const [resultOwner, setResultOwner] = useState(result);
+  if (result !== resultOwner) {
+    setResultOwner(result);
     setSelectedNodeId(null);
     setMigrationStepIndex(0);
     setMergeStepIndex(0);
+  }
+
+  useEffect(() => {
     // Roadmap 028: a new run invalidates the previous run's async counts —
     // the effective key stats and the Overview's behavior count (083), both
     // recomputed by their views once the new derivations settle (they reset as
     // one, which is what `usePanelStats` exists for) — and any "back to where I
     // was" target from the run that just ended.
+    //
+    // This half stays an effect: `resetPanelStats` and `clearBackTab` belong to
+    // other hooks, and a cross-hook call during render is the side effect React
+    // is free to replay. Both are identity-stable (`useCallback`s with no
+    // dependencies, in `usePanelStats` and `useResultsTab`), so listing them
+    // leaves this effect firing on the result and nothing else — they are here
+    // because `exhaustive-deps` cannot see that.
     resetPanelStats();
     clearBackTab();
-    // Both are identity-stable (`useCallback`s with no dependencies, in
-    // `usePanelStats` and `useResultsTab`), so listing them leaves this effect
-    // firing on the result and nothing else — they are here because
-    // `exhaustive-deps` cannot see that.
-    //
-    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is the TRIGGER: what is invalidated here belongs to the run that just ENDED, so the body reads nothing out of the new one. It cannot move into render either — `resetPanelStats` and `clearBackTab` belong to other hooks, and a cross-hook call during render is the side effect React is free to replay.
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is the TRIGGER: what is invalidated here belongs to the run that just ENDED, so the body reads nothing out of the new one.
   }, [result, resetPanelStats, clearBackTab]);
 
   // Roadmap 028's post-Run scroll-into-view lives in ResultsColumn since 031:
@@ -799,8 +813,10 @@ export function App() {
     return skips;
   }, [globalParse.config, inheritedParse.config]);
 
-  // Apply pending link view state after the run's result exists. Declared after
-  // the reset effect so it wins over the reset for a decoded link.
+  // Apply pending link view state after the run's result exists — after the
+  // new-run invalidation above, which the link's own view state overrides: the
+  // selection and the two stepper indices are reset during the render that
+  // observed the result, and this effect runs on the commit that follows it.
   useEffect(() => {
     if (!result) {
       return;

--- a/packages/app/src/app/ResultsColumn.tsx
+++ b/packages/app/src/app/ResultsColumn.tsx
@@ -322,12 +322,15 @@ export function ResultsColumn({
    * an applied fix clearing the banner cannot shift the control the reader is
    * about to click out from under the pointer.
    */
-  const [invalidSeen, setInvalidSeen] = useState(false);
-  useEffect(() => {
-    if (validateHasErrors) {
-      setInvalidSeen(true);
-    }
-  }, [validateHasErrors]);
+  //
+  // A latch, set during render rather than in an effect: the condition is the
+  // whole trigger, and `validateHasErrors && !invalidSeen` converges after one
+  // extra render pass and never fires again. As an effect the reserved height
+  // arrived one committed frame after the banner it reserves space for.
+  const [invalidSeen, setInvalidSeen] = useState(validateHasErrors);
+  if (validateHasErrors && !invalidSeen) {
+    setInvalidSeen(true);
+  }
 
   // Rendered by the tab shell above ALL panels rather than inside one: every
   // banner here is a property of the run, and the tab a run lands on depends on

--- a/packages/app/src/app/use-platform-context.ts
+++ b/packages/app/src/app/use-platform-context.ts
@@ -20,7 +20,7 @@
  * suppression from the new value — over-suppressing would break a legitimate
  * private repo load, under-suppressing would leak the token.
  */
-import { type RefObject, useCallback, useEffect, useMemo, useState } from "react";
+import { type RefObject, useCallback, useMemo, useState } from "react";
 import { useRef } from "react";
 import { DEFAULT_ENDPOINT, DEFAULT_PLATFORM, PLATFORM_ENDPOINTS } from "@/data/platform-endpoints";
 import {
@@ -121,11 +121,21 @@ export function usePlatformContext(): PlatformContext {
 
   // An override only exists relative to global-config values; when the global
   // config stops defining platform/endpoint, snap back to normal behavior.
-  useEffect(() => {
+  //
+  // React's "adjust state when a prop changes" idiom rather than an effect: the
+  // global config gaining or losing a platform context is the whole trigger and
+  // the snap-back reads nothing else. It is a real CLEAR and not a mask over the
+  // flag: a global config that comes back later must not resurrect an override
+  // the user set against the previous one. Done during render, the toolbar never
+  // paints a frame claiming an override against a global config that no longer
+  // states one.
+  const [globalContextOwner, setGlobalContextOwner] = useState(hasGlobalContext);
+  if (hasGlobalContext !== globalContextOwner) {
+    setGlobalContextOwner(hasGlobalContext);
     if (!hasGlobalContext) {
       setPlatformOverride(false);
     }
-  }, [hasGlobalContext]);
+  }
 
   const applyUntrustedGuard = useCallback((next: UntrustedEndpointGuard | null) => {
     untrustedGuardRef.current = next;

--- a/packages/app/src/app/use-repo-picker.ts
+++ b/packages/app/src/app/use-repo-picker.ts
@@ -57,6 +57,32 @@ export function useRepoPicker(host: RepoPickerHost): RepoPickerView | null {
   // settled probe reports through `badges`.
   const probing = useRef(new Set<string>());
 
+  // A sign-out invalidates the list (it was THAT account's); drop it so a later
+  // session starts fresh instead of showing someone else's repos. During render
+  // — React's "adjust state when a prop changes" idiom: the flag is the trigger
+  // and the drop reads nothing else, and the previous account's rows are gone
+  // before the paint rather than one committed frame after it. The fetch below
+  // cannot race in between: it is gated on `signedIn` too.
+  const [signedInOwner, setSignedInOwner] = useState(signedIn);
+  if (signedIn !== signedInOwner) {
+    setSignedInOwner(signedIn);
+    if (!signedIn) {
+      setRepos(null);
+      setFailed(false);
+      setBadges(new Map());
+    }
+  }
+  // The in-flight set is a ref, so its half of the same invalidation stays an
+  // effect: a ref write during render is one React is free to replay. It has to
+  // happen — a name left in here after the badges were dropped would never be
+  // re-probed — and it runs before the probe effect below, which is declared
+  // after it.
+  useEffect(() => {
+    if (!signedIn) {
+      probing.current.clear();
+    }
+  }, [signedIn]);
+
   const wanted = open && signedIn;
   useEffect(() => {
     if (!wanted || repos !== null || failed) {
@@ -79,17 +105,6 @@ export function useRepoPicker(host: RepoPickerHost): RepoPickerView | null {
       cancelled = true;
     };
   }, [wanted, repos, failed]);
-
-  // A sign-out invalidates the list (it was THAT account's); drop it so a
-  // later session starts fresh instead of showing someone else's repos.
-  useEffect(() => {
-    if (!signedIn) {
-      setRepos(null);
-      setFailed(false);
-      setBadges(new Map());
-      probing.current.clear();
-    }
-  }, [signedIn]);
 
   const filtered = useMemo(() => filterUserRepos(repos ?? [], query), [repos, query]);
   const visible = useMemo(() => filtered.slice(0, VISIBLE_ROWS), [filtered]);

--- a/packages/app/src/components/StageRail.tsx
+++ b/packages/app/src/components/StageRail.tsx
@@ -282,17 +282,27 @@ export function StageRailPreview({
   // Read once, at mount: the landing lives for exactly one screen, and this is
   // an OS preference, not something worth subscribing to for that long.
   const [reducedMotion] = useState(prefersReducedMotion);
+  const stepping = running && !reducedMotion;
+  // Every walk starts at its first frame. React's "adjust state when a prop
+  // changes" idiom rather than a reset branch inside the interval effect: the
+  // walk starting or stopping is the whole trigger, and the rail shows the first
+  // frame in the render that observed it instead of a committed frame later.
+  const [steppingOwner, setSteppingOwner] = useState(stepping);
+  if (stepping !== steppingOwner) {
+    setSteppingOwner(stepping);
+    setStep(0);
+  }
+  // The interval is the external system this effect exists for — nothing else.
+  // `setStep` inside its callback fires per tick, long after the effect body.
   useEffect(() => {
-    if (!running || reducedMotion) {
-      setStep(0);
+    if (!stepping) {
       return;
     }
     const id = window.setInterval(() => {
       setStep((prev) => Math.min(prev + 1, LAST_STAGE_INDEX));
     }, RUNNING_STEP_MS);
     return () => window.clearInterval(id);
-  }, [running, reducedMotion]);
-  const stepping = running && !reducedMotion;
+  }, [stepping]);
   useEffect(() => {
     // No walk under reduced motion, so nothing to hold the results for.
     if (running && reducedMotion) {

--- a/packages/app/src/features/effective-config/EffectiveConfig.tsx
+++ b/packages/app/src/features/effective-config/EffectiveConfig.tsx
@@ -129,6 +129,35 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     setIncludeDefaults(false);
   }
 
+  // Roadmap 069: the description card's "show raw order" link lands on the blame
+  // ledger — the row is one of ~90, so arriving at the tab is not arriving at
+  // the answer. Filter, expand, no focus steal: the reader is here to read.
+  // …which means clearing the OTHER filter too, not just setting the query:
+  // "only overridden" left over from earlier reading would hide the very row the
+  // link promised, and the reader would land on "No keys match".
+  // …and, since 075, re-opening the decided-by bands for the same reason: a
+  // reader who folded the presets band shut earlier would otherwise land on a
+  // collapsed band instead of the ledger the link promised. The defaults band
+  // stays shut — `description` has no Renovate default, so it can never be the
+  // band this row is in.
+  //
+  // DURING RENDER for the same reason as the reset above, and BELOW it so that a
+  // commit carrying both a new provenance and a new nonce still lands: the run's
+  // reset clears the query, and the link's landing sets it afterwards. The owner
+  // starts at `undefined`, so a nonce that is already set when this view mounts
+  // (the link that switched to this tab) is honoured on the first render.
+  const [nonceOwner, setNonceOwner] = useState<number | undefined>(undefined);
+  if (nonceOwner !== focusDescriptionNonce) {
+    setNonceOwner(focusDescriptionNonce);
+    if (focusDescriptionNonce) {
+      setView("keys");
+      setQuery(DESCRIPTION_KEY);
+      setOnlyOverridden(false);
+      resetExpandedRows(new Set([DESCRIPTION_KEY]));
+      resetCollapsedSections(DEFAULT_COLLAPSED);
+    }
+  }
+
   const entries = useMemo(() => (provenance ? [...provenance.values()] : []), [provenance]);
 
   const filtered = useMemo(() => {
@@ -181,27 +210,6 @@ export const EffectiveConfig = memo(function EffectiveConfig({
     }
     onStats?.(tallies);
   }, [tallies, onStats, provenance]);
-
-  // Roadmap 069: the description card's "show raw order" link lands on the blame
-  // ledger — the row is one of ~90, so arriving at the tab is not arriving at
-  // the answer. Filter, expand, no focus steal: the reader is here to read.
-  // …which means clearing the OTHER filter too, not just setting the query:
-  // "only overridden" left over from earlier reading would hide the very row the
-  // link promised, and the reader would land on "No keys match".
-  // …and, since 075, re-opening the decided-by bands for the same reason: a
-  // reader who folded the presets band shut earlier would otherwise land on a
-  // collapsed band instead of the ledger the link promised. The defaults band
-  // stays shut — `description` has no Renovate default, so it can never be the
-  // band this row is in.
-  useEffect(() => {
-    if (focusDescriptionNonce) {
-      setView("keys");
-      setQuery(DESCRIPTION_KEY);
-      setOnlyOverridden(false);
-      resetExpandedRows(new Set([DESCRIPTION_KEY]));
-      resetCollapsedSections(DEFAULT_COLLAPSED);
-    }
-  }, [focusDescriptionNonce, resetExpandedRows, resetCollapsedSections]);
 
   if (!result.finalConfig) {
     return null;

--- a/packages/app/src/features/simulator/RuleRow.tsx
+++ b/packages/app/src/features/simulator/RuleRow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import type { MergedKey, ProvenanceLayer, RuleEvaluation } from "@renovate-config-debugger/engine";
 import { Caret } from "@/components/Caret";
 import { CopyMarkdownButton } from "@/components/CopyMarkdownButton";
@@ -81,8 +81,15 @@ export function RuleRow({
   defaultExpanded?: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
-  // Re-sync when the filter toggles (re-expand my-rules rows, collapse otherwise).
-  useEffect(() => setExpanded(defaultExpanded), [defaultExpanded]);
+  // Re-sync when the filter toggles (re-expand my-rules rows, collapse
+  // otherwise). React's "adjust state when a prop changes" idiom rather than an
+  // effect: the prop is both the trigger and the whole new value, and the row
+  // re-renders in its new shape before the paint instead of one frame after it.
+  const [defaultOwner, setDefaultOwner] = useState(defaultExpanded);
+  if (defaultExpanded !== defaultOwner) {
+    setDefaultOwner(defaultExpanded);
+    setExpanded(defaultExpanded);
+  }
   const quote = rule.verdict === "matched" ? description : undefined;
   return (
     // Roadmap 068: a cross-link lands ON this row (`landOnTarget`), so it has

--- a/packages/app/src/features/simulator/use-rule-focus.ts
+++ b/packages/app/src/features/simulator/use-rule-focus.ts
@@ -76,23 +76,38 @@ export function useRuleFocus({
   setFocusHint: Dispatch<SetStateAction<number | null>>;
 }): RuleFocus {
   const cardRef = useRef<HTMLDivElement>(null);
-  // Roadmap 013: the merged index awaiting a scroll+flash.
-  const [scrollTarget, setScrollTarget] = useState<number | null>(null);
-
-  useEffect(() => {
+  // Roadmap 013: the merged index awaiting a scroll+flash. An index the
+  // EXTERNAL prop already carries at mount is one of them, so it is the initial
+  // value rather than something an effect copies in a commit later.
+  const [scrollTarget, setScrollTarget] = useState<number | null>(focusRuleIndex ?? null);
+  // A later external index is adopted through React's "adjust state when a prop
+  // changes" idiom rather than an effect: the prop is the whole trigger and the
+  // copy reads nothing else, so the landing below starts from the render that
+  // observed the cross-link instead of one commit after it. Null is the prop's
+  // "consumed" state (`onRuleFocused` clears it) and clears no target: the
+  // landing owns when a target is done.
+  const [focusIndexOwner, setFocusIndexOwner] = useState(focusRuleIndex);
+  if (focusRuleIndex !== focusIndexOwner) {
+    setFocusIndexOwner(focusRuleIndex);
     if (focusRuleIndex != null) {
       setScrollTarget(focusRuleIndex);
     }
-  }, [focusRuleIndex]);
+  }
 
   // Performs the actual scroll+flash once the target row is guaranteed to be
   // in the DOM: if a filter facet is currently hiding it, reveal it first and
   // let the effect re-run on the next render (checked against `sim` and the
   // list's own `ruleVisible` predicate, never a copy of its filtering).
+  //
+  // A reveal-then-land machine, and only an effect can be one: every pass asks
+  // a question about a COMMITTED DOM. `landed` is the pass's verdict, and there
+  // is exactly one place that acts on it — a reveal returns with the target
+  // still set so the next commit gets another pass, and a landing consumes it.
   useEffect(() => {
     if (scrollTarget == null) {
       return;
     }
+    let landed = true;
     if (!sim) {
       // No simulation has run yet, so the target row isn't rendered anywhere.
       // Land the user on the simulator and prompt them to run one, rather than
@@ -102,41 +117,39 @@ export function useRuleFocus({
       // form it names.
       landOnCard(cardRef.current);
       setFocusHint(scrollTarget);
-      setScrollTarget(null);
-      onRuleFocused?.();
+    } else {
+      const rule = sim.rules.find((r) => r.index === scrollTarget);
+      if (!rule) {
+        // A merged index this simulation does not contain — its rules describe
+        // the config as it was when it ran. There is no row to flash and (the
+        // hint above renders only before the first simulation) nothing to say,
+        // so the card is the whole landing: without it this exit moved neither
+        // the page nor the focus, which is exactly what a dead link looks like.
+        landOnCard(cardRef.current);
+      } else if (!rulesOpen) {
+        // Roadmap 047: the rows live inside the rules drawer now — open it
+        // first (nothing a link can reach may sit behind a closed drawer), then
+        // let the effect re-run once the row is actually in the DOM.
+        setRulesOpen(true);
+        landed = false;
+      } else if (!ruleVisible(rule, ruleFilters, layerByIndex)) {
+        // Reveal the target row if either facet is hiding it, then let the
+        // effect re-run. Both are dropped at once (rather than relaxed one at a
+        // time): the link's promise is "here is that rule", and a second re-run
+        // to get past the other facet would scroll the page twice to keep it.
+        setRuleFilters({ verdict: "all", preset: "all" });
+        landed = false;
+      } else {
+        const el = document.getElementById(`sim-rule-${scrollTarget}`);
+        if (el) {
+          landOnTarget(el, "center");
+        }
+      }
+    }
+    if (!landed) {
       return;
     }
-    const rule = sim.rules.find((r) => r.index === scrollTarget);
-    if (!rule) {
-      // A merged index this simulation does not contain — its rules describe
-      // the config as it was when it ran. There is no row to flash and (the
-      // hint above renders only before the first simulation) nothing to say, so
-      // the card is the whole landing: without it this exit moved neither the
-      // page nor the focus, which is exactly what a dead link looks like.
-      landOnCard(cardRef.current);
-      setScrollTarget(null);
-      onRuleFocused?.();
-      return;
-    }
-    // Roadmap 047: the rows live inside the rules drawer now — open it first
-    // (nothing a link can reach may sit behind a closed drawer), then let the
-    // effect re-run once the row is actually in the DOM.
-    if (!rulesOpen) {
-      setRulesOpen(true);
-      return;
-    }
-    // Reveal the target row if either facet is hiding it, then let the effect
-    // re-run. Both are dropped at once (rather than relaxed one at a time):
-    // the link's promise is "here is that rule", and a second re-run to get
-    // past the other facet would scroll the page twice to keep it.
-    if (!ruleVisible(rule, ruleFilters, layerByIndex)) {
-      setRuleFilters({ verdict: "all", preset: "all" });
-      return;
-    }
-    const el = document.getElementById(`sim-rule-${scrollTarget}`);
-    if (el) {
-      landOnTarget(el, "center");
-    }
+    // oxlint-disable-next-line react/set-state-in-effect -- the one consume point of the machine described above, and it can live nowhere else: only a pass that has read the committed DOM knows the landing HAPPENED. Leaving the target set instead would re-land the page on every later filter change; clearing it during render would end the loop before its first pass ran.
     setScrollTarget(null);
     onRuleFocused?.();
   }, [

--- a/packages/app/src/features/simulator/use-simulation-run.ts
+++ b/packages/app/src/features/simulator/use-simulation-run.ts
@@ -86,16 +86,30 @@ export function useSimulationRun({
   // this link triggered just produced.
   const simulateRef = useRef<Simulate | null>(null);
 
-  // A new run invalidates any previous simulation (the rules may differ).
-  useEffect(() => {
+  // A new run invalidates any previous simulation (the rules may differ). This
+  // hook's OWN half of that invalidation happens during render — React's
+  // "adjust state when a prop changes" idiom, the same one `StepThrough` uses:
+  // `result` is the trigger and the reset reads nothing out of it, so as an
+  // effect the new run was a dependency the body never touched. Done here the
+  // stale verdict is also gone BEFORE the paint, where an effect left one
+  // committed frame showing the previous run's rules under the new run's config.
+  const [resultOwner, setResultOwner] = useState(result);
+  if (result !== resultOwner) {
+    setResultOwner(result);
     setSim(null);
     setSimForm(null);
     setRanKey(null);
     setError(null);
     setRuleFilters(DEFAULT_RULE_FILTERS);
     setFocusHint(null);
+  }
+
+  // The empty-form guard is the half that cannot: it belongs to
+  // `useSimulatorForm`, and a cross-hook call during render is the side effect
+  // React is free to replay.
+  useEffect(() => {
     clearGuard();
-    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is this effect's TRIGGER, not an input: the invalidation reads nothing from the new run, it only has to happen once per run. It cannot move into render (React's "adjust state when a prop changes" idiom) because `clearGuard` belongs to another hook, and a cross-hook call during render is the side effect React is free to replay.
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `result` is this effect's TRIGGER, not an input: the guard belongs to the run that just ENDED, so the body reads nothing out of the new one — it only has to be cleared once per run.
   }, [result, clearGuard]);
 
   // Roadmap 016: restore the scroll position captured in `simulate` right

--- a/packages/app/src/features/simulator/use-simulator-drawers.ts
+++ b/packages/app/src/features/simulator/use-simulator-drawers.ts
@@ -40,18 +40,26 @@ export function useSimulatorDrawers({
 }): SimulatorDrawers {
   const [openFieldGroup, setOpenFieldGroup] = useState(-1);
   const [rulesOpen, setRulesOpen] = useState(false);
-  const [mergeOpen, setMergeOpen] = useState(false);
+  // Roadmap 047: a share link whose `simStep` points at a merge stop must
+  // arrive with the merge drawer open — the stop it restored is inside it. An
+  // index that is already restored when this hook mounts is known right here,
+  // so the drawer STARTS open rather than being opened a commit later.
+  const [mergeOpen, setMergeOpen] = useState(() => mergeStepIndex > 0);
   const rulesDrawerRef = useRef<HTMLDetailsElement>(null);
   const mergeDrawerRef = useRef<HTMLDetailsElement>(null);
 
-  // Roadmap 047: a share link whose `simStep` points at a merge stop must
-  // arrive with the merge drawer open — the stop it restored is inside it.
-  // One-way: a re-simulation resetting the index to 0 never folds the drawer.
-  useEffect(() => {
+  // …and an index restored AFTER mount opens it through React's "adjust state
+  // when a prop changes" idiom rather than an effect: the index is the TRIGGER
+  // and nothing here reads it afterwards, so as an effect it was a dependency
+  // whose value the body only compared against zero. One-way either way: a
+  // re-simulation resetting the index to 0 never folds the drawer.
+  const [mergeStepOwner, setMergeStepOwner] = useState(mergeStepIndex);
+  if (mergeStepIndex !== mergeStepOwner) {
+    setMergeStepOwner(mergeStepIndex);
     if (mergeStepIndex > 0) {
       setMergeOpen(true);
     }
-  }, [mergeStepIndex]);
+  }
 
   // Roadmap 047: cross-links OPEN what they target. The drawer's <details>
   // element exists whether or not its body is mounted, but SummaryDrawer only
@@ -60,19 +68,23 @@ export function useSimulatorDrawers({
   // near the bottom of the page it is a visual no-op. Defer the scroll until
   // the commit where the body exists (same pending-target idiom as
   // `focusKey` in use-thread-nav.ts).
-  const [pendingScroll, setPendingScroll] = useState<"rules" | "merge" | null>(null);
+  //
+  // The request is a fresh OBJECT per jump rather than a name the effect clears
+  // once it has scrolled: identity is what makes two jumps to the same drawer
+  // two runs of this effect, and it gets there without the effect writing state
+  // back into the render it was started by.
+  const [pendingScroll, setPendingScroll] = useState<{ drawer: "rules" | "merge" } | null>(null);
   useEffect(() => {
     if (pendingScroll === null) {
       return;
     }
-    const ref = pendingScroll === "rules" ? rulesDrawerRef : mergeDrawerRef;
+    const ref = pendingScroll.drawer === "rules" ? rulesDrawerRef : mergeDrawerRef;
     ref.current?.scrollIntoView(motionScrollOptions("start"));
-    setPendingScroll(null);
   }, [pendingScroll]);
 
   function jumpToRules() {
     setRulesOpen(true);
-    setPendingScroll("rules");
+    setPendingScroll({ drawer: "rules" });
   }
 
   /** A verdict-card jump link → open the merge drawer, select that stop, and
@@ -80,7 +92,7 @@ export function useSimulatorDrawers({
   function jumpToStep(stopIndex: number) {
     setMergeOpen(true);
     onMergeStepChange(stopIndex);
-    setPendingScroll("merge");
+    setPendingScroll({ drawer: "merge" });
   }
 
   return {

--- a/packages/app/src/features/simulator/use-thread-nav.ts
+++ b/packages/app/src/features/simulator/use-thread-nav.ts
@@ -58,22 +58,36 @@ export function useThreadNav(sim: SimulationResult | null): ThreadNav {
     remove: removeThread,
   } = useToggleSet();
   const [returnKey, setReturnKey] = useState<string | null>(null);
-  // The key awaiting a scroll+flash once its row has committed (same idiom as
-  // use-rule-focus's `scrollTarget`).
-  const [focusKey, setFocusKey] = useState<string | null>(null);
+  // The thread awaiting a scroll+flash once its row has committed. A fresh
+  // OBJECT per request rather than a key the landing effect clears afterwards:
+  // identity is what makes two returns to the SAME thread two landings, and it
+  // gets there without the effect writing state back into its own trigger.
+  const [focusRequest, setFocusRequest] = useState<{ key: string } | null>(null);
   const pendingThreadRef = useRef<string | null>(null);
   const returnKeyRef = useLatestRef(returnKey);
 
-  // A new run is new evidence: its threads start collapsed, and whatever jump
-  // the previous run's threads sent the reader on is over. A link's requested
-  // thread is consumed HERE, inside the same effect, so the reset can never
-  // land after it and fold the very thread the link asked for.
+  // A new run is new evidence, so whatever jump the previous run's threads sent
+  // the reader on is over. During render — React's "adjust state when a prop
+  // changes" idiom, as in `StepThrough`: `sim` is the trigger and the pill's
+  // dismissal reads nothing out of it, and the pill offering a way back into
+  // evidence that no longer exists is gone before the paint rather than one
+  // committed frame after it.
+  const [simOwner, setSimOwner] = useState(sim);
+  if (sim !== simOwner) {
+    setSimOwner(sim);
+    setReturnKey(null);
+  }
+
+  // The threads themselves start collapsed. This half stays an effect: a link's
+  // requested thread is CONSUMED here, and consuming a ref is a write React is
+  // free to replay during render. Consuming it inside the same effect as the
+  // reset is also what keeps the reset from landing after it and folding the
+  // very thread the link asked for.
   useEffect(() => {
     const pending = pendingThreadRef.current;
     pendingThreadRef.current = null;
     resetThreads(pending === null ? undefined : new Set([pending]));
-    setReturnKey(null);
-    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `sim` is this effect's TRIGGER: "a new run is new evidence" is a statement about the run ARRIVING, and the reset reads nothing out of it (the only thing it consumes is the pending link request, held in a ref). It has to stay an effect too — consuming that ref is a write, which during render React is free to replay.
+    // oxlint-disable-next-line react/exhaustive-effect-dependencies -- `sim` is this effect's TRIGGER: "a new run is new evidence" is a statement about the run ARRIVING, and the reset reads nothing out of it (the only thing it consumes is the pending link request, held in a ref).
   }, [sim, resetThreads]);
 
   // The landing itself. One pass is enough, unlike use-rule-focus: a thread's
@@ -97,19 +111,19 @@ export function useThreadNav(sim: SimulationResult | null): ThreadNav {
   // is App's state and nothing the simulator holds selects it (see
   // `returnToThread`).
   useEffect(() => {
-    if (focusKey === null) {
+    if (focusRequest === null) {
       return;
     }
-    setFocusKey(null);
-    const el = document.getElementById(threadHeadId(focusKey));
+    const el = document.getElementById(threadHeadId(focusRequest.key));
     if (el === null) {
       return;
     }
     landOnTarget(el, "center");
     if (document.activeElement === el) {
+      // oxlint-disable-next-line react/set-state-in-effect -- the DOM is the external system this whole effect synchronizes with, and this line is its READING: `document.activeElement` after `landOnTarget` is the only witness that the return actually happened, and nothing before the commit can answer it. Spending the pill during render or in the gesture that started the jump would spend it on the landings that silently fail — the case 068 added this check for.
       setReturnKey(null);
     }
-  }, [focusKey]);
+  }, [focusRequest]);
 
   // Where focus reached the PILL from, or null whenever the pill does not hold
   // focus — reported by the pill itself through `notePillFocus`.
@@ -236,7 +250,7 @@ export function useThreadNav(sim: SimulationResult | null): ThreadNav {
       return;
     }
     addThread(key);
-    setFocusKey(key);
+    setFocusRequest({ key });
     // A stable ref object — listed only because `exhaustive-deps` cannot see
     // the `useRef()` behind `useLatestRef`. The identity stays stable.
   }, [returnKeyRef, addThread]);


### PR DESCRIPTION
Twelve of the fourteen sites became real restructures: lazy state
initializers where the mount value was already known, React's
adjust-state-during-render idiom for reset-on-new-evidence state,
identity-nonce request objects the landing effects no longer clear, and
split effects that keep only their cross-hook or ref work. The two
remaining setState calls need a committed DOM to answer (a landing's
consume point, an activeElement witness) and carry inline disables
stating that invariant.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>