### PR TITLE
fix(simulator): give the pin funnel's rule lead the standard preset token

### DIFF
--- a/packages/app/src/features/simulator/PinRuleSections.tsx
+++ b/packages/app/src/features/simulator/PinRuleSections.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from "react";
-import { ProvenanceChip } from "@/components/ProvenanceChip";
+import { PresetName } from "@/components/PresetName";
 import { nf } from "@/lib/format";
 import { ClauseGrid } from "./ClauseGrid";
 import type { PinFailedRule, PinMatchedRule, PinRuleRef } from "./pin-outcome";
@@ -61,7 +61,9 @@ export function PinSectionHead({
 }
 
 /** The row's lead: the `packageRules[N]` reference as the expand toggle, then
- *  the preset chip when a preset contributed the rule. */
+ *  the preset that declared the rule. The standard `PresetName` token (081),
+ *  not `RuleRow`'s bare chip: "from ⟨X⟩" names a preset inside a sentence,
+ *  where the chip answers which LAYER a value arrived through. */
 function RuleRefLead({
   rule,
   expanded,
@@ -73,15 +75,20 @@ function RuleRefLead({
   onToggle: () => void;
   onSelectPreset?: (nodeId: string) => void;
 }) {
+  const layer = rule.layer;
   return (
     <>
       <button type="button" className="pin-rule-index" aria-expanded={expanded} onClick={onToggle}>
         {ruleRef(rule.index)}
       </button>
-      {rule.layer?.kind === "preset" ? (
+      {layer?.kind === "preset" ? (
         <>
           <span className="pin-rule-from">from</span>
-          <ProvenanceChip layer={rule.layer} onSelectPreset={onSelectPreset} />
+          <PresetName
+            name={layer.name}
+            nodeId={layer.nodeId}
+            onClick={onSelectPreset ? () => onSelectPreset(layer.nodeId) : undefined}
+          />
         </>
       ) : null}
     </>


### PR DESCRIPTION
`RuleRefLead` renders "packageRules[N] from ⟨preset⟩", which names a preset inside a sentence — 081's "purple = preset, everywhere" case — but it wrote a bare `ProvenanceChip` before 081 existed and never adopted the token. The reference now carries the standard purple token and its hover card (via chain, extends counts, "show the full tree →") instead of the layer glossary card.

`RuleRow`'s trailing chip is untouched: that one answers which LAYER a value arrived through, which is the bare-chip case `LayerSource`'s header rules intended. The layer already carries the preset's name and node id, so the token costs no lookup the row wasn't already holding.