### PR TITLE
chore(lint): enable react/refs, ending the react-compiler burn-down

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -44,19 +44,6 @@
     // index/assertion really is the honest answer carry an inline disable that
     // states the invariant, so there is no tier left for a hit to hide in.
     "react/no-array-index-key": "error",
-    // oxlint 1.79.0 split the react-compiler diagnostics into per-category
-    // rules and activated them under `correctness`/`suspicious`, so the bump
-    // PR surfaced them at error — which is this config's designed decision
-    // point. Decision: off. These are React Compiler migration diagnostics,
-    // and this app does not run the compiler; the 56 hits at evaluation time
-    // (refs 20, set-state-in-effect 15, exhaustive-effect-dependencies 10,
-    // immutability 5, preserve-manual-memoization 2, memo-dependencies 2,
-    // globals 2) are dominated by deliberate patterns — useLatestRef-style
-    // ref reads during render, effect-driven state sync, and test files
-    // reassigning outer probes from render. Adopting any of them means the
-    // matching refactor first; until then "off" is the recorded decision,
-    // not an oversight.
-    "react/refs": "off",
     "typescript/no-non-null-assertion": "error",
     // Named exports keep re-exports and IDE rename working; the tool-mandated
     // default exports are listed in the overrides below.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useInsertionEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -126,10 +127,15 @@ const ResultsColumn = lazy(() =>
  * column's own, forwarded unchanged.
  */
 function ResultsPane(props: ResultsColumnProps) {
+  // Destructured rather than `ref={props.resultsColRef}`: handing a MEMBER of
+  // an object to `ref=` makes `react/refs` read the whole object as a ref, and
+  // the spread below then counts as dereferencing it during render. Pulled out
+  // by name it is what it always was — the column's own ref, forwarded.
+  const { resultsColRef } = props;
   return (
     // Roadmap 068: `id`/`tabIndex` are the skip link's target — see the
     // config column's matching pair.
-    <div className="results-col" id="results-column" tabIndex={-1} ref={props.resultsColRef}>
+    <div className="results-col" id="results-column" tabIndex={-1} ref={resultsColRef}>
       {/* Roadmap 031: the results chunk is preloaded at idle and on Run
           intent, so this fallback is a formality — and once the lazy module
           has resolved, re-renders never suspend, so the mounted shell (and all
@@ -607,16 +613,15 @@ export function App() {
   // the memoized panels get the stable wrapper below (032, latest-ref idiom)
   // and a click always jumps against offsets from the CURRENT text, never a
   // closure over stale one.
-  const focusEditorRepoIndexRef = useRef<((repoIndex: number) => void) | undefined>(undefined);
-  focusEditorRepoIndexRef.current = (repoIndex: number) => {
+  const focusEditorRepoIndexRef = useLatestRef((repoIndex: number) => {
     const offset = packageRuleOffsets?.[repoIndex];
     if (offset !== undefined) {
       configEditorRef.current?.highlightOffset(offset);
     }
-  };
+  });
   const focusEditorRepoIndex = useCallback(
-    (repoIndex: number) => focusEditorRepoIndexRef.current?.(repoIndex),
-    [],
+    (repoIndex: number) => focusEditorRepoIndexRef.current(repoIndex),
+    [focusEditorRepoIndexRef],
   );
 
   /** Roadmap 016: the one path every authoritative content load goes
@@ -1241,8 +1246,7 @@ export function App() {
    * that quietly threw away a clean run's config would be the same bug in a
    * case that is merely less annoying.
    */
-  const signInRef = useRef<(() => Promise<void>) | undefined>(undefined);
-  signInRef.current = async () => {
+  const signInRef = useLatestRef(async () => {
     let returnHash = window.location.hash;
     if (result) {
       try {
@@ -1253,12 +1257,12 @@ export function App() {
       }
     }
     await beginSignIn(returnHash);
-  };
+  });
   // Roadmap 032: identity-stable (latest-ref idiom) — this prop reaches the
   // memoized results panels, and it reads `result`, which changes per run.
   const onSignIn = useCallback(() => {
-    void signInRef.current?.();
-  }, []);
+    void signInRef.current();
+  }, [signInRef]);
 
   /**
    * Roadmap 009 (auth-failure surfacing): the banner's "Run again" — the same
@@ -1268,11 +1272,10 @@ export function App() {
    * panel: the user is looking at the thing they just acted on, and a run that
    * bounced them to another tab would hide its own answer.
    */
-  const onRunAgainRef = useRef<(() => void) | undefined>(undefined);
-  onRunAgainRef.current = () => {
+  const onRunAgainRef = useLatestRef(() => {
     void onRun(undefined, undefined, { preserveScroll: true, keepTab: true });
-  };
-  const onRunAgain = useCallback(() => onRunAgainRef.current?.(), []);
+  });
+  const onRunAgain = useCallback(() => onRunAgainRef.current(), [onRunAgainRef]);
 
   function onSignOut() {
     signOut();
@@ -1283,19 +1286,16 @@ export function App() {
   // Roadmap 032: `onInject` reads `injected` and so is redeclared with it —
   // handed out directly it was the one unstable prop defeating PresetTree's
   // memo on every keystroke. Latest-ref idiom, as with `selectPresetNodeRef`.
-  const onInjectRef = useRef<
-    ((key: string, contentObj: Record<string, unknown>) => void) | undefined
-  >(undefined);
-  onInjectRef.current = (key: string, contentObj: Record<string, unknown>) => {
+  const onInjectRef = useLatestRef((key: string, contentObj: Record<string, unknown>) => {
     const next = { ...injected, [key]: contentObj };
     setInjected(next);
     // Injecting preset content is done FROM the preset tree — keep the user
     // there rather than bouncing them to the landing tab (028).
     void onRun(next, undefined, { preserveScroll: true, keepTab: true });
-  };
+  });
   const onInject = useCallback(
-    (key: string, contentObj: Record<string, unknown>) => onInjectRef.current?.(key, contentObj),
-    [],
+    (key: string, contentObj: Record<string, unknown>) => onInjectRef.current(key, contentObj),
+    [onInjectRef],
   );
 
   // Roadmap 048: every number derived from a finished run — the tab-strip
@@ -1344,8 +1344,14 @@ export function App() {
     configEditorRef,
   });
   // …and the forward handle `selectPresetNode` (declared far above, because
-  // `presetHover` needs it) lands through. See its declaration.
-  landOnPresetNodeRef.current = landOnPresetNode;
+  // `presetHover` needs it) lands through. See its declaration. The write is
+  // `useLatestRef`'s, inlined because the ref has to be declared up there
+  // rather than here: an insertion effect, so it is not a render-time ref
+  // write (`react/refs`) and still lands before anything can activate a
+  // cross-link.
+  useInsertionEffect(() => {
+    landOnPresetNodeRef.current = landOnPresetNode;
+  });
 
   /**
    * Roadmap 032: `applyErrorFix` reads `content` and `errorLib`, so the

--- a/packages/app/src/features/editor/ConfigEditor.tsx
+++ b/packages/app/src/features/editor/ConfigEditor.tsx
@@ -5,6 +5,7 @@ import CodeMirror, {
 } from "@uiw/react-codemirror";
 import { json } from "@codemirror/lang-json";
 import { forwardRef, type ReactNode, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import { useLatestRef } from "@/hooks/use-latest-ref";
 import type { PresetHoverContext } from "@/lib/preset-hover";
 import { flashTarget, motionScrollOptions } from "@/lib/motion";
 import { useEffectiveScheme } from "./use-effective-scheme";
@@ -49,13 +50,14 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
   ref,
 ) {
   // Kept current every render so the once-built hover extension reads fresh
-  // tree data (a Run updates it without remounting the editor).
-  const presetHoverRef = useRef<PresetHoverContext | null>(presetHover ?? null);
-  presetHoverRef.current = presetHover ?? null;
+  // tree data (a Run updates it without remounting the editor). Roadmap 032's
+  // latest-ref helper rather than a hand-rolled `useRef` + render-time write:
+  // both refs here are the idiom exactly — written per render, dereferenced
+  // only from a hover or a keypress, i.e. always after the commit.
+  const presetHoverRef = useLatestRef<PresetHoverContext | null>(presetHover ?? null);
   // Same idiom, same reason: the run keymap is built once, and reads whatever
   // `onRun` is current when the chord is actually pressed.
-  const onRunRef = useRef<(() => void) | undefined>(onRun);
-  onRunRef.current = onRun;
+  const onRunRef = useLatestRef(onRun);
   // Roadmap 031: the editor mounts with plain JSON language support only —
   // the ~160 kB gz schema layer (codemirror-json-schema + Renovate's own
   // schema JSON + its markdown/yaml stack) is `import()`ed after mount and
@@ -76,7 +78,9 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
       // no accessible name of its own.
       EditorView.contentAttributes.of({ "aria-label": "Renovate config" }),
     ],
-    [compartment],
+    // `onRunRef` is a ref object: its identity never changes, so the extension
+    // list is still built exactly once for the editor's lifetime.
+    [compartment, onRunRef],
   );
   const cmRef = useRef<ReactCodeMirrorRef>(null);
 
@@ -112,7 +116,9 @@ export const ConfigEditor = forwardRef<ConfigEditorHandle, Props>(function Confi
     return () => {
       cancelled = true;
     };
-  }, [fileName, compartment]);
+    // `presetHoverRef` is listed for the same reason as in the memo above —
+    // an identity-pinned ref object, so this stays a per-file registration.
+  }, [fileName, compartment, presetHoverRef]);
 
   useImperativeHandle(
     ref,

--- a/packages/app/src/features/presets/PresetListPane.tsx
+++ b/packages/app/src/features/presets/PresetListPane.tsx
@@ -51,6 +51,12 @@ export function PresetListPane({
   descFacts: ReadonlyMap<string, NodeDescriptionFacts> | null;
   onShowDescriptionOrder?: () => void;
 }) {
+  // Destructured rather than read as `win.…` below: `win.ref` is a CALLBACK
+  // ref, and handing a member of an object to `ref=` makes `react/refs` treat
+  // every other member of that object as a ref read during render too — which
+  // `padTop`/`padBottom` (plain numbers derived from scroll state, and the
+  // whole point of this render) are not.
+  const { ref: containerRef, padTop, padBottom } = win;
   return (
     <div>
       {view === "table" ? (
@@ -68,12 +74,12 @@ export function PresetListPane({
           ))}
         </div>
       ) : null}
-      <div className="preset-tree" role={view === "tree" ? "tree" : "table"} ref={win.ref}>
+      <div className="preset-tree" role={view === "tree" ? "tree" : "table"} ref={containerRef}>
         {activeCount === 0 ? (
           <p className="empty-note">No presets match the filter.</p>
         ) : (
           <>
-            <div style={{ height: win.padTop }} />
+            <div style={{ height: padTop }} />
             {view === "tree"
               ? treeSlice.map((row) => (
                   <TreeRow
@@ -98,7 +104,7 @@ export function PresetListPane({
                     onSelect={onSelectNode}
                   />
                 ))}
-            <div style={{ height: win.padBottom }} />
+            <div style={{ height: padBottom }} />
           </>
         )}
       </div>

--- a/packages/app/src/features/simulator/use-pinned-tests.ts
+++ b/packages/app/src/features/simulator/use-pinned-tests.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useInsertionEffect, useRef, useState } from "react";
 import type { SimulationResult, TraceResult } from "@renovate-config-debugger/engine";
 import type { PinnedTest } from "./pins";
 import { runSimulation } from "./run-simulation";
@@ -53,9 +53,17 @@ export function usePinnedTests({
   const [state, setState] = useState<PinState>({ result: null, byId: {} });
   // Read by the async loop below to know what is ALREADY evaluated for this
   // result, without listing `state` in the effect's deps — which would restart
-  // the loop after every pin it finishes.
+  // the loop after every pin it finishes. The write is `useLatestRef`'s,
+  // inlined rather than the helper itself: the effect below reads
+  // `stateRef.current.result`, and `exhaustive-deps` only knows a `.current`
+  // read is not a dependency when it can see the `useRef()` call — behind a
+  // custom hook it demands the DEREFERENCED value, which is the one thing that
+  // must never be in this list. An insertion effect lands the value before
+  // every effect of the same commit, which is all that reads it.
   const stateRef = useRef(state);
-  stateRef.current = state;
+  useInsertionEffect(() => {
+    stateRef.current = state;
+  });
 
   useEffect(() => {
     const finalConfig = result.finalConfig;

--- a/packages/app/src/features/simulator/use-simulation-run.ts
+++ b/packages/app/src/features/simulator/use-simulation-run.ts
@@ -3,6 +3,7 @@ import {
   type RefObject,
   type SetStateAction,
   useEffect,
+  useInsertionEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -178,10 +179,16 @@ export function useSimulationRun({
       setRunning(false);
     }
   }
-  // Assigned during render so the ref always holds the closure that sees this
-  // render's config — the share-link effect's own guard (`!result.finalConfig`)
-  // keeps it from running one against a config that doesn't exist yet.
-  simulateRef.current = simulate;
+  // The ref always holds the closure that sees this render's config — the
+  // share-link effect's own guard (`!result.finalConfig`) keeps it from running
+  // one against a config that doesn't exist yet. The write is `useLatestRef`'s,
+  // inlined because the ref is declared (and documented) above with the state
+  // it belongs to: an insertion effect, so it lands before every effect and
+  // handler of this commit — the only places it is read — without being a
+  // render-time ref write (`react/refs`).
+  useInsertionEffect(() => {
+    simulateRef.current = simulate;
+  });
 
   return {
     sim,

--- a/packages/app/src/hooks/use-latest-ref.ts
+++ b/packages/app/src/hooks/use-latest-ref.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useRef } from "react";
+import { type RefObject, useInsertionEffect, useRef } from "react";
 
 /**
  * The "latest-ref idiom" (roadmap 032), named once instead of re-spelled at
@@ -7,14 +7,24 @@ import { type RefObject, useRef } from "react";
  * value without re-registering — which is what keeps the memoized panels'
  * props identity-stable and the keystroke render budget flat.
  *
- * Assigning during render is deliberate and safe here: the ref is only ever
- * READ from an effect or an event handler (i.e. after the commit), never during
- * the render that writes it, so a render React discards leaves nothing behind.
+ * The write happens in a `useInsertionEffect`, not during render, which is
+ * what `react/refs` asks for and is also the more honest spelling of the
+ * invariant the idiom always had: the ref is only ever READ after the commit
+ * (an effect, an event handler), never during the render that produces the
+ * value. Insertion effects run in the mutation phase — before every layout and
+ * passive effect of the same commit, and before any handler can fire — so
+ * every legitimate reader still sees this render's value, while a render React
+ * throws away now leaves the ref untouched instead of poisoning it. The
+ * `useRef` seed covers the first render, which has no earlier commit to
+ * inherit from.
+ *
  * A site that needs to read the ref during render, or that writes it
  * conditionally, is NOT this idiom and keeps its own `useRef`.
  */
 export function useLatestRef<T>(value: T): RefObject<T> {
   const ref = useRef(value);
-  ref.current = value;
+  useInsertionEffect(() => {
+    ref.current = value;
+  });
   return ref;
 }

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -12,7 +12,7 @@
  * rule — all live here; their comments moved with the statements they
  * annotate.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useInsertionEffect, useRef, useState } from "react";
 import { useLatestRef } from "./use-latest-ref";
 import type { TraceResult } from "@renovate-config-debugger/engine";
 import {
@@ -195,8 +195,14 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
   // `.current` read is not a dependency when it can see the `useRef()` call
   // itself — routed through a custom hook it demands the DEREFERENCED value in
   // the list, which is the one thing that must never be in there.
+  // The write itself is `useLatestRef`'s, inlined: an insertion effect, so it
+  // is not a render-time ref write (`react/refs`) while still landing before
+  // every effect and handler of the same commit — which is all this ref is
+  // ever read from.
   const hostRef = useRef(host);
-  hostRef.current = host;
+  useInsertionEffect(() => {
+    hostRef.current = host;
+  });
 
   /** Roadmap 017: the one path every self-initiated hash write goes through —
    *  updates the address bar and records the token (or lack of one) so the


### PR DESCRIPTION
useLatestRef now commits its value in useInsertionEffect — before any
layout effect or handler can read it, but no longer during a render
React is free to discard — keeping the RefObject API every call site
depends on. The hand-rolled latest-refs converge onto the helper (or the
same insertion-effect spelling where their comments document why the
helper is unusable), and the PresetListPane/App hits were callback-ref
taints of a container object, fixed by destructuring. No inline
disables. This removes the last rule of the oxlint 1.79.0 react-compiler
block plus its decision comment from .oxlintrc.json.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>