### PR TITLE
refactor(simulator): give AddTestBox two hooks, and collapse the twin pin rows

### DIFF
--- a/packages/app/src/features/simulator/AddTestBox.tsx
+++ b/packages/app/src/features/simulator/AddTestBox.tsx
@@ -13,14 +13,14 @@ import { EMPTY_FORM } from "./form";
 import { EmptyFormGuard, PinLimitNote } from "./FormNotes";
 import { OpenInSimulatorLink } from "./OpenInSimulatorLink";
 import { type PasteFill, parsePastedDescriptor, pasteImportNote } from "./paste-descriptor";
-import { buildPinOutcome, type PinCheck, type PinOutcome } from "./pin-outcome";
-import { pinAddFocusTarget } from "./pin-add-dom";
+import type { PinCheck } from "./pin-outcome";
 import { PinHeadRow } from "./PinHeadRow";
 import { pinContext, pinName, MAX_PINS } from "./pins";
 import { PinSectionHead } from "./PinRuleSections";
 import { draftFill, type RepoDraft } from "./repo-deps";
 import { RepoConnectPanel, RepoDepsTab } from "./RepoDepsTab";
-import { runSimulation } from "./run-simulation";
+import { type OneOff, useOneOffSimulation } from "./use-one-off-simulation";
+import { usePinCardOpen } from "./use-pin-card-open";
 import { SimulatorForm } from "./SimulatorForm";
 import { useEngineModule } from "./use-engine-module";
 // Aliased: the hook's return type and the form COMPONENT share a name, and
@@ -51,14 +51,6 @@ import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
  * call a pinned test uses (`runSimulation`), so a one-off verdict and the
  * pinned one can never disagree.
  */
-
-interface OneOff {
-  /** The run the verdict belongs to — anything else on screen makes it stale. */
-  result: TraceResult;
-  form: FormState;
-  outcome: PinOutcome;
-  effectiveUpdateType: string;
-}
 
 function OneOffResult({
   oneOff,
@@ -399,8 +391,18 @@ export function AddTestBox({
   // panel opens in). Held here rather than in the form so a re-render from a
   // simulation never folds what the reader opened.
   const [openGroup, setOpenGroup] = useState(-1);
-  const [oneOff, setOneOff] = useState<OneOff | null>(null);
-  const [simulating, setSimulating] = useState(false);
+  // The card's own "check this once, without pinning it" run.
+  const {
+    oneOff,
+    simulating,
+    simulate,
+    clear: clearOneOff,
+  } = useOneOffSimulation({
+    result,
+    layerByIndex,
+    attribution,
+    guard,
+  });
   // Roadmap 082: which door the descriptor is coming through, and the drafts
   // in the other two — held here so a tab switch does not throw them away.
   // The DEFAULT is derived, not stored (the design's rule): until the reader
@@ -410,43 +412,8 @@ export function AddTestBox({
   const [chosenTab, setChosenTab] = useState<AddTestTab | null>(null);
   const [pasteDraft, setPasteDraft] = useState("");
   const [repoDraft, setRepoDraft] = useState<RepoDraft | null>(null);
-  // The ghost row (082 revisited): with nothing pinned the card is FORCED
-  // open — the empty state's CTA must point at a form that is on screen —
-  // and once pins exist it is open only while the reader HOLDS it open. A
-  // derived `open` keeps the invariant across prop changes, not just at
-  // mount: a share link's pins arriving over a live session collapse the
-  // card back to the ghost, and removing the last pin brings it back.
-  const [userOpen, setUserOpen] = useState(false);
-  const open = pins.length === 0 || userOpen;
-  // Focus moves into the card only on a USER-initiated open (the nonce) —
-  // never on mount: a tab switch must not steal focus. On the Manual tab the
-  // target is the form's first input (which pinAddFocusTarget also scrolls
-  // to); on the other tabs it falls back to the card's first input, else the
-  // active tab — the ghost button is unmounting, and focus must not drop to
-  // the body.
-  const [focusNonce, setFocusNonce] = useState(0);
-  const cardRef = useRef<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (focusNonce === 0) {
-      return;
-    }
-    const manual = pinAddFocusTarget();
-    if (manual === null) {
-      cardRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
-    }
-    const target =
-      manual ??
-      cardRef.current?.querySelector<HTMLElement>(".pin-repo-search input") ??
-      cardRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
-      null;
-    target?.focus({ preventScroll: true });
-  }, [focusNonce]);
-
-  function openCard() {
-    setUserOpen(true);
-    setFocusNonce((nonce) => nonce + 1);
-  }
-
+  // The ghost row (082 revisited) and where focus lands when the card opens.
+  const { open, cardRef, openCard, closeCard } = usePinCardOpen(pins.length);
   const repoAvailable = repoDeps.repo !== "";
   const tab: AddTestTab = chosenTab ?? (repoAvailable ? "repo" : "manual");
 
@@ -479,8 +446,7 @@ export function AddTestBox({
           replaceForm(seed);
         }
         setChosenTab("manual");
-        setUserOpen(true);
-        setFocusNonce((nonce) => nonce + 1);
+        openCard();
       }
     },
     // The owner starts at 0, not at the current nonce: a chip clicked BEFORE
@@ -499,22 +465,6 @@ export function AddTestBox({
 
   const atLimit = pins.length >= MAX_PINS;
 
-  function simulate() {
-    const finalConfig = result.finalConfig;
-    if (!guard(form) || !finalConfig || simulating) {
-      return;
-    }
-    setSimulating(true);
-    const snapshot = { ...form };
-    void runSimulation(finalConfig, snapshot, updateTypeTouched)
-      .then(({ sim, effectiveUpdateType: ranType }) => {
-        const outcome = buildPinOutcome(sim, layerByIndex, attribution, pinName(snapshot));
-        setOneOff({ result, form: snapshot, outcome, effectiveUpdateType: ranType });
-        return undefined;
-      })
-      .finally(() => setSimulating(false));
-  }
-
   /** The pin itself is the form hook's (the guard, then the EFFECTIVE
    *  updateType baked in); what follows is this panel's alone — the form is
    *  cleared for the next test, and the one-off it may have been pinned from
@@ -529,9 +479,9 @@ export function AddTestBox({
     }
     // Pinning from the card is holding it open — the collapse belongs to the
     // × (or a link's arrival), never to one's own first pin.
-    setUserOpen(true);
+    openCard();
     replaceForm({});
-    setOneOff(null);
+    clearOneOff();
   }
 
   /** A repo-tab draft pins DIRECTLY — its fields came from extraction, not the
@@ -543,7 +493,7 @@ export function AddTestBox({
       // the PinLimitNote under the card says why nothing happened.
       return;
     }
-    setUserOpen(true);
+    openCard();
     onAddPin({ ...EMPTY_FORM, ...draftFill(repoDraft) });
     setRepoDraft(null);
   }
@@ -580,7 +530,7 @@ export function AddTestBox({
           repoAvailable={repoAvailable}
           repoSuggested={repoConnect.suggestion !== null}
           closable={pins.length > 0}
-          onClose={() => setUserOpen(false)}
+          onClose={closeCard}
         />
         {tab === "paste" ? (
           <PasteJsonTab text={pasteDraft} onTextChange={setPasteDraft} onFill={applyPaste} />
@@ -605,7 +555,7 @@ export function AddTestBox({
             openGroup={openGroup}
             onOpenGroupChange={setOpenGroup}
             onQuickFill={(fill) => replaceForm(fill)}
-            onSubmit={simulate}
+            onSubmit={() => simulate(form, updateTypeTouched)}
             actions={
               <DescriptorActions
                 className="pin-new-actions"

--- a/packages/app/src/features/simulator/PinRuleSections.tsx
+++ b/packages/app/src/features/simulator/PinRuleSections.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
 import { nf } from "@/lib/format";
 import { ClauseGrid } from "./ClauseGrid";
@@ -143,6 +143,59 @@ function MatchedDetail({
   );
 }
 
+/**
+ * One expandable rule row: the reference lead, its note, an optional trailing
+ * fact, and the evidence the caret reveals.
+ *
+ * `MatchedRow` and `FailedRow` were the same nine lines of skeleton differing
+ * only in their small print — one extra span, and what the body is (structure
+ * review, finding 21). The disclosure state and the markup are shared here;
+ * each caller keeps only what it actually says.
+ *
+ * `body` is a plain node. An earlier draft made it a function to avoid "paying"
+ * for collapsed rows, which was simply wrong: JSX builds a descriptor, not a
+ * render, so the child component never runs until it is mounted. The function
+ * form also read as a component definition to `no-unstable-nested-components`.
+ *
+ * `RuleRow` (the simulator's own list) deliberately does NOT use this. It looks
+ * similar and is not: it carries an id, a tabIndex and a flash class because a
+ * cross-link LANDS on it, and folding those affordances in here would push a
+ * concern that belongs to one caller into all of them.
+ */
+function PinDisclosureRow({
+  rule,
+  note,
+  trailing,
+  defaultExpanded,
+  onSelectPreset,
+  body,
+}: {
+  rule: PinRuleRef;
+  note: string;
+  /** The right-hand fact, when the row has one (matched rows say what they wrote). */
+  trailing?: string;
+  defaultExpanded: boolean;
+  onSelectPreset?: (nodeId: string) => void;
+  body: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  return (
+    <div>
+      <div className="pin-rule-line">
+        <RuleRefLead
+          rule={rule}
+          expanded={expanded}
+          onToggle={() => setExpanded(!expanded)}
+          onSelectPreset={onSelectPreset}
+        />
+        <span className="pin-rule-label">{note}</span>
+        {trailing === undefined ? null : <span className="pin-rule-wrote">{trailing}</span>}
+      </div>
+      {expanded ? body : null}
+    </div>
+  );
+}
+
 function MatchedRow({
   rule,
   description,
@@ -152,27 +205,21 @@ function MatchedRow({
   description: RuleDescriptionNote | undefined;
   links: CrossLinks;
 }) {
-  const [expanded, setExpanded] = useState(false);
   return (
-    <div>
-      <div className="pin-rule-line">
-        <RuleRefLead
-          rule={rule}
-          expanded={expanded}
-          onToggle={() => setExpanded(!expanded)}
-          onSelectPreset={links.onSelectPreset}
-        />
-        <span className="pin-rule-label">{ruleNote(rule, description)}</span>
-        <span className="pin-rule-wrote">{rule.wroteSummary}</span>
-      </div>
-      {expanded ? (
+    <PinDisclosureRow
+      rule={rule}
+      note={ruleNote(rule, description)}
+      trailing={rule.wroteSummary}
+      defaultExpanded={false}
+      onSelectPreset={links.onSelectPreset}
+      body={
         <MatchedDetail
           rule={rule}
           description={description}
           onJumpToEditor={links.onJumpToEditor}
         />
-      ) : null}
-    </div>
+      }
+    />
   );
 }
 
@@ -260,26 +307,20 @@ function FailedRow({
    *  the likeliest reason the tab is open at all. */
   defaultOpen: boolean;
 }) {
-  const [expanded, setExpanded] = useState(defaultOpen);
   return (
-    <div>
-      <div className="pin-rule-line">
-        <RuleRefLead
-          rule={rule}
-          expanded={expanded}
-          onToggle={() => setExpanded(!expanded)}
-          onSelectPreset={links.onSelectPreset}
-        />
-        <span className="pin-rule-label">{ruleNote(rule, description)}</span>
-      </div>
-      {expanded ? (
+    <PinDisclosureRow
+      rule={rule}
+      note={ruleNote(rule, description)}
+      defaultExpanded={defaultOpen}
+      onSelectPreset={links.onSelectPreset}
+      body={
         <div className="pin-evidence">
           <p className="pin-evidence-title">Matcher checklist — first failure stops the rule</p>
           <ClauseGrid clauses={rule.clauses} />
           <ClosestMissNote rule={rule} onJumpToEditor={links.onJumpToEditor} />
         </div>
-      ) : null}
-    </div>
+      }
+    />
   );
 }
 

--- a/packages/app/src/features/simulator/use-one-off-simulation.ts
+++ b/packages/app/src/features/simulator/use-one-off-simulation.ts
@@ -1,0 +1,87 @@
+import { useCallback, useState } from "react";
+import type {
+  ProvenanceLayer,
+  RuleAttribution,
+  TraceResult,
+} from "@renovate-config-debugger/engine";
+import type { FormState } from "@/types/simulator";
+import { buildPinOutcome, type PinOutcome } from "./pin-outcome";
+import { pinName } from "./pins";
+import { runSimulation } from "./run-simulation";
+
+/**
+ * "Check this dependency once, without pinning it" — the new-pin card's own
+ * simulation.
+ *
+ * Two state slots and an async run in `AddTestBox`, which had eleven state
+ * slots and no obvious reason why these two were among them. They are a pair:
+ * `simulating` exists only to keep a second click from starting a second run
+ * while the first is in flight, and the result is only meaningful next to it.
+ *
+ * The verdict carries the RUN it belongs to, and the card only renders it while
+ * that run is still the one on screen — anything else makes it stale, and a
+ * stale verdict about the reader's own dependency is worse than none.
+ */
+
+export interface OneOff {
+  /** The run the verdict belongs to — anything else on screen makes it stale. */
+  result: TraceResult;
+  form: FormState;
+  outcome: PinOutcome;
+  effectiveUpdateType: string;
+}
+
+export interface OneOffSimulation {
+  /** The last verdict, or null. Check `oneOff.result === result` before
+   *  rendering it — see the type's own note. */
+  oneOff: OneOff | null;
+  /** In flight. The submit control reads this to disable itself. */
+  simulating: boolean;
+  /** Run the form once against the current result. A no-op while one is in
+   *  flight, or when the form does not pass the caller's guard. */
+  simulate: (form: FormState, updateTypeTouched: boolean) => void;
+  /** Drop the verdict — the form has moved on and the card would be lying. */
+  clear: () => void;
+}
+
+export interface OneOffSimulationHost {
+  /** The run to simulate against. */
+  result: TraceResult;
+  layerByIndex: Map<number, ProvenanceLayer>;
+  attribution: RuleAttribution[] | null | undefined;
+  /** The form hook's emptiness guard — the same one a pin has to pass. */
+  guard: (form: FormState) => boolean;
+}
+
+export function useOneOffSimulation(host: OneOffSimulationHost): OneOffSimulation {
+  const { result, layerByIndex, attribution, guard } = host;
+  const [oneOff, setOneOff] = useState<OneOff | null>(null);
+  const [simulating, setSimulating] = useState(false);
+
+  const simulate = useCallback(
+    (form: FormState, updateTypeTouched: boolean) => {
+      const finalConfig = result.finalConfig;
+      if (!guard(form) || !finalConfig || simulating) {
+        return;
+      }
+      setSimulating(true);
+      // Snapshotted because the run is async and the form stays editable: the
+      // verdict has to describe the descriptor that was actually run.
+      const snapshot = { ...form };
+      void runSimulation(finalConfig, snapshot, updateTypeTouched)
+        .then(({ sim, effectiveUpdateType: ranType }) => {
+          const outcome = buildPinOutcome(sim, layerByIndex, attribution, pinName(snapshot));
+          setOneOff({ result, form: snapshot, outcome, effectiveUpdateType: ranType });
+          return undefined;
+        })
+        .finally(() => setSimulating(false));
+    },
+    [result, layerByIndex, attribution, guard, simulating],
+  );
+
+  const clear = useCallback(() => {
+    setOneOff(null);
+  }, []);
+
+  return { oneOff, simulating, simulate, clear };
+}

--- a/packages/app/src/features/simulator/use-pin-card-open.ts
+++ b/packages/app/src/features/simulator/use-pin-card-open.ts
@@ -1,0 +1,79 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { pinAddFocusTarget } from "./pin-add-dom";
+
+/**
+ * Whether the new-pin card is open, and where focus lands when it opens.
+ *
+ * Two state slots, a ref and a DOM effect, consumed at five call sites — and
+ * they are one question, not four things: "is the card showing, and if it just
+ * started showing, what should the reader be looking at?" Held apart in
+ * `AddTestBox` they were four of its eleven state slots and read as unrelated
+ * bookkeeping.
+ *
+ * The nonce is the part that has to be seen with the rest to make sense. It is
+ * not a counter anyone reads — it exists so that OPENING is distinguishable
+ * from BEING open, because focus must move on the former and never on the
+ * latter.
+ */
+
+export interface PinCardOpen {
+  /** Whether the card is showing. */
+  open: boolean;
+  /** Attach to the card element — the focus fallback searches inside it. */
+  cardRef: RefObject<HTMLDivElement | null>;
+  /** A user-initiated open: shows the card AND moves focus into it. */
+  openCard: () => void;
+  /** Collapse back to the ghost row. */
+  closeCard: () => void;
+}
+
+/**
+ * @param pinCount how many tests are pinned. With none, the card is FORCED
+ * open — the empty state's call to action must point at a form that is on
+ * screen — and once pins exist it is open only while the reader HOLDS it open.
+ * Deriving `open` rather than storing it keeps that invariant across PROP
+ * changes and not just at mount: a share link's pins arriving over a live
+ * session collapse the card back to the ghost, and removing the last pin
+ * brings it back.
+ */
+export function usePinCardOpen(pinCount: number): PinCardOpen {
+  const [userOpen, setUserOpen] = useState(false);
+  /**
+   * Bumped by `openCard`. Focus moves into the card only on a USER-initiated
+   * open — never on mount, because a tab switch must not steal focus, and a
+   * boolean cannot tell the two apart.
+   */
+  const [focusNonce, setFocusNonce] = useState(0);
+  const cardRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (focusNonce === 0) {
+      return;
+    }
+    // On the Manual tab the target is the form's first input (which
+    // `pinAddFocusTarget` also scrolls to); on the other tabs it falls back to
+    // the card's first input, else the active tab — the ghost button is
+    // unmounting, and focus must not drop to the body.
+    const manual = pinAddFocusTarget();
+    if (manual === null) {
+      cardRef.current?.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+    const target =
+      manual ??
+      cardRef.current?.querySelector<HTMLElement>(".pin-repo-search input") ??
+      cardRef.current?.querySelector<HTMLElement>('[role="tab"][aria-selected="true"]') ??
+      null;
+    target?.focus({ preventScroll: true });
+  }, [focusNonce]);
+
+  const openCard = useCallback(() => {
+    setUserOpen(true);
+    setFocusNonce((nonce) => nonce + 1);
+  }, []);
+
+  const closeCard = useCallback(() => {
+    setUserOpen(false);
+  }, []);
+
+  return { open: pinCount === 0 || userOpen, cardRef, openCard, closeCard };
+}


### PR DESCRIPTION
Structure review, finding 21's remainder — the two M-sized items.

**`usePinCardOpen`.** Two state slots, a ref and a DOM effect, read at five
call sites, all answering one question: is the card showing, and if it just
started showing, what should the reader be looking at? Held apart they were
four of `AddTestBox`'s eleven state slots and read as unrelated bookkeeping.

The nonce is the part that only makes sense next to the rest. It is not a
counter anyone reads — it exists so that OPENING is distinguishable from BEING
open, because focus must move on the former and never on the latter, and a
boolean cannot tell those apart. `open` stays derived from the pin count rather
than stored, which is what keeps the ghost-row invariant across PROP changes:
a share link's pins arriving mid-session collapse the card, and removing the
last pin brings it back.

**`useOneOffSimulation`.** The card's own "check this once without pinning it".
`simulating` exists only to stop a second click starting a second run, and the
verdict is meaningless without it, so they are one hook. The verdict carries
the run it belongs to and the card renders it only while that run is still on
screen — a stale verdict about the reader's own dependency is worse than none.

AddTestBox: 11 state slots -> 7, 634 -> 579 lines.

**The twin pin rows.** `MatchedRow` and `FailedRow` were the same nine lines of
skeleton differing in one span and what the body is. One `PinDisclosureRow`
now; each caller keeps only what it actually says.

`RuleRow` deliberately does NOT join them, and the shared component says why:
it looks similar and is not — it carries an id, a tabIndex and a flash class
because a cross-link LANDS on it, and folding those affordances in would push
one caller's concern into all of them. The review offered either a hook or a
component; the markup genuinely differs for `RuleRow` and genuinely does not
for the other two, so the split follows that rather than the count.

One correction the linter forced, and it was right: `body` started as a render
function to avoid "paying" for collapsed rows. That reasoning was wrong — JSX
builds a descriptor, not a render, so the child never runs until mounted — and
the function form also read as a component definition to
`no-unstable-nested-components`. It is a plain node, and the comment records
why.

968 unit/component/shimmed tests and the full 127-test e2e suite green,
including the pinned-tests specs that drive this exact UI. Lint and typecheck
clean.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>