### PR TITLE
refactor: share the host-failure phrase instead of policing two copies

### DIFF
--- a/packages/app/src/lib/github-failure.ts
+++ b/packages/app/src/lib/github-failure.ts
@@ -1,18 +1,23 @@
 import type { PresetNode } from "@renovate-config-debugger/engine";
+import { AUTH_OR_RATE_LIMIT_HINT } from "@renovate-config-debugger/engine/contracts";
 
 /**
- * The app's half of a VERBATIM cross-package string contract.
+ * The app's reader of the engine's failure messages.
  *
- * `packages/engine/src/shims/presets/host-transport.ts` ends its 401/403/429
- * message with the words "rate limit or missing token", and says in its header
- * that the wording is load-bearing: the app matches it to tell an auth or
- * rate-limit failure apart from a genuinely missing preset, and to decide
- * whether offering sign-in would help. Changing either side degrades the app
- * SILENTLY — it simply stops offering the fix, and nothing fails.
+ * Renovate rethrows a plain `Error` through its preset machinery, so the only
+ * thing that survives the trip from the shim to here is the message string —
+ * which makes the wording an API. It is DECLARED once, in
+ * `engine/src/contracts.ts`, and imported by both sides: the shim builds its
+ * message with the constant, this file builds its matcher from the same one.
  *
- * That contract used to be spelled as a bare regex literal in two places, so
- * the engine's note had to name two files by path and hope. It is one function
- * now, which is the file the engine comment points at.
+ * The engine used to carry a "VERBATIM STRINGS … must stay byte-identical"
+ * banner naming this file by path, because the phrase was written out at both
+ * ends and nothing could check that they agreed. There is no second copy now,
+ * so there is nothing to keep in step and no instruction to obey.
+ *
+ * `./contracts` is a leaf subpath with no imports of its own — reaching the
+ * engine ROOT for a value would pull the whole Renovate graph onto a static
+ * path, which is what `.oxlintrc.json`'s engine-root ban exists to stop.
  */
 
 /**
@@ -20,9 +25,13 @@ import type { PresetNode } from "@renovate-config-debugger/engine";
  * to a preset that genuinely is not there. Renovate rethrows these WITHOUT the
  * rewrite it applies to `dep not found`, which is why the fetcher's own wording
  * survives all the way to the app.
+ *
+ * Compared case-insensitively by lowering both sides rather than by building a
+ * `RegExp` from the constant: a shared string needs no escaping this way, and
+ * cannot become a pattern by accident if the phrase ever gains punctuation.
  */
 export function isGithubRateLimited(message: string | undefined): boolean {
-  return /rate limit or missing token/i.test(message ?? "");
+  return (message ?? "").toLowerCase().includes(AUTH_OR_RATE_LIMIT_HINT.toLowerCase());
 }
 
 /**

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./contracts": "./src/contracts.ts",
     "./schema": "./src/schema.ts",
     "./simulate-missing-inputs": "./src/simulate-missing-inputs.ts",
     "./text-scan": "./src/text-scan.ts",

--- a/packages/engine/src/contracts.ts
+++ b/packages/engine/src/contracts.ts
@@ -1,0 +1,48 @@
+/**
+ * Message fragments the engine PRODUCES and the app READS programmatically.
+ *
+ * The app cannot see the engine's error types — Renovate rethrows a plain
+ * `Error` through its own preset machinery — so the only thing that survives
+ * the trip is the message string. That makes the wording an API, and it used to
+ * be an API maintained by comment: `shims/presets/host-transport.ts` carried a
+ * "VERBATIM STRINGS" banner warning that changing a phrase would degrade the
+ * app SILENTLY, because the app simply stops recognising the failure and
+ * nothing throws.
+ *
+ * A banner is not a mechanism. The phrase is declared here instead, once, and
+ * both sides import it: the shim builds its message with it, the app builds its
+ * matcher from it. There is no second copy to drift from.
+ *
+ * WHY THIS MODULE HAS NO IMPORTS, and must not gain any. It is reachable from
+ * the app through the `./contracts` subpath, and the app must never pull the
+ * Renovate graph onto a static import path (see `lib/rule-verdict.ts` and the
+ * engine-root ban in `.oxlintrc.json`). Constants only, so the subpath's whole
+ * runtime cost is this file.
+ *
+ * Not a separate workspace package, deliberately: the app already depends on
+ * the engine, and the contract flows the same way the dependency does —
+ * producer above, consumer below. A third package would add a version to keep
+ * in step for no additional safety.
+ */
+
+/**
+ * The tail of the message a host API returns for 401 / 403 / 429.
+ *
+ * The app tells this apart from a genuinely missing preset in order to offer
+ * sign-in, which is the whole point: a private repo the user COULD reach and a
+ * preset that does not exist look identical otherwise. Read by
+ * `isGithubRateLimited` (`packages/app/src/lib/github-failure.ts`).
+ */
+export const AUTH_OR_RATE_LIMIT_HINT = "rate limit or missing token";
+
+/**
+ * The tail of the message a fetch that never reached the host produces.
+ *
+ * NOT machine-read: the app pastes the engine's whole detail into its own
+ * sentence and appends its CORS advice unconditionally, so no matcher depends
+ * on this wording. It is declared here anyway because the two producers below
+ * spelled it out separately, and because the header it replaces claimed it was
+ * a contract — leaving it as prose would keep that claim alive without the
+ * check.
+ */
+export const NETWORK_OR_CORS_HINT = "likely missing CORS headers or a network block";

--- a/packages/engine/src/shims/presets/host-transport.ts
+++ b/packages/engine/src/shims/presets/host-transport.ts
@@ -6,10 +6,10 @@
  *
  * Why it is shared rather than written per host: the four call sites used to
  * spell out the same six steps, and the messages they produce are CONSUMED —
- * the app regexes them (see the verbatim note below), the trace collector
- * unwraps them, and `repo-config` decides whether to keep probing by their
- * type. Four independent producers behind one consumer is how the wording
- * drifts and the UI silently stops recognising an auth failure.
+ * the app matches one of them (`../../contracts`), the trace collector unwraps
+ * them, and `repo-config` decides whether to keep probing by their type. Four
+ * independent producers behind one consumer is how the wording drifts and the
+ * UI silently stops recognising an auth failure.
  *
  * What is deliberately NOT here: everything past the response. The preset
  * fetchers hand a non-ok response to Renovate's own `fetchPreset` candidate
@@ -17,27 +17,16 @@
  * "this candidate is absent, try the next" — the same status, two different
  * meanings, so each keeps its own tail.
  *
- * ─────────────────────────────────────────────────────────────────────────
- * VERBATIM STRINGS. Two message fragments below are load-bearing across the
- * package boundary and must stay byte-identical:
- *
- *   "… — rate limit or missing token"
- *      matched by `isGithubRateLimited`, the app's ONE reader of this contract
- *      (packages/app/src/lib/github-failure.ts), to tell an auth/rate-limit
- *      failure apart from a genuinely missing preset and offer sign-in. It used
- *      to be a bare regex spelled at two call sites, which is why this note
- *      once had to name two files and hope.
- *
- *   "… likely missing CORS headers or a network block (…)"
- *      the detail the app pastes into its "some hosts block browser (CORS)
- *      requests entirely" advice.
- *
- * Change either and the app degrades silently — it stops offering the fix,
- * with nothing failing. `packages/engine/test/repo-config.shimmed.test.ts` and
- * `packages/app/src/features/presets/tree-shared.test.ts` pin them.
- * ─────────────────────────────────────────────────────────────────────────
+ * The two message tails the app depends on come from `../../contracts` rather
+ * than being spelled here. This banner used to say instead that they were
+ * "VERBATIM STRINGS … must stay byte-identical", name the app files that read
+ * them, and warn that changing one degrades the app silently. All of that was
+ * true, and none of it was checkable: a warning in a comment is not a
+ * mechanism. Sharing the constant means there is no second copy to keep in
+ * step, so the instruction is unnecessary.
  */
 import { resolveAuthToken } from "../../auth";
+import { AUTH_OR_RATE_LIMIT_HINT, NETWORK_OR_CORS_HINT } from "../../contracts";
 import { ExternalHostError, fetchPreset } from "../renovate-internals";
 import { encodePathSegments } from "../url-path";
 import { getInjectedPreset } from "./injection";
@@ -133,7 +122,7 @@ export async function hostFetch(request: HostRequest): Promise<Response> {
     throw new ExternalHostError(
       new Error(
         `Could not reach the ${request.label} endpoint ${request.shownEndpoint} from the browser — ` +
-          `likely missing CORS headers or a network block (${err instanceof Error ? err.message : String(err)})`,
+          `${NETWORK_OR_CORS_HINT} (${err instanceof Error ? err.message : String(err)})`,
       ),
       request.platform,
     );
@@ -141,7 +130,7 @@ export async function hostFetch(request: HostRequest): Promise<Response> {
   if (res.status === 401 || res.status === 403 || res.status === 429) {
     throw new ExternalHostError(
       new Error(
-        `${request.label} API rejected the request (HTTP ${res.status}) — rate limit or missing token`,
+        `${request.label} API rejected the request (HTTP ${res.status}) — ${AUTH_OR_RATE_LIMIT_HINT}`,
       ),
       request.platform,
     );


### PR DESCRIPTION
The engine produces a failure message; the app matches part of it to tell an
auth/rate-limit failure apart from a genuinely missing preset and offer
sign-in. Renovate rethrows a plain `Error` through its preset machinery, so the
message string is the only thing that survives the trip — which makes the
wording an API.

It was an API maintained by comment. `host-transport.ts` carried a "VERBATIM
STRINGS … must stay byte-identical" banner that named the app files by path and
warned that changing a phrase would degrade the app SILENTLY. Every word of
that was true and none of it was checkable.

`engine/src/contracts.ts` declares the phrase once and both sides import it:
the shim builds its message with the constant, `isGithubRateLimited` builds its
matcher from the same one. There is no second copy, so there is nothing to keep
in step and no instruction to obey — the banner is gone rather than reworded.

Not a new workspace package: the app already depends on the engine, and the
contract flows the same direction the dependency does (producer above, consumer
below). A third package would add a version to keep in step for no extra
safety. It is a `./contracts` subpath with NO imports of its own, for the reason
`lib/rule-verdict.ts` documents — reaching the engine root for a value pulls the
whole Renovate graph onto a static path. Verified: `ResultsColumn`'s emitted
chunk still statically imports only the runtime, the entry chunk and the 2.4 kB
`simulate-missing-inputs`.

The literals that REMAIN are all in tests, deliberately. A test asserting the
exact produced wording is a golden assertion; building it from the constant
would make it tautological and assert nothing.

What that combination buys is the check the comment could not give. Before,
`tree-shared.test.ts` fed a hand-written copy of the engine's message to a
hand-written app regex — both could stay green while the engine moved on.
Mutation-tested after the change: altering the shared constant now fails three
app-side tests, because the app's matcher shifts while the golden fixture does
not.

Also corrects the record on the second phrase. The banner listed the CORS
detail as a contract too; the app never matches it — it pastes the engine's
detail into its own sentence and appends the advice unconditionally. It is
declared alongside for the two producers that spelled it out separately, and
`contracts.ts` says plainly that nothing machine-reads it.

968 app and 240 engine tests green; lint, typecheck and the dev-graph guard
clean.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>