### PR TITLE
chore(renovate): disable updates for the engine's extract fixtures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,14 @@
           "packages/engine/test/__snapshots__/**"
         ]
       }
+    },
+    {
+      "description": [
+        "The engine's extract fixtures are test data, not dependencies of this repo.",
+        ":ignoreModulesAndTests exempts nuget from its `**/test/**` glob (renovatebot/renovate#31146), so App.csproj escapes ignorePaths."
+      ],
+      "matchFileNames": ["packages/engine/test/fixtures/**"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## What

Adds a `packageRules` entry to `renovate.json` that disables updates for everything under `packages/engine/test/fixtures/**`.

```json
{
  "description": [
    "The engine's extract fixtures are test data, not dependencies of this repo.",
    ":ignoreModulesAndTests exempts nuget from its `**/test/**` glob (renovatebot/renovate#31146), so App.csproj escapes ignorePaths."
  ],
  "matchFileNames": ["packages/engine/test/fixtures/**"],
  "enabled": false
}
```

## Why

`config:best-practices` → `config:recommended` → `:ignoreModulesAndTests` sets `ignorePaths` including `**/test/**`, which covers the whole fixture corpus — for every manager *except* nuget. The preset carries a manager-scoped override:

```js
ignoreModulesAndTests: {
  description: "Ignore `node_modules`, `bower_components`, `vendor` and various test/tests (except for nuget) directories.",
  ignorePaths: [ ..., "**/__tests__/**", "**/test/**", "**/tests/**", "**/__fixtures__/**" ],
  nuget: { ignorePaths: [ "**/node_modules/**", "**/bower_components/**", "**/vendor/**", "**/examples/**", "**/__fixtures__/**" ] },
}
```

`getManagerConfig(config, 'nuget')` merges `config.nuget` over the top level, so the nuget manager loses the three test globs. That carve-out landed in renovatebot/renovate#31146 (Renovate 38.77.5), closing renovatebot/renovate#12755 — in .NET a test project is a first-class project with its own `.csproj` and its own dependencies, so `test/` there isn't scaffolding the way it is in a JS repo.

Our `App.csproj` is a *fixture*, not a test project, so the carve-out's premise is inverted here. Result: it was the only file in `packages/engine/test/fixtures/extract/` that Renovate detected (confirmed on the Dependency Dashboard — package.json, Dockerfile, go.mod, pom.xml and even `renovate-config/renovate.json` in the same directory are all correctly ignored), and it produced #253 and #254.

## Why `matchFileNames` rather than a `nuget.ignorePaths` block

`ignorePaths` is not a mergeable option, so the documented workaround requires restating the preset's full nuget list to avoid dropping `**/node_modules/**` and friends. Matching by file name is manager-agnostic and covers the whole fixture corpus no matter which manager picks up a future fixture.

## Verification

`rcd validate` accepts the edited config. Simulated against both runs, with the pinned Renovate 44.39.1:

- `Newtonsoft.Json` `13.0.3` → `13.0.4` in `packages/engine/test/fixtures/extract/App.csproj` — *"This patch update WOULD NOT be raised at all (skipReason: package-rules)"*, `enabled: false`.
- `renovate` `44.39.1` → `44.39.2` in `packages/engine/package.json` — unaffected: `enabled: true`, and the existing "Regnerate shims and snapshots" rule still fires with `semanticCommitType: fix`.

Closes the source of #253 and #254 (both can be closed once this merges).
