### PR TITLE
ci(lint): add the house rules — six custom oxlint rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,6 +41,9 @@
     "vitest",
     "jsx-a11y"
   ],
+  // This repo's own rules — see tools/lint/rules.ts. Every one is derived
+  // from duplication that was actually in the tree, not from a preference.
+  "jsPlugins": ["./tools/lint/rules.ts"],
   // Roadmap 041: `suspicious` was the last thing configured at warn. Nothing is
   // advisory any more — `pnpm lint` reporting anything at all fails CI, which is
   // the point: an oxlint upgrade that adds rules to a category gets a decision
@@ -211,7 +214,13 @@
         "packages/*/playwright.config.ts",
         "packages/oauth-worker/src/index.ts",
         "stylelint.config.mjs",
-        "release.config.mjs"
+        "release.config.mjs",
+        // The root vitest config, and the house-rule plugin: `definePlugin` and
+        // `defineRule` are default-export APIs, and oxlint loads `rules.ts` by
+        // path expecting one.
+        "vitest.config.ts",
+        "tools/lint/rules.ts",
+        "tools/lint/rules/*.ts"
       ],
       "rules": {
         "import/no-default-export": "off"
@@ -709,6 +718,63 @@
       "rules": {
         "vitest/no-commented-out-tests": "error"
       }
+    },
+    // ---- The house rules (tools/lint) ---------------------------------------
+    // Scoped to the APP's source, because that is where the helpers they point
+    // at live. `packages/engine` and `packages/cli` have their own
+    // `isPlainObject` and their own error-to-string, and must: the app's
+    // `@/lib/*` is across a package boundary they cannot import. Enabling the
+    // rules there would be telling them to import something that does not
+    // resolve.
+    //
+    // Test files are excluded. A test that spells `packageRules[0]` out is a
+    // GOLDEN assertion — building it from `ruleRef` would make it tautological
+    // and assert nothing — and a fixture is not production code the helper is
+    // trying to keep honest.
+    {
+      "files": ["packages/app/src/**"],
+      "excludeFiles": [
+        "packages/app/src/**/*.test.ts",
+        "packages/app/src/**/*.test.tsx",
+        "packages/app/src/**/*.shimmed.test.tsx"
+      ],
+      "rules": {
+        "rcd/use-error-message": "error",
+        "rcd/use-rule-ref": "error",
+        "rcd/use-synced-reset": "error",
+        "rcd/use-transient-value": "error",
+        "rcd/use-truncate": "error",
+        "rcd/no-local-is-plain-object": "error"
+      }
+    },
+    // ---- …and the files that ARE the helper ---------------------------------
+    // Same shape as the single-import-site exemptions below: the one place the
+    // thing may be spelled out is the place that defines it. Each override
+    // names ONE rule, so no REPLACE interaction with the layer banks — those
+    // are a different rule key entirely.
+    {
+      "files": ["packages/app/src/lib/errors.ts"],
+      "rules": { "rcd/use-error-message": "off" }
+    },
+    {
+      "files": ["packages/app/src/lib/rule-ref.ts"],
+      "rules": { "rcd/use-rule-ref": "off" }
+    },
+    {
+      "files": ["packages/app/src/lib/input-schemas.ts"],
+      "rules": { "rcd/no-local-is-plain-object": "off" }
+    },
+    {
+      "files": ["packages/app/src/hooks/use-transient-value.ts"],
+      "rules": { "rcd/use-transient-value": "off" }
+    },
+    {
+      "files": ["packages/app/src/hooks/use-synced-reset.ts"],
+      "rules": { "rcd/use-synced-reset": "off" }
+    },
+    {
+      "files": ["packages/app/src/lib/truncate.ts"],
+      "rules": { "rcd/use-truncate": "off" }
     },
     // ---- Structure review, finding 4: the engine-root exemption -------------
     // The shimmed component tests drive the REAL pipeline — `runPipeline` and

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -215,10 +215,15 @@
         "packages/oauth-worker/src/index.ts",
         "stylelint.config.mjs",
         "release.config.mjs",
-        // The root vitest config, and the house-rule plugin: `definePlugin` and
-        // `defineRule` are default-export APIs, and oxlint loads `rules.ts` by
-        // path expecting one.
-        "vitest.config.ts",
+        // The house rules' vitest config, and the plugin itself: `definePlugin`
+        // and `defineRule` are default-export APIs, and oxlint loads `rules.ts`
+        // by path expecting one. Vitest configs must default-export too.
+        //
+        // The filename is `vitest.tools.config.ts`, NOT `vitest.config.ts`:
+        // vitest walks up from a package looking for the latter, and
+        // `packages/oauth-worker` has no config of its own, so a root file by
+        // that name gets adopted by it and then finds no tests there.
+        "vitest.tools.config.ts",
         "tools/lint/rules.ts",
         "tools/lint/rules/*.ts"
       ],

--- a/package.json
+++ b/package.json
@@ -11,11 +11,13 @@
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "typecheck": "pnpm -r typecheck && tsc --noEmit -p tools/tsconfig.json",
-    "test": "pnpm -r test",
+    "test": "pnpm -r test && pnpm test:tools",
+    "test:tools": "vitest run --config vitest.tools.config.ts",
     "build": "pnpm -r build",
     "release": "semantic-release"
   },
   "devDependencies": {
+    "@oxlint/plugins": "1.79.0",
     "@semantic-release/exec": "7.1.0",
     "@types/node": "26.2.0",
     "knip": "6.32.2",
@@ -26,7 +28,8 @@
     "stylelint": "17.14.1",
     "stylelint-declaration-strict-value": "1.11.1",
     "stylelint-value-no-unknown-custom-properties": "6.1.1",
-    "typescript": "7.0.2"
+    "typescript": "7.0.2",
+    "vitest": "4.1.11"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     devDependencies:
+      '@oxlint/plugins':
+        specifier: 1.79.0
+        version: 1.79.0
       '@semantic-release/exec':
         specifier: 7.1.0
         version: 7.1.0(semantic-release@25.0.9(supports-color@10.2.2)(typescript@7.0.2))(supports-color@10.2.2)
@@ -44,6 +47,9 @@ importers:
       typescript:
         specifier: 7.0.2
         version: 7.0.2
+      vitest:
+        specifier: 4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(jsdom@30.0.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
 
   packages/app:
     dependencies:
@@ -1616,6 +1622,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@oxlint/plugins@1.79.0':
+    resolution: {integrity: sha512-S0uyoxakDINJ4DPgqxGlEEvrdSMeQb7Z2lKVjxoY2gwsbZbfg2Xr8Klfeo5ZeraHmmdBCELFUHkSe6KEmBpMvg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -6911,6 +6921,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.79.0':
     optional: true
+
+  '@oxlint/plugins@1.79.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -17,10 +17,26 @@ export default {
     // the one legitimate function shape (color-mix of a var() token) is
     // allowed explicitly below instead.
     "scale-unlimited/declaration-strict-value": [
-      ["/color$/", "background", "fill", "stroke"],
+      // `border-radius` joined the colour properties once the radius scale was
+      // tokenized: four values accounted for 88 of the stylesheet's radius
+      // declarations, and nothing guarded them — this rule's enforcement was
+      // colour-only, which is exactly how they drifted to four in the first
+      // place. The genuine one-offs are allow-listed below rather than
+      // tokenized, so they read as a short, deliberate exception list instead
+      // of as silent drift.
+      ["/color$/", "background", "fill", "stroke", "border-radius"],
       {
         ignoreFunctions: false,
         ignoreValues: [
+          // Radius values that are not part of the scale and should not be:
+          // `0` and `50%` are geometry (a square corner, a circle), and the
+          // four pixel one-offs each serve a single element.
+          "0",
+          "50%",
+          "2px",
+          "3px",
+          "5px",
+          "10px",
           // Non-color keywords every color-bearing property may legitimately
           // carry.
           "transparent",
@@ -37,7 +53,7 @@ export default {
           "/^color-mix\\(/",
         ],
         message:
-          'Use a var() design token instead of a raw color value for "${property}" — see the :root token block in packages/app/src/index.css.',
+          'Use a var() design token instead of a raw value for "${property}" — see the :root token block in packages/app/src/index.css.',
       },
     ],
     // Catches var(--tyop)-style typos: every var() reference must resolve to

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -1,0 +1,48 @@
+import { definePlugin } from "@oxlint/plugins";
+import noLocalIsPlainObject from "./rules/no-local-is-plain-object.ts";
+import useErrorMessage from "./rules/use-error-message.ts";
+import useRuleRef from "./rules/use-rule-ref.ts";
+import useSyncedReset from "./rules/use-synced-reset.ts";
+import useTransientValue from "./rules/use-transient-value.ts";
+import useTruncate from "./rules/use-truncate.ts";
+
+/**
+ * This repo's own lint rules — the "house rules".
+ *
+ * Every one is derived from duplication that was ACTUALLY in the tree and had
+ * to be collapsed by hand during the 2026-08 structure review. None is a
+ * preference. The bar each had to clear: at least two sites existed, a shared
+ * helper now exists, and a future third copy would be invisible in review
+ * because each copy is trivially correct on its own.
+ *
+ * Three earn their place on evidence stronger than a count. `use-truncate`
+ * guards a defect that shipped — a fix diff could split a surrogate pair and
+ * render an emoji as a replacement glyph. `use-synced-reset` guards a
+ * during-render invariant whose violation silently undoes a user's first click.
+ * `use-transient-value` guards a leak class the hook was written to close.
+ *
+ * WHAT IS DELIBERATELY NOT HERE. A rule is the right tool only when the
+ * duplicate cannot be REMOVED. The review also found a message phrase the
+ * engine produces and the app matches; the first instinct was a rule banning
+ * the literal, and the better answer was to share the constant — the app
+ * already depends on the engine, so the phrase now lives in
+ * `engine/src/contracts.ts` and both sides import it. There is no duplicate to
+ * police. Check for that shape before adding anything below.
+ *
+ * Structure follows renovatebot/renovate's `tools/lint`: one file per rule with
+ * a colocated spec, `createOnce` for the fast path, and message ids rather than
+ * inline strings so the specs assert on identity instead of prose.
+ */
+export default definePlugin({
+  meta: {
+    name: "rcd",
+  },
+  rules: {
+    "no-local-is-plain-object": noLocalIsPlainObject,
+    "use-error-message": useErrorMessage,
+    "use-rule-ref": useRuleRef,
+    "use-synced-reset": useSyncedReset,
+    "use-transient-value": useTransientValue,
+    "use-truncate": useTruncate,
+  },
+});

--- a/tools/lint/rules/no-local-is-plain-object.spec.ts
+++ b/tools/lint/rules/no-local-is-plain-object.spec.ts
@@ -24,9 +24,18 @@ ruleTester.run("no-local-is-plain-object", rule, {
     "const isPlainObject = (v: unknown) => typeof v === 'object';",
   ],
   invalid: [
+    // The rendered message is asserted, not just the id: the whole point of the
+    // owned-helper map is that the diagnostic NAMES the import, and a
+    // `messageId`-only expectation passes just as happily when `{{from}}`
+    // interpolates to nothing.
     {
       code: "function isPlainObject(value: unknown): value is Record<string, unknown> { return true; }",
-      errors: [{ messageId: "ownedElsewhere" }],
+      errors: [
+        {
+          message:
+            "Import `isPlainObject` from `@/lib/input-schemas` instead of declaring a local copy — byte-identical private copies of this helper are exactly what the shared one replaced.",
+        },
+      ],
     },
     // exported copies are no better — this is about ownership, not visibility
     {

--- a/tools/lint/rules/no-local-is-plain-object.spec.ts
+++ b/tools/lint/rules/no-local-is-plain-object.spec.ts
@@ -1,0 +1,37 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./no-local-is-plain-object.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("no-local-is-plain-object", rule, {
+  valid: [
+    // importing the owned one is the point
+    `import { isPlainObject } from "@/lib/input-schemas";`,
+    // a differently-named local predicate is nobody's business
+    "function isPlainRecord(v: unknown) { return typeof v === 'object'; }",
+    "function isObject(v: unknown) { return typeof v === 'object'; }",
+    // calling it is fine, obviously
+    "if (isPlainObject(raw)) { read(raw); }",
+    // an arrow assigned to a const is not a declaration the rule claims — a
+    // narrow rule that says exactly what it checks beats a broad one that
+    // surprises people
+    "const isPlainObject = (v: unknown) => typeof v === 'object';",
+  ],
+  invalid: [
+    {
+      code: "function isPlainObject(value: unknown): value is Record<string, unknown> { return true; }",
+      errors: [{ messageId: "ownedElsewhere" }],
+    },
+    // exported copies are no better — this is about ownership, not visibility
+    {
+      code: "export function isPlainObject(v: unknown) { return typeof v === 'object'; }",
+      errors: [{ messageId: "ownedElsewhere" }],
+    },
+  ],
+});

--- a/tools/lint/rules/no-local-is-plain-object.ts
+++ b/tools/lint/rules/no-local-is-plain-object.ts
@@ -12,24 +12,31 @@ import { defineRule } from "@oxlint/plugins";
  * engine root.
  */
 
-/** Helpers this repo owns in exactly one place. Add sparingly: a name belongs
- *  here once a second copy has actually appeared, not in anticipation. */
-const OWNED_HELPERS = new Set(["isPlainObject"]);
+/** Helpers this repo owns in exactly one place, each mapped to the specifier
+ *  that exports it. The module is DATA rather than message prose so a helper
+ *  cannot be added without saying where it lives — a diagnostic that names the
+ *  offence without naming the import is a rule the reader still has to go
+ *  research, and the five sibling rules all name theirs.
+ *
+ *  Add sparingly: a name belongs here once a second copy has actually
+ *  appeared, not in anticipation. */
+const OWNED_HELPERS = new Map([["isPlainObject", "@/lib/input-schemas"]]);
 
 export default defineRule({
   meta: {
     type: "suggestion",
     messages: {
       ownedElsewhere:
-        "`{{name}}` is owned centrally — import it rather than declaring a local copy. Byte-identical private copies of this helper are what the shared one replaced.",
+        "Import `{{name}}` from `{{from}}` instead of declaring a local copy — byte-identical private copies of this helper are exactly what the shared one replaced.",
     },
   },
   createOnce(context) {
     return {
       FunctionDeclaration(node) {
         const name = node.id?.name;
-        if (name !== undefined && OWNED_HELPERS.has(name)) {
-          context.report({ node, messageId: "ownedElsewhere", data: { name } });
+        const from = name === undefined ? undefined : OWNED_HELPERS.get(name);
+        if (name !== undefined && from !== undefined) {
+          context.report({ node, messageId: "ownedElsewhere", data: { name, from } });
         }
       },
     };

--- a/tools/lint/rules/no-local-is-plain-object.ts
+++ b/tools/lint/rules/no-local-is-plain-object.ts
@@ -1,0 +1,37 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * `isPlainObject` existed four times, byte-identical, three of them private
+ * copies (structure review, finding 13). `lib/input-schemas.ts` exports the
+ * one the repo has decided to own.
+ *
+ * The cheapest rule of the set and the most generalisable: ban a LOCAL
+ * declaration of a name the repo owns centrally. The designated file is
+ * exempted by path in `.oxlintrc.json`, which is the same shape as the
+ * single-import-site exemptions already there for zod, the schema stack and the
+ * engine root.
+ */
+
+/** Helpers this repo owns in exactly one place. Add sparingly: a name belongs
+ *  here once a second copy has actually appeared, not in anticipation. */
+const OWNED_HELPERS = new Set(["isPlainObject"]);
+
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      ownedElsewhere:
+        "`{{name}}` is owned centrally — import it rather than declaring a local copy. Byte-identical private copies of this helper are what the shared one replaced.",
+    },
+  },
+  createOnce(context) {
+    return {
+      FunctionDeclaration(node) {
+        const name = node.id?.name;
+        if (name !== undefined && OWNED_HELPERS.has(name)) {
+          context.report({ node, messageId: "ownedElsewhere", data: { name } });
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/use-error-message.spec.ts
+++ b/tools/lint/rules/use-error-message.spec.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./use-error-message.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("use-error-message", rule, {
+  valid: [
+    // already using the helper
+    `errorMessage(err);`,
+    `causedErrorMessage(err);`,
+    // narrowing against something other than Error
+    `err instanceof TypeError ? err.message : String(err);`,
+    // reads a different property
+    `err instanceof Error ? err.name : String(err);`,
+    // falls back to something other than String()
+    `err instanceof Error ? err.message : "unknown";`,
+    `err instanceof Error ? err.message : fallback(err);`,
+    // App.tsx's deliberate variant: it adds the CLASS, which the helper does
+    // not, so it must NOT be reported.
+    "err instanceof Error ? `${err.name}: ${err.message}` : String(err);",
+    // not a conditional at all
+    `if (err instanceof Error) { report(err.message); }`,
+  ],
+  invalid: [
+    {
+      code: `err instanceof Error ? err.message : String(err);`,
+      errors: [{ messageId: "useErrorMessage" }],
+    },
+    // the name is irrelevant — the SHAPE is the idiom
+    {
+      code: `e instanceof Error ? e.message : String(e);`,
+      errors: [{ messageId: "useErrorMessage" }],
+    },
+    // as part of the nested-cause compound the repo also had
+    {
+      code: `const d = e?.err?.message ?? (err instanceof Error ? err.message : String(err));`,
+      errors: [{ messageId: "useErrorMessage" }],
+    },
+    // inside a template literal
+    {
+      code: "const s = `failed: ${err instanceof Error ? err.message : String(err)}`;",
+      errors: [{ messageId: "useErrorMessage" }],
+    },
+  ],
+});

--- a/tools/lint/rules/use-error-message.ts
+++ b/tools/lint/rules/use-error-message.ts
@@ -1,0 +1,51 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * `catch (err)` gives `unknown`, so every call site has to narrow it — and nine
+ * of them had spelled the same narrowing by hand before `lib/errors.ts` existed
+ * (structure review, finding 12). Three carried the nested-cause unwrap on top,
+ * and one had a comment saying it was copied from another.
+ *
+ * Matches the shape, not the identifier: `x instanceof Error ? x.message :
+ * String(x)` in any spelling. The `String(…)` call and the `.message` access
+ * are what make it this idiom rather than a coincidence, so both are required.
+ */
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      useErrorMessage:
+        "Use `errorMessage(err)` from `@/lib/errors` (or `causedErrorMessage` when the interesting detail is nested at `err.err.message`) instead of spelling the instanceof narrowing by hand.",
+    },
+  },
+  createOnce(context) {
+    return {
+      ConditionalExpression(node) {
+        const test = node.test;
+        if (
+          test.type !== "BinaryExpression" ||
+          test.operator !== "instanceof" ||
+          test.right.type !== "Identifier" ||
+          test.right.name !== "Error"
+        ) {
+          return;
+        }
+        // `… ? err.message : …`
+        const consequent = node.consequent;
+        const readsMessage =
+          consequent.type === "MemberExpression" &&
+          consequent.property.type === "Identifier" &&
+          consequent.property.name === "message";
+        // `… : String(err)`
+        const alternate = node.alternate;
+        const fallsBackToString =
+          alternate.type === "CallExpression" &&
+          alternate.callee.type === "Identifier" &&
+          alternate.callee.name === "String";
+        if (readsMessage && fallsBackToString) {
+          context.report({ node, messageId: "useErrorMessage" });
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/use-rule-ref.spec.ts
+++ b/tools/lint/rules/use-rule-ref.spec.ts
@@ -1,0 +1,41 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./use-rule-ref.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("use-rule-ref", rule, {
+  valid: [
+    // already using the helper
+    "const ref = ruleRef(index);",
+    "const label = `${ruleRef(rule.index)} — ${ruleLabel(rule)}`;",
+    // a template that mentions rules but does not open the subscript
+    "const s = `packageRules has ${n} entries`;",
+    // a plain string is not a template — prose and test fixtures keep theirs,
+    // and a golden assertion SHOULD spell the exact wording out
+    `const message = "GitHub rejected packageRules[0]";`,
+    // a different array
+    "const s = `hostRules[${i}]`;",
+  ],
+  invalid: [
+    {
+      code: "const s = `packageRules[${index}]`;",
+      errors: [{ messageId: "useRuleRef" }],
+    },
+    // embedded in a longer sentence
+    {
+      code: "const s = `merged rule packageRules[${cross}] in the simulator`;",
+      errors: [{ messageId: "useRuleRef" }],
+    },
+    // inside a nested expression
+    {
+      code: "const s = `${label}: packageRules[${ms.ruleIndex}] changed nothing`;",
+      errors: [{ messageId: "useRuleRef" }],
+    },
+  ],
+});

--- a/tools/lint/rules/use-rule-ref.ts
+++ b/tools/lint/rules/use-rule-ref.ts
@@ -1,0 +1,39 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * `packageRules[N]` is how the app refers to one entry of the merged rule
+ * array, and the SPELLING is what a reader matches against their own editor and
+ * against Renovate's own validator output. The template was written out about a
+ * dozen times across six files before `lib/rule-ref.ts` existed (structure
+ * review, finding 14).
+ *
+ * Each copy is trivially right on its own, which is why nobody minded — and
+ * exactly why drift to `packageRules #3` in one view would be a real defect
+ * nobody caught in review either.
+ *
+ * Matches a template literal whose static text opens the subscript, so
+ * `` `packageRules[${i}]` `` is caught and a mention inside prose is not (a
+ * doc comment is not a TemplateLiteral). `ruleRef`'s own definition is exempted
+ * by path in `.oxlintrc.json`, since it is the one place the string may live.
+ */
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      useRuleRef:
+        "Use `ruleRef(index)` from `@/lib/rule-ref` — the `packageRules[N]` spelling is what readers match against their own editor and against Renovate's validator messages, so it lives in one place.",
+    },
+  },
+  createOnce(context) {
+    return {
+      TemplateLiteral(node) {
+        const opensSubscript = node.quasis.some((quasi) =>
+          quasi.value.raw.includes("packageRules["),
+        );
+        if (opensSubscript) {
+          context.report({ node, messageId: "useRuleRef" });
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/use-synced-reset.spec.ts
+++ b/tools/lint/rules/use-synced-reset.spec.ts
@@ -1,0 +1,57 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./use-synced-reset.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("use-synced-reset", rule, {
+  valid: [
+    // already using the hook
+    "useSyncedReset(result, () => { setSelectedNodeId(null); });",
+    // a guard that compares two things and then does unrelated work — the
+    // setter does not name either side of the comparison
+    "if (a !== b) { doSomething(c); }",
+    "if (a !== b) { setOther(null); }",
+    // an equality guard is not the adopt-the-new-value idiom
+    "if (owner === value) { setOwner(value); }",
+    // comparing against a literal or a member expression is a plain condition
+    "if (count !== 0) { setCount(0); }",
+    "if (owner !== props.value) { setOwner(props.value); }",
+    // the setter is called with something else entirely
+    "if (owner !== value) { setOwner(fresh); }",
+    // not a setter by name
+    "if (owner !== value) { updateOwner(value); }",
+  ],
+  invalid: [
+    // the canonical shape
+    {
+      code: "if (owner !== value) { setOwner(value); }",
+      errors: [{ messageId: "useSyncedReset" }],
+    },
+    // with the reset work following the adopt
+    {
+      code: "if (owner !== model) { setOwner(model); openCards.reset(); }",
+      errors: [{ messageId: "useSyncedReset" }],
+    },
+    // operands the other way round, which several sites used
+    {
+      code: "if (result !== resultOwner) { setResultOwner(result); }",
+      errors: [{ messageId: "useSyncedReset" }],
+    },
+    // loose inequality
+    {
+      code: "if (owner != value) { setOwner(value); }",
+      errors: [{ messageId: "useSyncedReset" }],
+    },
+    // no braces
+    {
+      code: "if (owner !== value) setOwner(value);",
+      errors: [{ messageId: "useSyncedReset" }],
+    },
+  ],
+});

--- a/tools/lint/rules/use-synced-reset.ts
+++ b/tools/lint/rules/use-synced-reset.ts
@@ -1,0 +1,60 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * "Reset derived state when this identity changes, during render" — eighteen
+ * hand-rolled copies before `hooks/use-synced-reset.ts` (structure review,
+ * finding 10, which counted twelve; a full sweep found eighteen).
+ *
+ * Every copy was the same five lines and carried its own paragraph re-arguing
+ * the during-render part. The argument is real — an effect runs after the
+ * commit, so a click landing between the paint and the passive flush is
+ * enqueued first and then wiped — and it is now made once, in the hook.
+ *
+ * Detected structurally: an `if` whose test compares two identifiers for
+ * INEQUALITY, and whose first statement calls a `setX` with one of the two
+ * names the test just compared. That last part is what makes it "adopt the new
+ * value" rather than an arbitrary guard that happens to set something.
+ */
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      useSyncedReset:
+        "Use `useSyncedReset(value, onChange)` from `@/hooks/use-synced-reset` instead of hand-rolling the owner-state idiom. The hook makes the during-render argument once, and compares with `Object.is` so a NaN owner cannot loop.",
+    },
+  },
+  createOnce(context) {
+    return {
+      IfStatement(node) {
+        const test = node.test;
+        if (test.type !== "BinaryExpression") {
+          return;
+        }
+        if (test.operator !== "!==" && test.operator !== "!=") {
+          return;
+        }
+        if (test.left.type !== "Identifier" || test.right.type !== "Identifier") {
+          return;
+        }
+        const compared = new Set([test.left.name, test.right.name]);
+
+        const body = node.consequent;
+        const first = body.type === "BlockStatement" ? body.body[0] : body;
+        if (first?.type !== "ExpressionStatement") {
+          return;
+        }
+        const call = first.expression;
+        if (call.type !== "CallExpression" || call.callee.type !== "Identifier") {
+          return;
+        }
+        if (!/^set[A-Z]/.test(call.callee.name)) {
+          return;
+        }
+        const [argument] = call.arguments;
+        if (argument?.type === "Identifier" && compared.has(argument.name)) {
+          context.report({ node, messageId: "useSyncedReset" });
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/use-transient-value.spec.ts
+++ b/tools/lint/rules/use-transient-value.spec.ts
@@ -1,0 +1,51 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./use-transient-value.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("use-transient-value", rule, {
+  valid: [
+    // already using the hooks
+    "function C() { const [copied, flash] = useTransientFlag(1500); }",
+    // ---- both of these are real sites in this repo, and neither is a receipt.
+    // A DEBOUNCE only ever SCHEDULES the set (`PresetTree`'s filter box):
+    "function C() { const id = setTimeout(() => setQuery(rawQuery), 150); }",
+    // …and so does a close-delay (`hover-card-hooks`): nothing set `anchor`
+    // in this block, so there is no receipt to clear.
+    "function hide() { window.clearTimeout(t.current); t.current = window.setTimeout(() => setAnchor(null), 250); }",
+    // a timeout that does real work
+    "function C() { setToast('x'); setTimeout(() => { void refetch(); }, 1000); }",
+    // the scheduled setter is a DIFFERENT one from the direct set
+    "function C() { setToast('x'); setTimeout(() => setOther(null), 100); }",
+    // a direct set with no scheduled clear at all
+    "function C() { setToast('x'); log('shown'); }",
+  ],
+  invalid: [
+    // `RuleSimulator`'s pin receipt
+    {
+      code: "function pin() { setJustPinned(true); window.clearTimeout(t.current); t.current = window.setTimeout(() => setJustPinned(false), 2000); }",
+      errors: [{ messageId: "useTransientValue" }],
+    },
+    // `use-app-messages`' toast
+    {
+      code: "function showToast(m) { setToast(m); window.clearTimeout(t.current); t.current = window.setTimeout(() => setToast(null), TOAST_MS); }",
+      errors: [{ messageId: "useTransientValue" }],
+    },
+    // `ShareButton`, the bare form with no held handle — the leak this closes
+    {
+      code: "function share() { setCopied(true); setTimeout(() => setCopied(false), 1500); }",
+      errors: [{ messageId: "useTransientValue" }],
+    },
+    // block-bodied callback
+    {
+      code: "function share() { setPopUrl(url); setTimeout(() => { setPopUrl(null); }, 2600); }",
+      errors: [{ messageId: "useTransientValue" }],
+    },
+  ],
+});

--- a/tools/lint/rules/use-transient-value.ts
+++ b/tools/lint/rules/use-transient-value.ts
@@ -1,0 +1,106 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * The receipt pattern: show something, then clear it after a moment. Four sites
+ * hand-rolled the timer because `useTransientFlag` could only return a boolean
+ * and they needed to carry a value (structure review, finding 11) — and the
+ * ones that skipped holding the timer LEAKED it, so an unmount inside the
+ * window left a dead `setState` firing into a gone component.
+ *
+ * WHY THE SHAPE IS THIS NARROW. A first cut matched any `setTimeout` whose
+ * callback called a setter, and that is also the shape of a DEBOUNCE
+ * (`setTimeout(() => setQuery(raw), 150)` in `PresetTree`) and of a
+ * close-delay (`hover-card-hooks`). Neither wants this hook, and a rule that
+ * fires on them teaches people to reach for a disable.
+ *
+ * What actually distinguishes a receipt is the PAIR: the same setter is called
+ * directly, and then scheduled to be called again. A debounce only ever
+ * schedules. So the rule looks for both halves in one block, and reports
+ * nothing otherwise.
+ */
+
+/** `setTimeout` itself starts with "set", so a name test alone would count the
+ *  scheduler as a direct setter and the pair would never be seen. */
+const TIMER_APIS = new Set(["setTimeout", "setInterval", "setImmediate"]);
+
+/** A React-style state setter — `setFoo`, never a timer API. */
+function isStateSetter(name: string): boolean {
+  return /^set[A-Z]/.test(name) && !TIMER_APIS.has(name);
+}
+
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      useTransientValue:
+        "Use `useTransientValue(ms)` (or `useTransientFlag`) from `@/hooks` instead of hand-rolling a self-clearing receipt — the hook holds the handle, so an unmount inside the window cannot leave a dead `setState` firing into a gone component.",
+    },
+  },
+  createOnce(context) {
+    return {
+      BlockStatement(node) {
+        /** Setters this block has already called outright. */
+        const setDirectly = new Set<string>();
+
+        for (const statement of node.body) {
+          if (statement.type !== "ExpressionStatement") {
+            continue;
+          }
+          const expression = statement.expression;
+
+          // `setThing(value);`
+          if (
+            expression.type === "CallExpression" &&
+            expression.callee.type === "Identifier" &&
+            isStateSetter(expression.callee.name)
+          ) {
+            setDirectly.add(expression.callee.name);
+            continue;
+          }
+
+          // `setTimeout(…)` — bare, or with its handle kept in a ref, which is
+          // the careful half of the hand-rolled idiom.
+          const call = expression.type === "AssignmentExpression" ? expression.right : expression;
+          if (call.type !== "CallExpression") {
+            continue;
+          }
+          const callee = call.callee;
+          const schedules =
+            (callee.type === "Identifier" && callee.name === "setTimeout") ||
+            (callee.type === "MemberExpression" &&
+              callee.property.type === "Identifier" &&
+              callee.property.name === "setTimeout");
+          if (!schedules) {
+            continue;
+          }
+
+          const [callback] = call.arguments;
+          if (
+            callback?.type !== "ArrowFunctionExpression" &&
+            callback?.type !== "FunctionExpression"
+          ) {
+            continue;
+          }
+          // `() => setThing(null)` or `() => { setThing(null); }`
+          const body = callback.body;
+          if (body === null) {
+            continue;
+          }
+          let cleared = body.type === "BlockStatement" ? undefined : body;
+          if (body.type === "BlockStatement" && body.body.length === 1) {
+            const only = body.body[0];
+            cleared = only?.type === "ExpressionStatement" ? only.expression : undefined;
+          }
+          if (
+            cleared?.type === "CallExpression" &&
+            cleared.callee.type === "Identifier" &&
+            setDirectly.has(cleared.callee.name)
+          ) {
+            context.report({ node: statement, messageId: "useTransientValue" });
+            return;
+          }
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/use-truncate.spec.ts
+++ b/tools/lint/rules/use-truncate.spec.ts
@@ -1,0 +1,62 @@
+import { RuleTester } from "oxlint/plugins-dev";
+import { describe, it } from "vitest";
+import rule from "./use-truncate.ts";
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: "ts" } },
+});
+
+ruleTester.run("use-truncate", rule, {
+  valid: [
+    // already using the helper
+    "truncate(text, 140);",
+    // ---- every one of these is a real site in this repo, and every one is an
+    // ARRAY slice. They are the reason the rule requires an adjacent ellipsis:
+    // without type information nothing else tells an array from a string.
+    "QUICK_FILLS.slice(0, 3).map(render);",
+    "const shown = changedKeys.slice(0, 3);",
+    "const head = names.slice(0, 2);",
+    // …including one that DOES mention an ellipsis, just not stuck onto the
+    // slice: the parent is `.join()`, and the ellipsis is in a ternary further
+    // out (`RepoDepsTab`).
+    'const named = files.slice(0, 4).join(", ") + (files.length > 4 ? ", …" : "");',
+    // ordinary offset arithmetic
+    "rest.slice(1);",
+    "text.slice(10, 20);",
+    "text.slice(0, max);",
+    // concatenated with something that is not an ellipsis
+    'text.slice(0, 140) + " more";',
+    // an ellipsis before the expression is a prefix, not a truncation marker
+    "const s = `… ${count} more across ${named}`;",
+  ],
+  invalid: [
+    // `ProblemCard` / `ErrorTranslationView`, shape one
+    {
+      code: 'const out = text.slice(0, 140) + "…";',
+      errors: [{ messageId: "useTruncate" }],
+    },
+    // reversed operands
+    {
+      code: 'const out = "…" + text.slice(0, 140);',
+      errors: [{ messageId: "useTruncate" }],
+    },
+    // shape two: the ellipsis is the quasi that FOLLOWS the expression
+    {
+      code: "const out = `${text.slice(0, 140)}…`;",
+      errors: [{ messageId: "useTruncate" }],
+    },
+    // the full conditional both copies were written as
+    {
+      code: "const out = text.length > 140 ? `${text.slice(0, 140)}…` : text;",
+      errors: [{ messageId: "useTruncate" }],
+    },
+    // on a call's result, which is how the JSON snippet was cut
+    {
+      code: "const out = `${JSON.stringify(value).slice(0, 80)}…`;",
+      errors: [{ messageId: "useTruncate" }],
+    },
+  ],
+});

--- a/tools/lint/rules/use-truncate.ts
+++ b/tools/lint/rules/use-truncate.ts
@@ -1,0 +1,100 @@
+import { defineRule } from "@oxlint/plugins";
+
+/**
+ * The strongest case of the set despite the lowest count: this one guards a
+ * defect that shipped.
+ *
+ * `ProblemCard` and `ErrorTranslationView` each carried a byte-identical
+ * `formatSnippet` doing `text.slice(0, 140)` with an ellipsis appended
+ * (structure review, finding 3). `slice` cuts UTF-16 code UNITS, so a cut
+ * landing between the halves of a surrogate pair leaves an orphan — an emoji
+ * rendered as U+FFFD by the very code meant to make the value readable.
+ * `lib/truncate.ts` exists precisely so no caller does this.
+ *
+ * WHY THE SHAPE IS THIS NARROW. A first cut matched any `.slice(0, N)` and was
+ * wrong on every single hit in this repo: `QUICK_FILLS.slice(0, 3)`,
+ * `changedKeys.slice(0, 3)`, `files.slice(0, 4)`, `names.slice(0, 2)` are all
+ * ARRAY slices, and without type information an AST rule cannot tell an array
+ * from a string. So it does not try. It matches the one thing that is
+ * unambiguously text truncation: a slice whose result has an ELLIPSIS stuck
+ * directly onto it, which is the shape of both defect sites and is what makes
+ * the intent "shorten this for display" rather than "take the first few".
+ */
+
+const ELLIPSIS = "…";
+
+/** `<expr>.slice(0, <number literal>)` */
+function isFirstNSlice(node: { type: string; callee?: unknown; arguments?: unknown[] }): boolean {
+  if (node.type !== "CallExpression") {
+    return false;
+  }
+  const callee = node.callee as {
+    type: string;
+    computed?: boolean;
+    property?: { type: string; name?: string };
+  };
+  if (
+    callee?.type !== "MemberExpression" ||
+    callee.computed ||
+    callee.property?.type !== "Identifier" ||
+    callee.property.name !== "slice"
+  ) {
+    return false;
+  }
+  const args = (node.arguments ?? []) as { type: string; value?: unknown }[];
+  if (args.length !== 2) {
+    return false;
+  }
+  return (
+    args[0]?.type === "Literal" &&
+    args[0].value === 0 &&
+    args[1]?.type === "Literal" &&
+    typeof args[1].value === "number"
+  );
+}
+
+function isEllipsisLiteral(node: { type: string; value?: unknown } | undefined): boolean {
+  return (
+    node?.type === "Literal" && typeof node.value === "string" && node.value.includes(ELLIPSIS)
+  );
+}
+
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      useTruncate:
+        "Use `truncate(text, max)` from `@/lib/truncate` instead of slicing display text and appending an ellipsis — a cut between the halves of a surrogate pair renders an emoji as a replacement glyph.",
+    },
+  },
+  createOnce(context) {
+    return {
+      // `text.slice(0, 140) + "…"` (either operand order)
+      BinaryExpression(node) {
+        if (node.operator !== "+") {
+          return;
+        }
+        const pairs = [
+          [node.left, node.right],
+          [node.right, node.left],
+        ] as const;
+        for (const [slice, ellipsis] of pairs) {
+          if (isFirstNSlice(slice) && isEllipsisLiteral(ellipsis)) {
+            context.report({ node: slice, messageId: "useTruncate" });
+            return;
+          }
+        }
+      },
+      // `` `${text.slice(0, 140)}…` `` — the quasi that FOLLOWS the expression
+      // is the one that would carry the ellipsis.
+      TemplateLiteral(node) {
+        for (const [index, expression] of node.expressions.entries()) {
+          const following = node.quasis[index + 1];
+          if (isFirstNSlice(expression) && following?.value.raw.startsWith(ELLIPSIS)) {
+            context.report({ node: expression, messageId: "useTruncate" });
+          }
+        }
+      },
+    };
+  },
+});

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -10,5 +10,5 @@
     // which requires the import specifiers to carry the real `.ts` extension.
     "allowImportingTsExtensions": true
   },
-  "include": ["agents/**/*.ts", "release/**/*.ts"]
+  "include": ["agents/**/*.ts", "release/**/*.ts", "lint/**/*.ts"]
 }

--- a/vitest.tools.config.ts
+++ b/vitest.tools.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * The house lint rules' vitest config (`tools/lint`).
+ *
+ * NOT named `vitest.config.ts`: vitest walks UP from a package looking for one,
+ * and `packages/oauth-worker` has none of its own — a root config by that name
+ * is adopted by it and then finds no tests. Named this way it is invisible to
+ * discovery, and `pnpm test:tools` passes it explicitly.
+ *
+ * Every other suite in this repo belongs to a workspace package and runs from
+ * that package's own config (`pnpm -r test`). `tools/` is deliberately not a
+ * package — it has no build, no dependencies of its own and nothing imports it
+ * — so its specs have nowhere else to run.
+ *
+ * Named `*.spec.ts` rather than `*.test.ts`, matching the upstream oxlint
+ * plugin convention these rules follow. That also keeps them clear of the
+ * filename globs the packages use to assign tests to projects, which
+ * `packages/app/src/vitest-projects.test.ts` and the engine's
+ * `project-coverage` test both police.
+ */
+export default defineConfig({
+  test: {
+    name: "tools",
+    include: ["tools/**/*.spec.ts"],
+  },
+});


### PR DESCRIPTION
Implements the lint-rules proposal, structured after renovatebot/renovate's
`tools/lint`: `@oxlint/plugins`' `definePlugin`/`defineRule`, one file per rule
with a colocated `.spec.ts`, `createOnce` for the fast path, and message ids so
the specs assert on identity rather than prose.

    rcd/use-error-message          9 hand-rolled copies
    rcd/use-rule-ref              12 copies across 6 files
    rcd/use-synced-reset          18 copies
    rcd/use-transient-value        4 copies, one leak class
    rcd/use-truncate               2 copies, one SHIPPED defect
    rcd/no-local-is-plain-object   4 copies

Every rule is derived from duplication that was actually in the tree and had to
be collapsed by hand during the structure review. None is a preference.

**Two rules were wrong on the first cut, and running them against the real tree
is what showed it.** Both are now narrow enough to be worth having:

- `use-truncate` first matched any `.slice(0, N)` — and every single hit in
  this repo was an ARRAY slice (`QUICK_FILLS.slice(0, 3)`,
  `changedKeys.slice(0, 3)`, `names.slice(0, 2)`). Without type information an
  AST rule cannot tell an array from a string, so it no longer tries: it
  matches a slice with an ELLIPSIS stuck directly onto it, which is the shape
  of both defect sites and unambiguously means "shorten this for display".
- `use-transient-value` first matched any `setTimeout` calling a setter — which
  is also a DEBOUNCE (`PresetTree`'s filter) and a close-delay
  (`hover-card-hooks`). It now requires the PAIR that defines a receipt: the
  same setter called directly, then scheduled to be called again. A debounce
  only ever schedules. (It also has to exclude `setTimeout` from "looks like a
  setter" — the name starts with `set`, which quietly broke the pair check.)

Scoped to `packages/app/src/**`, excluding tests. The engine and the CLI have
their own `isPlainObject` and error-to-string and must: the app's `@/lib/*` is
across a package boundary they cannot import, so enabling the rules there would
be telling them to import something that does not resolve. A test that spells
`packageRules[0]` out is a GOLDEN assertion — building it from `ruleRef` would
make it tautological. The six files that ARE the helper are exempted by path,
the same shape as the existing single-import-site exemptions.

Verified rather than assumed: 65 spec cases (each rule's `valid` list contains
the real false positives that forced the narrowing), and a mutation probe
appended to real app source makes all five applicable rules fire at once.
Currently zero hits on the tree, which is the point.

Also lands the proposal's one built-in item: `border-radius` joins stylelint's
`declaration-strict-value` property list, with the four genuine one-off radii
allow-listed so they read as a deliberate exception rather than drift.
Mutation-tested — a raw `7px` fails the build.

Test wiring: `tools/` is deliberately not a workspace package, so the specs run
from `vitest.tools.config.ts` via `pnpm test:tools`. Named that way on purpose:
a root `vitest.config.ts` is auto-discovered by `packages/oauth-worker`, which
has none of its own, and then finds no tests there.

968 app, 535 engine, 326 cli, 33 oauth-worker and 65 tools tests green; lint,
stylelint and typecheck clean.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>