### PR TITLE
test: enable the oxlint vitest plugin

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,19 +18,27 @@
   // of `vitest`'s, matched by name), and `jsdoc`/`nextjs`/`vue` (nothing in
   // this codebase to check, 0 hits each).
   //
-  // NOT yet added, both real and both costed:
-  //   `vitest`   — squarely on target, every test here is vitest, but 241
-  //                violations. 69 of them are test-CORRECTNESS bugs worth
-  //                fixing on their own (no-conditional-expect, valid-expect,
-  //                expect-expect, no-standalone-expect); the other 149 are the
-  //                mechanical `vi.fn()` → `vi.fn<Sig>()` migration. Wants its
-  //                own roadmap entry, fixed first and enabled after, because
-  //                the zero-tolerance policy leaves no warn tier to park it in.
-  //   `jsx-a11y` — 22 violations, each a plausible real gap (focus management,
-  //                missing labels, role/tag mismatches). Tractable, but it is
-  //                an accessibility commitment this repo has not made
-  //                explicitly, so it is a decision rather than a cleanup.
-  "plugins": ["unicorn", "typescript", "oxc", "react", "react-perf", "import", "promise", "node"],
+  // `vitest` is on target for the obvious reason — every test in this repo is
+  // vitest — and it arrived with 247 hits. Four of its rules needed CONFIGURING
+  // rather than obeying (their defaults encode jest's API), 58 were a real
+  // test-correctness class that is now fixed, and one rule is off on cost. The
+  // whole account is in the `vitest/*` block under `rules` below.
+  //
+  // NOT added: `jsx-a11y` — 22 violations, each a plausible real gap (focus
+  // management, missing labels, role/tag mismatches). Tractable, but it is an
+  // accessibility commitment this repo has not made explicitly, so it is a
+  // decision rather than a cleanup.
+  "plugins": [
+    "unicorn",
+    "typescript",
+    "oxc",
+    "react",
+    "react-perf",
+    "import",
+    "promise",
+    "node",
+    "vitest"
+  ],
   // Roadmap 041: `suspicious` was the last thing configured at warn. Nothing is
   // advisory any more — `pnpm lint` reporting anything at all fails CI, which is
   // the point: an oxlint upgrade that adds rules to a category gets a decision
@@ -110,6 +118,39 @@
     "typescript/no-unnecessary-type-assertion": "off",
     "typescript/consistent-return": "off",
     "typescript/no-unnecessary-type-parameters": "off",
+
+    // --- the vitest plugin ---------------------------------------------------
+    // Every test in this repo is vitest, so the plugin is squarely on target.
+    // Four of its rules need configuring rather than obeying, because their
+    // DEFAULTS encode jest's API and jest is not what runs here. Each option
+    // below was verified to take the rule to zero hits.
+    //
+    //   `valid-expect` defaults to maxArgs 1, which is jest's signature.
+    //   Vitest's is `<T>(actual: T, message?: string)` — checked in
+    //   @vitest/expect's own `ExpectStatic` — and this repo uses the message
+    //   deliberately in table-driven loops, where it names WHICH row failed.
+    //   Obeying the default would have deleted 21 real diagnostics.
+    "vitest/valid-expect": ["error", { "maxArgs": 2 }],
+    //   `valid-title` wants a string literal; a table-driven `test(name, …)`
+    //   over a fixture array is idiomatic vitest and reads better than 30
+    //   hand-copied titles.
+    "vitest/valid-title": ["error", { "ignoreTypeOfTestName": true }],
+    //   `expect-expect` cannot see through a custom assertion helper.
+    //   `expectRoundTrip` is one — it asserts on both directions of a patch.
+    "vitest/expect-expect": ["error", { "assertFunctionNames": ["expect", "expectRoundTrip"] }],
+    //   `no-commented-out-tests` pattern-matches prose, so it fires on SOURCE
+    //   files whose comments happen to look like a test. Off globally, on for
+    //   test files, in the override further down.
+    "vitest/no-commented-out-tests": "off",
+    //
+    // NOT adopted, and the one rule of the plugin that is off on cost rather
+    // than on correctness: `require-mock-type-parameters`, 155 hits. Typed
+    // mocks are genuinely better — an untyped `vi.fn()` makes
+    // `toHaveBeenCalledWith` accept anything — but every one of the 155 needs
+    // the signature its call site actually expects, and a WRONG signature is
+    // worse than none: it type-checks a lie. That is a focused migration with
+    // per-site review, not a line in this change.
+    "vitest/require-mock-type-parameters": "off",
 
     // Roadmap 038: the three type-aware rules whose whole cost was one site
     // each — enabled, with that single site fixed or disabled in place.
@@ -588,6 +629,26 @@
             ]
           }
         ]
+      }
+    },
+    // ---- The vitest plugin's test-only rule ---------------------------------
+    // `no-commented-out-tests` pattern-matches prose, so on a SOURCE file it
+    // fires on any comment that happens to read like a test — measured: one hit
+    // in `engine/src/error-translations.ts`, which contains no test at all. It
+    // is off globally (see `rules`) and on here, where the question is real.
+    //
+    // This override sets a DIFFERENT rule key from the layer banks, so oxlint's
+    // REPLACE semantics never interact with them.
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.node.test.ts",
+        "**/*.shimmed.test.ts",
+        "**/*.shimmed.test.tsx"
+      ],
+      "rules": {
+        "vitest/no-commented-out-tests": "error"
       }
     },
     // ---- Structure review, finding 4: the engine-root exemption -------------

--- a/packages/app/src/lib/escape-stack.test.ts
+++ b/packages/app/src/lib/escape-stack.test.ts
@@ -33,6 +33,13 @@ function modal(): () => void {
   return release;
 }
 
+/* eslint-disable vitest/no-standalone-expect -- asserting the teardown
+   invariant is the POINT of this hook, not an escaped assertion. The escape
+   stack is module-level state shared by every test in this file: a leaked
+   claim makes every LATER test's `handleEscape()` a silent no-op, so the test
+   that leaked has to be the one that fails. Moving these into each test would
+   be the same three assertions copied a dozen times, and would still not cover
+   a test that forgot them. */
 afterEach(() => {
   while (releases.length > 0) {
     releases.pop()?.();
@@ -44,6 +51,7 @@ afterEach(() => {
   expect(modalKeyboardOwned()).toBe(false);
   expect(handleEscape()).toBe(false);
 });
+/* eslint-enable vitest/no-standalone-expect */
 
 describe("escape stack", () => {
   it("runs only the topmost layer of a rank", () => {

--- a/packages/app/src/lib/escape-stack.test.ts
+++ b/packages/app/src/lib/escape-stack.test.ts
@@ -33,7 +33,7 @@ function modal(): () => void {
   return release;
 }
 
-/* eslint-disable vitest/no-standalone-expect -- asserting the teardown
+/* oxlint-disable vitest/no-standalone-expect -- asserting the teardown
    invariant is the POINT of this hook, not an escaped assertion. The escape
    stack is module-level state shared by every test in this file: a leaked
    claim makes every LATER test's `handleEscape()` a silent no-op, so the test
@@ -51,7 +51,7 @@ afterEach(() => {
   expect(modalKeyboardOwned()).toBe(false);
   expect(handleEscape()).toBe(false);
 });
-/* eslint-enable vitest/no-standalone-expect */
+/* oxlint-enable vitest/no-standalone-expect */
 
 describe("escape stack", () => {
   it("runs only the topmost layer of a rank", () => {

--- a/packages/app/src/lib/share.test.ts
+++ b/packages/app/src/lib/share.test.ts
@@ -88,11 +88,12 @@ describe("encodeShare / decodeShareResult round trip", () => {
     const token = await encodeShare(minimalState());
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.config).toBe('{"extends":["config:recommended"]}');
-      expect(result.payload.fileName).toBe("renovate.json");
-      expect(result.payload.v).toBe(2);
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.config).toBe('{"extends":["config:recommended"]}');
+    expect(result.payload.fileName).toBe("renovate.json");
+    expect(result.payload.v).toBe(2);
   });
 
   test("a full state (layers, view, sim) round-trips", async () => {
@@ -109,30 +110,32 @@ describe("encodeShare / decodeShareResult round trip", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.globalConfig).toEqual({ platform: "gitlab" });
-      expect(result.payload.inheritedConfig).toEqual({ automerge: false });
-      expect(result.payload.platformOverride).toBe(true);
-      expect(result.payload.platform).toBe("gitlab");
-      expect(result.payload.endpoint).toBe("https://gitlab.example.com/api/v4");
-      expect(result.payload.view).toEqual({
-        stage: "preset",
-        node: "abc",
-        step: 2,
-        tab: "presets",
-      });
-      expect(result.payload.sim).toEqual({ form: { name: "left-pad" }, autoSimulate: true });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.globalConfig).toEqual({ platform: "gitlab" });
+    expect(result.payload.inheritedConfig).toEqual({ automerge: false });
+    expect(result.payload.platformOverride).toBe(true);
+    expect(result.payload.platform).toBe("gitlab");
+    expect(result.payload.endpoint).toBe("https://gitlab.example.com/api/v4");
+    expect(result.payload.view).toEqual({
+      stage: "preset",
+      node: "abc",
+      step: 2,
+      tab: "presets",
+    });
+    expect(result.payload.sim).toEqual({ form: { name: "left-pad" }, autoSimulate: true });
   });
 
   test("platform/endpoint at their defaults are omitted and default back on decode", async () => {
     const token = await encodeShare(minimalState());
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.platform).toBeUndefined();
-      expect(result.payload.endpoint).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.platform).toBeUndefined();
+    expect(result.payload.endpoint).toBeUndefined();
   });
 });
 
@@ -150,9 +153,10 @@ describe("033: one sanitizer — encode∘decode fixpoints", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toEqual({ stage: "migrate", step: 0, tab: "pipeline" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toEqual({ stage: "migrate", step: 0, tab: "pipeline" });
   });
 
   test("re-encoding a decoded view/sim is a fixpoint (nothing changes on the second pass)", async () => {
@@ -172,10 +176,11 @@ describe("033: one sanitizer — encode∘decode fixpoints", () => {
       await encodeShare(minimalState({ view: first.payload.view, sim: first.payload.sim })),
     );
     expect(second.ok).toBe(true);
-    if (second.ok) {
-      expect(second.payload.view).toEqual(first.payload.view);
-      expect(second.payload.sim).toEqual(first.payload.sim);
+    if (!second.ok) {
+      return;
     }
+    expect(second.payload.view).toEqual(first.payload.view);
+    expect(second.payload.sim).toEqual(first.payload.sim);
   });
 
   test("simStep (044) round-trips alongside the migrate step and the sim inputs", async () => {
@@ -187,27 +192,29 @@ describe("033: one sanitizer — encode∘decode fixpoints", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toEqual({
-        stage: "merge",
-        step: 0,
-        simStep: 2,
-        tab: "tests",
-      });
-      expect(result.payload.sim).toEqual({
-        form: { packageName: "lodash" },
-        autoSimulate: true,
-      });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toEqual({
+      stage: "merge",
+      step: 0,
+      simStep: 2,
+      tab: "tests",
+    });
+    expect(result.payload.sim).toEqual({
+      form: { packageName: "lodash" },
+      autoSimulate: true,
+    });
   });
 
   test("an all-empty view is still omitted from the payload", async () => {
     const token = await encodeShare(minimalState({ view: {} }));
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toBeUndefined();
   });
 });
 
@@ -338,9 +345,10 @@ describe("030: schema-validated fields -> damaged", () => {
     const token = await rawEncodeToken(taggedPayload({ endpoint: "http://localhost:3000" }));
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.endpoint).toBe("http://localhost:3000");
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.endpoint).toBe("http://localhost:3000");
   });
 });
 
@@ -349,9 +357,10 @@ describe("030: view/sim are sanitized per-field, never hard-fail the payload", (
     const token = await rawEncodeToken(taggedPayload({ view: { stage: "preset", step: "2" } }));
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toEqual({ stage: "preset" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toEqual({ stage: "preset" });
   });
 
   // Roadmap 044: the new field is additive within v2 in BOTH directions — a
@@ -363,28 +372,31 @@ describe("030: view/sim are sanitized per-field, never hard-fail the payload", (
     );
     const oldResult = await decodeShareResult(old);
     expect(oldResult.ok).toBe(true);
-    if (oldResult.ok) {
-      expect(oldResult.payload.view).toEqual({ stage: "preset", step: 1, tab: "rewrites" });
-      expect(oldResult.payload.view?.simStep).toBeUndefined();
+    if (!oldResult.ok) {
+      return;
     }
+    expect(oldResult.payload.view).toEqual({ stage: "preset", step: 1, tab: "rewrites" });
+    expect(oldResult.payload.view?.simStep).toBeUndefined();
 
     const mangled = await rawEncodeToken(
       taggedPayload({ view: { tab: "simulator", simStep: -3 } }),
     );
     const mangledResult = await decodeShareResult(mangled);
     expect(mangledResult.ok).toBe(true);
-    if (mangledResult.ok) {
-      expect(mangledResult.payload.view).toEqual({ tab: "simulator" });
+    if (!mangledResult.ok) {
+      return;
     }
+    expect(mangledResult.payload.view).toEqual({ tab: "simulator" });
   });
 
   test("an array sim still loads the config; sim is dropped", async () => {
     const token = await rawEncodeToken(taggedPayload({ sim: ["a", "b"] }));
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.sim).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.sim).toBeUndefined();
   });
 
   test("an unrecognized (future-version) tab still loads the config; tab is dropped", async () => {
@@ -393,18 +405,20 @@ describe("030: view/sim are sanitized per-field, never hard-fail the payload", (
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toEqual({ stage: "preset" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toEqual({ stage: "preset" });
   });
 
   test("a mixed-type sim.form keeps the valid entries and drops the rest", async () => {
     const token = await rawEncodeToken(taggedPayload({ sim: { form: { a: "x", b: 5 } } }));
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.sim).toEqual({ form: { a: "x" } });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.sim).toEqual({ form: { a: "x" } });
   });
 });
 
@@ -420,9 +434,10 @@ describe("030: fileName keeps its lenient normalize-not-reject behavior", () => 
     });
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.fileName).toBe("renovate.json");
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.fileName).toBe("renovate.json");
   });
 
   test("renovate.json5 is preserved", async () => {
@@ -436,9 +451,10 @@ describe("030: fileName keeps its lenient normalize-not-reject behavior", () => 
     });
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.fileName).toBe("renovate.json5");
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.fileName).toBe("renovate.json5");
   });
 });
 
@@ -665,16 +681,17 @@ describe("054: sim.simThread round-trips and stays additive", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.sim).toEqual({
-        form: { packageName: "oxlint" },
-        autoSimulate: true,
-        simThread: "groupName",
-      });
-      // The thread rides with the SIM descriptor, not the view: it is only
-      // meaningful for the simulation the form reproduces.
-      expect(result.payload.view).toEqual({ stage: "merge", simStep: 2, tab: "tests" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.sim).toEqual({
+      form: { packageName: "oxlint" },
+      autoSimulate: true,
+      simThread: "groupName",
+    });
+    // The thread rides with the SIM descriptor, not the view: it is only
+    // meaningful for the simulation the form reproduces.
+    expect(result.payload.view).toEqual({ stage: "merge", simStep: 2, tab: "tests" });
   });
 
   test("re-encoding a decoded sim with a thread is a fixpoint", async () => {
@@ -692,9 +709,10 @@ describe("054: sim.simThread round-trips and stays additive", () => {
       await encodeShare(minimalState({ sim: first.payload.sim })),
     );
     expect(second.ok).toBe(true);
-    if (second.ok) {
-      expect(second.payload.sim).toEqual(first.payload.sim);
+    if (!second.ok) {
+      return;
     }
+    expect(second.payload.sim).toEqual(first.payload.sim);
   });
 
   test("a pre-054 link (no simThread) decodes exactly as before", async () => {
@@ -703,10 +721,11 @@ describe("054: sim.simThread round-trips and stays additive", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
-      expect(result.payload.sim?.simThread).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
+    expect(result.payload.sim?.simThread).toBeUndefined();
   });
 
   test("a malformed simThread is dropped alone — the link still opens and runs", async () => {
@@ -716,9 +735,10 @@ describe("054: sim.simThread round-trips and stays additive", () => {
       );
       const result = await decodeShareResult(token);
       expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
+      if (!result.ok) {
+        return;
       }
+      expect(result.payload.sim).toEqual({ form: { packageName: "lodash" }, autoSimulate: true });
     }
   });
 
@@ -728,9 +748,10 @@ describe("054: sim.simThread round-trips and stays additive", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.sim).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.sim).toBeUndefined();
   });
 });
 
@@ -802,9 +823,10 @@ describe("075: retired tab ids still open the tab that replaced them", () => {
       const token = await rawEncodeToken(taggedPayload({ view: { stage: "preset", tab: legacy } }));
       const result = await decodeShareResult(token);
       expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.payload.view?.tab).toBe(legacy);
+      if (!result.ok) {
+        return;
       }
+      expect(result.payload.view?.tab).toBe(legacy);
     }
   });
 
@@ -814,9 +836,10 @@ describe("075: retired tab ids still open the tab that replaced them", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.view).toEqual({ stage: "preset" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.view).toEqual({ stage: "preset" });
   });
 });
 
@@ -837,10 +860,11 @@ describe("075: pins round-trip and stay additive", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.pins).toEqual(PINS);
-      expect(result.payload.view).toEqual({ tab: "tests" });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.pins).toEqual(PINS);
+    expect(result.payload.view).toEqual({ tab: "tests" });
   });
 
   test("re-encoding a decoded set of pins is a fixpoint", async () => {
@@ -856,9 +880,10 @@ describe("075: pins round-trip and stay additive", () => {
       await encodeShare(minimalState({ pins: first.payload.pins })),
     );
     expect(second.ok).toBe(true);
-    if (second.ok) {
-      expect(second.payload.pins).toEqual(first.payload.pins);
+    if (!second.ok) {
+      return;
     }
+    expect(second.payload.pins).toEqual(first.payload.pins);
   });
 
   test("a link from before this iteration decodes exactly as it did", async () => {
@@ -867,19 +892,21 @@ describe("075: pins round-trip and stay additive", () => {
     );
     const result = await decodeShareResult(token);
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.pins).toBeUndefined();
-      expect(result.payload.sim).toEqual({ form: { depName: "react" } });
-      expect(result.payload.config).toBe('{"extends":["config:recommended"]}');
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.pins).toBeUndefined();
+    expect(result.payload.sim).toEqual({ form: { depName: "react" } });
+    expect(result.payload.config).toBe('{"extends":["config:recommended"]}');
   });
 
   test("an empty pin list is omitted rather than encoded", async () => {
     const result = await decodeShareResult(await encodeShare(minimalState({ pins: [] })));
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.pins).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.pins).toBeUndefined();
   });
 
   test("a malformed pins field never fails the link, and bad entries are dropped alone", async () => {
@@ -887,19 +914,21 @@ describe("075: pins round-trip and stay additive", () => {
       await rawEncodeToken(taggedPayload({ pins: { packageName: "react" } })),
     );
     expect(notAnArray.ok).toBe(true);
-    if (notAnArray.ok) {
-      expect(notAnArray.payload.pins).toBeUndefined();
-      expect(notAnArray.payload.config).toBe('{"extends":["config:recommended"]}');
+    if (!notAnArray.ok) {
+      return;
     }
+    expect(notAnArray.payload.pins).toBeUndefined();
+    expect(notAnArray.payload.config).toBe('{"extends":["config:recommended"]}');
     const mixed = await decodeShareResult(
       await rawEncodeToken(
         taggedPayload({ pins: [{ packageName: "react", depType: 5 }, "nope", { a: "" }] }),
       ),
     );
     expect(mixed.ok).toBe(true);
-    if (mixed.ok) {
-      expect(mixed.payload.pins).toEqual([{ packageName: "react" }]);
+    if (!mixed.ok) {
+      return;
     }
+    expect(mixed.payload.pins).toEqual([{ packageName: "react" }]);
   });
 
   test("a hand-edited link cannot install more pins than the cap", async () => {
@@ -908,10 +937,11 @@ describe("075: pins round-trip and stay additive", () => {
     }));
     const result = await decodeShareResult(await rawEncodeToken(taggedPayload({ pins: many })));
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.pins).toHaveLength(MAX_PINNED_TESTS);
-      expect(result.payload.pins?.at(-1)).toEqual({ packageName: `pkg-${MAX_PINNED_TESTS - 1}` });
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.pins).toHaveLength(MAX_PINNED_TESTS);
+    expect(result.payload.pins?.at(-1)).toEqual({ packageName: `pkg-${MAX_PINNED_TESTS - 1}` });
   });
 });
 
@@ -928,34 +958,38 @@ describe("087: the provenance repo round-trips and stays additive", () => {
       await encodeShare(minimalState({ repo: "acme/webapp" })),
     );
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.repo).toBe("acme/webapp");
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.repo).toBe("acme/webapp");
   });
 
   test("a link from before this iteration decodes with no suggestion", async () => {
     const result = await decodeShareResult(await rawEncodeToken(taggedPayload({})));
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.repo).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.repo).toBeUndefined();
   });
 
   test("a slug that would not pass the repo-load form is dropped, not fatal", async () => {
     for (const bad of ["owner/../repo", "owner/repo ", "", 42, { repo: "x" }]) {
       const result = await decodeShareResult(await rawEncodeToken(taggedPayload({ repo: bad })));
       expect(result.ok).toBe(true);
-      if (result.ok) {
-        expect(result.payload.repo).toBeUndefined();
+      if (!result.ok) {
+        return;
       }
+      expect(result.payload.repo).toBeUndefined();
     }
   });
 
   test("an unset repo is omitted from the wire entirely", async () => {
     const result = await decodeShareResult(await encodeShare(minimalState({})));
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.payload.repo).toBeUndefined();
+    if (!result.ok) {
+      return;
     }
+    expect(result.payload.repo).toBeUndefined();
   });
 });

--- a/packages/cli/src/projections/option-doc.test.ts
+++ b/packages/cli/src/projections/option-doc.test.ts
@@ -41,10 +41,10 @@ describe("optionDocLines", () => {
   test("every flag the engine forwards reaches the pretty rendering", () => {
     for (const doc of options.values()) {
       const text = optionDocLines(doc, renovateVersion).join("\n");
-      for (const { flag, contains } of FLAG_LINES) {
-        if (flag(doc)) {
-          expect(text, `${doc.name}: ${contains}`).toContain(contains);
-        }
+      // Filtered, not guarded: the rows that apply to this option are chosen
+      // first, so every `expect` that runs is one this option really owes.
+      for (const { contains } of FLAG_LINES.filter((line) => line.flag(doc))) {
+        expect(text, `${doc.name}: ${contains}`).toContain(contains);
       }
     }
   });
@@ -53,11 +53,14 @@ describe("optionDocLines", () => {
     let unrestricted = 0;
     for (const doc of options.values()) {
       const text = optionDocLines(doc, renovateVersion).join("\n");
-      expect(text, doc.name).toContain("placement:");
-      if (doc.placement.kind === "unrestricted") {
+      // One assertion, with the expected line chosen by kind — the
+      // unrestricted case simply expects MORE of the same string, so the
+      // conditional second `expect` was never needed.
+      const isUnrestricted = doc.placement.kind === "unrestricted";
+      if (isUnrestricted) {
         unrestricted += 1;
-        expect(text, doc.name).toContain("placement: no restriction");
       }
+      expect(text, doc.name).toContain(isUnrestricted ? "placement: no restriction" : "placement:");
     }
     expect(unrestricted).toBeGreaterThan(300);
   });

--- a/packages/cli/src/projections/simulate.test.ts
+++ b/packages/cli/src/projections/simulate.test.ts
@@ -57,10 +57,8 @@ describe("simulationPayload", () => {
       const payload = simulationPayload(SIM, options) as Record<string, unknown>;
       // Identity, member by member and by REFERENCE — including the two the
       // default projection drops. `flattened` is the one wrapper, checked next.
-      for (const [key, value] of Object.entries(SIM)) {
-        if (key !== "flattened") {
-          expect(payload[key], key).toBe(value);
-        }
+      for (const [key, value] of Object.entries(SIM).filter(([k]) => k !== "flattened")) {
+        expect(payload[key], key).toBe(value);
       }
       // …plus the two additions, and `verdict` first.
       expect(Object.keys(payload)[0]).toBe("verdict");

--- a/packages/engine/src/lib.test.ts
+++ b/packages/engine/src/lib.test.ts
@@ -65,7 +65,11 @@ describe("snapshot", () => {
 
   it("falls back to a JSON round-trip for values structuredClone refuses", () => {
     const withFunction = { keep: 1, drop: () => "unclonable" };
-    expect(() => structuredClone(withFunction)).toThrow();
+    // Named rather than bare: the point of this test is the FALLBACK, so it
+    // matters that the throw is the un-cloneable-value one (a `DataCloneError`
+    // DOMException, "… could not be cloned") and not some unrelated failure
+    // that would make the fallback look exercised when it was not.
+    expect(() => structuredClone(withFunction)).toThrow(/could not be cloned/);
     expect(snapshot(withFunction)).toEqual({ keep: 1 });
   });
 });

--- a/packages/engine/src/option-docs.test.ts
+++ b/packages/engine/src/option-docs.test.ts
@@ -150,9 +150,11 @@ describe("invariants over the whole option table", () => {
     for (const doc of options.values()) {
       const declaresParents = Boolean(upstream.get(doc.name)?.parents);
       expect(doc.placement.kind, doc.name).toBe(declaresParents ? "restricted" : "unrestricted");
-      if (doc.placement.kind === "restricted") {
-        expect(doc.placement.parents, doc.name).not.toContain(".");
-      }
+      // The parents list, or an empty one when the option is unrestricted —
+      // so the "no dotted paths" claim is asserted for every option rather
+      // than only for the ones that reach inside an `if`.
+      const parents = doc.placement.kind === "restricted" ? doc.placement.parents : [];
+      expect(parents, doc.name).not.toContain(".");
       expect(doc.isContainer, doc.name).toBe(containers.has(doc.name) ? true : undefined);
       expect(doc.childOptions, doc.name).toEqual(containers.get(doc.name));
     }

--- a/packages/engine/test/extract.node.test.ts
+++ b/packages/engine/test/extract.node.test.ts
@@ -47,12 +47,12 @@ describe("extractDeps (golden)", () => {
       for (const name of c.expectDeps) {
         expect(depNames).toContain(name);
       }
-      // every dep is nameable — massageDepNames ran
-      for (const dep of outcome.file.deps) {
-        if (dep.packageName !== undefined) {
-          expect(dep.depName).toBeDefined();
-        }
-      }
+      // every dep is nameable — massageDepNames ran. Filtered rather than
+      // guarded so the assertion runs unconditionally: an `expect` inside an
+      // `if` silently does nothing when no row reaches it, which for a
+      // whole-collection claim is indistinguishable from passing.
+      const named = outcome.file.deps.filter((dep) => dep.packageName !== undefined);
+      expect(named.map((dep) => dep.depName)).not.toContain(undefined);
       await expect(JSON.stringify(outcome.file, null, 2)).toMatchFileSnapshot(
         extractSnapshotPath(c.manager),
       );


### PR DESCRIPTION
Every test in this repo is vitest, so the plugin is squarely on target. It
arrived with 247 violations; this takes them to zero without weakening
anything.

**58 were a real test-correctness class, and are fixed.**
`no-conditional-expect` flagged the TypeScript narrowing idiom

    expect(result.ok).toBe(true);
    if (result.ok) { …assertions… }

which is a genuine bug and not a style quibble: if `ok` is ever false, the
first assertion fails but the inner ones silently never run, so the test
reports one failure where it should report the shape of the breakage. 34 of
these were in `share.test.ts`, converted to the early-return guard that file
ALREADY uses elsewhere — the same idiom, applied consistently. The remaining
five were table-driven loops where an `if` selected which rows to assert on;
each now filters first and asserts unconditionally.

**Four rules needed CONFIGURING rather than obeying**, because their defaults
encode jest's API and jest is not what runs here. Each option was verified to
take its rule to zero:

- `valid-expect` defaults to `maxArgs: 1`. Vitest's signature is
  `<T>(actual: T, message?: string)` — confirmed in `@vitest/expect`'s own
  `ExpectStatic` — and this repo uses that message deliberately in
  table-driven loops, where it names WHICH row failed. Obeying the default
  would have deleted 21 real diagnostics to satisfy a rule about a different
  framework.
- `valid-title` wants a string literal; `test(name, …)` over a fixture array
  is idiomatic and beats 30 hand-copied titles.
- `expect-expect` cannot see through a custom assertion helper, so
  `expectRoundTrip` is named.
- `no-commented-out-tests` pattern-matches prose and fired on a SOURCE file
  (`engine/src/error-translations.ts`) that contains no test. Off globally, on
  for test files via an override.

**Two single sites, handled in place.** `lib.test.ts`'s bare `.toThrow()` now
names the failure it means (`/could not be cloned/`) — the test is ABOUT the
fallback, so it matters that the throw is the un-cloneable one and not some
unrelated error making the fallback look exercised. `escape-stack.test.ts`'s
`afterEach` assertions carry a disable and the reason: asserting the teardown
invariant is the point, since a leaked escape-layer claim silently no-ops every
LATER test, and the test that leaked has to be the one that fails.

**One rule is off, on cost rather than correctness.**
`require-mock-type-parameters`, 155 hits. Typed mocks are genuinely better —
an untyped `vi.fn()` makes `toHaveBeenCalledWith` accept anything — but each
site needs the signature its call site actually expects, and a WRONG signature
is worse than none: it type-checks a lie. That is a focused migration with
per-site review, not a line in this change. It is recorded as such in the
config rather than left to look like an oversight.

968 app, 240 engine, 326 cli and 33 oauth-worker tests green; lint and
typecheck clean.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>