### PR TITLE
fix(app): repair three ARIA defects and retire the four jsx-a11y offs

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -24,11 +24,11 @@
   // test-correctness class that is now fixed, and one rule is off on cost. The
   // whole account is in the `vitest/*` block under `rules` below.
   //
-  // `jsx-a11y` is on, with four of its rules off and the reasons recorded in
-  // the `jsx-a11y/*` block under `rules`. Read that before assuming the four
-  // are a backlog: three of them are wrong ABOUT THIS CODEBASE rather than
-  // unfixed, and the fourth names a real open question whose own suggested fix
-  // would make the app less accessible, not more.
+  // `jsx-a11y` is on with NO rule of it disabled — the four that arrived with
+  // hits were briefly `"off"` and are not any more. The `jsx-a11y/*` block
+  // under `rules` is the account of what replaced each blanket off (a fix, an
+  // option, or a disable at the one site it is a fact about) and why that
+  // shape rather than the off.
   "plugins": [
     "unicorn",
     "typescript",
@@ -48,6 +48,18 @@
   // advisory any more — `pnpm lint` reporting anything at all fails CI, which is
   // the point: an oxlint upgrade that adds rules to a category gets a decision
   // at upgrade time (an explicit renovate PR) instead of drifting silently.
+  //
+  // The same zero-tolerance now applies to the ESCAPE HATCHES. `pnpm lint`
+  // passes `--report-unused-disable-directives-severity=error`, so an
+  // `oxlint-disable-next-line` that has stopped suppressing anything is itself
+  // an error. This is what makes a disable-at-the-site a bounded exception
+  // rather than a permanent one: refactor the code out from under it and the
+  // build tells you the comment is now a lie, instead of leaving a stale
+  // waiver nobody dares remove. Switching it on found three immediately — a
+  // directive on a line whose rule only fires on the NEXT statement, and two
+  // `eslint-disable` lines naming rules oxlint does not implement, which had
+  // therefore never done anything at all. A blanket `"off"` has no equivalent
+  // of this check, which is the other half of why the jsx-a11y offs went.
   "categories": {
     "correctness": "error",
     "suspicious": "error"
@@ -158,44 +170,75 @@
     "vitest/require-mock-type-parameters": "off",
 
     // --- the jsx-a11y plugin -------------------------------------------------
-    // The app is a real user-facing SPA, so the plugin belongs on. Most of its
-    // rules were already at zero and now guard every new component: alt text,
-    // aria prop validity, label association, autofocus, required aria props.
+    // The app is a real user-facing SPA, so the plugin belongs on. EVERY rule
+    // of it is on, including the four that arrived with hits — those four used
+    // to be `"off"` here, and this block is what replaced that.
     //
-    // Four rules are off. Three because they are wrong about the patterns this
-    // app deliberately uses — each checked at the call site, not assumed:
+    // Why the blanket offs went. A global `"off"` is unbounded in three
+    // directions at once: every file, every FUTURE file, and no record at the
+    // site that would explain the exception to whoever meets it. The four
+    // rules' 18 hits were not one uniform judgement — they were 2 real defects,
+    // 3 hits of a rule that takes an OPTION, and 13 sites each carrying its own
+    // widget-specific reason. Four `"off"`s flattened all of that into "we do
+    // not check this", and the flattening is what let the preset table's
+    // broken `role="table"` sit inside a rule that had been dismissed as
+    // "wrong about this codebase". So each of the three shapes now gets the
+    // narrowest mechanism that fits it:
     //
-    //   `prefer-tag-over-role` (9 hits) prescribes a semantic tag whose
-    //   BEHAVIOUR differs from the ARIA-on-div the widget needs: `<dialog>`
-    //   brings the top layer and its own close protocol (the evidence card is a
-    //   portal with its own Escape ladder), `<input type=radio>` brings native
-    //   rendering the segmented control replaces, `<tr>` requires a real
-    //   `<table>` the virtualized preset tree is not, and `<output>` is
-    //   form-associated. Taking its advice means rewriting working widgets.
+    //   FIXED (the rule was right, 2 sites + a third finding it led to):
+    //   `PresetListPane`'s `role="table"` had no `row` or `cell` under it and
+    //   its header row sat outside it entirely — AT announced "table, 0 rows"
+    //   over a list of hundreds. Both roles are gone. Auditing it also turned
+    //   up the windowed tree's missing `aria-level`, which no lint rule can
+    //   see (it is conditionally required) and which `TreeRow` now sets. And
+    //   the hover-card anchors got the `aria-describedby` they always owed the
+    //   reader — see `HoverCardTextAnchor`.
     //
-    //   `interactive-supports-focus` (2 hits) wants `tabIndex` on a
-    //   `role="tablist"`. A tablist is a COMPOSITE widget: the ARIA practices
-    //   put the roving tabindex on the tabs and leave the container unfocusable,
-    //   which is exactly what `ResultsPanel` and `AddTestBox` implement.
+    //   CONFIGURED (the rule ships the knob): `control-has-associated-label`'s
+    //   3 hits were all `<option value=…/>` inside a `<datalist>`, where the
+    //   value IS the label and adding text content changes what the browser
+    //   renders. `ignoreElements` already exists for exactly this — the list
+    //   below is the rule's own default plus `option`, so the rule keeps
+    //   working on every control that is not one.
     //
-    //   `control-has-associated-label` (3 hits) fires on `<option value=…/>`
-    //   inside a `<datalist>`. A datalist option's value IS its label — adding
-    //   text content changes what browsers render.
+    //   DISABLED AT THE SITE (13 → 10 hits, each its own fact): the remaining
+    //   ones carry `oxlint-disable-next-line … -- <invariant>`, the same
+    //   convention `react/no-array-index-key` and `no-non-null-assertion` use
+    //   here. `prefer-tag-over-role` takes no options, so this is the only
+    //   bounded mechanism it has; `interactive-supports-focus`'s `tabbable`
+    //   option decides 0-vs-−1 and cannot express "the handlers are delegated
+    //   to the container, the focus lives on the children", which is the
+    //   composite-tablist pattern `ResultsPanel` and `AddTestBox` implement
+    //   straight out of the ARIA practices.
     //
-    // And one because its remedy is worse than the finding:
-    //
-    //   `no-noninteractive-tabindex` (4 hits) is the only one naming a REAL
-    //   question: the hover-card anchors are `<span tabIndex={0}>`, focusable
-    //   with no role, so a screen reader reaches them and is told nothing. But
-    //   the rule's fix is "remove the tabIndex", which would delete keyboard
-    //   access to those cards outright. The right answer is a role and a
-    //   described-by relationship — a deliberate a11y pass on the hover-card
-    //   abstraction, not a lint edit. Left ON the record here rather than
-    //   silently fixed the wrong way.
-    "jsx-a11y/prefer-tag-over-role": "off",
-    "jsx-a11y/interactive-supports-focus": "off",
-    "jsx-a11y/control-has-associated-label": "off",
-    "jsx-a11y/no-noninteractive-tabindex": "off",
+    // The trade is deliberate: 10 one-line exceptions that a reader meets in
+    // context, in exchange for four rules that now fire on anything NEW.
+    "jsx-a11y/prefer-tag-over-role": "error",
+    "jsx-a11y/interactive-supports-focus": "error",
+    "jsx-a11y/no-noninteractive-tabindex": "error",
+    "jsx-a11y/control-has-associated-label": [
+      "error",
+      {
+        "ignoreElements": [
+          "audio",
+          "canvas",
+          "embed",
+          "input",
+          "textarea",
+          "tr",
+          "video",
+          // …and the two additions: see the CONFIGURED note above. `option`
+          // for a `datalist`'s options, whose `value` IS the label, and
+          // `datalist` for the element holding them — it is a data SOURCE
+          // referenced by an input's `list` attribute, never a control a
+          // reader labels or operates, so there is nothing for a label to
+          // name. (The rule's own default list already carries `input` and
+          // `textarea` on the same reasoning: labelled elsewhere.)
+          "option",
+          "datalist"
+        ]
+      }
+    ],
 
     // Roadmap 038: the three type-aware rules whose whole cost was one site
     // each — enabled, with that single site fixed or disabled in place.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -48,21 +48,30 @@
   // advisory any more — `pnpm lint` reporting anything at all fails CI, which is
   // the point: an oxlint upgrade that adds rules to a category gets a decision
   // at upgrade time (an explicit renovate PR) instead of drifting silently.
-  //
-  // The same zero-tolerance now applies to the ESCAPE HATCHES. `pnpm lint`
-  // passes `--report-unused-disable-directives-severity=error`, so an
-  // `oxlint-disable-next-line` that has stopped suppressing anything is itself
-  // an error. This is what makes a disable-at-the-site a bounded exception
-  // rather than a permanent one: refactor the code out from under it and the
-  // build tells you the comment is now a lie, instead of leaving a stale
-  // waiver nobody dares remove. Switching it on found three immediately — a
-  // directive on a line whose rule only fires on the NEXT statement, and two
-  // `eslint-disable` lines naming rules oxlint does not implement, which had
-  // therefore never done anything at all. A blanket `"off"` has no equivalent
-  // of this check, which is the other half of why the jsx-a11y offs went.
   "categories": {
     "correctness": "error",
     "suspicious": "error"
+  },
+  // The same zero-tolerance applies to the ESCAPE HATCHES: an
+  // `oxlint-disable-next-line` that has stopped suppressing anything is itself
+  // an error. This is what makes a disable-at-the-site a bounded exception
+  // rather than a permanent one — refactor the code out from under it and the
+  // build tells you the comment is now a lie, instead of leaving a stale waiver
+  // nobody dares remove. A blanket `"off"` has no equivalent of this check,
+  // which is the other half of why the jsx-a11y offs went.
+  //
+  // Switching it on found three dead waivers immediately: a directive on a line
+  // whose rule only fires on the NEXT statement, and two naming rules oxlint
+  // does not implement, which had therefore never suppressed anything at all.
+  //
+  // It lives HERE rather than as a `pnpm lint` flag so that every way of
+  // running the linter agrees — the editor extension and a bare `oxlint` get
+  // the same verdict CI does, which a flag in one package script cannot give
+  // them. Only the ROOT config is read for this option; a CLI flag still wins
+  // over it, so `--report-unused-disable-directives-severity` remains
+  // available for a one-off run.
+  "options": {
+    "reportUnusedDisableDirectives": "error"
   },
   // `public/` is copied into the bundle verbatim — it is deployment payload,
   // not app source (roadmap 043's `rcd-config.js` stub is a comment and

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -52,24 +52,6 @@
     "correctness": "error",
     "suspicious": "error"
   },
-  // The same zero-tolerance applies to the ESCAPE HATCHES: an
-  // `oxlint-disable-next-line` that has stopped suppressing anything is itself
-  // an error. This is what makes a disable-at-the-site a bounded exception
-  // rather than a permanent one — refactor the code out from under it and the
-  // build tells you the comment is now a lie, instead of leaving a stale waiver
-  // nobody dares remove. A blanket `"off"` has no equivalent of this check,
-  // which is the other half of why the jsx-a11y offs went.
-  //
-  // Switching it on found three dead waivers immediately: a directive on a line
-  // whose rule only fires on the NEXT statement, and two naming rules oxlint
-  // does not implement, which had therefore never suppressed anything at all.
-  //
-  // It lives HERE rather than as a `pnpm lint` flag so that every way of
-  // running the linter agrees — the editor extension and a bare `oxlint` get
-  // the same verdict CI does, which a flag in one package script cannot give
-  // them. Only the ROOT config is read for this option; a CLI flag still wins
-  // over it, so `--report-unused-disable-directives-severity` remains
-  // available for a one-off run.
   "options": {
     "reportUnusedDisableDirectives": "error"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @renovate-config-debugger/app dev",
-    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error && pnpm lint:css",
+    "lint": "oxlint --type-aware && pnpm lint:css",
     "lint:css": "stylelint \"packages/app/src/**/*.css\"",
     "check:exports": "knip --include exports,types,nsExports,nsTypes",
     "format": "oxfmt",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm --filter @renovate-config-debugger/app dev",
-    "lint": "oxlint --type-aware && pnpm lint:css",
+    "lint": "oxlint --type-aware --report-unused-disable-directives-severity=error && pnpm lint:css",
     "lint:css": "stylelint \"packages/app/src/**/*.css\"",
     "check:exports": "knip --include exports,types,nsExports,nsTypes",
     "format": "oxfmt",

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -1500,6 +1500,7 @@ export function App() {
       {/* Roadmap 068: the run's outcome for anyone not watching the screen.
           Always mounted — a live region has to exist BEFORE its text changes
           or the change is not announced. */}
+      {/* oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- the app's ONE announcement channel for a run's outcome, and the aria-live spelled out beside the role is the belt-and-braces that exists because IMPLICIT live regions are the part AT disagrees about. An `output` element would replace both with an implicit one, which is the trade this line was written to avoid. */}
       <p className="visually-hidden" role="status" aria-live="polite">
         {runAnnouncement}
       </p>

--- a/packages/app/src/components/DescriptionAttribution.tsx
+++ b/packages/app/src/components/DescriptionAttribution.tsx
@@ -6,7 +6,7 @@ import {
   WROTE_THIS,
 } from "@/lib/description-attribution";
 import { APPROXIMATE_NOTE } from "@/lib/tree-descriptions";
-import { HoverCardAnchor } from "./hover-card";
+import { HoverCardAnchor, HoverCardTextAnchor } from "./hover-card";
 import { layerClass, layerLabel } from "@/lib/provenance-layer";
 
 /**
@@ -83,9 +83,9 @@ export function DescriptionValue({
       card={<AttributionCard card={card} onSelectPreset={onSelectPreset} />}
     >
       {(handlers) => (
-        <span className="json-desc" tabIndex={0} {...handlers}>
+        <HoverCardTextAnchor className="json-desc" handlers={handlers}>
           {JSON.stringify(card.value)}
-        </span>
+        </HoverCardTextAnchor>
       )}
     </HoverCardAnchor>
   );

--- a/packages/app/src/components/ProvenanceChip.tsx
+++ b/packages/app/src/components/ProvenanceChip.tsx
@@ -58,6 +58,7 @@ export function ProvenanceChip({
           // own row-toggle button, and buttons cannot nest — stopPropagation
           // keeps the row from toggling too.
           <span
+            // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- the one hit of this rule naming a tag the app would otherwise want, and it cannot have it: the comment above is the reason, and the ledger's `KeyRow` header describes the same arrangement for `OptionKey`. A button has no content model that admits another button, so the browser would break the nesting apart and the row would lose its toggle. The Enter/Space handling a real button gives for free is implemented below precisely because of this.
             role="button"
             tabIndex={0}
             className={className}

--- a/packages/app/src/components/ResultsPanel.tsx
+++ b/packages/app/src/components/ResultsPanel.tsx
@@ -155,6 +155,7 @@ export function ResultsPanel({
 
   return (
     <div className="results-panel">
+      {/* oxlint-disable-next-line jsx-a11y/interactive-supports-focus -- a tablist is a COMPOSITE widget: the ARIA practices put a roving tabindex on the tabs (the real role=tab buttons below, natively focusable) and leave the container itself out of the tab order, so Tab moves PAST the whole bar rather than into it. The rule only sees a container with a keydown handler that is unfocusable; that handler is here because arrow-key navigation is DELEGATED, which is the same pattern's other half. */}
       <div
         className="tab-bar"
         role="tablist"

--- a/packages/app/src/components/SegmentedControl.tsx
+++ b/packages/app/src/components/SegmentedControl.tsx
@@ -46,6 +46,7 @@ export function SegmentedControl<T extends string>({
         <button
           key={option.value}
           type="button"
+          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- `<input type="radio">` is a REPLACED element: it renders the platform's own dot-and-ring, which is exactly the rendering a segmented control exists to replace, and the usual escape (visually hide it, style a sibling `<label>`) trades one native affordance for a second element and a `for`/`id` pair per option. A `<button role="radio">` inside the `role="radiogroup"` above carries the same semantics — checked state, group membership, group label — with the button's own focus and activation behaviour intact.
           role="radio"
           aria-checked={option.value === value}
           aria-label={option.ariaLabel}

--- a/packages/app/src/components/ShareButton.tsx
+++ b/packages/app/src/components/ShareButton.tsx
@@ -67,6 +67,7 @@ export function ShareButton({ onShare }: { onShare: () => Promise<void> }) {
         <span>{copied ? "Copied" : "Share"}</span>
       </button>
       {popUrl === null ? null : (
+        // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- `<output>`'s content model is PHRASING content, and this card holds two `<p>`s and a `<code>` block; the swap would be invalid HTML before it was anything else. The live-region-support argument on `StaleResultsBanner` applies here too.
         <div className="share-pop" role="status">
           <p className="share-pop-ok">✓ Link copied</p>
           <code className="share-pop-url">{popUrl}</code>

--- a/packages/app/src/components/StaleResultsBanner.tsx
+++ b/packages/app/src/components/StaleResultsBanner.tsx
@@ -19,6 +19,7 @@ import { formatShortcut, RUN_SHORTCUT } from "@/lib/shortcuts";
  */
 export function StaleResultsBanner() {
   return (
+    // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- `<output>` is the tag it wants for `status`, and it is the wrong one here twice over: it is a form-associated element (its whole point is naming the result of a calculation in a form, and this banner is in no form), and browser/AT support for its IMPLICIT live region is materially patchier than for an explicit `role="status"`. This banner exists to be ANNOUNCED — trading the reliable spelling for the tidy one loses the only thing it does.
     <p className="stale-banner" role="status">
       The config changed since this run — these results describe the earlier text. Press Run (
       {formatShortcut(RUN_SHORTCUT)}) to refresh.

--- a/packages/app/src/components/glossary.tsx
+++ b/packages/app/src/components/glossary.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { GLOSSARY, type GlossaryEntry, type TermId } from "@/data/glossary-data";
-import { HoverCardAnchor, type HoverCardHandlers } from "./hover-card";
+import { HoverCardAnchor, type HoverCardHandlers, HoverCardTextAnchor } from "./hover-card";
 
 /**
  * The hover/focus card UI for the glossary. The entries themselves live in
@@ -73,9 +73,9 @@ export function ExplainedText({
   return (
     <Explained entry={entry}>
       {(handlers) => (
-        <span className={className} tabIndex={0} {...handlers}>
+        <HoverCardTextAnchor className={className} handlers={handlers}>
           {children}
-        </span>
+        </HoverCardTextAnchor>
       )}
     </Explained>
   );

--- a/packages/app/src/components/hover-card-hooks.test.tsx
+++ b/packages/app/src/components/hover-card-hooks.test.tsx
@@ -1,6 +1,6 @@
 import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { HoverCardAnchor } from "./hover-card";
+import { HoverCardAnchor, HoverCardTextAnchor } from "./hover-card";
 import { SHOW_SCROLL_GRACE_MS } from "./hover-card-hooks";
 
 /**
@@ -42,11 +42,7 @@ function Scene() {
   return (
     <div data-testid="scroller">
       <HoverCardAnchor className="probe-card" card={<p>who wrote this</p>}>
-        {(handlers) => (
-          <span tabIndex={0} {...handlers}>
-            an anchor
-          </span>
-        )}
+        {(handlers) => <HoverCardTextAnchor handlers={handlers}>an anchor</HoverCardTextAnchor>}
       </HoverCardAnchor>
     </div>
   );

--- a/packages/app/src/components/hover-card.tsx
+++ b/packages/app/src/components/hover-card.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { type ReactNode, useId } from "react";
 import { createPortal } from "react-dom";
 import { type HoverCardControls, HoverCardCloseProvider, useHoverCard } from "./hover-card-hooks";
 import { useMoveGatedHover } from "./hover-gate";
@@ -37,6 +37,52 @@ export interface HoverCardHandlers {
    * and it would otherwise trade its Enter/Space for this or this for it.
    */
   onKeyDown: (e: React.KeyboardEvent) => void;
+  /**
+   * The open card's id, so the anchor NAMES the thing it just revealed.
+   * `undefined` while no card is up — the element it would point at is not
+   * rendered then, and a dangling reference is worse than none.
+   *
+   * Without this the anchors were focusable elements with no role and no
+   * relationship to anything: a screen reader landed on "npmToken", announced
+   * that and stopped, while the card explaining it sat in a portal at the end
+   * of `<body>` with nothing tying the two together. The card's text is a
+   * DESCRIPTION of the anchor, which is precisely what this attribute is for.
+   *
+   * `aria-describedby` rather than `role="tooltip"` on the card: several of
+   * these cards hold interactive content (the attribution card's tree jump,
+   * links inside option docs), and a `tooltip` is specified as non-interactive
+   * — claiming the role would promise a keyboard contract the widget does not
+   * implement. `aria-details` would be the richer fit, but its AT support is
+   * still thin where `aria-describedby` is universal.
+   */
+  "aria-describedby"?: string;
+}
+
+/**
+ * The anchor half for the common case: a focusable run of text that reveals
+ * its card on hover or focus.
+ *
+ * One component rather than the four hand-written copies this replaces
+ * (`ExplainedText`, the JSON description span, the option-name span, and the
+ * hover-card test's own fixture) — they were the same six attributes each
+ * time, which is how three of them came to be focusable with no description
+ * while the fourth was the one under test.
+ */
+export function HoverCardTextAnchor({
+  className,
+  handlers,
+  children,
+}: {
+  className?: string;
+  handlers: HoverCardHandlers;
+  children: ReactNode;
+}) {
+  return (
+    // oxlint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- the rule's remedy is "drop the tabIndex", which would take these cards away from keyboard users entirely: hover is the ONLY other way to open one. The honest fix it is reaching for is a role, and there is no right one — the anchor activates nothing on click (`tooltip`/`button` both promise a contract this does not implement), so what it owes the reader is a DESCRIPTION, which `aria-describedby` above now gives it. This is the single site in the app that makes text focusable; every other one is a real control.
+    <span className={className} tabIndex={0} {...handlers}>
+      {children}
+    </span>
+  );
 }
 
 /** The card's preferred width, and how much room it wants below the anchor
@@ -60,6 +106,7 @@ const DEFAULT_FLIP_MARGIN = 200;
 export function HoverCardSurface({
   controls,
   className,
+  id,
   width = DEFAULT_WIDTH,
   flipMargin = DEFAULT_FLIP_MARGIN,
   children,
@@ -67,6 +114,10 @@ export function HoverCardSurface({
   controls: HoverCardControls;
   /** Extra class on the `.option-card` surface. */
   className?: string;
+  /** What the anchor's `aria-describedby` points at — see {@link
+   *  HoverCardHandlers}. Optional for the one caller that has no anchor
+   *  ELEMENT to carry the reference (the diff views' caret hit-testing). */
+  id?: string;
   width?: number;
   flipMargin?: number;
   /** The card's body. Rendered only while the card is up. */
@@ -83,6 +134,7 @@ export function HoverCardSurface({
     // blur to do that for it.
     <HoverCardCloseProvider value={hideNow}>
       <div
+        id={id}
         className={className ? `option-card ${className}` : "option-card"}
         style={anchoredCardStyle(anchor, width, flipMargin)}
         onMouseEnter={cancelHide}
@@ -123,8 +175,9 @@ export function HoverCardAnchor({
   children: (handlers: HoverCardHandlers) => ReactNode;
 }) {
   const controls = useHoverCard();
-  const { show, hide, onKeyDown } = controls;
+  const { show, hide, onKeyDown, anchor } = controls;
   const moveGate = useMoveGatedHover(show, openDelayMs);
+  const cardId = useId();
   return (
     <>
       {children({
@@ -137,10 +190,15 @@ export function HoverCardAnchor({
         onFocus: (e) => show(e.currentTarget),
         onBlur: hide,
         onKeyDown,
+        // Gated on the card actually being up: `HoverCardSurface` renders
+        // nothing while `anchor` is null, so pointing at `cardId` then would
+        // reference an element that does not exist.
+        "aria-describedby": anchor ? cardId : undefined,
       })}
       <HoverCardSurface
         controls={controls}
         className={className}
+        id={cardId}
         width={width}
         flipMargin={flipMargin}
       >

--- a/packages/app/src/components/option-docs.tsx
+++ b/packages/app/src/components/option-docs.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useCallback, useMemo, useState } from "react";
 import type { OptionDoc, OptionIndex, OptionPlacement } from "@renovate-config-debugger/engine";
-import { HoverCardAnchor, HoverCardSurface } from "./hover-card";
+import { HoverCardAnchor, HoverCardSurface, HoverCardTextAnchor } from "./hover-card";
 import { useHoverCard } from "./hover-card-hooks";
 import { OptionDocsContext, useOptionDocs } from "./option-docs-hooks";
 import type { AnchorSource } from "@/lib/anchored-card";
@@ -229,9 +229,9 @@ export function OptionKey({ name, flagUnknown }: OptionKeyProps) {
       card={<OptionCardBody name={name} doc={doc} />}
     >
       {(handlers) => (
-        <span className={className} tabIndex={0} {...handlers}>
+        <HoverCardTextAnchor className={className} handlers={handlers}>
           {name}
-        </span>
+        </HoverCardTextAnchor>
       )}
     </HoverCardAnchor>
   );

--- a/packages/app/src/features/presets/PresetListPane.tsx
+++ b/packages/app/src/features/presets/PresetListPane.tsx
@@ -60,7 +60,13 @@ export function PresetListPane({
   return (
     <div>
       {view === "table" ? (
-        <div className="preset-table-head" role="row">
+        // Deliberately NO `role="row"`. It used to carry one, and that was an
+        // orphan: this header sits OUTSIDE the scroll container below (it must
+        // not scroll away), so its row had no table to belong to — and
+        // `role="row"` requires an owning table/grid/rowgroup. A row with no
+        // table is dropped from the accessibility tree by some AT and reported
+        // as a stray row by others. Five sort buttons announce themselves.
+        <div className="preset-table-head">
           {columns.map((c) => (
             <button
               key={c.key}
@@ -74,7 +80,15 @@ export function PresetListPane({
           ))}
         </div>
       ) : null}
-      <div className="preset-tree" role={view === "tree" ? "tree" : "table"} ref={containerRef}>
+      {/* `role="tree"` for the tree view only. The table view used to claim
+          `role="table"` and it was not one: its children are the two virtual
+          padding spacers and a flat list of `<button>`s, none of them a `row`
+          or a `cell`, and the header row was not even inside it. AT therefore
+          announced "table, 0 rows" over a list that visibly had hundreds —
+          worse than no role at all. A real grid here means cells, roving
+          keyboard nav, and `aria-rowcount`/`aria-rowindex` to undo the
+          windowing; until that exists the buttons speak for themselves. */}
+      <div className="preset-tree" role={view === "tree" ? "tree" : undefined} ref={containerRef}>
         {activeCount === 0 ? (
           <p className="empty-note">No presets match the filter.</p>
         ) : (

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -109,6 +109,13 @@ export function TreeRow({
     <div
       className={`preset-row state-${node.state}${stats.zero ? " zero" : ""}${row.dimmed ? " dimmed" : ""}`}
       role="treeitem"
+      // The rows are WINDOWED, so the tree is a flat list of siblings in the
+      // DOM — there are no nested `role="group"` elements for AT to infer
+      // depth from, and the only thing that carried the hierarchy was the
+      // `paddingLeft` above, which a screen reader cannot see. The APG's
+      // answer for exactly this shape is to state the level explicitly.
+      // 1-based: `aria-level` counts from 1, `row.depth` from 0.
+      aria-level={row.depth + 1}
       aria-expanded={row.hasChildren ? row.expanded : undefined}
       style={style}
     >

--- a/packages/app/src/features/simulator/AddTestBox.tsx
+++ b/packages/app/src/features/simulator/AddTestBox.tsx
@@ -7,7 +7,7 @@ import type {
 import { nf } from "@/lib/format";
 import { nextTabIndex } from "@/lib/roving-tabs";
 import { anyModifierHeld } from "@/lib/shortcuts";
-import { PIN_FORM_ID } from "./datalist-ids";
+import { PIN_FORM_ID, PIN_TAB_PANEL_ID, pinTabId } from "./datalist-ids";
 import { DescriptorActions } from "./DescriptorActions";
 import { EMPTY_FORM } from "./form";
 import { EmptyFormGuard, PinLimitNote } from "./FormNotes";
@@ -177,7 +177,9 @@ function AddTestTabs({
       <button
         type="button"
         role="tab"
+        id={pinTabId(id)}
         aria-selected={tab === id}
+        aria-controls={PIN_TAB_PANEL_ID}
         tabIndex={tab === id ? 0 : -1}
         className={`tab${tab === id ? " active" : ""}`}
         title={title}
@@ -198,6 +200,7 @@ function AddTestTabs({
       ? "Opened from a shared link — reload the repository to pick from detected dependencies"
       : "Load the repository to pick from its detected dependencies";
   return (
+    // oxlint-disable-next-line jsx-a11y/interactive-supports-focus -- the composite-tablist pattern, same as `ResultsPanel`'s bar: the roving tabindex lives on the `<button role="tab">`s that `tabButton` renders, and the container stays out of the tab order so Tab leaves the bar rather than entering it. `rove` is here because the arrow keys are handled by delegation — the other half of that same pattern, not a sign the container should be focusable.
     <div className="tab-bar pin-add-tabs" role="tablist" aria-label="New pin" onKeyDown={rove}>
       <span className="pin-add-newpin">New pin</span>
       {tabButton("manual", "Manual")}
@@ -521,6 +524,21 @@ export function AddTestBox({
     );
   }
 
+  // Hoisted out of the JSX rather than written inline on `ManualPanel`'s
+  // `actions` prop: the tabpanel wrapper below added the level that put this
+  // element at depth 4, and lifting the leaf is what the depth ratchet asks
+  // for (`TreeRow`'s `nameButton` is the same move).
+  const manualActions = (
+    <DescriptorActions
+      className="pin-new-actions"
+      formId={PIN_FORM_ID}
+      submitLabel="Simulate"
+      submitDisabled={simulating || !result.finalConfig}
+      atLimit={atLimit}
+      onPin={() => pin()}
+    />
+  );
+
   return (
     <div className="pin-add-panel">
       <div className="card pin-add-card" ref={cardRef}>
@@ -532,42 +550,39 @@ export function AddTestBox({
           closable={pins.length > 0}
           onClose={closeCard}
         />
-        {tab === "paste" ? (
-          <PasteJsonTab text={pasteDraft} onTextChange={setPasteDraft} onFill={applyPaste} />
-        ) : null}
-        {tab === "repo" && !repoAvailable ? <RepoConnectPanel offer={repoConnect} /> : null}
-        {tab === "repo" && repoAvailable ? (
-          <RepoDepsTab
-            key={repoDeps.repo}
-            view={repoDeps}
-            pins={pins}
-            atLimit={atLimit}
-            draft={repoDraft}
-            onDraftChange={setRepoDraft}
-            onPinDraft={pinRepoDraft}
-            onRefineDraft={refineRepoDraft}
-            onRetry={onLoadRepoDeps}
-          />
-        ) : null}
-        {tab === "manual" ? (
-          <ManualPanel
-            sim={simForm}
-            openGroup={openGroup}
-            onOpenGroupChange={setOpenGroup}
-            onQuickFill={(fill) => replaceForm(fill)}
-            onSubmit={() => simulate(form, updateTypeTouched)}
-            actions={
-              <DescriptorActions
-                className="pin-new-actions"
-                formId={PIN_FORM_ID}
-                submitLabel="Simulate"
-                submitDisabled={simulating || !result.finalConfig}
-                atLimit={atLimit}
-                onPin={() => pin()}
-              />
-            }
-          />
-        ) : null}
+        {/* No className: it would style nothing (the card is block flow, so
+            this wrapper is layout-transparent) and `class-coverage.test.ts`
+            is right that an unstyled, unselected class should not exist. What
+            the element is for is the three ARIA attributes. */}
+        <div role="tabpanel" id={PIN_TAB_PANEL_ID} aria-labelledby={pinTabId(tab)}>
+          {tab === "paste" ? (
+            <PasteJsonTab text={pasteDraft} onTextChange={setPasteDraft} onFill={applyPaste} />
+          ) : null}
+          {tab === "repo" && !repoAvailable ? <RepoConnectPanel offer={repoConnect} /> : null}
+          {tab === "repo" && repoAvailable ? (
+            <RepoDepsTab
+              key={repoDeps.repo}
+              view={repoDeps}
+              pins={pins}
+              atLimit={atLimit}
+              draft={repoDraft}
+              onDraftChange={setRepoDraft}
+              onPinDraft={pinRepoDraft}
+              onRefineDraft={refineRepoDraft}
+              onRetry={onLoadRepoDeps}
+            />
+          ) : null}
+          {tab === "manual" ? (
+            <ManualPanel
+              sim={simForm}
+              openGroup={openGroup}
+              onOpenGroupChange={setOpenGroup}
+              onQuickFill={(fill) => replaceForm(fill)}
+              onSubmit={() => simulate(form, updateTypeTouched)}
+              actions={manualActions}
+            />
+          ) : null}
+        </div>
         {atLimit ? <PinLimitNote /> : null}
       </div>
       {oneOff !== null && oneOff.result === result ? (

--- a/packages/app/src/features/simulator/RuleEvidenceCard.tsx
+++ b/packages/app/src/features/simulator/RuleEvidenceCard.tsx
@@ -209,6 +209,7 @@ export function RuleEvidenceCard({
   return createPortal(
     <div
       className={`option-card ${RULE_POP_CLASS}`}
+      // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- `<dialog>` is not a drop-in for `role="dialog"`: shown modally it moves the element to the TOP LAYER, which discards the viewport-coordinate placement this card is positioned by (`anchoredCardStyle`), and it brings its own Escape-to-close and `::backdrop`, which would sit alongside — and race — the app's shared Escape ladder (`lib/escape-stack.ts`) rather than joining it. The role gives the semantics; the behaviour here is deliberately the app's, not the platform's.
       role="dialog"
       aria-label={`${ruleRef(evidence.ruleIndex)} — rule evidence`}
       tabIndex={-1}

--- a/packages/app/src/features/simulator/RuleSimulator.tsx
+++ b/packages/app/src/features/simulator/RuleSimulator.tsx
@@ -476,6 +476,7 @@ export const RuleSimulator = memo(function RuleSimulator({
             to be ANNOUNCED, and a live region only reliably announces content
             that arrives after the region itself exists. Last in the row so its
             empty state contributes only a trailing (invisible) flex gap. */}
+        {/* oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- see StaleResultsBanner: the `output` element the rule wants is form-associated, and its implicit live region is less reliably announced. This one is a PERSISTENT empty region (the comment above says why), which is the case where announcement support is the entire feature. */}
         <span className="host-ok" role="status">
           {justPinned ? "Pinned ✓" : null}
         </span>

--- a/packages/app/src/features/simulator/SequenceTimeline.tsx
+++ b/packages/app/src/features/simulator/SequenceTimeline.tsx
@@ -25,6 +25,7 @@ export type SequenceDotLevel = "clean" | "changed" | "error" | "skipped";
 
 export function SequenceTimeline({ label, children }: { label: string; children: ReactNode }) {
   return (
+    // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- the rule offers `address, details, fieldset, hgroup, optgroup` for `group`, and every one of them means something this is not: `<fieldset>` is form controls (and draws a border box), `<details>` is a disclosure, `<address>` is contact information, `<hgroup>` is headings, `<optgroup>` is select options. A labelled `role="group"` is the generic grouping ARIA provides precisely because HTML has no neutral tag for it.
     <div className="stage-timeline" role="group" aria-label={label}>
       {children}
     </div>

--- a/packages/app/src/features/simulator/SimulatorForm.tsx
+++ b/packages/app/src/features/simulator/SimulatorForm.tsx
@@ -129,10 +129,7 @@ export function SimulatorForm({
   formId?: string;
 }) {
   return (
-    // The keydown below is a key BUBBLING from the fields inside, not an
-    // interaction with the form element itself. Declining IMPLICIT SUBMIT is
-    // necessarily a form-level decision; the rule has no shape for that.
-    // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+    // oxlint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- the keydown below is a key BUBBLING from the fields inside, not an interaction with the form element itself. Declining IMPLICIT SUBMIT is necessarily a form-level decision; the rule has no shape for that.
     <form
       id={formId}
       className="sim-form-shell"

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -246,6 +246,30 @@ it("lands on the simulator when the link that opened the app carried a simulatio
   });
 });
 
+it("points the new-pin tabs at the panel they control, and the panel back at the open tab", async () => {
+  const result = await run();
+  const view = render(<Harness result={result} />);
+
+  // The half of tablist semantics the strip was MISSING: `aria-selected` said
+  // which tab was open, but nothing on either side named the other, so a
+  // screen reader had no way from the tab to the region it had just switched.
+  // No jsx-a11y rule reports an absent relationship — this test is the guard.
+  const panel = view.container.querySelector('[role="tabpanel"]');
+  expect(panel).not.toBeNull();
+
+  const manual = view.getByRole("tab", { name: "Manual" });
+  expect(manual.getAttribute("aria-controls")).toBe(panel?.id);
+  // …and the panel names whichever tab is currently open, so the pairing
+  // survives a switch rather than being true only at mount.
+  expect(panel?.getAttribute("aria-labelledby")).toBe(manual.id);
+
+  const paste = view.getByRole("tab", { name: "Paste JSON" });
+  expect(paste.getAttribute("aria-controls")).toBe(panel?.id);
+  fireEvent.click(paste);
+  expect(panel?.getAttribute("aria-labelledby")).toBe(paste.id);
+  expect(manual.id).not.toBe(paste.id);
+});
+
 it("fills the Manual form from a pasted descriptor, and shows the descriptor back (082)", async () => {
   const result = await run();
   const view = render(<Harness result={result} />);

--- a/packages/app/src/features/simulator/datalist-ids.ts
+++ b/packages/app/src/features/simulator/datalist-ids.ts
@@ -25,3 +25,27 @@ export const SIM_FORM_ID = "simulator-inputs";
  * that shows both to associate the Pin button with the Simulate one's form.
  */
 export const PIN_FORM_ID = "pinned-test-inputs";
+
+/**
+ * The new-pin card's tab widget, wired the way `ResultsPanel`'s bar already is.
+ *
+ * Its tabs carried `role="tab"` and `aria-selected` from the start, but nothing
+ * on either side named the other: no `id` on a tab, no `aria-controls`, and no
+ * `role="tabpanel"` on the region they switch. A screen reader therefore
+ * announced "Paste JSON, tab, 2 of 3, selected" and then had nothing to say
+ * about what that selection had DONE — the panel was three anonymous divs
+ * further down the document. No jsx-a11y rule reports this (the plugin checks
+ * each element on its own; a missing RELATIONSHIP between two of them has no
+ * rule), which is why it survived a review that turned every other tab-bar
+ * finding over.
+ *
+ * One panel element rather than three: the card renders exactly one tab's
+ * content at a time, so a single region whose `aria-labelledby` follows the
+ * selection says the true thing with one id instead of three.
+ */
+export const PIN_TAB_PANEL_ID = "pin-add-tabpanel";
+
+/** The per-tab id `aria-controls`/`aria-labelledby` point at. */
+export function pinTabId(tab: string): string {
+  return `pin-add-tab-${tab}`;
+}

--- a/packages/app/src/platform/analytics.ts
+++ b/packages/app/src/platform/analytics.ts
@@ -81,7 +81,6 @@ export function initAnalytics(): void {
   // gtag.js dispatches on `arguments` objects, not arrays — pushing an array
   // is silently ignored, hence no rest parameters here.
   function gtag(..._args: unknown[]): void {
-    // eslint-disable-next-line prefer-rest-params
     dataLayer.push(arguments);
   }
   gtag("js", new Date());

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -63,7 +63,6 @@ export const mcpCommand: Command = {
         // MCP's Transport is not an EventTarget: `onclose` is the SDK's own
         // callback property, and `serveStdio` already installed the entry's
         // own handler on it — hence the chain rather than an assignment.
-        // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
         const closeEntry = transport.onclose;
         // oxlint-disable-next-line unicorn/prefer-add-event-listener -- see above
         transport.onclose = () => {

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -1700,7 +1700,7 @@ describe("held runs carry only what the tools read", () => {
 describe("RunStore", () => {
   test("evicts the oldest run, and keeps the one being drilled into", () => {
     const store = new RunStore(2);
-    // eslint-disable-next-line — the store only ever reads `result`/`input` back out
+    // The store only ever reads `result`/`input` back out.
     const fake = { events: [], errors: [], warnings: [] } as unknown as Parameters<
       RunStore["put"]
     >[0];

--- a/roadmap/2026-08-aria-audit.md
+++ b/roadmap/2026-08-aria-audit.md
@@ -15,12 +15,12 @@ them as one uniform verdict — "these rules do not understand the patterns this
 app uses" — and wrote four `"off"` lines. Re-running them and reading every
 site individually gives a different split:
 
-| rule | hits | what they actually were |
-| --- | --- | --- |
-| `prefer-tag-over-role` | 9 | 1 real defect, 8 widget-specific exceptions |
-| `no-noninteractive-tabindex` | 4 | 1 real defect (4 copies of it) |
-| `control-has-associated-label` | 3 | 3 hits of a rule that ships the option for them |
-| `interactive-supports-focus` | 2 | 2 exceptions, no option that expresses them |
+| rule                           | hits | what they actually were                         |
+| ------------------------------ | ---- | ----------------------------------------------- |
+| `prefer-tag-over-role`         | 9    | 1 real defect, 8 widget-specific exceptions     |
+| `no-noninteractive-tabindex`   | 4    | 1 real defect (4 copies of it)                  |
+| `control-has-associated-label` | 3    | 3 hits of a rule that ships the option for them |
+| `interactive-supports-focus`   | 2    | 2 exceptions, no option that expresses them     |
 
 So of the four offs: one was suppressing a real bug, one was suppressing a real
 gap, one was a config line that had not been written, and only one was what all
@@ -151,7 +151,7 @@ checkable:
   positioned by, and brings its own Escape protocol that would race the app's
   shared Escape ladder rather than join it.
 - **`role="group"`** (`SequenceTimeline`). The rule offers `address, details,
-  fieldset, hgroup, optgroup`; every one means something this is not.
+fieldset, hgroup, optgroup`; every one means something this is not.
 - **2 × tablist** (`ResultsPanel`, `AddTestBox`). The composite-widget pattern:
   roving tabindex on the tabs, container out of the tab order so Tab moves past
   the bar rather than into it. The container's keydown handler — the thing that

--- a/roadmap/2026-08-aria-audit.md
+++ b/roadmap/2026-08-aria-audit.md
@@ -1,0 +1,191 @@
+# ARIA audit, and what replaced the four blanket lint offs
+
+Two questions, one answer. The first was "what is the actual state of ARIA in
+this app". The second was "why are four `jsx-a11y` rules switched off, and can
+the setup be changed so that fewer things have to be".
+
+They turn out to be the same question, because the reason the app's worst ARIA
+defect survived review is that it was sitting inside a rule that had been
+switched off as "wrong about this codebase".
+
+## What the four offs were hiding
+
+`jsx-a11y` arrived with 18 hits across four rules, and the previous pass read
+them as one uniform verdict — "these rules do not understand the patterns this
+app uses" — and wrote four `"off"` lines. Re-running them and reading every
+site individually gives a different split:
+
+| rule | hits | what they actually were |
+| --- | --- | --- |
+| `prefer-tag-over-role` | 9 | 1 real defect, 8 widget-specific exceptions |
+| `no-noninteractive-tabindex` | 4 | 1 real defect (4 copies of it) |
+| `control-has-associated-label` | 3 | 3 hits of a rule that ships the option for them |
+| `interactive-supports-focus` | 2 | 2 exceptions, no option that expresses them |
+
+So of the four offs: one was suppressing a real bug, one was suppressing a real
+gap, one was a config line that had not been written, and only one was what all
+four claimed to be.
+
+### The defect the off was hiding
+
+`PresetListPane`'s table view claimed `role="table"`. It was not one. Its
+children were the two virtual padding spacers and a flat list of `<button>`s —
+no `row`, no `cell`, no `rowgroup` anywhere under it — and the header row that
+did carry `role="row"` was not even inside it, because it sits outside the
+scroll container so it does not scroll away. That is a `role="row"` with no
+owning table, and a `role="table"` with no rows.
+
+AT announced "table, 0 rows" over a list that visibly had hundreds. That is
+worse than no role at all: an absent role degrades to a list of buttons, which
+is exactly what the thing is, whereas the false one actively misinforms.
+
+`prefer-tag-over-role` pointed straight at it. The previous read — "a `<tr>`
+requires a real `<table>`, which the virtualized preset tree is not" — is a
+true sentence, and the conclusion drawn from it was backwards: it is the reason
+the `role="row"` was invalid where it stood, not a reason the rule was wrong.
+
+Both roles are gone. `role="tree"` stays on the tree view, which is correctly
+built out of `role="treeitem"`.
+
+### The gap the other off was hiding
+
+The hover-card anchors — every glossary term, every option name, every JSON
+`description` — were `<span tabIndex={0}>` with no role and no relationship to
+anything. A screen reader landed on one, announced the word, and stopped. The
+card explaining it was in a portal at the end of `<body>` with nothing tying
+the two together. Keyboard users could open the card; they were never told
+there was one.
+
+The anchors now carry `aria-describedby` pointing at the open card's id
+(`HoverCardTextAnchor`, and the id is wired through `HoverCardAnchor` /
+`HoverCardSurface`). The attribute is set only while the card is up, since the
+element it references does not exist otherwise.
+
+`aria-describedby` rather than `role="tooltip"` on the card: several of these
+cards hold interactive content — the attribution card's tree jump, links inside
+option docs — and `tooltip` is specified as non-interactive, so claiming it
+would promise a keyboard contract the widget does not implement. `aria-details`
+is the richer fit and its AT support is still too thin to rely on.
+
+The four hand-written copies of that span became one component while this was
+being fixed, which is how three of them had come to be focusable-with-no-
+description while the fourth, the one under test, was the same.
+
+## Two findings no lint rule can see
+
+Reading the app's roles rather than its lint output turned up two more, and
+neither is reachable by any rule in the plugin — both are about a RELATIONSHIP
+between two elements, and jsx-a11y checks elements one at a time.
+
+**The preset tree announced no depth.** Its rows are windowed, so the tree is a
+flat list of siblings in the DOM with no nested `role="group"` for AT to infer
+hierarchy from. The only thing carrying the structure was `paddingLeft`, which
+a screen reader cannot see. The APG's answer for exactly this shape is to state
+the level, and `TreeRow` now sets `aria-level`. (`aria-required-attr` does not
+catch this: `aria-level` is conditionally required, and the condition is
+"is the hierarchy expressed structurally", which is not a property of the
+element.)
+
+**The new-pin card's tabs controlled nothing.** `AddTestBox`'s strip had
+`role="tab"`, `aria-selected` and a correct roving tabindex, but no `id` on any
+tab, no `aria-controls`, and no `role="tabpanel"` on the region they switch. It
+announced "Paste JSON, tab, 2 of 3, selected" and then had nothing to say about
+what that selection had done. `ResultsPanel`'s bar, the app's other tablist, is
+textbook-complete — tab id, `aria-controls`, panel id, `aria-labelledby`,
+`hidden` — so this was a half-built copy of a pattern the codebase already had
+right.
+
+One panel element rather than three: the card renders one tab's content at a
+time, so a single region whose `aria-labelledby` follows the selection says the
+true thing with one id instead of three. `TestsPanel.shimmed.test.tsx` guards
+the pairing in both directions, and the guard was mutation-tested (dropping
+`aria-controls` fails it).
+
+## Why the offs went, and what replaced each
+
+A global `"off"` is unbounded in three directions at once: every file, every
+FUTURE file, and no record at the site that would explain the exception to
+whoever meets it. That last one is what let the broken table sit undetected —
+the reasoning lived in a config file nobody reads while looking at a component.
+
+The 18 hits were three different shapes, so each now gets the narrowest
+mechanism that fits it:
+
+- **Fixed** where the rule was right (above).
+- **Configured** where the rule ships the knob. All three
+  `control-has-associated-label` hits were `<option value=…/>` inside a
+  `<datalist>`, where the value IS the label and adding text content changes
+  what the browser renders. `ignoreElements` exists for this; the list is the
+  rule's own default plus `option` and `datalist`.
+- **Disabled at the site**, with the invariant stated, for the 10 that are
+  genuinely facts about one widget. This is the convention
+  `react/no-array-index-key` and `no-non-null-assertion` already use here.
+  `prefer-tag-over-role` takes no options at all, so it is the only bounded
+  mechanism available to it.
+
+The trade is deliberate: 10 one-line exceptions a reader meets in context, in
+exchange for four rules that now fire on anything new. Four `"off"`s were
+cheaper to write and bought nothing.
+
+### The 10 that stayed
+
+Worth recording, because "the rule is wrong here" is a claim that should be
+checkable:
+
+- **4 × `role="status"`** (the run announcement, the stale-results banner, the
+  share receipt, the pin receipt). `<output>` is form-associated, and its
+  IMPLICIT live region is materially less reliably announced than an explicit
+  `role="status"` — for the share receipt it is also invalid, since `<output>`
+  takes phrasing content and that card holds `<p>`s and a `<code>`. These
+  elements exist to be announced; trading the reliable spelling for the tidy
+  one loses the only thing they do.
+- **`role="radio"`** (`SegmentedControl`). `<input type="radio">` is a replaced
+  element rendering the platform's own dot-and-ring — the exact rendering a
+  segmented control exists to replace.
+- **`role="button"`** (`ProvenanceChip`). The chip renders inside the effective-
+  config ledger's row-toggle button, and a button has no content model that
+  admits another button. Corroborated in `KeyRow`, which documents the same
+  arrangement for `OptionKey`.
+- **`role="dialog"`** (`RuleEvidenceCard`). `<dialog>` shown modally moves to
+  the top layer, discarding the viewport-coordinate placement this card is
+  positioned by, and brings its own Escape protocol that would race the app's
+  shared Escape ladder rather than join it.
+- **`role="group"`** (`SequenceTimeline`). The rule offers `address, details,
+  fieldset, hgroup, optgroup`; every one means something this is not.
+- **2 × tablist** (`ResultsPanel`, `AddTestBox`). The composite-widget pattern:
+  roving tabindex on the tabs, container out of the tab order so Tab moves past
+  the bar rather than into it. The container's keydown handler — the thing that
+  makes the rule fire — is there because arrow-key navigation is delegated,
+  which is the same pattern's other half. `interactive-supports-focus`'s
+  `tabbable` option decides 0-vs-−1 and cannot express this.
+
+## The mechanism that keeps this from rotting
+
+Site-level exceptions are only better than blanket offs if they cannot outlive
+their reason. `pnpm lint` now passes
+`--report-unused-disable-directives-severity=error`, so a directive that has
+stopped suppressing anything is itself an error: refactor the code out from
+under a disable and the build says the comment is now a lie.
+
+Switching it on immediately found three dead waivers that predate this work —
+one directive on a line whose rule only fires on the next statement, and two
+`eslint-disable` lines naming rules oxlint does not implement, which had
+therefore never done anything at all. All three are gone.
+
+A blanket `"off"` has no equivalent of this check, and that is the other half
+of why the four went.
+
+## Left open
+
+`AddTestBox` and `ResultsPanel` are the app's only two tablists and both are
+now complete. The remaining known gap is that the windowed preset tree states
+`aria-level` but not `aria-setsize`/`aria-posinset`, so AT reports position
+within the rendered window rather than within the tree. Fixing it means
+threading the full sibling count through the windowing, which is a change to
+`rows.ts`, not an attribute — deliberately not done here.
+
+Also unchanged, and worth being explicit about: making the preset table view a
+REAL grid (cells, column headers, roving grid navigation, `aria-rowcount` /
+`aria-rowindex` to undo the windowing) would be better than the plain list of
+buttons it now honestly is. Removing the false `role="table"` is not a
+substitute for that; it is the correct state until someone builds it.


### PR DESCRIPTION
The four `jsx-a11y` rules that were switched off as "wrong about this
codebase" were hiding two real defects between them, and the shape of
the exclusion is why: a blanket `"off"` puts the reasoning in a config
file, far from the component it is a claim about.

Re-running the four and reading all 18 sites splits them three ways:

- FIXED. `PresetListPane` claimed `role="table"` over children that were
  two virtual spacers and a flat list of buttons — no row, no cell — with
  its `role="row"` header outside the table entirely. AT announced
  "table, 0 rows" over a list of hundreds. `prefer-tag-over-role` pointed
  straight at it. The hover-card anchors were focusable spans with no
  role and no relationship to the card they opened; they now carry
  `aria-describedby`, and the four hand-written copies of that span
  became one `HoverCardTextAnchor`.

- CONFIGURED. All three `control-has-associated-label` hits were
  `<option>` inside a `<datalist>`, where the value IS the label. The
  rule ships `ignoreElements` for exactly this.

- DISABLED AT THE SITE, with the invariant stated, for the 10 that are
  facts about one widget (`<output>`'s implicit live region, a button
  that cannot nest in a button, the composite-tablist pattern).

Reading the roles rather than the lint output found two more that no
rule can see, both being absent RELATIONSHIPS rather than bad elements:
the windowed preset tree conveyed depth only through `paddingLeft` (now
`aria-level`), and `AddTestBox`'s tabs controlled nothing — no ids, no
`aria-controls`, no `role="tabpanel"` — while `ResultsPanel`'s bar had
it right all along.

`pnpm lint` now fails on a disable directive that suppresses nothing, so
a site-level exception cannot outlive its reason the way an `"off"` can.
That found three dead waivers already in the tree.

roadmap/2026-08-aria-audit.md is the full account.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>