### PR TITLE
feat(app): build provenance — the "verify this build" popover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,17 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      # Roadmap 088: what signs the build-manifest attestation on main.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Roadmap 088: the baked build identity derives its version from
+          # `git describe --tags`, which needs the tag history, not the tip.
+          fetch-depth: 0
       - uses: ./.github/actions/setup
 
       - name: Browser bundle build
@@ -96,6 +105,22 @@ jobs:
         # entry script + its modulepreload graph + the stylesheet), so a chunk
         # sliding back into the entry set is visible next to the build.
         run: node packages/app/scripts/report-entry-size.mjs
+
+      # Roadmap 088: dist/build-manifest.json — the sha256 of every served
+      # file, keyed to the commit. Generated before the uploads so both the
+      # Pages artifact and the e2e dist carry it.
+      - name: Build manifest (roadmap 088)
+        run: pnpm --filter @renovate-config-debugger/app build:manifest
+
+      # The signed statement "this workflow built this manifest from this
+      # commit" — what `gh attestation verify` (and the app's "verify this
+      # build" popover) checks. Main-only, and only where a public deployment
+      # exists to verify.
+      - name: Attest build provenance (roadmap 088)
+        if: github.ref == 'refs/heads/main' && vars.DEPLOY_PAGES == 'true'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: packages/app/dist/build-manifest.json
 
       # Handed over to the e2e job, which drives this dist via `vite preview`
       # and never rebuilds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,15 +112,19 @@ jobs:
       - name: Build manifest (roadmap 088)
         run: pnpm --filter @renovate-config-debugger/app build:manifest
 
-      # The signed statement "this workflow built this manifest from this
+      # The signed statement "this workflow built these files from this
       # commit" — what `gh attestation verify` (and the app's "verify this
-      # build" popover) checks. Main-only, and only where a public deployment
-      # exists to verify.
+      # build" popover) checks. The subjects are EVERY served file plus the
+      # manifest (build-checksums.txt, written by build:manifest), so any
+      # downloaded asset verifies individually. Main-only, and only where a
+      # public deployment exists to verify. (actions/attest with no predicate
+      # inputs emits SLSA build provenance — attest-build-provenance v4 is
+      # just this wrapper, and points new uses here.)
       - name: Attest build provenance (roadmap 088)
         if: github.ref == 'refs/heads/main' && vars.DEPLOY_PAGES == 'true'
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-path: packages/app/dist/build-manifest.json
+          subject-checksums: packages/app/build-checksums.txt
 
       # Handed over to the e2e job, which drives this dist via `vite preview`
       # and never rebuilds.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules/
 dist/
 coverage/
 
+# Attestation input written by `build:manifest` (roadmap 088)
+build-checksums.txt
+
 # Copied into every public package by tools/release/prepare.ts so the AGPL text
 # travels with each npm tarball — the tree keeps exactly one copy, at the root.
 packages/*/LICENSE

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -100,8 +100,12 @@
     "unicorn/no-array-for-each": "error",
     // Roadmap 043: the `__RCD_*__` globals are the injected deployment config —
     // the dangling underscores are the convention that says "written by a
-    // deployment, not by this codebase". Everything else keeps the rule.
-    "no-underscore-dangle": ["error", { "allow": ["__RCD_OAUTH__", "__RCD_ANALYTICS__"] }],
+    // deployment, not by this codebase" — or, for __BUILD_INFO__, "injected
+    // by the build". Everything else keeps the rule.
+    "no-underscore-dangle": [
+      "error",
+      { "allow": ["__RCD_OAUTH__", "__RCD_ANALYTICS__", "__BUILD_INFO__"] }
+    ],
 
     // --- Type-aware tier (needs `--type-aware` + oxlint-tsgolint) -----------
     "typescript/no-misused-promises": "error",

--- a/mise.toml
+++ b/mise.toml
@@ -12,6 +12,16 @@ postinstall = '''
 [ -n "$CI" ] || pnpm install
 '''
 
+# The "rebuild & diff" half of "verify this build" (roadmap 088) — what the
+# app's popover tells a verifier to run after clone + checkout + mise install.
+[tasks.verify-build]
+description = "Rebuild the app from this checkout and diff it against a deployment"
+run = '''
+pnpm install
+pnpm --filter @renovate-config-debugger/app build
+node tools/verify-deployment.ts "$@"
+'''
+
 [settings]
 # needed for hooks
 experimental = true

--- a/packages/app/e2e/22-build-info.spec.ts
+++ b/packages/app/e2e/22-build-info.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Roadmap 088 — the "verify this build" popover.
+ *
+ * A build without git bakes no identity and renders no anchors (the Docker
+ * image) — this skips there rather than fail on the environment.
+ */
+test.describe("build-info popover (088)", () => {
+  test("clicks inside the panel keep it open; outside closes it", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator(".cm-content")).toContainText("config:recommended");
+
+    const trigger = page.getByRole("button", { name: "About this build" });
+    test.skip((await trigger.count()) === 0, "build carries no baked identity");
+
+    await trigger.click();
+    const panel = page.locator(".build-info-panel");
+    await expect(panel).toBeVisible();
+
+    // Non-interactive content: before the panel carried tabindex=-1, this
+    // click let focus fall to the config column (a tabindex=-1 skip-link
+    // target), and the hook's focus-left close fired for a click INSIDE.
+    await panel.locator(".build-info-cmd").click();
+    await expect(panel).toBeVisible();
+    await panel.locator(".build-info-note").click();
+    await expect(panel).toBeVisible();
+
+    // The rebuild tab: the whole runnable recipe, clone to diff.
+    await panel.getByRole("button", { name: "rebuild & diff" }).click();
+    await expect(panel).toBeVisible();
+    await expect(panel.locator(".build-info-cmd")).toContainText("git clone");
+    await expect(panel.locator(".build-info-cmd")).toContainText("node tools/verify-deployment.ts");
+
+    // A click outside still closes.
+    await page.locator(".landing-title").click();
+    await expect(panel).toHaveCount(0);
+  });
+});

--- a/packages/app/e2e/22-build-info.spec.ts
+++ b/packages/app/e2e/22-build-info.spec.ts
@@ -30,7 +30,7 @@ test.describe("build-info popover (088)", () => {
     await panel.getByRole("button", { name: "rebuild & diff" }).click();
     await expect(panel).toBeVisible();
     await expect(panel.locator(".build-info-cmd")).toContainText("git clone");
-    await expect(panel.locator(".build-info-cmd")).toContainText("node tools/verify-deployment.ts");
+    await expect(panel.locator(".build-info-cmd")).toContainText("mise run verify-build");
 
     // A click outside still closes.
     await page.locator(".landing-title").click();

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:manifest": "node scripts/build-manifest.mjs",
     "check:dev-graph": "node scripts/check-dev-module-graph.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",

--- a/packages/app/scripts/build-manifest.mjs
+++ b/packages/app/scripts/build-manifest.mjs
@@ -1,8 +1,9 @@
 // Roadmap 088 — writes dist/build-manifest.json: the sha256 of every file the
 // deployment serves, plus the build identity vite emitted to build-info.json.
-// CI attests THIS file (attest-build-provenance), so verifying the manifest's
-// signature and then the served files against it proves the deployment is
-// CI's build of the named commit. Run after `pnpm build`.
+// Also writes build-checksums.txt (next to dist, not in it): the same digests
+// in sha256sum format, manifest included — CI's attestation input, so EVERY
+// served file is an attested subject and `gh attestation verify` works on any
+// downloaded asset, not only the manifest. Run after `pnpm build`.
 import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readdir, readFile, writeFile } from "node:fs/promises";
@@ -67,5 +68,21 @@ const manifest = {
   files,
 };
 
-await writeFile(path.join(dist, MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
-console.log(`${MANIFEST}: ${paths.length} files hashed for ${identity.commit.slice(0, 7)}`);
+const manifestBody = `${JSON.stringify(manifest, null, 2)}\n`;
+await writeFile(path.join(dist, MANIFEST), manifestBody);
+
+// The attestation subjects: every served file plus the manifest itself.
+// actions/attest caps one invocation at 1024 subjects — warn well before the
+// main-only attest step starts failing.
+const checksums = [
+  ...paths.map((rel) => `${files[rel].sha256}  ${rel}`),
+  `${createHash("sha256").update(manifestBody).digest("hex")}  ${MANIFEST}`,
+];
+if (checksums.length > 1000) {
+  console.warn(`${checksums.length} subjects — actions/attest refuses more than 1024.`);
+}
+await writeFile(path.join(dist, "..", "build-checksums.txt"), `${checksums.join("\n")}\n`);
+console.log(
+  `${MANIFEST}: ${paths.length} files hashed for ${identity.commit.slice(0, 7)}; ` +
+    `build-checksums.txt: ${checksums.length} attestation subjects`,
+);

--- a/packages/app/scripts/build-manifest.mjs
+++ b/packages/app/scripts/build-manifest.mjs
@@ -1,0 +1,71 @@
+// Roadmap 088 — writes dist/build-manifest.json: the sha256 of every file the
+// deployment serves, plus the build identity vite emitted to build-info.json.
+// CI attests THIS file (attest-build-provenance), so verifying the manifest's
+// signature and then the served files against it proves the deployment is
+// CI's build of the named commit. Run after `pnpm build`.
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const MANIFEST = "build-manifest.json";
+// rcd-config.js is runtime deployment config — the Docker entrypoint may
+// overwrite it at container start — so it is deliberately not attested.
+const EXCLUDED = new Set([MANIFEST, "rcd-config.js"]);
+
+const dist = fileURLToPath(new URL("../dist", import.meta.url));
+
+let identity;
+try {
+  identity = JSON.parse(await readFile(path.join(dist, "build-info.json"), "utf8"));
+} catch {
+  console.error("dist/build-info.json missing — run `pnpm build` first (it emits the identity).");
+  process.exit(1);
+}
+if (!identity.commit) {
+  console.error("build-info.json has no commit (built without git?) — nothing to attest.");
+  process.exit(1);
+}
+
+function branch() {
+  if (process.env.GITHUB_REF_NAME) {
+    return process.env.GITHUB_REF_NAME;
+  }
+  try {
+    return execFileSync("git", ["branch", "--show-current"], { encoding: "utf8" }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+const entries = await readdir(dist, { recursive: true, withFileTypes: true });
+const paths = entries
+  .filter((entry) => entry.isFile())
+  .map((entry) =>
+    path.relative(dist, path.join(entry.parentPath, entry.name)).replaceAll(path.sep, "/"),
+  )
+  .filter((rel) => !EXCLUDED.has(rel))
+  .toSorted();
+
+const files = {};
+for (const rel of paths) {
+  const body = await readFile(path.join(dist, rel));
+  files[rel] = { sha256: createHash("sha256").update(body).digest("hex"), bytes: body.byteLength };
+}
+
+const manifest = {
+  schemaVersion: 1,
+  repo: identity.repo,
+  commit: identity.commit,
+  version: identity.version,
+  commitTime: identity.commitTime,
+  // Informational only — everything above is commit-derived (reproducible),
+  // the branch is whatever ref the building checkout happened to be on.
+  branch: branch(),
+  files,
+};
+
+await writeFile(path.join(dist, MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`${MANIFEST}: ${paths.length} files hashed for ${identity.commit.slice(0, 7)}`);

--- a/packages/app/src/app/ConfigColumn.tsx
+++ b/packages/app/src/app/ConfigColumn.tsx
@@ -4,6 +4,7 @@ import type { StoredUser } from "@/platform/oauth";
 import type { ConfigEditorHandle } from "@/features/editor/ConfigEditor";
 import { ConfigEditorCard } from "@/features/editor/ConfigEditorCard";
 import { ConfigToolbar } from "@/features/editor/ConfigToolbar";
+import { BuildStamp, BuildVerifyLine } from "@/components/BuildInfo";
 import { type AuthState, GithubAuthHint } from "@/components/GithubAuthHint";
 import { LandingIntro, LandingLaunch, LandingSteps } from "@/features/editor/Landing";
 import { NoticeBar } from "@/features/editor/NoticeBar";
@@ -275,6 +276,8 @@ export function ConfigColumn({
             skippedStages={previewSkippedStages}
           />
           <LandingSteps />
+          {/* Roadmap 088: which build this is, and the way to verify it. */}
+          <BuildVerifyLine />
         </>
       )}
 
@@ -291,10 +294,13 @@ export function ConfigColumn({
       {hasResult ? (
         // Roadmap 075 (iteration 6): the second half is a true statement about
         // what an edit DOES — the Tests tab re-checks every pinned descriptor
-        // against each run — rather than only where it happens.
-        <p className="pane-foot">
-          Everything runs in your browser · edits re-check your pinned tests on Run.
-        </p>
+        // against each run — rather than only where it happens. 088 adds the
+        // build stamp at the right edge: the shell reader's way to "verify
+        // this build", mirroring the landing's line.
+        <div className="pane-foot">
+          <p>Everything runs in your browser · edits re-check your pinned tests on Run.</p>
+          <BuildStamp />
+        </div>
       ) : null}
     </div>
   );

--- a/packages/app/src/components/BuildInfo.test.tsx
+++ b/packages/app/src/components/BuildInfo.test.tsx
@@ -57,7 +57,7 @@ describe("BuildStamp", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "rebuild & diff" }));
     expect(panel.textContent).toContain(
-      `node tools/verify-deployment.ts ${window.location.origin}`,
+      `mise install && mise run verify-build ${window.location.origin}`,
     );
     expect(panel.textContent).not.toContain("gh attestation verify");
   });

--- a/packages/app/src/components/BuildInfo.test.tsx
+++ b/packages/app/src/components/BuildInfo.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type * as BuildInfoModule from "@/lib/build-info";
+import { AboutBuildButton, BuildStamp, BuildVerifyLine } from "./BuildInfo";
+
+/**
+ * Roadmap 088 — the "verify this build" popover. Vitest applies no vite
+ * `define`, so the real module exports `BUILD_INFO: null` (and every anchor
+ * renders nothing — the Docker-build behavior); the fixture below is what a
+ * CI-built bundle carries.
+ */
+
+const IDENTITY = vi.hoisted(() => ({
+  repo: "secustor/renovate-config-debugger",
+  commit: "d58538fab3a0000000000000000000000000000f",
+  version: "0.2.0",
+  commitTime: "2026-08-25T14:02:33+02:00",
+}));
+
+vi.mock("@/lib/build-info", async (importOriginal) => {
+  const original = await importOriginal<typeof BuildInfoModule>();
+  return { ...original, BUILD_INFO: IDENTITY };
+});
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+function openPanel(trigger: HTMLElement): HTMLElement {
+  fireEvent.click(trigger);
+  const panel = document.querySelector<HTMLElement>(".build-info-panel");
+  if (!panel) {
+    throw new Error("panel did not open");
+  }
+  return panel;
+}
+
+describe("BuildStamp", () => {
+  it("stamps the version and short sha, and opens the panel", () => {
+    render(<BuildStamp />);
+    const trigger = screen.getByRole("button", { name: /v0\.2\.0 d58538f/ });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    const panel = openPanel(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    // The identity line links the full commit.
+    const link = screen.getByRole("link", { name: "d58538f" });
+    expect(link.getAttribute("href")).toBe(
+      `https://github.com/${IDENTITY.repo}/commit/${IDENTITY.commit}`,
+    );
+    expect(panel.textContent).toContain("2026-08-25 12:02 UTC");
+  });
+
+  it("defaults to the attestation command and switches to rebuild & diff", () => {
+    render(<BuildStamp />);
+    const panel = openPanel(screen.getByRole("button", { name: /d58538f/ }));
+    expect(panel.textContent).toContain("gh attestation verify build-manifest.json");
+
+    fireEvent.click(screen.getByRole("button", { name: "rebuild & diff" }));
+    expect(panel.textContent).toContain(
+      `node tools/verify-deployment.ts ${window.location.origin}`,
+    );
+    expect(panel.textContent).not.toContain("gh attestation verify");
+  });
+
+  it("closes on Escape and hands focus back to the trigger", () => {
+    render(<BuildStamp />);
+    const trigger = screen.getByRole("button", { name: /d58538f/ });
+    openPanel(trigger);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(document.querySelector(".build-info-panel")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe("the landing anchors", () => {
+  it("the subtitle ⓘ is named for assistive tech and opens the same panel", () => {
+    render(<AboutBuildButton />);
+    const trigger = screen.getByRole("button", { name: "About this build" });
+    openPanel(trigger);
+    expect(screen.getByRole("button", { name: "gh attestation" })).toBeTruthy();
+  });
+
+  it("the build line says what this deployment is and offers the way in", () => {
+    const { container } = render(<BuildVerifyLine />);
+    expect(container.textContent).toContain("built 2026-08-25");
+    const panel = openPanel(screen.getByRole("button", { name: "verify this build" }));
+    expect(panel.textContent).toContain("gh attestation verify");
+  });
+});

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -1,0 +1,232 @@
+import { type RefObject, useId, useState } from "react";
+import {
+  BUILD_INFO,
+  type BuildIdentity,
+  commitUrl,
+  formatCommitTime,
+  shortCommit,
+  verifyCommands,
+} from "@/lib/build-info";
+import { CopyButton } from "@/components/CopyButton";
+import { ESCAPE_PRIORITY } from "@/lib/escape-stack";
+import { useAnchoredPopover } from "@/hooks/use-anchored-popover";
+
+/**
+ * Roadmap 088 — "verify this build": the popover that lets a reader check the
+ * served bundle really is CI's build of the open-source code, plus its three
+ * anchors (the ⓘ beside the landing subtitle, the landing's build line, the
+ * pane-foot stamp). Design: `Build Provenance.dc.html`.
+ *
+ * Deliberately NOT called "provenance" anywhere user-facing — that word
+ * already means config-value provenance (which layer set an option) in this
+ * app; here the copy says "build" and "verify".
+ *
+ * Every anchor renders nothing when `BUILD_INFO` is null (a build without
+ * git, e.g. the Docker image): no identity, nothing to verify.
+ */
+
+const TABS = [
+  { id: "attest", label: "gh attestation" },
+  { id: "rebuild", label: "rebuild & diff" },
+] as const;
+type VerifyTab = (typeof TABS)[number]["id"];
+
+function BuildIdentityLine({ info }: { info: BuildIdentity }) {
+  const time = info.commitTime ? formatCommitTime(info.commitTime) : null;
+  return (
+    <p className="build-info-id">
+      {info.version ? `v${info.version} · ` : null}
+      <a href={commitUrl(info)} target="_blank" rel="noreferrer">
+        {shortCommit(info)}
+      </a>
+      {time ? ` · ${time}` : null}
+    </p>
+  );
+}
+
+function VerifyTabs({ tab, onPick }: { tab: VerifyTab; onPick: (tab: VerifyTab) => void }) {
+  return (
+    <div className="build-info-tabs">
+      {TABS.map((t) => (
+        <button
+          key={t.id}
+          type="button"
+          className="build-info-tab"
+          aria-pressed={tab === t.id}
+          onClick={() => onPick(t.id)}
+        >
+          {t.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function VerifyCommand({
+  info,
+  tab,
+  command,
+}: {
+  info: BuildIdentity;
+  tab: VerifyTab;
+  command: string;
+}) {
+  const note =
+    tab === "attest"
+      ? `Checks GitHub's signed attestation that CI built the served bundle from ${shortCommit(info)}.`
+      : `From a checkout of ${shortCommit(info)}: rebuilds it and diffs every served asset hash against this deployment.`;
+  return (
+    <div className="build-info-cmd-wrap">
+      <pre className="build-info-cmd">
+        <span className="build-info-prompt" aria-hidden="true">
+          ${" "}
+        </span>
+        {command}
+      </pre>
+      <CopyButton
+        iconOnly
+        className="build-info-copy"
+        getText={() => command}
+        label="Copy command"
+      />
+      <p className="build-info-note">{note}</p>
+    </div>
+  );
+}
+
+interface PanelProps {
+  info: BuildIdentity;
+  panelId: string;
+  panelRef: RefObject<HTMLDivElement | null>;
+  /** Where the panel sits relative to its anchor — a CSS modifier class. */
+  placement: "below-center" | "above-center" | "above-end";
+}
+
+function BuildInfoPanel({ info, panelId, panelRef, placement }: PanelProps) {
+  const [tab, setTab] = useState<VerifyTab>("attest");
+  const commands = verifyCommands(info, window.location.origin);
+  return (
+    <div className={`build-info-panel ${placement}`} id={panelId} ref={panelRef}>
+      <BuildIdentityLine info={info} />
+      <VerifyTabs tab={tab} onPick={setTab} />
+      <VerifyCommand
+        info={info}
+        tab={tab}
+        command={tab === "attest" ? commands.attest : commands.rebuild}
+      />
+    </div>
+  );
+}
+
+/** Octicon `info`, inlined like CopyButton's icons (031: no icon dep). */
+function InfoIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+    </svg>
+  );
+}
+
+function AboutBuildTrigger({ info }: { info: BuildIdentity }) {
+  const { open, triggerRef, panelRef, toggle } = useAnchoredPopover(ESCAPE_PRIORITY.popover);
+  const panelId = useId();
+  return (
+    <span className="build-info-anchor">
+      <button
+        type="button"
+        ref={triggerRef}
+        className="build-info-about"
+        aria-label="About this build"
+        title="About this build"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={toggle}
+      >
+        <InfoIcon />
+      </button>
+      {open ? (
+        <BuildInfoPanel
+          info={info}
+          panelId={panelId}
+          panelRef={panelRef}
+          placement="below-center"
+        />
+      ) : null}
+    </span>
+  );
+}
+
+/** The ⓘ beside the landing subtitle. */
+export function AboutBuildButton() {
+  return BUILD_INFO ? <AboutBuildTrigger info={BUILD_INFO} /> : null;
+}
+
+function BuildVerifyLineInner({ info }: { info: BuildIdentity }) {
+  const { open, triggerRef, panelRef, toggle } = useAnchoredPopover(ESCAPE_PRIORITY.popover);
+  const panelId = useId();
+  // The committer date's day, as the committer wrote it — %cI's ISO prefix.
+  const built = info.commitTime?.slice(0, 10) ?? null;
+  return (
+    <div className="build-info-line">
+      <span>
+        debugger {info.version ? `v${info.version} · ` : ""}
+        <a href={commitUrl(info)} target="_blank" rel="noreferrer">
+          {shortCommit(info)}
+        </a>
+        {built ? ` · built ${built}` : ""} —{" "}
+      </span>
+      <button
+        type="button"
+        ref={triggerRef}
+        className="build-info-verify"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={toggle}
+      >
+        verify this build
+      </button>
+      {open ? (
+        <BuildInfoPanel
+          info={info}
+          panelId={panelId}
+          panelRef={panelRef}
+          placement="above-center"
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** The landing's closing line: the deployment's identity, and the way in. */
+export function BuildVerifyLine() {
+  return BUILD_INFO ? <BuildVerifyLineInner info={BUILD_INFO} /> : null;
+}
+
+function BuildStampInner({ info }: { info: BuildIdentity }) {
+  const { open, triggerRef, panelRef, toggle } = useAnchoredPopover(ESCAPE_PRIORITY.popover);
+  const panelId = useId();
+  return (
+    <span className="build-info-anchor build-info-stamp-anchor">
+      <button
+        type="button"
+        ref={triggerRef}
+        className="build-info-stamp"
+        title="About this build"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={toggle}
+      >
+        · {info.version ? `v${info.version} ` : ""}
+        {shortCommit(info)}
+      </button>
+      {open ? (
+        <BuildInfoPanel info={info} panelId={panelId} panelRef={panelRef} placement="above-end" />
+      ) : null}
+    </span>
+  );
+}
+
+/** The pane-foot's version stamp — the shell reader's way to the same panel. */
+export function BuildStamp() {
+  return BUILD_INFO ? <BuildStampInner info={BUILD_INFO} /> : null;
+}

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -74,7 +74,7 @@ function VerifyCommand({
   const note =
     tab === "attest"
       ? `Checks GitHub's signed attestation that CI built this from ${shortCommit(info)}. Every served file is an attested subject — the same command verifies any downloaded asset.`
-      : `Clones the source, rebuilds ${shortCommit(info)} (needs Node + pnpm), and diffs every served asset hash against this deployment.`;
+      : `Clones the source, rebuilds ${shortCommit(info)} with the pinned toolchain (needs mise), and diffs every served asset hash against this deployment.`;
   return (
     <div className="build-info-cmd-wrap">
       <pre className="build-info-cmd">

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -74,7 +74,7 @@ function VerifyCommand({
   const note =
     tab === "attest"
       ? `Checks GitHub's signed attestation that CI built this from ${shortCommit(info)}. Every served file is an attested subject — the same command verifies any downloaded asset.`
-      : `From a checkout of ${shortCommit(info)}: rebuilds it and diffs every served asset hash against this deployment.`;
+      : `Clones the source, rebuilds ${shortCommit(info)} (needs Node + pnpm), and diffs every served asset hash against this deployment.`;
   return (
     <div className="build-info-cmd-wrap">
       <pre className="build-info-cmd">
@@ -106,7 +106,11 @@ function BuildInfoPanel({ info, panelId, panelRef, placement }: PanelProps) {
   const [tab, setTab] = useState<VerifyTab>("attest");
   const commands = verifyCommands(info, window.location.origin);
   return (
-    <div className={`build-info-panel ${placement}`} id={panelId} ref={panelRef}>
+    // tabIndex: a click on non-interactive panel content must settle focus ON
+    // the panel — without it, focus falls to the nearest focusable ancestor
+    // (the config column is a tabindex=-1 skip-link target), and the hook's
+    // focus-left close fires for a click INSIDE the panel.
+    <div className={`build-info-panel ${placement}`} id={panelId} ref={panelRef} tabIndex={-1}>
       <BuildIdentityLine info={info} />
       <VerifyTabs tab={tab} onPick={setTab} />
       <VerifyCommand

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -73,7 +73,7 @@ function VerifyCommand({
 }) {
   const note =
     tab === "attest"
-      ? `Checks GitHub's signed attestation that CI built the served bundle from ${shortCommit(info)}.`
+      ? `Checks GitHub's signed attestation that CI built this from ${shortCommit(info)}. Every served file is an attested subject — the same command verifies any downloaded asset.`
       : `From a checkout of ${shortCommit(info)}: rebuilds it and diffs every served asset hash against this deployment.`;
   return (
     <div className="build-info-cmd-wrap">

--- a/packages/app/src/features/editor/Landing.tsx
+++ b/packages/app/src/features/editor/Landing.tsx
@@ -1,3 +1,4 @@
+import { AboutBuildButton } from "@/components/BuildInfo";
 import { formatShortcut, RUN_SHORTCUT } from "@/lib/shortcuts";
 
 /**
@@ -24,6 +25,8 @@ export function LandingIntro() {
       <h2 className="landing-title">What does your Renovate config actually do?</h2>
       <p className="landing-subtitle">
         Renovate&apos;s own code processes it right here — nothing leaves your browser.
+        {/* Roadmap 088: the promise's receipt — which build, and how to check. */}
+        <AboutBuildButton />
       </p>
     </div>
   );

--- a/packages/app/src/features/session/use-session-menu.ts
+++ b/packages/app/src/features/session/use-session-menu.ts
@@ -1,104 +1,32 @@
-import { useCallback, useEffect, useRef, useState } from "react";
 import { ESCAPE_PRIORITY } from "@/lib/escape-stack";
-import { FOCUSABLE_SELECTOR } from "@/lib/focusable";
-import { useEscapeLayer } from "@/hooks/use-escape-layer";
+import { useAnchoredPopover } from "@/hooks/use-anchored-popover";
 
 /**
  * Roadmap 066 — the open/close contract of the header's session menu.
  *
- * This is the repo-form disclosure (023/039, `use-repo-load.ts`) applied to a
- * popover rather than an inline panel, and it keeps that feature's rule:
- * closing by Escape or by choosing an item hands focus back to the button that
- * opened it, because the panel the user was in is gone and focus has to land
- * somewhere deliberate.
+ * The mechanics (outside-click, Tab-away, Escape-with-refocus, focus into the
+ * panel on open) moved to `useAnchoredPopover` when the build-info popover
+ * (088) needed them too; this keeps the menu's one distinguishing choice, its
+ * Escape rank.
  *
- * The two closes that DON'T refocus are the ones where the user has already
- * said where they are going: a pointer press outside the panel (yanking focus
- * back to the header would fight the click that is landing) and focus leaving
- * by Tab.
+ * 068 review, on what this menu gave up by no longer listening for Escape
+ * itself: the ladder declines a press in three cases, and none of them can
+ * reach a menu that is open, because the hook's `focusin` close is what makes
+ * them unreachable. While this panel is up, focus is inside it or on the
+ * trigger — anywhere else closes it in the same event that moved it.
  *
- * There is deliberately no scroll listener. The panel is `position: absolute`
- * inside the header, so it scrolls WITH its anchor — unlike the portalled
- * hover cards in `glossary.tsx`, which are `position: fixed` and must close
- * when the thing they point at moves out from under them.
+ * - `defaultPrevented`: the two surfaces that claim Escape are CodeMirror and
+ *   the repo-load form, and focus reaching either has already closed the menu.
+ *   Nothing the panel itself renders claims the key — its items are buttons
+ *   and `ThemeSwitch`'s radios, with no key handler between them — and no
+ *   registry shortcut binds Escape.
+ * - The combobox yield: `mayOwnNativePopup` is the simulator's two `<input
+ *   list>` fields, which are two panels away from this one.
+ * - `modalKeyboardOwned()`: `?` is exempt from the overlay gate, so the sheet
+ *   CAN be opened over this menu — and `showModal()` moves focus into the
+ *   dialog, which closes the menu on the way in rather than stranding it
+ *   behind a claim it cannot outlast.
  */
 export function useSessionMenu() {
-  const [open, setOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  const toggle = useCallback(() => {
-    setOpen((wasOpen) => !wasOpen);
-  }, []);
-
-  /** Close and return focus — Escape, and every item that closes the menu. */
-  const dismiss = useCallback(() => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }, []);
-
-  // Roadmap 068: Escape through the shared ladder, so a hover card opened
-  // from inside the panel closes first and the menu survives that press —
-  // by rank, which holds whichever of the two mounted first.
-  //
-  // 068 review, on what this menu gave up by no longer listening for Escape
-  // itself: the ladder declines a press in three cases, and none of them can
-  // reach a menu that is open, because the `focusin` close below is what makes
-  // them unreachable. While this panel is up, focus is inside it or on the
-  // trigger — anywhere else closes it in the same event that moved it.
-  //
-  // - `defaultPrevented`: the two surfaces that claim Escape are CodeMirror and
-  //   the repo-load form, and focus reaching either has already closed the menu.
-  //   Nothing the panel itself renders claims the key — its items are buttons
-  //   and `ThemeSwitch`'s radios, with no key handler between them — and no
-  //   registry shortcut binds Escape.
-  // - The combobox yield: `mayOwnNativePopup` is the simulator's two `<input
-  //   list>` fields, which are two panels away from this one.
-  // - `modalKeyboardOwned()`: `?` is exempt from the overlay gate, so the sheet
-  //   CAN be opened over this menu — and `showModal()` moves focus into the
-  //   dialog, which closes the menu on the way in rather than stranding it
-  //   behind a claim it cannot outlast.
-  useEscapeLayer(open, dismiss, ESCAPE_PRIORITY.menu);
-
-  useEffect(() => {
-    if (!open) {
-      return;
-    }
-
-    // WAI-ARIA's menu-button behavior: opening moves focus into the panel, so
-    // a keyboard user is already on the first action and Tab walks the rest.
-    panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
-
-    function owns(node: EventTarget | null): boolean {
-      return (
-        node instanceof Node &&
-        (panelRef.current?.contains(node) === true || triggerRef.current?.contains(node) === true)
-      );
-    }
-
-    function onPointerDown(event: PointerEvent) {
-      // The trigger owns its own click — closing here would race `toggle` and
-      // reopen the panel the same press just closed.
-      if (!owns(event.target)) {
-        setOpen(false);
-      }
-    }
-
-    function onFocusIn(event: FocusEvent) {
-      if (!owns(event.target)) {
-        setOpen(false);
-      }
-    }
-
-    // Capture phase: a handler inside the panel that stops propagation must
-    // not be able to keep the menu open behind the user's back.
-    document.addEventListener("pointerdown", onPointerDown, true);
-    document.addEventListener("focusin", onFocusIn);
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
-      document.removeEventListener("focusin", onFocusIn);
-    };
-  }, [open]);
-
-  return { open, triggerRef, panelRef, toggle, dismiss };
+  return useAnchoredPopover(ESCAPE_PRIORITY.menu);
 }

--- a/packages/app/src/hooks/use-anchored-popover.ts
+++ b/packages/app/src/hooks/use-anchored-popover.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { EscapePriority } from "@/lib/escape-stack";
+import { FOCUSABLE_SELECTOR } from "@/lib/focusable";
+import { useEscapeLayer } from "@/hooks/use-escape-layer";
+
+/**
+ * The open/close contract of a panel anchored to its trigger button —
+ * extracted from the session menu (066) when the build-info popover (088)
+ * needed the identical mechanics at a different Escape rank.
+ *
+ * The contract, in full (066's rules, unchanged):
+ * - Escape and in-panel closes hand focus back to the trigger, because the
+ *   panel the user was in is gone and focus has to land somewhere deliberate.
+ * - The two closes that DON'T refocus are the ones where the user has already
+ *   said where they are going: a pointer press outside the panel (yanking
+ *   focus back would fight the click that is landing) and focus leaving by
+ *   Tab — both watched with document listeners while open.
+ * - Opening moves focus to the panel's first focusable element (WAI-ARIA
+ *   menu-button behavior), so a keyboard user is already on the first action.
+ * - Escape goes through the shared ladder (068), at the rank the caller
+ *   names — never a local keydown listener.
+ * - Deliberately no scroll listener: the panel is `position: absolute` inside
+ *   its anchor, so it scrolls WITH it — unlike the portalled hover cards in
+ *   glossary.tsx, which are fixed and must close when their anchor moves.
+ */
+export function useAnchoredPopover(escapePriority: EscapePriority) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const toggle = useCallback(() => {
+    setOpen((wasOpen) => !wasOpen);
+  }, []);
+
+  /** Close and return focus — Escape, and every item that closes the panel. */
+  const dismiss = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  useEscapeLayer(open, dismiss, escapePriority);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    panelRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
+
+    function owns(node: EventTarget | null): boolean {
+      return (
+        node instanceof Node &&
+        (panelRef.current?.contains(node) === true || triggerRef.current?.contains(node) === true)
+      );
+    }
+
+    function onPointerDown(event: PointerEvent) {
+      // The trigger owns its own click — closing here would race `toggle` and
+      // reopen the panel the same press just closed.
+      if (!owns(event.target)) {
+        setOpen(false);
+      }
+    }
+
+    function onFocusIn(event: FocusEvent) {
+      if (!owns(event.target)) {
+        setOpen(false);
+      }
+    }
+
+    // Capture phase: a handler inside the panel that stops propagation must
+    // not be able to keep the panel open behind the user's back.
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("focusin", onFocusIn);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("focusin", onFocusIn);
+    };
+  }, [open]);
+
+  return { open, triggerRef, panelRef, toggle, dismiss };
+}

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -84,6 +84,13 @@
      — dark mode is already dark, so the same alpha would read as near-black. */
   --backdrop: light-dark(rgba(31, 35, 40, 0.35), rgba(0, 0, 0, 0.6));
 
+  /* Roadmap 088: the verify-build command block reads as a terminal in BOTH
+     themes — dark ground on the light theme too (Build Provenance artboard),
+     one step deeper than the dark surfaces so it still reads raised there. */
+  --terminal: light-dark(#1f2328, #010409);
+  --on-terminal: #d1d9e0;
+  --terminal-accent: #7ee787;
+
   /* The selected/current ring on a stage-rail glyph: the accent halo sits
      OUTSIDE a canvas-coloured one, so the node keeps hiding the rail line while
      wearing it. Two sites repeat it — the live rail's selected node and the

--- a/packages/app/src/lib/build-info.test.ts
+++ b/packages/app/src/lib/build-info.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  type BuildIdentity,
+  commitUrl,
+  formatCommitTime,
+  parseBuildIdentity,
+  shortCommit,
+  verifyCommands,
+} from "./build-info";
+
+const IDENTITY: BuildIdentity = {
+  repo: "secustor/renovate-config-debugger",
+  commit: "d58538fab3a0000000000000000000000000000f",
+  version: "0.2.0",
+  commitTime: "2026-08-25T14:02:33+02:00",
+};
+
+describe("parseBuildIdentity", () => {
+  it("accepts the injected shape", () => {
+    expect(parseBuildIdentity({ ...IDENTITY })).toEqual(IDENTITY);
+  });
+
+  it("nulls the optional halves without dropping the identity", () => {
+    expect(parseBuildIdentity({ repo: IDENTITY.repo, commit: IDENTITY.commit })).toEqual({
+      repo: IDENTITY.repo,
+      commit: IDENTITY.commit,
+      version: null,
+      commitTime: null,
+    });
+  });
+
+  it("refuses an identity without a commit — nothing to verify", () => {
+    expect(parseBuildIdentity({ repo: IDENTITY.repo, commit: null, version: "1.0.0" })).toBeNull();
+    expect(parseBuildIdentity({ repo: "", commit: IDENTITY.commit })).toBeNull();
+    expect(parseBuildIdentity(undefined)).toBeNull();
+    expect(parseBuildIdentity("d58538f")).toBeNull();
+  });
+});
+
+describe("the derived display values", () => {
+  it("short sha and commit link", () => {
+    expect(shortCommit(IDENTITY)).toBe("d58538f");
+    expect(commitUrl(IDENTITY)).toBe(
+      `https://github.com/secustor/renovate-config-debugger/commit/${IDENTITY.commit}`,
+    );
+  });
+
+  it("renders the committer date in UTC, or refuses garbage", () => {
+    expect(formatCommitTime("2026-08-25T14:02:33+02:00")).toBe("2026-08-25 12:02 UTC");
+    expect(formatCommitTime("not a date")).toBeNull();
+  });
+});
+
+describe("verifyCommands", () => {
+  it("targets the deployment the reader is on, and the repo the build named", () => {
+    const commands = verifyCommands(IDENTITY, "https://renovate.secustor.dev");
+    expect(commands.attest).toContain("curl -sO https://renovate.secustor.dev/build-manifest.json");
+    expect(commands.attest).toContain(
+      "gh attestation verify build-manifest.json -R secustor/renovate-config-debugger",
+    );
+    expect(commands.rebuild).toBe("node tools/verify-deployment.ts https://renovate.secustor.dev");
+  });
+});

--- a/packages/app/src/lib/build-info.test.ts
+++ b/packages/app/src/lib/build-info.test.ts
@@ -58,6 +58,13 @@ describe("verifyCommands", () => {
     expect(commands.attest).toContain(
       "gh attestation verify build-manifest.json -R secustor/renovate-config-debugger",
     );
-    expect(commands.rebuild).toBe("node tools/verify-deployment.ts https://renovate.secustor.dev");
+    expect(commands.rebuild).toBe(
+      [
+        "git clone https://github.com/secustor/renovate-config-debugger && cd renovate-config-debugger",
+        `git checkout ${IDENTITY.commit}`,
+        "pnpm install && pnpm --filter @renovate-config-debugger/app build",
+        "node tools/verify-deployment.ts https://renovate.secustor.dev",
+      ].join("\n"),
+    );
   });
 });

--- a/packages/app/src/lib/build-info.test.ts
+++ b/packages/app/src/lib/build-info.test.ts
@@ -62,8 +62,7 @@ describe("verifyCommands", () => {
       [
         "git clone https://github.com/secustor/renovate-config-debugger && cd renovate-config-debugger",
         `git checkout ${IDENTITY.commit}`,
-        "pnpm install && pnpm --filter @renovate-config-debugger/app build",
-        "node tools/verify-deployment.ts https://renovate.secustor.dev",
+        "mise install && mise run verify-build https://renovate.secustor.dev",
       ].join("\n"),
     );
   });

--- a/packages/app/src/lib/build-info.ts
+++ b/packages/app/src/lib/build-info.ts
@@ -63,13 +63,19 @@ export function formatCommitTime(iso: string): string | null {
 export interface VerifyCommands {
   /** Fetch the served manifest, check GitHub's signed CI attestation on it. */
   attest: string;
-  /** From a checkout: rebuild the manifest's commit and diff every asset. */
+  /** Clone, rebuild the served commit, and diff every asset hash — the whole
+   *  recipe, so the block is runnable as shown from an empty directory. */
   rebuild: string;
 }
 
 export function verifyCommands(info: BuildIdentity, origin: string): VerifyCommands {
+  const dir = info.repo.split("/")[1] ?? info.repo;
   return {
     attest: `curl -sO ${origin}/build-manifest.json\ngh attestation verify build-manifest.json -R ${info.repo}`,
-    rebuild: `node tools/verify-deployment.ts ${origin}`,
+    rebuild:
+      `git clone https://github.com/${info.repo} && cd ${dir}\n` +
+      `git checkout ${info.commit}\n` +
+      `pnpm install && pnpm --filter @renovate-config-debugger/app build\n` +
+      `node tools/verify-deployment.ts ${origin}`,
   };
 }

--- a/packages/app/src/lib/build-info.ts
+++ b/packages/app/src/lib/build-info.ts
@@ -64,7 +64,8 @@ export interface VerifyCommands {
   /** Fetch the served manifest, check GitHub's signed CI attestation on it. */
   attest: string;
   /** Clone, rebuild the served commit, and diff every asset hash — the whole
-   *  recipe, so the block is runnable as shown from an empty directory. */
+   *  recipe, runnable as shown from an empty directory. `mise run
+   *  verify-build` (mise.toml) is install + build + diff, pinned toolchain. */
   rebuild: string;
 }
 
@@ -75,7 +76,6 @@ export function verifyCommands(info: BuildIdentity, origin: string): VerifyComma
     rebuild:
       `git clone https://github.com/${info.repo} && cd ${dir}\n` +
       `git checkout ${info.commit}\n` +
-      `pnpm install && pnpm --filter @renovate-config-debugger/app build\n` +
-      `node tools/verify-deployment.ts ${origin}`,
+      `mise install && mise run verify-build ${origin}`,
   };
 }

--- a/packages/app/src/lib/build-info.ts
+++ b/packages/app/src/lib/build-info.ts
@@ -1,0 +1,75 @@
+import { isPlainObject } from "@/lib/input-schemas";
+
+/**
+ * Roadmap 088 — the build identity behind "verify this build".
+ *
+ * `__BUILD_INFO__` is a vite `define` (see vite.config.ts): only
+ * commit-derived facts, so rebuilding the same commit reproduces the bundle
+ * byte-for-byte. A build without git (the Docker image) has `commit: null`,
+ * and everything downstream — the landing line, the pane-foot stamp — hides
+ * itself rather than showing an identity nothing can verify.
+ */
+
+export interface BuildIdentity {
+  /** GitHub `owner/name` slug — the attestation's `-R` argument. */
+  repo: string;
+  /** Full commit SHA the bundle was built from. */
+  commit: string;
+  /** Latest release tag at that commit (without the `v`), if any. */
+  version: string | null;
+  /** The commit's committer date (ISO 8601) — shown as "built". */
+  commitTime: string | null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v !== "" ? v : null;
+}
+
+/** Validated read of the injected value — exported for its tests. */
+export function parseBuildIdentity(raw: unknown): BuildIdentity | null {
+  if (!isPlainObject(raw)) {
+    return null;
+  }
+  const repo = str(raw.repo);
+  const commit = str(raw.commit);
+  if (!repo || !commit) {
+    return null;
+  }
+  return { repo, commit, version: str(raw.version), commitTime: str(raw.commitTime) };
+}
+
+export const BUILD_INFO: BuildIdentity | null =
+  typeof __BUILD_INFO__ === "undefined" ? null : parseBuildIdentity(__BUILD_INFO__);
+
+export function shortCommit(info: BuildIdentity): string {
+  return info.commit.slice(0, 7);
+}
+
+export function commitUrl(info: BuildIdentity): string {
+  return `https://github.com/${info.repo}/commit/${info.commit}`;
+}
+
+/** "2026-08-25 14:02 UTC" — stable regardless of the reader's locale. */
+export function formatCommitTime(iso: string): string | null {
+  const time = new Date(iso);
+  if (Number.isNaN(time.getTime())) {
+    return null;
+  }
+  const day = time.toISOString().slice(0, 10);
+  const clock = time.toISOString().slice(11, 16);
+  return `${day} ${clock} UTC`;
+}
+
+export interface VerifyCommands {
+  /** Fetch the served manifest, check GitHub's signed CI attestation on it. */
+  attest: string;
+  /** From a checkout: rebuild the manifest's commit and diff every asset. */
+  rebuild: string;
+}
+
+export function verifyCommands(info: BuildIdentity, origin: string): VerifyCommands {
+  return {
+    attest: `curl -sO ${origin}/build-manifest.json\ngh attestation verify build-manifest.json -R ${info.repo}`,
+    rebuild: `node tools/verify-deployment.ts ${origin}`,
+  };
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -28,6 +28,7 @@ import "./styles/13-effective.css";
 import "./styles/14-overview-ledgers.css";
 import "./styles/15-pins.css";
 import "./styles/16-tabs.css";
+import "./styles/17-build-info.css";
 
 // Roadmap 033: one-time storage migrations run before the App's `useState`
 // initializers read storage — and, unlike their old module-scope home, they

--- a/packages/app/src/styles/08-landing.css
+++ b/packages/app/src/styles/08-landing.css
@@ -288,8 +288,18 @@
 /* The shell's counterpart to the landing's subtitle: the same promise, for a
    reader who arrived through a share link and never saw the landing. */
 .pane-foot {
+  align-items: baseline;
   color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
   font-size: 0.78rem;
+  gap: 0.3rem;
+  margin: 0;
+  /* The build stamp's popover (088, 17-build-info.css) anchors here. */
+  position: relative;
+}
+
+.pane-foot p {
   margin: 0;
 }
 

--- a/packages/app/src/styles/17-build-info.css
+++ b/packages/app/src/styles/17-build-info.css
@@ -1,0 +1,181 @@
+/* Roadmap 088 — "verify this build": the build-identity popover and its three
+   anchors (landing subtitle ⓘ, landing build line, pane-foot stamp). New file
+   at the end of the cascade — a new cross-cutting surface, per main.tsx. */
+
+.build-info-anchor {
+  display: inline-flex;
+  position: relative;
+}
+
+/* The pane-foot stamp sits at the strip's right edge. */
+.build-info-stamp-anchor {
+  margin-left: auto;
+}
+
+/* The ⓘ beside the landing subtitle. */
+.build-info-about {
+  background: none;
+  border: none;
+  border-radius: var(--radius-pill);
+  color: var(--accent);
+  cursor: pointer;
+  display: inline-flex;
+  margin-left: 0.3rem;
+  padding: 0.1rem;
+  vertical-align: text-bottom;
+}
+
+.build-info-about:hover {
+  background: var(--accent-bg);
+}
+
+.build-info-about svg {
+  fill: currentColor;
+}
+
+/* The landing's closing line, under the three steps. */
+.build-info-line {
+  color: var(--faint);
+  font-size: 0.75rem;
+  margin-top: 0.9rem;
+  position: relative;
+  text-align: center;
+}
+
+.build-info-line a,
+.build-info-stamp,
+.build-info-id {
+  font-family: var(--font-mono);
+}
+
+.build-info-verify {
+  background: none;
+  border: none;
+  border-bottom: 1px dashed var(--accent);
+  color: var(--accent);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0;
+}
+
+.build-info-stamp {
+  background: none;
+  border: none;
+  color: var(--faint);
+  cursor: pointer;
+  font-size: 0.72rem;
+  padding: 0;
+}
+
+.build-info-stamp:hover {
+  color: var(--accent);
+}
+
+/* ---------- the panel ---------- */
+
+.build-info-panel {
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-popover);
+  position: absolute;
+  text-align: left;
+  width: min(26rem, calc(100vw - 2rem));
+  z-index: var(--z-popover);
+}
+
+.build-info-panel.below-center {
+  left: 50%;
+  top: calc(100% + 0.4rem);
+  transform: translateX(-50%);
+}
+
+.build-info-panel.above-center {
+  bottom: calc(100% + 0.4rem);
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.build-info-panel.above-end {
+  bottom: calc(100% + 0.35rem);
+  right: 0;
+}
+
+.build-info-id {
+  font-size: 0.76rem;
+  margin: 0;
+  padding: 0.65rem 0.8rem 0.5rem;
+}
+
+.build-info-tabs {
+  display: flex;
+  gap: 0.3rem;
+  padding: 0 0.8rem 0.55rem;
+}
+
+.build-info-tab {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  padding: 0.15rem 0.5rem;
+}
+
+.build-info-tab[aria-pressed="true"] {
+  background: var(--accent-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.build-info-cmd-wrap {
+  padding: 0 0.8rem 0.8rem;
+  position: relative;
+}
+
+.build-info-cmd {
+  background: var(--terminal);
+  border-radius: var(--radius-md);
+  color: var(--on-terminal);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.6;
+  margin: 0;
+  overflow-x: auto;
+  padding: 0.55rem 0.65rem;
+  white-space: pre;
+}
+
+.build-info-prompt {
+  color: var(--terminal-accent);
+}
+
+/* The code-block copy rule (Standard Components): icon-only, top-right INSIDE
+   the block — recolored for the terminal ground it sits on. */
+.copy-btn.build-info-copy {
+  background: none;
+  border: none;
+  color: color-mix(in srgb, var(--on-terminal) 65%, transparent);
+  padding: 0.2rem;
+  position: absolute;
+  right: 1.1rem;
+  top: 0.35rem;
+}
+
+.copy-btn.build-info-copy:hover {
+  color: var(--on-terminal);
+}
+
+.copy-btn.build-info-copy.copied {
+  color: var(--terminal-accent);
+}
+
+.build-info-note {
+  color: var(--faint);
+  font-size: 0.72rem;
+  margin: 0.45rem 0 0;
+}

--- a/packages/app/src/vite-env.d.ts
+++ b/packages/app/src/vite-env.d.ts
@@ -32,3 +32,10 @@ declare var __RCD_OAUTH__: unknown;
  * Expected shape: `{ measurementId: string }` (a GA4 `G-…` id).
  */
 declare var __RCD_ANALYTICS__: unknown;
+
+/**
+ * Roadmap 088 — the build identity injected by vite.config.ts's `define`.
+ * Typed `unknown` and validated in `lib/build-info.ts`: vitest applies no
+ * define, so the identifier can be entirely absent (guard with `typeof`).
+ */
+declare const __BUILD_INFO__: unknown;

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -184,11 +185,67 @@ function devFakeOAuth(env: Record<string, string>): Plugin | null {
   };
 }
 
+interface BuildIdentity {
+  repo: string;
+  commit: string | null;
+  version: string | null;
+  commitTime: string | null;
+}
+
+function git(...args: string[]): string | null {
+  try {
+    return execFileSync("git", args, { encoding: "utf8" }).trim() || null;
+  } catch {
+    // No git / no history (e.g. the Docker build context excludes .git) —
+    // the UI hides its build line rather than showing a made-up identity.
+    return null;
+  }
+}
+
+/**
+ * Roadmap 088 — the build identity baked into the bundle (`__BUILD_INFO__`)
+ * and echoed to `dist/build-info.json`. Only commit-derived facts, so a
+ * verifier rebuilding the same commit gets byte-identical output: no branch
+ * name, no wall-clock build time — "built" is the committer date.
+ */
+function collectBuildIdentity(): BuildIdentity {
+  const commit = process.env.GITHUB_SHA ?? git("rev-parse", "HEAD");
+  return {
+    repo: process.env.GITHUB_REPOSITORY ?? "secustor/renovate-config-debugger",
+    commit,
+    // The latest release tag reachable from this commit (CI fetches the full
+    // history for this — see ci.yml's build job).
+    version: git("describe", "--tags", "--abbrev=0")?.replace(/^v/, "") ?? null,
+    commitTime: commit ? git("show", "-s", "--format=%cI", commit) : null,
+  };
+}
+
+function emitBuildInfo(identity: BuildIdentity): Plugin {
+  return {
+    name: "rcd-build-info",
+    apply: "build",
+    generateBundle() {
+      this.emitFile({
+        type: "asset",
+        fileName: "build-info.json",
+        source: `${JSON.stringify(identity, null, 2)}\n`,
+      });
+    },
+  };
+}
+
+const buildIdentity = collectBuildIdentity();
+
 export default defineConfig(({ mode, command }) => ({
   // Served from the domain root everywhere: renovate.secustor.dev in
   // production (custom domains host at "/", and a repo-prefixed base 404s
   // every asset there), localhost + the self-host images elsewhere.
   base: "/",
+  define: {
+    // Read through src/lib/build-info.ts, never directly — vitest applies no
+    // define, so consumers must survive the identifier being absent.
+    __BUILD_INFO__: JSON.stringify(buildIdentity),
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),
@@ -198,6 +255,7 @@ export default defineConfig(({ mode, command }) => ({
     react(),
     renovateShims(),
     codemirrorJsonSchemaShims(),
+    emitBuildInfo(buildIdentity),
     // Guarded here, not just by the plugin's own `apply: "serve"`: the
     // factory VALIDATES the dev-only vars and throws on a bad value, and the
     // config callback runs for `vite build` too — a typo'd .env entry must

--- a/roadmap/088-build-provenance.md
+++ b/roadmap/088-build-provenance.md
@@ -1,0 +1,88 @@
+# 088 — Build provenance: "verify this build"
+
+Milestone: M21 · Status: done.
+Design: Claude Design project "Renovate Config Debugger", artboards
+`Build Provenance.dc.html` (the popover), `Landing Transition.dc.html` (the
+subtitle ⓘ and the landing build line) and
+`Proposal F - Integrated Shell.dc.html` (the pane-foot stamp).
+
+## The ask
+
+The landing promises "nothing leaves your browser", and everything about the
+app's trust story hangs on the visitor believing the served bundle really is a
+build of the open-source code. Nothing on the page backed that promise: the
+app displayed no version, no commit, and there was no way — for any deployment
+— to check the served bytes against the repository. Give the promise a
+receipt: which build this is, and a command that verifies it.
+
+## The mechanism
+
+Three layers, each independently checkable:
+
+1. **The baked identity.** `vite.config.ts` defines `__BUILD_INFO__`
+   (repo slug, commit, latest release tag, committer date) and emits the same
+   object as `dist/build-info.json`. Only **commit-derived** facts, so
+   rebuilding the same commit reproduces the bundle byte-for-byte — which is
+   why the branch name and a wall-clock build time are deliberately absent
+   ("built" is the committer date, and the design mock's `· main ·` segment
+   was dropped). Read through `src/lib/build-info.ts`, which validates the
+   injected value and exports `BUILD_INFO: null` where the identifier is
+   absent (vitest applies no define) or the build had no git (the Docker
+   image excludes `.git`) — every UI anchor then renders nothing, rather than
+   an identity nothing can verify.
+2. **The attested manifest.** `scripts/build-manifest.mjs` hashes every file
+   in `dist/` into `build-manifest.json` (excluding itself, and
+   `rcd-config.js`, which the Docker entrypoint may rewrite at container
+   start). CI generates it before the Pages upload and signs it with
+   `actions/attest-build-provenance` on main — GitHub's statement that this
+   workflow built this manifest from this commit, checkable with
+   `gh attestation verify build-manifest.json -R secustor/renovate-config-debugger`.
+   The build job fetches the full history (`fetch-depth: 0`) so
+   `git describe` can name the release tag.
+3. **The rebuild proof.** `tools/verify-deployment.ts` (plain `node`, like
+   every tools/ script) fetches the served manifest, re-fetches and re-hashes
+   every file it lists (served ≡ manifest), and — when a local
+   `packages/app/dist` exists — diffs the local build against the manifest:
+   run from a checkout of the manifest's commit, that is the independent
+   proof that needs no trust in GitHub's attestation service.
+
+## The UI
+
+One popover (`src/components/BuildInfo.tsx`), three anchors mirroring the
+app's promise-stated-twice seam (075):
+
+- the ⓘ after the landing subtitle ("About this build", panel opens below);
+- the landing's closing line — `debugger v0.2.0 · d58538f · built … — verify
+this build` (panel opens above);
+- the pane-foot stamp `· v0.2.0 d58538f` at the strip's right edge, for the
+  share-link reader who never saw the landing (panel opens above-right).
+
+The panel: identity line (release tag, linked short commit, committer time in
+UTC), two command chips — `gh attestation` and `rebuild & diff` — a
+terminal-styled command block with the standard icon-only copy button, and a
+one-line note saying what the shown command actually proves. The open/close
+mechanics are the session menu's, extracted to
+`hooks/use-anchored-popover.ts` (066's contract, parameterized by Escape
+rank — this popover dismisses at `popover` rank, above the menu).
+
+Deliberately **not called "provenance" anywhere user-facing**: that word
+already means config-value provenance (which layer set an option) here. The
+copy says "build" and "verify".
+
+## Rulings
+
+- **Branch dropped from the baked identity** (deviation from the artboard's
+  `· main ·`): a verifier's rebuild is on a detached HEAD, so a baked branch
+  name would break byte-reproducibility for the one chunk that carries the
+  identity. The manifest still records the branch, informationally.
+- **`node tools/verify-deployment.ts`**, not the artboard's `npx tsx`: tools/
+  scripts run under Node's native type stripping everywhere else in this
+  repo, and the verifier has a checkout (they need one to rebuild anyway).
+- **Docker deployments show nothing** rather than something unverifiable: the
+  build context excludes `.git`, `collectBuildIdentity()` returns a null
+  commit, and every anchor hides. A self-host that wants the line can pass
+  `GITHUB_SHA`/`GITHUB_REPOSITORY` as build env. Deferred: a build arg wired
+  through the Dockerfile.
+- **Attestation is main-only and gated on `DEPLOY_PAGES`** — the same switch
+  that decides whether a public deployment exists to verify; fork PRs never
+  hold the `id-token` permission the signature needs.

--- a/roadmap/088-build-provenance.md
+++ b/roadmap/088-build-provenance.md
@@ -30,15 +30,20 @@ Three layers, each independently checkable:
    absent (vitest applies no define) or the build had no git (the Docker
    image excludes `.git`) — every UI anchor then renders nothing, rather than
    an identity nothing can verify.
-2. **The attested manifest.** `scripts/build-manifest.mjs` hashes every file
+2. **The attested files.** `scripts/build-manifest.mjs` hashes every file
    in `dist/` into `build-manifest.json` (excluding itself, and
    `rcd-config.js`, which the Docker entrypoint may rewrite at container
-   start). CI generates it before the Pages upload and signs it with
-   `actions/attest-build-provenance` on main — GitHub's statement that this
-   workflow built this manifest from this commit, checkable with
-   `gh attestation verify build-manifest.json -R secustor/renovate-config-debugger`.
-   The build job fetches the full history (`fetch-depth: 0`) so
-   `git describe` can name the release tag.
+   start), and writes the same digests — manifest included — to
+   `build-checksums.txt` (next to `dist/`, gitignored: attestation input,
+   not deployment payload). CI generates both before the Pages upload and,
+   on main, signs the checksums with `actions/attest`
+   (`subject-checksums`) — GitHub's statement that this workflow built
+   these files from this commit. So EVERY served file is an attested
+   subject: `gh attestation verify build-manifest.json -R
+secustor/renovate-config-debugger` is the entry point, but the same
+   command verifies any downloaded asset individually. The build job
+   fetches the full history (`fetch-depth: 0`) so `git describe` can name
+   the release tag.
 3. **The rebuild proof.** `tools/verify-deployment.ts` (plain `node`, like
    every tools/ script) fetches the served manifest, re-fetches and re-hashes
    every file it lists (served ≡ manifest), and — when a local
@@ -86,3 +91,9 @@ copy says "build" and "verify".
 - **Attestation is main-only and gated on `DEPLOY_PAGES`** — the same switch
   that decides whether a public deployment exists to verify; fork PRs never
   hold the `id-token` permission the signature needs.
+- **`actions/attest`, not `actions/attest-build-provenance`**: v4 of the
+  latter is a wrapper that points new uses at the former, and only the
+  former takes `subject-checksums` (all served files as subjects of one
+  SLSA-provenance attestation — no predicate inputs means it emits build
+  provenance). One invocation caps at 1024 subjects; the manifest script
+  warns at 1000 (a build today has ~475).

--- a/roadmap/088-build-provenance.md
+++ b/roadmap/088-build-provenance.md
@@ -83,6 +83,10 @@ copy says "build" and "verify".
 - **`node tools/verify-deployment.ts`**, not the artboard's `npx tsx`: tools/
   scripts run under Node's native type stripping everywhere else in this
   repo, and the verifier has a checkout (they need one to rebuild anyway).
+  The popover shows it wrapped as `mise run verify-build <origin>`
+  (mise.toml): install + build + diff in one command, with the toolchain
+  pinned to what CI built with — which is what byte-reproducibility
+  depends on.
 - **Docker deployments show nothing** rather than something unverifiable: the
   build context excludes `.git`, `collectBuildIdentity()` returns a null
   commit, and every anchor hides. A self-host that wants the line can pass

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -92,6 +92,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [085](085-load-from-repo-options.md)                    | Load-from-repo options: paste any URL, or pick from your repos       | M21                  | done                                                                                                                                                 |
 | [086](086-app-state-sharing.md)                         | The App.tsx state-sharing ruling: context, hooks, no store           | M21                  | done                                                                                                                                                 |
 | [087](087-ghost-row-and-repo-deps.md)                   | The ghost row, and dependencies from the loaded repo                 | M21                  | done                                                                                                                                                 |
+| [088](088-build-provenance.md)                          | Build provenance: "verify this build"                                | M21                  | done                                                                                                                                                 |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -10,5 +10,5 @@
     // which requires the import specifiers to carry the real `.ts` extension.
     "allowImportingTsExtensions": true
   },
-  "include": ["agents/**/*.ts", "release/**/*.ts", "lint/**/*.ts"]
+  "include": ["agents/**/*.ts", "release/**/*.ts", "lint/**/*.ts", "verify-deployment.ts"]
 }

--- a/tools/verify-deployment.ts
+++ b/tools/verify-deployment.ts
@@ -1,0 +1,171 @@
+/**
+ * Roadmap 088 — the "rebuild & diff" half of "verify this build".
+ *
+ *   node tools/verify-deployment.ts [origin]     (default: https://renovate.secustor.dev)
+ *
+ * Three checks, from weakest to strongest:
+ * 1. Fetches <origin>/build-manifest.json and every file it lists, and
+ *    compares served hashes to the manifest — the deployment is internally
+ *    consistent with what it claims to be.
+ * 2. Prints the `gh attestation verify` command — GitHub's signed statement
+ *    that CI built that manifest from the named commit.
+ * 3. If packages/app/dist exists locally, diffs its hashes against the
+ *    manifest — run from a checkout of the manifest's commit after
+ *    `pnpm --filter @renovate-config-debugger/app build && pnpm --filter
+ *    @renovate-config-debugger/app build:manifest`, this is the independent
+ *    rebuild proof (the baked identity is commit-derived, so the same commit
+ *    reproduces the same bytes).
+ *
+ * Exit codes: 0 verified, 1 mismatch, 2 could not check.
+ */
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+interface ManifestFile {
+  sha256: string;
+  bytes: number;
+}
+
+interface Manifest {
+  repo: string;
+  commit: string;
+  version: string | null;
+  commitTime: string | null;
+  branch: string | null;
+  files: Record<string, ManifestFile>;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+function parseManifest(raw: unknown): Manifest | null {
+  if (!isRecord(raw) || typeof raw.repo !== "string" || typeof raw.commit !== "string") {
+    return null;
+  }
+  if (!isRecord(raw.files)) {
+    return null;
+  }
+  const files: Record<string, ManifestFile> = {};
+  for (const [file, entry] of Object.entries(raw.files)) {
+    if (!isRecord(entry) || typeof entry.sha256 !== "string" || typeof entry.bytes !== "number") {
+      return null;
+    }
+    files[file] = { sha256: entry.sha256, bytes: entry.bytes };
+  }
+  return {
+    repo: raw.repo,
+    commit: raw.commit,
+    version: typeof raw.version === "string" ? raw.version : null,
+    commitTime: typeof raw.commitTime === "string" ? raw.commitTime : null,
+    branch: typeof raw.branch === "string" ? raw.branch : null,
+    files,
+  };
+}
+
+const sha256 = (body: Uint8Array): string => createHash("sha256").update(body).digest("hex");
+
+async function forEachConcurrent<T>(
+  items: readonly T[],
+  limit: number,
+  work: (item: T) => Promise<void>,
+): Promise<void> {
+  // One shared (synchronous) iterator — each worker pulls the next item.
+  const queue = items.values();
+  async function worker() {
+    for (const item of queue) {
+      await work(item);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+}
+
+const origin = (process.argv[2] ?? "https://renovate.secustor.dev").replace(/\/+$/, "");
+
+const manifestResponse = await fetch(`${origin}/build-manifest.json`);
+if (!manifestResponse.ok) {
+  console.error(
+    `${origin}/build-manifest.json → HTTP ${manifestResponse.status} — this deployment publishes no manifest.`,
+  );
+  process.exit(2);
+}
+const manifest = parseManifest(await manifestResponse.json());
+if (!manifest) {
+  console.error("build-manifest.json is not the expected shape.");
+  process.exit(2);
+}
+
+const shortCommit = manifest.commit.slice(0, 7);
+console.log(`Deployment: ${origin}`);
+console.log(
+  `Claims: ${manifest.version ? `v${manifest.version} · ` : ""}${shortCommit}` +
+    `${manifest.branch ? ` · ${manifest.branch}` : ""}${manifest.commitTime ? ` · ${manifest.commitTime}` : ""}`,
+);
+console.log(`Attestation check: gh attestation verify build-manifest.json -R ${manifest.repo}\n`);
+
+// 1 — the served files against the manifest they were served with.
+const entries = Object.entries(manifest.files);
+const servedProblems: string[] = [];
+await forEachConcurrent(entries, 8, async ([name, expected]) => {
+  const response = await fetch(`${origin}/${name}`);
+  if (!response.ok) {
+    servedProblems.push(`${name}: HTTP ${response.status}`);
+    return;
+  }
+  const digest = sha256(new Uint8Array(await response.arrayBuffer()));
+  if (digest !== expected.sha256) {
+    servedProblems.push(
+      `${name}: served ${digest.slice(0, 12)}… ≠ manifest ${expected.sha256.slice(0, 12)}…`,
+    );
+  }
+});
+if (servedProblems.length > 0) {
+  console.error(`SERVED ≠ MANIFEST (${servedProblems.length} of ${entries.length} files):`);
+  for (const problem of servedProblems.toSorted()) {
+    console.error(`  ${problem}`);
+  }
+  process.exit(1);
+}
+console.log(`Served files: all ${entries.length} match the manifest.`);
+
+// 2 — the local rebuild, when one is present.
+const dist = fileURLToPath(new URL("../packages/app/dist", import.meta.url));
+if (!existsSync(dist)) {
+  console.log(
+    `\nNo local build to diff. For the independent proof, from a checkout of ${shortCommit}:\n` +
+      `  git checkout ${manifest.commit}\n` +
+      `  pnpm install && pnpm --filter @renovate-config-debugger/app build\n` +
+      `then re-run this script.`,
+  );
+  process.exit(0);
+}
+
+const rebuildProblems: string[] = [];
+await forEachConcurrent(entries, 8, async ([name, expected]) => {
+  try {
+    const digest = sha256(await readFile(`${dist}/${name}`));
+    if (digest !== expected.sha256) {
+      rebuildProblems.push(
+        `${name}: local ${digest.slice(0, 12)}… ≠ manifest ${expected.sha256.slice(0, 12)}…`,
+      );
+    }
+  } catch {
+    rebuildProblems.push(`${name}: missing from the local build`);
+  }
+});
+if (rebuildProblems.length > 0) {
+  console.error(`\nLOCAL BUILD ≠ MANIFEST (${rebuildProblems.length} of ${entries.length} files):`);
+  for (const problem of rebuildProblems.toSorted()) {
+    console.error(`  ${problem}`);
+  }
+  console.error(
+    `A differing local build usually means a different commit — the manifest names ${shortCommit}.`,
+  );
+  process.exit(1);
+}
+console.log(
+  `Local rebuild: all ${entries.length} files match — this deployment is a build of ${shortCommit}.`,
+);

--- a/tools/verify-deployment.ts
+++ b/tools/verify-deployment.ts
@@ -104,7 +104,10 @@ console.log(
   `Claims: ${manifest.version ? `v${manifest.version} · ` : ""}${shortCommit}` +
     `${manifest.branch ? ` · ${manifest.branch}` : ""}${manifest.commitTime ? ` · ${manifest.commitTime}` : ""}`,
 );
-console.log(`Attestation check: gh attestation verify build-manifest.json -R ${manifest.repo}\n`);
+console.log(
+  `Attestation check: gh attestation verify build-manifest.json -R ${manifest.repo}\n` +
+    `  (every served file is an attested subject — the same command verifies any downloaded asset)\n`,
+);
 
 // 1 — the served files against the manifest they were served with.
 const entries = Object.entries(manifest.files);

--- a/tools/verify-deployment.ts
+++ b/tools/verify-deployment.ts
@@ -10,11 +10,10 @@
  * 2. Prints the `gh attestation verify` command — GitHub's signed statement
  *    that CI built that manifest from the named commit.
  * 3. If packages/app/dist exists locally, diffs its hashes against the
- *    manifest — run from a checkout of the manifest's commit after
- *    `pnpm --filter @renovate-config-debugger/app build && pnpm --filter
- *    @renovate-config-debugger/app build:manifest`, this is the independent
- *    rebuild proof (the baked identity is commit-derived, so the same commit
- *    reproduces the same bytes).
+ *    manifest — run from a checkout of the manifest's commit, this is the
+ *    independent rebuild proof (the baked identity is commit-derived, so the
+ *    same commit reproduces the same bytes). `mise run verify-build <origin>`
+ *    is the one-command wrapper: install, build, then this script.
  *
  * Exit codes: 0 verified, 1 mismatch, 2 could not check.
  */
@@ -138,10 +137,9 @@ console.log(`Served files: all ${entries.length} match the manifest.`);
 const dist = fileURLToPath(new URL("../packages/app/dist", import.meta.url));
 if (!existsSync(dist)) {
   console.log(
-    `\nNo local build to diff. For the independent proof, from a checkout of ${shortCommit}:\n` +
+    `\nNo local build to diff. For the independent proof, from a checkout:\n` +
       `  git checkout ${manifest.commit}\n` +
-      `  pnpm install && pnpm --filter @renovate-config-debugger/app build\n` +
-      `then re-run this script.`,
+      `  mise install && mise run verify-build ${origin}`,
   );
   process.exit(0);
 }


### PR DESCRIPTION
Implements the Build Provenance design

## The mechanism
- **Baked identity** — `vite.config.ts` defines `__BUILD_INFO__` (repo, commit, latest tag, committer date) and emits `dist/build-info.json`. Commit-derived facts only, so rebuilding the same commit is byte-identical (verified: two local builds produce identical manifests).
- **Attested files** — `scripts/build-manifest.mjs` hashes every served file into `dist/build-manifest.json` and writes the same digests (manifest included) to `build-checksums.txt`; CI signs them with `actions/attest` (`subject-checksums`) on main (gated on `DEPLOY_PAGES`), so **every served file is an attested subject** — `gh attestation verify` works on the manifest or on any downloaded asset. (`attest-build-provenance` v4 is a wrapper that points new uses at `actions/attest`.)
- **Rebuild proof** — `tools/verify-deployment.ts` fetches the served manifest, re-hashes every served file against it, and diffs a local rebuild when present (verified end-to-end against `vite preview`).

## The UI
One popover, three anchors: the ⓘ after the landing subtitle, the landing's closing `debugger v0.2.0 · d58538f · built … — verify this build` line, and the pane-foot stamp in the shell. Session-menu popover mechanics extracted to `hooks/use-anchored-popover.ts` (same contract, parameterized Escape rank).

## Rulings (details in `roadmap/088-build-provenance.md`)
- Branch dropped from the baked identity (reproducibility); the manifest still records it informationally.
- `node tools/verify-deployment.ts` instead of the artboard's `npx tsx` — tools/ scripts run under Node's native type stripping here.
- Docker builds (no `.git` in context) show no build line at all rather than an unverifiable one.
- User-facing copy never says "provenance" — that word already means config-value provenance in this app.

Gates: lint, format, typecheck, check:exports, all 980 app tests, and the four landing-affecting e2e specs (49 tests) pass.
