### PR TITLE
fix: recover from GitHub access tokens revoked before their recorded expiry

### DIFF
--- a/docs/Auth-Flow.md
+++ b/docs/Auth-Flow.md
@@ -89,17 +89,75 @@ sequenceDiagram
 ```
 
 GitHub rotates the refresh token on every use, which is why the restore and
-refresh paths are single-flight: a second concurrent `/refresh` would post the
-cookie the first one already burned.
+refresh paths are single-flight within a tab — and serialized ACROSS tabs by a
+Web Lock (`rcd.oauth.refresh`): a second concurrent `/refresh`, from a
+StrictMode remount or from a sibling tab booting at the same moment, would
+post the cookie the first one already burned and end the whole session. After
+waiting on the lock, a tab re-checks its state before posting: a sibling's
+refresh may already have handed it a fresh token (below), and then there is
+nothing left to do.
 
 Only a definitive 4xx ends the session; a transient failure never destroys
 state, because signing out fires `/logout` and could burn a still-good cookie
 over a network blip.
 
+## Cross-tab coordination (cookie mode)
+
+In cookie mode every tab shares ONE grant — the cookie — while each tab keeps
+its own access token in per-tab `sessionStorage`. GitHub revokes the old
+access token whenever the grant is refreshed ("that refresh token and the old
+user access token will no longer work"), so any tab's refresh invalidates the
+token every sibling tab still holds, hours before its recorded expiry — and
+the sibling cannot tell locally: its stored horizon still looks fine, so the
+silent-refresh machinery never fires.
+
+Two mechanisms close the gap:
+
+- **Token broadcast.** After a cookie-mode refresh, the new access token goes
+  out on a `BroadcastChannel` (`rcd.oauth`) and sibling tabs adopt it. A tab
+  adopts only when the shared-grant marker is live (the sender re-set it
+  before broadcasting) and never over an in-JS refresh token (that tab has its
+  own 009 grant); the message is validated like any stored value before it can
+  reach a request header. Sign-out broadcasts too, so siblings stop believing
+  in tokens the teardown just orphaned.
+- **401 recovery.** If a revoked token is sent anyway (the broadcast raced the
+  run, or the revocation came from outside — a revoked app grant), the engine
+  transport gives the 401 one recovery attempt: a registered
+  `AuthRefreshHandler` (engine `auth.ts`, registered per entry point in the
+  app's `run.ts`) forces the refresh past the trusted local expiry, pushes the
+  renewed auth state, and the request retries once with re-resolved headers.
+  If the grant is dead, the session ends cleanly and the retry — and the rest
+  of the run — goes out anonymously instead of failing on the dead token. The
+  CLI registers no handler, so the headless graph keeps the plain
+  throw-on-401.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Tab A
+    participant B as Tab B (booting)
+    participant Worker as oauth-worker
+    participant GitHub as api.github.com
+    B->>Worker: POST /refresh {} (shared cookie)
+    Worker-->>B: new access token + rotated cookie
+    Note over A: GitHub revoked A's access token just now
+    B--)A: BroadcastChannel: replacement token
+    A->>GitHub: content fetch (revoked token — broadcast raced the run)
+    GitHub-->>A: 401 Bad credentials
+    A->>A: AuthRefreshHandler: adopt the replacement<br/>(or refresh under the Web Lock)
+    A->>GitHub: retry once with the new token
+    GitHub-->>A: 200
+```
+
+A rejected personal access token or credentials-row token is not renewable
+here — nothing in the app manages those lifecycles — so its 401 surfaces
+unchanged.
+
 ## Sign-out
 
 `signOut()` clears memory, every `rcd.oauth.*` storage key, and the marker,
-then fires a best-effort `POST /logout`, since only the worker can clear the
-`HttpOnly` cookie (the answer carries a clearing `Max-Age=0`). True revocation of the GitHub
-grant can only be done on
+broadcasts the sign-out to sibling tabs, then fires a best-effort
+`POST /logout`, since only the worker can clear the `HttpOnly` cookie (the
+answer carries a clearing `Max-Age=0`). True revocation of the GitHub grant
+can only be done on
 [github.com/settings/apps/authorizations](https://github.com/settings/apps/authorizations).

--- a/docs/Auth-Flow.md
+++ b/docs/Auth-Flow.md
@@ -119,7 +119,8 @@ Two mechanisms close the gap:
   before broadcasting) and never over an in-JS refresh token (that tab has its
   own 009 grant); the message is validated like any stored value before it can
   reach a request header. Sign-out broadcasts too, so siblings stop believing
-  in tokens the teardown just orphaned.
+  in tokens the teardown just orphaned — a tab holding its own in-JS grant
+  ignores it, since that grant is nobody else's to tear down.
 - **401 recovery.** If a revoked token is sent anyway (the broadcast raced the
   run, or the revocation came from outside — a revoked app grant), the engine
   transport gives the 401 one recovery attempt: a registered

--- a/packages/app/src/app/use-oauth-session.ts
+++ b/packages/app/src/app/use-oauth-session.ts
@@ -1,9 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AuthState } from "@/components/GithubAuthHint";
 import {
   getOAuthConfig,
   getStoredUser,
   isSignedIn,
+  onSessionBroadcast,
   signOut,
   type StoredUser,
 } from "@/platform/oauth";
@@ -70,6 +71,19 @@ export function useOAuthSession(): OAuthSession {
     signOut();
     setSignedIn(false);
     setAuthUser(null);
+  }, []);
+
+  // A sibling tab's broadcast changes the session outside any React event —
+  // its refresh signs this tab in, its sign-out tears this tab down — so the
+  // chip re-reads the module state when one lands.
+  useEffect(() => {
+    if (!OAUTH_CONFIG) {
+      return;
+    }
+    return onSessionBroadcast(() => {
+      setSignedIn(isSignedIn());
+      setAuthUser(getStoredUser());
+    });
   }, []);
 
   return {

--- a/packages/app/src/platform/oauth-test-harness.ts
+++ b/packages/app/src/platform/oauth-test-harness.ts
@@ -1,0 +1,54 @@
+/**
+ * The shared half of the oauth.ts test harnesses: the in-memory storage
+ * doubles, the Worker/GitHub fetch surface, and the constants both suites
+ * address. oauth.session.test.ts and oauth.crosstab.test.ts stub the same
+ * module the same way — one copy here keeps their mocks from drifting apart
+ * when the Worker surface changes.
+ */
+
+export const COOKIE_SESSION_KEY = "rcd.oauth.cookieSession";
+export const WORKER_URL = "https://worker.example";
+
+export type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export function memoryStorage(): StorageLike & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** The Worker + GitHub responses the oauth paths reach for. `refresh` (read
+ *  per call, so a test may swap it mid-flight) decides what `POST /refresh`
+ *  answers; everything else is fixed. */
+export function makeWorkerFetch(refresh: () => Response) {
+  return function baseFetch(input: unknown, init?: RequestInit): Promise<Response> {
+    const url = String(input);
+    if (url === `${WORKER_URL}/refresh`) {
+      return Promise.resolve(refresh());
+    }
+    if (url === `${WORKER_URL}/logout`) {
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }
+    if (url === "https://api.github.com/user") {
+      return Promise.resolve(
+        jsonResponse({ login: "octocat", avatar_url: "https://ex.test/a.png" }),
+      );
+    }
+    return Promise.reject(new Error(`unexpected fetch: ${url} ${String(init?.method)}`));
+  };
+}

--- a/packages/app/src/platform/oauth.crosstab.test.ts
+++ b/packages/app/src/platform/oauth.crosstab.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  COOKIE_SESSION_KEY,
+  jsonResponse,
+  makeWorkerFetch,
+  memoryStorage,
+  type StorageLike,
+  WORKER_URL,
+} from "./oauth-test-harness";
 
 /**
  * The cross-tab half of oauth.ts: in cookie mode every tab shares one grant,
@@ -16,53 +24,16 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
  * not leak between tests.
  */
 
-const COOKIE_SESSION_KEY = "rcd.oauth.cookieSession";
 const TOKEN_KEY = "rcd.oauth.token";
 const TOKEN_EXPIRES_KEY = "rcd.oauth.tokenExpiresAt";
-const WORKER_URL = "https://worker.example";
-
-type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
-
-function memoryStorage(): StorageLike & { map: Map<string, string> } {
-  const map = new Map<string, string>();
-  return {
-    map,
-    getItem: (key) => map.get(key) ?? null,
-    setItem: (key, value) => {
-      map.set(key, value);
-    },
-    removeItem: (key) => {
-      map.delete(key);
-    },
-  };
-}
+const REFRESH_TOKEN_KEY = "rcd.oauth.refreshToken";
 
 const g = globalThis as { localStorage?: StorageLike; sessionStorage?: StorageLike };
 let local = memoryStorage();
 let session = memoryStorage();
 
 let refreshResponse: () => Response = () => jsonResponse({});
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function baseFetch(input: unknown, init?: RequestInit): Promise<Response> {
-  const url = String(input);
-  if (url === `${WORKER_URL}/refresh`) {
-    return Promise.resolve(refreshResponse());
-  }
-  if (url === `${WORKER_URL}/logout`) {
-    return Promise.resolve(new Response(null, { status: 204 }));
-  }
-  if (url === "https://api.github.com/user") {
-    return Promise.resolve(jsonResponse({ login: "octocat", avatar_url: "https://ex.test/a.png" }));
-  }
-  return Promise.reject(new Error(`unexpected fetch: ${url} ${String(init?.method)}`));
-}
+const baseFetch = makeWorkerFetch(() => refreshResponse());
 
 const fetchMock = vi.fn(baseFetch);
 
@@ -238,6 +209,22 @@ describe("token broadcast", () => {
     });
     expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(0);
   });
+
+  test("a sibling's sign-out leaves an independent in-JS (009) grant alone", async () => {
+    // No cookie marker, an own refresh token: this tab's grant is nobody
+    // else's to tear down.
+    session.map.set(TOKEN_KEY, "ghu_mine");
+    session.map.set(TOKEN_EXPIRES_KEY, String(Date.now() + 7_200_000));
+    session.map.set(REFRESH_TOKEN_KEY, "ghr_mine");
+    const { isSignedIn } = await freshOAuth();
+    expect(isSignedIn()).toBe(true);
+
+    siblingPosts({ type: "signout" });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(isSignedIn()).toBe(true);
+  });
 });
 
 describe("refresh lock", () => {
@@ -273,5 +260,22 @@ describe("refresh lock", () => {
     expect(await pending).toBe("ghu_from_sibling");
     // The whole point: no second /refresh with the already-rotated cookie.
     expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(0);
+  });
+
+  test("a lock manager that refuses does not wedge the refresh single-flight", async () => {
+    seedCookieTab("ghu_stale", 0);
+    refreshResponse = () =>
+      jsonResponse({ access_token: "ghu_renewed", expires_in: 28_800, refresh_token_cookie: true });
+    vi.stubGlobal("navigator", {
+      locks: {
+        request: () => Promise.reject(new Error("document is not fully active")),
+      },
+    });
+    const { getValidToken } = await freshOAuth();
+
+    // The refresh still runs (unserialized), and the in-flight slot clears.
+    expect(await getValidToken()).toBe("ghu_renewed");
+    expect(await getValidToken()).toBe("ghu_renewed");
+    expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(1);
   });
 });

--- a/packages/app/src/platform/oauth.crosstab.test.ts
+++ b/packages/app/src/platform/oauth.crosstab.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+/**
+ * The cross-tab half of oauth.ts: in cookie mode every tab shares one grant,
+ * and GitHub revokes the old access token whenever that grant is refreshed —
+ * so a sibling tab's refresh kills this tab's token hours before its recorded
+ * expiry. These tests cover the three mechanisms that close the gap: the
+ * recovery entry point a 401 triggers (`recoverRejectedToken`), the
+ * BroadcastChannel that hands a refreshed token to sibling tabs, and the
+ * refresh-lock recheck that keeps a woken tab from posting the cookie a
+ * sibling already rotated.
+ *
+ * Node's own BroadcastChannel delivers between instances in-process, so a
+ * plain second channel plays the sibling tab. Same re-import idiom as
+ * oauth.session.test.ts: module state (token, single-flights, channel) must
+ * not leak between tests.
+ */
+
+const COOKIE_SESSION_KEY = "rcd.oauth.cookieSession";
+const TOKEN_KEY = "rcd.oauth.token";
+const TOKEN_EXPIRES_KEY = "rcd.oauth.tokenExpiresAt";
+const WORKER_URL = "https://worker.example";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function memoryStorage(): StorageLike & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  return {
+    map,
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => {
+      map.set(key, value);
+    },
+    removeItem: (key) => {
+      map.delete(key);
+    },
+  };
+}
+
+const g = globalThis as { localStorage?: StorageLike; sessionStorage?: StorageLike };
+let local = memoryStorage();
+let session = memoryStorage();
+
+let refreshResponse: () => Response = () => jsonResponse({});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function baseFetch(input: unknown, init?: RequestInit): Promise<Response> {
+  const url = String(input);
+  if (url === `${WORKER_URL}/refresh`) {
+    return Promise.resolve(refreshResponse());
+  }
+  if (url === `${WORKER_URL}/logout`) {
+    return Promise.resolve(new Response(null, { status: 204 }));
+  }
+  if (url === "https://api.github.com/user") {
+    return Promise.resolve(jsonResponse({ login: "octocat", avatar_url: "https://ex.test/a.png" }));
+  }
+  return Promise.reject(new Error(`unexpected fetch: ${url} ${String(init?.method)}`));
+}
+
+const fetchMock = vi.fn(baseFetch);
+
+function fetchCalls(path: string) {
+  return fetchMock.mock.calls.filter(([input]) => String(input) === path);
+}
+
+async function freshOAuth() {
+  vi.resetModules();
+  return import("./oauth");
+}
+
+/** The signed-in state a cookie-mode tab holds: an access token in its own
+ *  sessionStorage, no in-JS refresh token, the shared marker in localStorage. */
+function seedCookieTab(token: string, expiresAt: number): void {
+  session.map.set(TOKEN_KEY, token);
+  session.map.set(TOKEN_EXPIRES_KEY, String(expiresAt));
+  local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 3_600_000));
+}
+
+/** A second channel on the module's name — the sibling tab. Collected and
+ *  closed per test so a leaked instance can't hear a later test's traffic. */
+const siblings: BroadcastChannel[] = [];
+
+function siblingChannel(): BroadcastChannel {
+  const ch = new BroadcastChannel("rcd.oauth");
+  siblings.push(ch);
+  return ch;
+}
+
+function siblingPosts(message: unknown): void {
+  // oxlint-disable-next-line unicorn/require-post-message-target-origin -- BroadcastChannel.postMessage has no targetOrigin parameter
+  siblingChannel().postMessage(message);
+}
+
+beforeEach(() => {
+  local = memoryStorage();
+  g.localStorage = local;
+  session = memoryStorage();
+  g.sessionStorage = session;
+  vi.stubEnv("VITE_GITHUB_CLIENT_ID", "client");
+  vi.stubEnv("VITE_OAUTH_WORKER_URL", WORKER_URL);
+  vi.stubEnv("VITE_GITHUB_APP_SLUG", undefined);
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(baseFetch);
+  refreshResponse = () => jsonResponse({});
+});
+
+afterEach(() => {
+  for (const ch of siblings.splice(0)) {
+    ch.close();
+  }
+  delete g.localStorage;
+  delete g.sessionStorage;
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("recoverRejectedToken", () => {
+  test("signed out: nothing to recover, no round trip", async () => {
+    const { recoverRejectedToken } = await freshOAuth();
+    expect(await recoverRejectedToken("ghu_notmine")).toEqual({ recovered: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a token a sibling already replaced answers the replacement without a refresh", async () => {
+    seedCookieTab("ghu_fresh", Date.now() + 7_200_000);
+    const { recoverRejectedToken } = await freshOAuth();
+    expect(await recoverRejectedToken("ghu_dead")).toEqual({ recovered: true, token: "ghu_fresh" });
+    expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(0);
+  });
+
+  test("the current token 401ing forces a refresh despite a future recorded expiry", async () => {
+    // The whole bug: the local clock says 7 h left, but the host revoked it.
+    seedCookieTab("ghu_dead", Date.now() + 25_200_000);
+    refreshResponse = () =>
+      jsonResponse({ access_token: "ghu_renewed", expires_in: 28_800, refresh_token_cookie: true });
+    const { recoverRejectedToken, isSignedIn } = await freshOAuth();
+
+    expect(await recoverRejectedToken("ghu_dead")).toEqual({
+      recovered: true,
+      token: "ghu_renewed",
+    });
+    expect(isSignedIn()).toBe(true);
+    expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(1);
+  });
+
+  test("with no refresh path left the session ends and the run may go anonymous", async () => {
+    session.map.set(TOKEN_KEY, "ghu_dead");
+    session.map.set(TOKEN_EXPIRES_KEY, String(Date.now() + 7_200_000));
+    // no cookie marker, no in-JS refresh token: nothing can renew this
+    const { recoverRejectedToken, isSignedIn } = await freshOAuth();
+
+    expect(await recoverRejectedToken("ghu_dead")).toEqual({ recovered: true, token: null });
+    expect(isSignedIn()).toBe(false);
+    expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(1);
+  });
+});
+
+describe("token broadcast", () => {
+  test("a cookie-mode refresh hands the replacement to sibling tabs", async () => {
+    seedCookieTab("ghu_dead", 0);
+    refreshResponse = () =>
+      jsonResponse({ access_token: "ghu_renewed", expires_in: 28_800, refresh_token_cookie: true });
+    const heard: unknown[] = [];
+    siblingChannel().addEventListener("message", (event) => {
+      heard.push((event as MessageEvent<unknown>).data);
+    });
+    const { getValidToken } = await freshOAuth();
+
+    expect(await getValidToken()).toBe("ghu_renewed");
+    await vi.waitFor(() => {
+      expect(heard).toContainEqual(
+        expect.objectContaining({ type: "token", token: "ghu_renewed" }),
+      );
+    });
+  });
+
+  test("a tab on the shared grant adopts a sibling's token", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 3_600_000));
+    const { isSignedIn, getValidToken } = await freshOAuth();
+    expect(isSignedIn()).toBe(false);
+
+    siblingPosts({
+      type: "token",
+      token: "ghu_shared",
+      tokenExpiresAt: Date.now() + 28_800_000,
+    });
+    await vi.waitFor(() => {
+      expect(isSignedIn()).toBe(true);
+    });
+    expect(await getValidToken()).toBe("ghu_shared");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a tab with no session and no marker stays signed out", async () => {
+    const { isSignedIn } = await freshOAuth();
+    siblingPosts({
+      type: "token",
+      token: "ghu_shared",
+      tokenExpiresAt: Date.now() + 28_800_000,
+    });
+    // deliver: the sibling's message has landed when its own echo would have
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(isSignedIn()).toBe(false);
+  });
+
+  test("a malformed broadcast token is refused (roadmap 030)", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 3_600_000));
+    const { isSignedIn } = await freshOAuth();
+    siblingPosts({
+      type: "token",
+      token: "bad\ntoken",
+      tokenExpiresAt: Date.now() + 28_800_000,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    expect(isSignedIn()).toBe(false);
+  });
+
+  test("a sibling's sign-out clears this tab without a second /logout", async () => {
+    seedCookieTab("ghu_live", Date.now() + 7_200_000);
+    const { isSignedIn } = await freshOAuth();
+    expect(isSignedIn()).toBe(true);
+
+    siblingPosts({ type: "signout" });
+    await vi.waitFor(() => {
+      expect(isSignedIn()).toBe(false);
+    });
+    expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(0);
+  });
+});
+
+describe("refresh lock", () => {
+  test("a tab that waited on the lock uses the sibling's token instead of the burned cookie", async () => {
+    seedCookieTab("ghu_stale", 0);
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // A minimal LockManager: the sibling "holds" the lock until release().
+    vi.stubGlobal("navigator", {
+      locks: {
+        request: async (_name: string, task: () => Promise<unknown>) => {
+          await gate;
+          return task();
+        },
+      },
+    });
+    const { getValidToken } = await freshOAuth();
+
+    const pending = getValidToken();
+    // While this tab waits, the sibling finishes its refresh and broadcasts.
+    siblingPosts({
+      type: "token",
+      token: "ghu_from_sibling",
+      tokenExpiresAt: Date.now() + 28_800_000,
+    });
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+    release?.();
+
+    expect(await pending).toBe("ghu_from_sibling");
+    // The whole point: no second /refresh with the already-rotated cookie.
+    expect(fetchCalls(`${WORKER_URL}/refresh`)).toHaveLength(0);
+  });
+});

--- a/packages/app/src/platform/oauth.crosstab.test.ts
+++ b/packages/app/src/platform/oauth.crosstab.test.ts
@@ -6,7 +6,7 @@ import {
   memoryStorage,
   type StorageLike,
   WORKER_URL,
-} from "./oauth-test-harness";
+} from "@tools/test/oauth-test-harness";
 
 /**
  * The cross-tab half of oauth.ts: in cookie mode every tab shares one grant,

--- a/packages/app/src/platform/oauth.session.test.ts
+++ b/packages/app/src/platform/oauth.session.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  COOKIE_SESSION_KEY,
+  jsonResponse,
+  makeWorkerFetch,
+  memoryStorage,
+  type StorageLike,
+  WORKER_URL,
+} from "./oauth-test-harness";
 
 /**
  * Roadmap 065 — the cookie-session half of oauth.ts: the localStorage marker
@@ -14,53 +22,14 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
  * test must not read as "already signed in" in the next.
  */
 
-const COOKIE_SESSION_KEY = "rcd.oauth.cookieSession";
-const WORKER_URL = "https://worker.example";
-
-type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
-
-function memoryStorage(): StorageLike & { map: Map<string, string> } {
-  const map = new Map<string, string>();
-  return {
-    map,
-    getItem: (key) => map.get(key) ?? null,
-    setItem: (key, value) => {
-      map.set(key, value);
-    },
-    removeItem: (key) => {
-      map.delete(key);
-    },
-  };
-}
-
 const g = globalThis as { localStorage?: StorageLike; sessionStorage?: StorageLike };
 let local = memoryStorage();
 let session = memoryStorage();
 
-/** The Worker + GitHub responses the paths below reach for. `refresh` decides
- *  what `POST /refresh` answers; everything else is fixed. */
+/** What `POST /refresh` answers; the rest of the Worker/GitHub surface is
+ *  fixed in the shared harness. */
 let refreshResponse: () => Response = () => jsonResponse({});
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function baseFetch(input: unknown, init?: RequestInit): Promise<Response> {
-  const url = String(input);
-  if (url === `${WORKER_URL}/refresh`) {
-    return Promise.resolve(refreshResponse());
-  }
-  if (url === `${WORKER_URL}/logout`) {
-    return Promise.resolve(new Response(null, { status: 204 }));
-  }
-  if (url === "https://api.github.com/user") {
-    return Promise.resolve(jsonResponse({ login: "octocat", avatar_url: "https://ex.test/a.png" }));
-  }
-  return Promise.reject(new Error(`unexpected fetch: ${url} ${String(init?.method)}`));
-}
+const baseFetch = makeWorkerFetch(() => refreshResponse());
 
 const fetchMock = vi.fn(baseFetch);
 

--- a/packages/app/src/platform/oauth.session.test.ts
+++ b/packages/app/src/platform/oauth.session.test.ts
@@ -6,7 +6,7 @@ import {
   memoryStorage,
   type StorageLike,
   WORKER_URL,
-} from "./oauth-test-harness";
+} from "@tools/test/oauth-test-harness";
 
 /**
  * Roadmap 065 — the cookie-session half of oauth.ts: the localStorage marker

--- a/packages/app/src/platform/oauth.ts
+++ b/packages/app/src/platform/oauth.ts
@@ -273,6 +273,100 @@ function storeTokenState(state: TokenState): void {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-tab coordination (cookie mode)
+// ---------------------------------------------------------------------------
+//
+// In cookie mode every tab shares ONE grant (the `HttpOnly` refresh cookie),
+// and GitHub revokes the old access token whenever that grant is refreshed —
+// so any tab's refresh silently kills the token every sibling tab still
+// holds, hours before its recorded expiry. Two mechanisms close the gap:
+// a BroadcastChannel hands the replacement token to the siblings, and a Web
+// Lock serializes cross-tab refreshes so a racing boot can never post the
+// already-rotated (burned) cookie and end the whole session.
+
+interface TokenBroadcast {
+  type: "token";
+  token: string;
+  tokenExpiresAt: number;
+  refreshTokenExpiresAt?: number;
+}
+
+type OAuthBroadcast = TokenBroadcast | { type: "signout" };
+
+function openChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") {
+    return null;
+  }
+  try {
+    const ch = new BroadcastChannel("rcd.oauth");
+    ch.addEventListener("message", (event: MessageEvent<unknown>) => {
+      receiveBroadcast(event.data);
+    });
+    // Node's BroadcastChannel (vitest) holds the process open unless unref'd;
+    // the browser one has no unref.
+    (ch as { unref?: () => void }).unref?.();
+    return ch;
+  } catch {
+    return null;
+  }
+}
+
+const channel = openChannel();
+
+function broadcast(message: OAuthBroadcast): void {
+  try {
+    // oxlint-disable-next-line unicorn/require-post-message-target-origin -- BroadcastChannel.postMessage has no targetOrigin parameter
+    channel?.postMessage(message);
+  } catch {
+    // a closed/failed channel only costs the siblings a silent refresh
+  }
+}
+
+/** A sibling tab's message. Same-origin by construction, but validated like
+ *  every stored value (roadmap 030) — the token goes into a request header. */
+function receiveBroadcast(data: unknown): void {
+  if (typeof data !== "object" || data === null) {
+    return;
+  }
+  const msg = data as Partial<Omit<TokenBroadcast, "type">> & { type?: string };
+  if (msg.type === "signout") {
+    clearLocalSession();
+    return;
+  }
+  if (msg.type !== "token") {
+    return;
+  }
+  if (typeof msg.token !== "string" || !isValidToken(msg.token)) {
+    return;
+  }
+  if (typeof msg.tokenExpiresAt !== "number" || !Number.isFinite(msg.tokenExpiresAt)) {
+    return;
+  }
+  // Only a tab on the shared cookie grant may adopt the token: the live
+  // marker is the evidence (the sender re-set it before broadcasting), and a
+  // tab holding its own in-JS refresh token has its own grant.
+  if (currentToken()?.refreshToken || !hasLiveCookieSession()) {
+    return;
+  }
+  storeTokenState({
+    token: msg.token,
+    tokenExpiresAt: msg.tokenExpiresAt,
+    refreshTokenExpiresAt:
+      typeof msg.refreshTokenExpiresAt === "number" && Number.isFinite(msg.refreshTokenExpiresAt)
+        ? msg.refreshTokenExpiresAt
+        : undefined,
+  });
+}
+
+/** GitHub rotates the grant on every use, so cross-tab refreshes must not
+ *  interleave. Best-effort: without Web Locks (old browser, tests) the
+ *  per-tab single-flight still holds. */
+function withRefreshLock<T>(task: () => Promise<T>): Promise<T> {
+  const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
+  return locks ? locks.request("rcd.oauth.refresh", task) : task();
+}
+
+// ---------------------------------------------------------------------------
 // Worker exchange
 // ---------------------------------------------------------------------------
 
@@ -372,6 +466,14 @@ function applyTokenResponse(data: TokenResponse): void {
   });
   if (data.refresh_token_cookie) {
     localSet(K.cookieSession, String(refreshExpiresAt ?? Number.MAX_SAFE_INTEGER));
+    // This refresh revoked the access token every sibling tab on the shared
+    // grant still holds (GitHub rotates) — hand them the replacement.
+    broadcast({
+      type: "token",
+      token: data.access_token as string,
+      tokenExpiresAt,
+      ...(refreshExpiresAt === undefined ? {} : { refreshTokenExpiresAt: refreshExpiresAt }),
+    });
   } else {
     // Mode-switch hygiene: a deployment that turned cookie mode back off (or
     // a 009 Worker answering a browser that still carries a marker) must not
@@ -590,11 +692,19 @@ async function restoreSessionImpl(): Promise<StoredUser | null> {
   if (!hasLiveCookieSession()) {
     return null;
   }
-  let data: TokenResponse;
+  let data: TokenResponse | null;
   try {
-    // Empty body: the refresh token is the cookie `credentials: "include"`
-    // sends, and the SPA has no copy of it to offer.
-    data = await postWorker("/refresh", {});
+    data = await withRefreshLock(async () => {
+      // A sibling tab's boot may have refreshed while we waited on the lock —
+      // its broadcast already signed this tab in, and posting again would
+      // burn the freshly rotated cookie.
+      if (currentToken()) {
+        return null;
+      }
+      // Empty body: the refresh token is the cookie `credentials: "include"`
+      // sends, and the SPA has no copy of it to offer.
+      return postWorker("/refresh", {});
+    });
   } catch (err) {
     // A definitive rejection (a 4xx: the cookie is gone, expired, or was
     // already rotated away) drops the marker so later boots stop probing. A
@@ -606,6 +716,9 @@ async function restoreSessionImpl(): Promise<StoredUser | null> {
       localRemove(K.cookieSession);
     }
     return null;
+  }
+  if (data === null) {
+    return getStoredUser();
   }
   applyTokenResponse(data);
   return fetchUser(data.access_token as string).catch(() => null);
@@ -643,8 +756,14 @@ export async function getValidToken(): Promise<string | null> {
   // per session, and a second concurrent cookie refresh would post the
   // already-rotated (burned) cookie and kill the session it is renewing.
   if (!refreshInFlight) {
-    refreshInFlight = (async () => {
+    refreshInFlight = withRefreshLock(async () => {
       try {
+        // Re-check under the cross-tab lock: a sibling's refresh (delivered
+        // by broadcast) may have renewed the token while we waited.
+        const renewed = currentToken();
+        if (renewed && Date.now() < renewed.tokenExpiresAt - skewMs) {
+          return renewed.token;
+        }
         const data = await postWorker(
           "/refresh",
           viaCookie ? {} : { refresh_token: state.refreshToken },
@@ -665,7 +784,7 @@ export async function getValidToken(): Promise<string | null> {
       } finally {
         refreshInFlight = null;
       }
-    })();
+    });
   }
   return refreshInFlight;
 }
@@ -684,6 +803,21 @@ export async function getValidToken(): Promise<string | null> {
  * body and throws on anything that isn't one.
  */
 export function signOut(): void {
+  clearLocalSession();
+  // The grant is being torn down (the /logout below clears the shared
+  // cookie), so sibling tabs must not keep believing in their tokens either.
+  broadcast({ type: "signout" });
+  const cfg = getOAuthConfig();
+  if (cfg) {
+    void fetch(`${cfg.workerUrl}/logout`, { method: "POST", credentials: "include" }).catch(
+      () => {},
+    );
+  }
+}
+
+/** This tab's session teardown alone — what a sibling's "signout" broadcast
+ *  applies. No re-broadcast (loop) and no /logout (the sender fired it). */
+function clearLocalSession(): void {
   memToken = null;
   memLoaded = true;
   for (const key of Object.values(K)) {
@@ -691,10 +825,30 @@ export function signOut(): void {
   }
   // The one localStorage key: the loop above is a no-op for it.
   localRemove(K.cookieSession);
-  const cfg = getOAuthConfig();
-  if (cfg) {
-    void fetch(`${cfg.workerUrl}/logout`, { method: "POST", credentials: "include" }).catch(
-      () => {},
-    );
+}
+
+/** The outcome of {@link recoverRejectedToken}: `recovered: false` means the
+ *  rejected credential is not the OAuth token (a PAT or credentials row —
+ *  nothing here can renew those); `token: null` means the session ended. */
+export type TokenRecovery = { recovered: false } | { recovered: true; token: string | null };
+
+/**
+ * A host answered 401 for `rejected` mid-run: the token was revoked before
+ * its recorded expiry — locally that looks valid, so the silent-refresh
+ * machinery never fired. Typical cause: another tab refreshed the shared
+ * cookie grant, which rotates it and revokes this tab's access token. If a
+ * sibling's broadcast already delivered the replacement, answer that;
+ * otherwise force the expiry and refresh (single-flight, cross-tab lock,
+ * sign-out on a definitive failure).
+ */
+export async function recoverRejectedToken(rejected: string): Promise<TokenRecovery> {
+  const state = currentToken();
+  if (!state) {
+    return { recovered: false };
   }
+  if (state.token !== rejected) {
+    return { recovered: true, token: state.token };
+  }
+  storeTokenState({ ...state, tokenExpiresAt: 0 });
+  return { recovered: true, token: await getValidToken() };
 }

--- a/packages/app/src/platform/oauth.ts
+++ b/packages/app/src/platform/oauth.ts
@@ -330,7 +330,12 @@ function receiveBroadcast(data: unknown): void {
   }
   const msg = data as Partial<Omit<TokenBroadcast, "type">> & { type?: string };
   if (msg.type === "signout") {
-    clearLocalSession();
+    // A tab holding its own in-JS refresh token (009) has its own grant — a
+    // sibling's sign-out tears down the SHARED grant only, not this one.
+    if (!currentToken()?.refreshToken) {
+      clearLocalSession();
+      notifySessionChanged();
+    }
     return;
   }
   if (msg.type !== "token") {
@@ -356,14 +361,50 @@ function receiveBroadcast(data: unknown): void {
         ? msg.refreshTokenExpiresAt
         : undefined,
   });
+  notifySessionChanged();
+}
+
+const sessionListeners = new Set<() => void>();
+
+/** Cross-tab session changes land outside any React event (a sibling's
+ *  refresh signing this tab in, its sign-out tearing this tab down), so the
+ *  UI layer subscribes here and re-reads `isSignedIn()`/`getStoredUser()`.
+ *  Returns the unsubscribe. */
+export function onSessionBroadcast(listener: () => void): () => void {
+  sessionListeners.add(listener);
+  return () => {
+    sessionListeners.delete(listener);
+  };
+}
+
+function notifySessionChanged(): void {
+  for (const listener of sessionListeners) {
+    listener();
+  }
 }
 
 /** GitHub rotates the grant on every use, so cross-tab refreshes must not
  *  interleave. Best-effort: without Web Locks (old browser, tests) the
  *  per-tab single-flight still holds. */
-function withRefreshLock<T>(task: () => Promise<T>): Promise<T> {
+async function withRefreshLock<T>(task: () => Promise<T>): Promise<T> {
   const locks = typeof navigator === "undefined" ? undefined : navigator.locks;
-  return locks ? locks.request("rcd.oauth.refresh", task) : task();
+  if (!locks) {
+    return task();
+  }
+  let started = false;
+  try {
+    return await locks.request("rcd.oauth.refresh", () => {
+      started = true;
+      return task();
+    });
+  } catch (err) {
+    if (started) {
+      throw err; // the task's own failure — its callers classify it
+    }
+    // The lock MANAGER refused (inactive document, denied API): run
+    // unserialized rather than wedging every later caller on this rejection.
+    return task();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -703,7 +744,12 @@ async function restoreSessionImpl(): Promise<StoredUser | null> {
       }
       // Empty body: the refresh token is the cookie `credentials: "include"`
       // sends, and the SPA has no copy of it to offer.
-      return postWorker("/refresh", {});
+      const fresh = await postWorker("/refresh", {});
+      // Stored (and broadcast) BEFORE the lock releases: a sibling waiting on
+      // it must find this token on its own re-check, not a gap it would fill
+      // by posting the just-rotated cookie.
+      applyTokenResponse(fresh);
+      return fresh;
     });
   } catch (err) {
     // A definitive rejection (a 4xx: the cookie is gone, expired, or was
@@ -718,9 +764,12 @@ async function restoreSessionImpl(): Promise<StoredUser | null> {
     return null;
   }
   if (data === null) {
-    return getStoredUser();
+    // Signed in while we waited. A broadcast-adopted token carries no stored
+    // profile in THIS tab's sessionStorage, so the chip's user is fetched —
+    // cosmetic, same never-rejects contract as below.
+    const adopted = currentToken();
+    return getStoredUser() ?? (adopted ? await fetchUser(adopted.token).catch(() => null) : null);
   }
-  applyTokenResponse(data);
   return fetchUser(data.access_token as string).catch(() => null);
 }
 
@@ -756,12 +805,16 @@ export async function getValidToken(): Promise<string | null> {
   // per session, and a second concurrent cookie refresh would post the
   // already-rotated (burned) cookie and kill the session it is renewing.
   if (!refreshInFlight) {
-    refreshInFlight = withRefreshLock(async () => {
+    const refresh = async (): Promise<string | null> => {
       try {
         // Re-check under the cross-tab lock: a sibling's refresh (delivered
-        // by broadcast) may have renewed the token while we waited.
+        // by broadcast) may have renewed the token — or its sign-out torn
+        // the session down — while we waited.
         const renewed = currentToken();
-        if (renewed && Date.now() < renewed.tokenExpiresAt - skewMs) {
+        if (!renewed) {
+          return null;
+        }
+        if (Date.now() < renewed.tokenExpiresAt - skewMs) {
           return renewed.token;
         }
         const data = await postWorker(
@@ -784,7 +837,10 @@ export async function getValidToken(): Promise<string | null> {
       } finally {
         refreshInFlight = null;
       }
-    });
+    };
+    // Only the shared (cookie) grant needs cross-tab serialization; a 009
+    // tab's in-JS grant is its own, and the per-tab single-flight suffices.
+    refreshInFlight = viaCookie ? withRefreshLock(refresh) : refresh();
   }
   return refreshInFlight;
 }

--- a/packages/app/src/platform/run.ts
+++ b/packages/app/src/platform/run.ts
@@ -1,5 +1,6 @@
 import type {
   AppliedTextFix,
+  AuthRefreshHandler,
   ErrorFixResult,
   OptionDoc,
   OptionIndex,
@@ -18,7 +19,7 @@ import { readCustomHostRules } from "@/lib/custom-host-rules";
 import { HOST_TOKENS } from "@/data/host-tokens";
 import { isValidToken } from "@/lib/input-schemas";
 import { type Engine, loadEngine } from "./engine-chunk";
-import { getValidToken } from "./oauth";
+import { getValidToken, recoverRejectedToken } from "./oauth";
 import { sessionGet } from "./storage";
 
 // Per-host PATs live in sessionStorage (roadmap 009/010 storage rules): they
@@ -89,6 +90,30 @@ function applyAuth(engine: Engine, oauthToken: string | null, opts?: RunOptions)
 }
 
 /**
+ * A GitHub 401 mid-run means the attached token was revoked before its
+ * recorded expiry (another tab's refresh of the shared cookie grant rotates
+ * it and revokes this tab's access token). The engine asks this handler once
+ * per rejected request: recover a usable token — or drop the dead one — push
+ * the new auth state, and let the transport retry. A rejected PAT or
+ * credentials row is not renewable here, so the 401 surfaces as before.
+ */
+function makeAuthRefreshHandler(engine: Engine): AuthRefreshHandler {
+  return async (hostType, _url, rejected) => {
+    if (hostType !== "github") {
+      return false;
+    }
+    const recovery = await recoverRejectedToken(rejected);
+    if (!recovery.recovered || recovery.token === rejected) {
+      return false;
+    }
+    // token: the sibling/refreshed replacement; null: the session ended, so
+    // the retry (and the rest of the run) goes out without the dead token.
+    applyAuth(engine, recovery.token);
+    return true;
+  };
+}
+
+/**
  * Roadmap 031: the engine chunk download and the OAuth token refresh (a
  * Worker round-trip when the token is stale) are independent, so they run
  * concurrently instead of back-to-back. Every ordering invariant holds:
@@ -96,7 +121,7 @@ function applyAuth(engine: Engine, oauthToken: string | null, opts?: RunOptions)
  * still carries the refreshed token; while the untrusted-endpoint guard
  * stands (`suppressTokens`), the token machinery is never even touched —
  * exactly as before, no refresh request leaves the browser for a run that
- * must not use credentials.
+ * must not use credentials, and no revoked-token recovery may re-attach one.
  */
 async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
   const [engine, oauthToken] = await Promise.all([
@@ -104,6 +129,7 @@ async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
     opts?.suppressTokens ? null : getValidToken(),
   ]);
   applyAuth(engine, oauthToken, opts);
+  engine.setAuthRefreshHandler(opts?.suppressTokens ? null : makeAuthRefreshHandler(engine));
   return engine;
 }
 

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -5,7 +5,8 @@
     "jsx": "react-jsx",
     "types": ["vite/client"],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@tools/*": ["../../tools/*"]
     }
   },
   "include": ["src", "vite.config.ts", "vitest.config.ts", "../engine/src/types/renovate-dist.d.ts"]

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -2,7 +2,11 @@ import { fileURLToPath } from "node:url";
 import { renovateShims } from "@renovate-config-debugger/engine/vite-plugin";
 import { defineConfig } from "vitest/config";
 
-const srcAlias = { "@": fileURLToPath(new URL("./src", import.meta.url)) };
+const srcAlias = {
+  "@": fileURLToPath(new URL("./src", import.meta.url)),
+  // test-only scaffolding lives outside the package so it can't ship
+  "@tools": fileURLToPath(new URL("../../tools", import.meta.url)),
+};
 
 /**
  * Three projects, assigned purely by filename (`vitest-projects.test.ts` pins

--- a/packages/engine/src/auth.ts
+++ b/packages/engine/src/auth.ts
@@ -56,6 +56,32 @@ export function setPresetAuth(next: PresetAuth): void {
   auth = { ...next };
 }
 
+/**
+ * Called by the transport when a host answers 401 for `rejectedToken` — the
+ * host revoked it before its recorded expiry (e.g. another tab's refresh
+ * rotated a shared OAuth grant, which revokes the old access token). The
+ * handler owns the credential lifecycle the engine cannot see: it may refresh
+ * the token and push the new auth state via {@link setPresetAuth}. Returns
+ * true when auth state changed and the request is worth retrying once.
+ */
+export type AuthRefreshHandler = (
+  hostType: PresetHostType,
+  url: string,
+  rejectedToken: string,
+) => Promise<boolean>;
+
+let refreshHandler: AuthRefreshHandler | null = null;
+
+/** Registered by the app per entry point; the CLI never registers one, so the
+ *  headless graph keeps the plain throw-on-401 behavior. */
+export function setAuthRefreshHandler(handler: AuthRefreshHandler | null): void {
+  refreshHandler = handler;
+}
+
+export function getAuthRefreshHandler(): AuthRefreshHandler | null {
+  return refreshHandler;
+}
+
 export function getPresetAuth(): PresetAuth {
   return auth;
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -37,10 +37,12 @@ export {
   type SimulationComparison,
 } from "./simulate-compare";
 export {
+  type AuthRefreshHandler,
   getPresetAuth,
   type PresetAuth,
   type PresetTokenKey,
   resolveAuthToken,
+  setAuthRefreshHandler,
   setPresetAuth,
 } from "./auth";
 export { deriveUpdateType, renovateVersion } from "./version";

--- a/packages/engine/src/shims/presets/host-transport.test.ts
+++ b/packages/engine/src/shims/presets/host-transport.test.ts
@@ -152,6 +152,34 @@ describe("hostFetch 401 recovery", () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 
+  it("hands the handler the token the attempt actually sent, not the current state", async () => {
+    setPresetAuth({ githubToken: "stale" });
+    const headers = authHeadersFor("github", request.url);
+    // A parallel request's recovery already replaced the state: the handler
+    // must still be told about "stale" (what THIS request sent), never
+    // "fresh" — reporting the live token as rejected would rotate it for
+    // nothing.
+    setPresetAuth({ githubToken: "fresh" });
+    const seen: Array<string | undefined> = [];
+    globalThis.fetch = vi.fn((_url: unknown, init?: { headers?: Record<string, string> }) => {
+      seen.push(init?.headers?.authorization);
+      return Promise.resolve(
+        seen.length === 1
+          ? new Response("nope", { status: 401 })
+          : new Response("{}", { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
+    const handler = vi.fn((_h: string, _u: string, rejected: string) => {
+      expect(rejected).toBe("stale");
+      return Promise.resolve(true);
+    });
+    setAuthRefreshHandler(handler);
+
+    const res = await hostFetch({ ...request, headers });
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(["Bearer stale", "Bearer fresh"]);
+  });
+
   it("retries anonymously when the handler dropped the dead token", async () => {
     setPresetAuth({ githubToken: "revoked" });
     const seen: Array<string | undefined> = [];

--- a/packages/engine/src/shims/presets/host-transport.test.ts
+++ b/packages/engine/src/shims/presets/host-transport.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { setAuthRefreshHandler, setPresetAuth } from "../../auth";
 import {
   authHeadersFor,
   defaultEndpointFor,
@@ -15,6 +16,8 @@ const realFetch = globalThis.fetch;
 
 afterEach(() => {
   globalThis.fetch = realFetch;
+  setPresetAuth({});
+  setAuthRefreshHandler(null);
   vi.restoreAllMocks();
 });
 
@@ -108,6 +111,117 @@ describe("hostFetch error messages (load-bearing verbatim)", () => {
       headers: {},
     });
     expect(res.status).toBe(404);
+  });
+});
+
+/** A revoked-before-expiry token (another tab refreshed the shared grant):
+ *  one recovery attempt through the registered handler, one retry, no loop. */
+describe("hostFetch 401 recovery", () => {
+  const request = {
+    platform: "github" as const,
+    url: "https://api.github.com/repos/a/b/contents/renovate.json",
+    label: "GitHub",
+    shownEndpoint: "https://api.github.com/",
+    headers: authHeadersFor("github", "https://api.github.com/repos/a/b/contents/renovate.json"),
+  };
+
+  it("retries once with the handler's replacement token and returns the 200", async () => {
+    setPresetAuth({ githubToken: "revoked" });
+    const seen: Array<string | undefined> = [];
+    globalThis.fetch = vi.fn((_url: unknown, init?: { headers?: Record<string, string> }) => {
+      seen.push(init?.headers?.authorization);
+      return Promise.resolve(
+        seen.length === 1
+          ? new Response("nope", { status: 401 })
+          : new Response("{}", { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
+    const handler = vi.fn((_h: string, _u: string, rejected: string) => {
+      expect(rejected).toBe("revoked");
+      setPresetAuth({ githubToken: "fresh" });
+      return Promise.resolve(true);
+    });
+    setAuthRefreshHandler(handler);
+
+    const res = await hostFetch({
+      ...request,
+      headers: authHeadersFor("github", request.url),
+    });
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(["Bearer revoked", "Bearer fresh"]);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries anonymously when the handler dropped the dead token", async () => {
+    setPresetAuth({ githubToken: "revoked" });
+    const seen: Array<string | undefined> = [];
+    globalThis.fetch = vi.fn((_url: unknown, init?: { headers?: Record<string, string> }) => {
+      seen.push(init?.headers?.authorization);
+      return Promise.resolve(
+        seen.length === 1
+          ? new Response("nope", { status: 401 })
+          : new Response("{}", { status: 200 }),
+      );
+    }) as unknown as typeof fetch;
+    setAuthRefreshHandler(() => {
+      setPresetAuth({});
+      return Promise.resolve(true);
+    });
+
+    const res = await hostFetch({ ...request, headers: authHeadersFor("github", request.url) });
+    expect(res.status).toBe(200);
+    expect(seen).toEqual(["Bearer revoked", undefined]);
+  });
+
+  it("throws the standard error when the handler declines, without a retry", async () => {
+    setPresetAuth({ githubToken: "revoked" });
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("nope", { status: 401 })));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setAuthRefreshHandler(() => Promise.resolve(false));
+
+    const message = await messageOf({ ...request, headers: authHeadersFor("github", request.url) });
+    expect(message).toBe(
+      "GitHub API rejected the request (HTTP 401) — rate limit or missing token",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries at most once even when the host keeps answering 401", async () => {
+    setPresetAuth({ githubToken: "revoked" });
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("nope", { status: 401 })));
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    const handler = vi.fn(() => {
+      setPresetAuth({ githubToken: "fresh" });
+      return Promise.resolve(true);
+    });
+    setAuthRefreshHandler(handler);
+
+    await expect(
+      hostFetch({ ...request, headers: authHeadersFor("github", request.url) }),
+    ).rejects.toMatchObject({ hostType: "github" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("never consults the handler for an anonymous 401 or a 403", async () => {
+    const handler = vi.fn(() => Promise.resolve(true));
+    setAuthRefreshHandler(handler);
+    stubFetch(() => Promise.resolve(new Response("nope", { status: 401 })));
+    await expect(hostFetch({ ...request, headers: {} })).rejects.toBeTruthy();
+    setPresetAuth({ githubToken: "t" });
+    stubFetch(() => Promise.resolve(new Response("nope", { status: 403 })));
+    await expect(
+      hostFetch({ ...request, headers: authHeadersFor("github", request.url) }),
+    ).rejects.toBeTruthy();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("treats a throwing handler as a decline", async () => {
+    setPresetAuth({ githubToken: "revoked" });
+    stubFetch(() => Promise.resolve(new Response("nope", { status: 401 })));
+    setAuthRefreshHandler(() => Promise.reject(new Error("worker down")));
+    const message = await messageOf({ ...request, headers: authHeadersFor("github", request.url) });
+    expect(message).toContain("rate limit or missing token");
   });
 });
 

--- a/packages/engine/src/shims/presets/host-transport.ts
+++ b/packages/engine/src/shims/presets/host-transport.ts
@@ -135,7 +135,7 @@ export async function hostFetch(request: HostRequest): Promise<Response> {
         request.platform,
       );
     }
-    if (res.status === 401 && attempt === 0 && (await refreshRejectedAuth(request))) {
+    if (res.status === 401 && attempt === 0 && (await refreshRejectedAuth(request, headers))) {
       headers = authHeadersFor(request.platform, request.url);
       continue;
     }
@@ -151,12 +151,24 @@ export async function hostFetch(request: HostRequest): Promise<Response> {
   }
 }
 
+/** The credential the 401'd attempt actually SENT, parsed back out of its own
+ *  headers — never re-resolved from the auth state, which a parallel request's
+ *  recovery may already have replaced (the handler would then be told a live
+ *  token was rejected and rotate it for nothing). */
+function sentToken(headers: Record<string, string>): string | undefined {
+  const raw = headers["PRIVATE-TOKEN"] ?? headers.authorization;
+  return raw?.replace(/^(?:Bearer|token) /, "");
+}
+
 /** True when the handler replaced the rejected credential in the auth state
  *  and the 401'd request should be retried. A missing handler, an anonymous
  *  request, or a handler failure all read as "no retry" — the plain throw. */
-async function refreshRejectedAuth(request: HostRequest): Promise<boolean> {
+async function refreshRejectedAuth(
+  request: HostRequest,
+  headers: Record<string, string>,
+): Promise<boolean> {
   const handler = getAuthRefreshHandler();
-  const rejected = resolveAuthToken(request.platform, request.url);
+  const rejected = sentToken(headers);
   if (!handler || rejected === undefined) {
     return false;
   }

--- a/packages/engine/src/shims/presets/host-transport.ts
+++ b/packages/engine/src/shims/presets/host-transport.ts
@@ -25,7 +25,7 @@
  * mechanism. Sharing the constant means there is no second copy to keep in
  * step, so the instruction is unnecessary.
  */
-import { resolveAuthToken } from "../../auth";
+import { getAuthRefreshHandler, resolveAuthToken } from "../../auth";
 import { AUTH_OR_RATE_LIMIT_HINT, NETWORK_OR_CORS_HINT } from "../../contracts";
 import { ExternalHostError, fetchPreset } from "../renovate-internals";
 import { encodePathSegments } from "../url-path";
@@ -112,30 +112,59 @@ export interface HostRequest {
  * - 401 / 403 / 429 — the host refused us, which is never "the file is
  *   missing" and must not be swallowed by a candidate chain.
  *
+ * A 401 with a token attached gets one recovery attempt first: the host
+ * revoked the credential before its recorded expiry (GitHub does this to the
+ * old access token whenever a shared OAuth grant is refreshed, e.g. by
+ * another tab), so the registered {@link AuthRefreshHandler} is asked to
+ * renew it and the request is retried once with re-resolved headers.
+ *
  * Every other response is returned as-is for the caller to classify.
  */
 export async function hostFetch(request: HostRequest): Promise<Response> {
-  let res: Response;
+  let headers = request.headers;
+  for (let attempt = 0; ; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(request.url, { headers });
+    } catch (err) {
+      throw new ExternalHostError(
+        new Error(
+          `Could not reach the ${request.label} endpoint ${request.shownEndpoint} from the browser — ` +
+            `${NETWORK_OR_CORS_HINT} (${err instanceof Error ? err.message : String(err)})`,
+        ),
+        request.platform,
+      );
+    }
+    if (res.status === 401 && attempt === 0 && (await refreshRejectedAuth(request))) {
+      headers = authHeadersFor(request.platform, request.url);
+      continue;
+    }
+    if (res.status === 401 || res.status === 403 || res.status === 429) {
+      throw new ExternalHostError(
+        new Error(
+          `${request.label} API rejected the request (HTTP ${res.status}) — ${AUTH_OR_RATE_LIMIT_HINT}`,
+        ),
+        request.platform,
+      );
+    }
+    return res;
+  }
+}
+
+/** True when the handler replaced the rejected credential in the auth state
+ *  and the 401'd request should be retried. A missing handler, an anonymous
+ *  request, or a handler failure all read as "no retry" — the plain throw. */
+async function refreshRejectedAuth(request: HostRequest): Promise<boolean> {
+  const handler = getAuthRefreshHandler();
+  const rejected = resolveAuthToken(request.platform, request.url);
+  if (!handler || rejected === undefined) {
+    return false;
+  }
   try {
-    res = await fetch(request.url, { headers: request.headers });
-  } catch (err) {
-    throw new ExternalHostError(
-      new Error(
-        `Could not reach the ${request.label} endpoint ${request.shownEndpoint} from the browser — ` +
-          `${NETWORK_OR_CORS_HINT} (${err instanceof Error ? err.message : String(err)})`,
-      ),
-      request.platform,
-    );
+    return await handler(request.platform, request.url, rejected);
+  } catch {
+    return false;
   }
-  if (res.status === 401 || res.status === 403 || res.status === 429) {
-    throw new ExternalHostError(
-      new Error(
-        `${request.label} API rejected the request (HTTP ${res.status}) — ${AUTH_OR_RATE_LIMIT_HINT}`,
-      ),
-      request.platform,
-    );
-  }
-  return res;
 }
 
 /** `?ref=…`, or nothing when the caller has no ref to pin. */

--- a/tools/test/oauth-test-harness.ts
+++ b/tools/test/oauth-test-harness.ts
@@ -3,7 +3,8 @@
  * doubles, the Worker/GitHub fetch surface, and the constants both suites
  * address. oauth.session.test.ts and oauth.crosstab.test.ts stub the same
  * module the same way — one copy here keeps their mocks from drifting apart
- * when the Worker surface changes.
+ * when the Worker surface changes. It lives under tools/test rather than in
+ * the app's src/ so test scaffolding can never ride into the production build.
  */
 
 export const COOKIE_SESSION_KEY = "rcd.oauth.cookieSession";


### PR DESCRIPTION
## The bug

Reported live: every GitHub fetch in a long-lived tab failing with `github API rejected the request (HTTP 401)` while the app's own bookkeeping said the OAuth token had 7+ hours left, and GitHub's response body said **Bad credentials** (revoked, not expired).

Root cause (confirmed against [GitHub's docs](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens)): in cookie mode (roadmap 065) every tab shares ONE grant — the `HttpOnly` refresh cookie — while each tab keeps its own access token in per-tab `sessionStorage`. GitHub **revokes the old access token the moment the grant is refreshed** ("that refresh token and the old user access token will no longer work"), so any sibling tab's boot-time `restoreSession` refresh silently killed the token this tab was still holding. The tab kept sending the dead token (its recorded expiry looked fine, so `getValidToken` never refreshed) and every run 401'd under the rate-limit banner until the tab closed. A secondary race — two tabs refreshing the rotating cookie concurrently — could burn the grant outright, which is why the cookie-session marker had already vanished when the report came in.

## The fix

1. **Transport (`engine`)**: a 401 with a token attached gets one recovery attempt — `hostFetch` asks a registered `AuthRefreshHandler` to renew (or drop) the credential, then retries once with re-resolved headers. No handler (the CLI / headless graph) → the plain throw, byte-identical messages.
2. **App handler (`run.ts` / `oauth.ts`)**: `recoverRejectedToken` forces the refresh machinery past the trusted local expiry; after a definitive failure the session ends cleanly and the retry (and rest of the run) goes out anonymously instead of failing on the dead token.
3. **Cross-tab coordination (cookie mode)**: a refresh broadcasts the replacement token to sibling tabs (`BroadcastChannel`, gated on the shared-grant marker, validated like any stored value — roadmap 030), and refreshes serialize behind a Web Lock with a post-lock recheck so a racing boot can no longer post the already-rotated cookie.

`suppressTokens` (untrusted-endpoint guard) unregisters the handler, so a credential-suppressed run can never re-attach a token via recovery.

## Tests

- `host-transport.test.ts`: retry-with-replacement, anonymous retry, decline, single-retry cap, handler never consulted for anonymous 401 / any 403, throwing handler = decline; existing verbatim-message tests unchanged.
- `oauth.crosstab.test.ts` (new): the recovery entry point, the token/signout broadcasts (adoption gates + validation), and the lock recheck that prevents the burned-cookie race — the sibling tab played by a second in-process `BroadcastChannel`.

Full workspace suite green (engine golden+shimmed, app 979, cli, oauth-worker, tools); lint/format/typecheck clean.