### PR TITLE
fix(provenance): attribute each packageRule to the preset that wrote it

### DIFF
--- a/packages/app/src/features/effective-config/CascadeStack.tsx
+++ b/packages/app/src/features/effective-config/CascadeStack.tsx
@@ -4,6 +4,7 @@ import { ConfigJson } from "@/components/ConfigJson";
 import { plural, pluralWord } from "@/lib/format";
 import { LayerSource } from "@/components/LayerSource";
 import { ProvenanceChip } from "@/components/ProvenanceChip";
+import { ruleOriginLayer } from "@/lib/rule-filters";
 import { summarizeRuleSelectors } from "@/lib/rule-selectors";
 
 const VERBS: Record<ProvenanceStep["action"], string> = {
@@ -73,9 +74,11 @@ export function Step({
   );
 }
 
-/** Roadmap 013: per-entry provenance for `packageRules` — which layer (repo /
- *  global / inherited / preset) contributed each merged rule, reusing the
- *  same chip the effective config's top-level keys already show. */
+/** Roadmap 013: per-entry provenance for `packageRules` — which config (repo /
+ *  global / inherited / preset) wrote each merged rule, reusing the same chip
+ *  the effective config's top-level keys already show. Like the cascade steps
+ *  above, the chip names the ORIGINATING preset when the engine verified one
+ *  ({@link ruleOriginLayer}), not the direct extend it arrived through. */
 function PackageRulesProvenance({
   rules,
   attribution,
@@ -104,7 +107,7 @@ function PackageRulesProvenance({
             <li key={i}>
               <span className="prov-rule-index">#{i + 1}</span>
               {attr ? (
-                <ProvenanceChip layer={attr.layer} onSelectPreset={onSelectPreset} />
+                <ProvenanceChip layer={ruleOriginLayer(attr)} onSelectPreset={onSelectPreset} />
               ) : (
                 <span className="badge prov-layer">source unknown</span>
               )}

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -10,7 +10,7 @@
  * wiring and not the verdict.
  */
 import { useState } from "react";
-import { runPipeline } from "@renovate-config-debugger/engine";
+import { presetInjectionKey, runPipeline } from "@renovate-config-debugger/engine";
 import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeAll, expect, it, vi } from "vitest";
 import type { SimRequest } from "@/hooks/use-share-link";
@@ -99,6 +99,40 @@ async function pinReact(view: ReturnType<typeof render>): Promise<void> {
   fireEvent.click(view.getByRole("button", { name: "Pin as a standing test" }));
   await waitFor(() => expect(view.container.querySelector(".pin-card")).not.toBeNull());
 }
+
+/**
+ * The Tests tab names the preset a rule COMES FROM, and a rule almost never
+ * comes from the preset the config extends: `config:best-practices` writes
+ * none of the ~730 rules it contributes. Injected presets stand in for that
+ * shape — an umbrella whose nested leaf writes the rule that fires.
+ */
+const NESTED_PRESETS = {
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/umbrella" })]: {
+    extends: ["github>test-org/leaf"],
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/leaf" })]: {
+    packageRules: [{ matchPackageNames: ["react"], groupName: "react" }],
+  },
+};
+
+it("names the nested preset that wrote a matched rule, not the extend it arrived through", async () => {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content: JSON.stringify({ extends: ["github>test-org/umbrella"] }),
+    injectedPresets: NESTED_PRESETS,
+  });
+  const view = render(<Harness result={result} />);
+  await pinReact(view);
+
+  const card = view.container.querySelector<HTMLElement>(".pin-card");
+  if (!card) {
+    throw new Error("pinning produced no card");
+  }
+  await waitFor(() => expect(card.textContent).toContain("grouped as “react”"));
+  fireEvent.click(within(card).getByRole("button", { expanded: false }));
+  expect(card.textContent).toContain("github>test-org/leaf");
+  expect(card.textContent).not.toContain("github>test-org/umbrella");
+});
 
 it("opens on the pins list, pins a dependency from the Add-a-test form, and checks it against the run", async () => {
   const result = await run();

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -37,6 +37,7 @@ export {
   filterRulesBySource,
   matchesVerdictFilter,
   ruleLayerIndex,
+  ruleOriginLayer,
   SOURCE_FILTERS,
   type SourceFilter,
   VERDICT_FILTERS,

--- a/packages/app/src/lib/rule-filters.test.ts
+++ b/packages/app/src/lib/rule-filters.test.ts
@@ -22,6 +22,7 @@ import {
   presetFilterOptions,
   REPO_RULES,
   ruleLayerIndex,
+  ruleOriginLayer,
   ruleVisible,
   verdictFilterOptions,
 } from "./rule-filters";
@@ -147,6 +148,29 @@ test("ruleLayerIndex turns the engine's attribution into the map the filters tak
     [1, PRESET_LAYER],
   ]);
   expect(ruleLayerIndex(null).size).toBe(0);
+});
+
+test("ruleLayerIndex names the nested body that wrote a rule, not the extend it arrived through", () => {
+  // The `config:best-practices` shape: the direct extend contributes every
+  // rule and writes none of them. A map keyed on `layer` answers all four of
+  // its consumers with one bucket named after a preset with no rules of its
+  // own.
+  const written = { nodeId: "p9", name: "security:minimumReleaseAgeNpm", sourceIndex: 0 };
+  const attribution: RuleAttribution[] = [
+    { index: 0, layer: PRESET_LAYER, sourceIndex: 0, writtenBy: written },
+    { index: 1, layer: PRESET_LAYER, sourceIndex: 1 },
+    { index: 2, layer: REPO_LAYER, sourceIndex: 0 },
+  ];
+  expect([...ruleLayerIndex(attribution).entries()]).toEqual([
+    [0, { kind: "preset", nodeId: "p9", name: "security:minimumReleaseAgeNpm" }],
+    // No writer: the extend wrote this one itself.
+    [1, PRESET_LAYER],
+    [2, REPO_LAYER],
+  ]);
+  expect(ruleOriginLayer(attribution[0] as RuleAttribution)).toMatchObject({
+    name: "security:minimumReleaseAgeNpm",
+  });
+  expect(ruleOriginLayer(attribution[2] as RuleAttribution)).toEqual(REPO_LAYER);
 });
 
 test("the verdict options state what each would leave", () => {

--- a/packages/app/src/lib/rule-filters.ts
+++ b/packages/app/src/lib/rule-filters.ts
@@ -184,15 +184,37 @@ export function filterRulesBySource(
  * `computeRuleProvenance`'s array as the index → layer lookup every filter
  * here takes. Shared so the simulator's memo and the CLI build the map the
  * same way (and so "provenance unavailable" is one empty map, not two shapes).
+ *
+ * The layer is the ORIGINATING preset when the engine verified one — the
+ * nested body that actually wrote the rule (`security:minimumReleaseAgeNpm`,
+ * not the `config:best-practices` it arrived through) — falling back to the
+ * direct extend. Every consumer of this map asks "which preset is this rule
+ * from": the rule rows, the merge stops, the pin buckets, and the drawer's
+ * preset facet, whose options are these same values. A `config:best-practices`
+ * config otherwise answers all four with one 731-rule bucket named after an
+ * extend that wrote none of them — the same asymmetry the effective config's
+ * cascade already avoids by preferring `ProvenanceStep.writtenBy`.
+ *
+ * `sourceIndex` stays layer-relative (see {@link RuleAttribution}); a surface
+ * that prints an index beside the name must read it off `writtenBy` too, or
+ * the two halves of the citation name different bodies.
  */
 export function ruleLayerIndex(
   attribution: readonly RuleAttribution[] | null | undefined,
 ): Map<number, ProvenanceLayer> {
   const map = new Map<number, ProvenanceLayer>();
   for (const attr of attribution ?? []) {
-    map.set(attr.index, attr.layer);
+    map.set(attr.index, ruleOriginLayer(attr));
   }
   return map;
+}
+
+/** One entry's originating layer — {@link ruleLayerIndex}'s rule, for a caller
+ *  holding the attribution itself rather than the map. */
+export function ruleOriginLayer(attr: RuleAttribution): ProvenanceLayer {
+  return attr.writtenBy
+    ? { kind: "preset", nodeId: attr.writtenBy.nodeId, name: attr.writtenBy.name }
+    : attr.layer;
 }
 
 export interface FilterOption {

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -473,8 +473,13 @@ describe("drill-down", () => {
    * Roadmap 071: the two narrowings the ranges point at. The ranges answer
    * "which layer", `rule` answers "what does rule N say" without shipping 714
    * bodies, and `source` answers "just mine".
+   *
+   * `rule` names the WRITING body, not the extend the rule arrived through:
+   * `config:recommended` writes none of its ~730 rules itself, and citing it
+   * as `packageRules[300]` of a preset whose own body has no rule 300 is two
+   * wrong halves of one citation.
    */
-  test("`rule` returns one merged rule's body, its layer and its index there", async () => {
+  test("`rule` returns one merged rule's body, its writer and its index there", async () => {
     const runId = await runConfig(RECOMMENDED_PLUS_RULE);
     const mid = (await call("get_provenance", { runId, key: "packageRules", rule: 300 })) as {
       index: number;
@@ -484,8 +489,12 @@ describe("drill-down", () => {
       rule: Record<string, unknown>;
     };
     expect(mid.index).toBe(300);
-    expect(mid.layer).toContain("preset config:recommended");
-    expect(mid.sourceIndex).toBe(300);
+    // A nested preset of `config:recommended`, and rule 300 is inside its own
+    // (much shorter) body — the two halves name the same config.
+    expect(mid.layer).toMatch(/^preset \S/);
+    expect(mid.layer).not.toBe("preset config:recommended");
+    expect(mid.sourceIndex).toBeLessThan(300);
+    expect(mid.citation).toContain(`packageRules[${mid.sourceIndex}] of ${mid.layer}`);
     expect(mid.rule).toBeTypeOf("object");
 
     // The caller's own rule, cited in the index scheme they wrote it in.

--- a/packages/cli/src/projections/rule-provenance.test.ts
+++ b/packages/cli/src/projections/rule-provenance.test.ts
@@ -22,14 +22,19 @@ function attr(
   index: number,
   layer: RuleAttribution["layer"],
   sourceIndex: number,
+  writtenBy?: RuleAttribution["writtenBy"],
 ): RuleAttribution {
-  return { index, layer, sourceIndex };
+  return { index, layer, sourceIndex, ...(writtenBy ? { writtenBy } : {}) };
 }
+
+/** The nested body that wrote merged rule 1 — `config:recommended` carries it
+ *  in, `npm:unpublishSafe` is what a reader would have to open to find it. */
+const NESTED = { nodeId: "n3", name: "npm:unpublishSafe", sourceIndex: 0 } as const;
 
 /** One preset, the SAME preset a second time, then two repo-authored rules. */
 const ATTRIBUTION: RuleAttribution[] = [
   attr(0, PRESET_A, 0),
-  attr(1, PRESET_A, 1),
+  attr(1, PRESET_A, 1, NESTED),
   attr(2, PRESET_B, 0),
   attr(3, { kind: "repo" }, 0),
   attr(4, { kind: "repo" }, 1),
@@ -54,7 +59,7 @@ const ENTRY: KeyProvenance = {
   ],
 };
 
-const [RICHEST, SHAPED, COUNTED] = RULE_DIGEST_PLANS;
+const [RICHEST, SHAPED, SHAPED_NO_WRITERS, COUNTED] = RULE_DIGEST_PLANS;
 
 describe("ruleSourceRanges", () => {
   test("one contiguous range per contributing layer", () => {
@@ -101,6 +106,15 @@ describe("ruleOrigin", () => {
     });
   });
 
+  test("a rule written by a nested preset cites THAT preset, and its index there", () => {
+    // Both halves from one body: `config:recommended packageRules[1]` would
+    // send the reader to a preset whose own body has no rule 1.
+    expect(ruleOrigin(1, ATTRIBUTION)).toEqual({
+      layer: "preset npm:unpublishSafe",
+      sourceIndex: 0,
+    });
+  });
+
   test("an unattributable run links nothing", () => {
     expect(ruleOrigin(0, undefined)).toBeUndefined();
     expect(ruleOrigin(99, ATTRIBUTION)).toBeUndefined();
@@ -132,10 +146,27 @@ describe("ruleProvenanceView", () => {
     expect(preset?.rules?.[1]).toContain("+1 → automerge");
   });
 
+  test("a digest line names the nested body that wrote its rule", () => {
+    const view = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, RICHEST);
+    // The range head says `config:recommended` for both of its rules; only the
+    // line can say that the second one came from two levels down.
+    expect(view.contributions?.[0]?.rules?.[0]).not.toContain("[from ");
+    expect(view.contributions?.[0]?.rules?.[1]).toContain("[from npm:unpublishSafe]");
+  });
+
+  test("the writer is the first thing dropped under the budget — before any line is", () => {
+    const lean = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, SHAPED_NO_WRITERS);
+    const lines = lean.contributions?.flatMap((c) => c.rules ?? []) ?? [];
+    // Still one line per merged rule — completeness outranks the writer.
+    expect(lines).toHaveLength(lean.total);
+    expect(lines.some((line) => line.includes("[from "))).toBe(false);
+    expect(lean.detailNote).toContain("size budget");
+  });
+
   test("`shape` drops the values but keeps every line, `counts` drops the lines", () => {
     const shaped = ruleProvenanceView(ENTRY, ATTRIBUTION, RULES, SHAPED);
     expect(shaped.contributions?.[0]?.rules?.[1]).toBe(
-      "1 matchDepTypes + matchUpdateTypes → automerge",
+      "1 matchDepTypes + matchUpdateTypes → automerge [from npm:unpublishSafe]",
     );
     // The authored layers keep their values at every level — they are a
     // handful of rules at any scale, and they are the ones the reader wrote.

--- a/packages/cli/src/projections/rule-provenance.ts
+++ b/packages/cli/src/projections/rule-provenance.ts
@@ -6,6 +6,7 @@ import type {
 import {
   isOverridden,
   multiContribBadgeKind,
+  ruleOriginLayer,
   ruleWrittenKeys,
   type SourceFilter,
   summarizeRuleSelectors,
@@ -56,18 +57,24 @@ export type RuleDigestDetail = "values" | "shape" | "counts";
 export interface RuleDigestPlan {
   authored: RuleDigestDetail;
   presets: RuleDigestDetail;
+  /** Whether a preset's digest lines name the nested body that wrote each rule
+   *  (`[from X]`). Dropped BEFORE any line is: naming the writer is an addition
+   *  to an answer whose completeness — one line per merged rule — is the older
+   *  promise, and the writer of one rule stays a `rule: <index>` away. */
+  writers: boolean;
 }
 
 /**
  * The plans a budget-limited caller walks, richest first (measured on
- * `config:best-practices` + one own rule, 727 merged rules: 61 kB, 47 kB,
- * <2 kB). The sentence a reader needs — "your `packageRules[0]` is merged rule
- * 726, matching `matchSourceUrls: […]`" — survives all three.
+ * `config:best-practices` + one own rule, ~730 merged rules: 96 kB, 53 kB,
+ * 33 kB, <2 kB). The sentence a reader needs — "your `packageRules[0]` is
+ * merged rule 730, matching `matchSourceUrls: […]`" — survives all four.
  */
 export const RULE_DIGEST_PLANS = [
-  { authored: "values", presets: "values" },
-  { authored: "values", presets: "shape" },
-  { authored: "values", presets: "counts" },
+  { authored: "values", presets: "values", writers: true },
+  { authored: "values", presets: "shape", writers: true },
+  { authored: "values", presets: "shape", writers: false },
+  { authored: "values", presets: "counts", writers: false },
 ] as const satisfies readonly RuleDigestPlan[];
 
 export interface RuleContribution extends RuleSourceRange {
@@ -123,13 +130,16 @@ const NOTE =
   "overrides another, so a rule's merged index is its position in one array built end to end — " +
   "the index `simulate` and Renovate's own validator messages cite. A rule's index inside its " +
   "own layer is `index - from`; for the `repo` contribution that is the `packageRules[N]` you " +
-  "wrote. Rule BODIES are not included here: ask for one with `rule: <index>` (`--rule <n>` on " +
+  "wrote. A preset range names the extend the rules ARRIVED through; `[from X]` on a digest " +
+  "line names the nested preset that actually wrote that one rule, which is also what " +
+  "`rule: <index>` cites. Rule BODIES are not included here: ask for one with `rule: <index>` (`--rule <n>` on " +
   'the CLI), or for all of them with get_final_config `keys: ["packageRules"]`.';
 
 const DEGRADED_NOTE =
-  "the per-rule digest lines were reduced to fit this answer's size budget — the ranges above " +
-  'are complete regardless. Narrow with `source: "repo"` for the rules you wrote, or ask for ' +
-  "one rule's body with `rule: <index>`.";
+  "the per-rule digest lines were reduced to fit this answer's size budget — shorter lines, or " +
+  "no `[from X]` writer, or no lines at all; the ranges above are complete regardless. Narrow " +
+  'with `source: "repo"` for the rules you wrote, or ask for one rule\'s body and its exact ' +
+  "writer with `rule: <index>`.";
 
 /** Layer identity, not layer KIND: the same preset extended twice contributes
  *  two separate blocks, and reporting them as one range would invent a
@@ -150,11 +160,18 @@ function rangeOf(attr: RuleAttribution): RuleSourceRange {
 }
 
 /**
- * The attribution, compressed to one range per contributing layer.
+ * The attribution, compressed to one range per contributing TOP-LEVEL layer.
  *
  * `computeRuleProvenance` emits the merged indexes in order, one contiguous
  * block per layer, so a new range starts exactly where the layer identity
  * changes — the ranges are exact, not inferred.
+ *
+ * Per top-level layer, not per writing body, and that is the whole point: the
+ * ranges are the part of every answer here that must survive a byte budget
+ * whole (~200 bytes, immune to the elider), and a `config:best-practices` run
+ * has ~700 distinct writing bodies. Which nested preset wrote ONE rule is a
+ * per-rule question, answered per-rule by {@link ruleOrigin} — where it costs
+ * nothing — and by the digest lines below.
  */
 export function ruleSourceRanges(
   attribution: readonly RuleAttribution[] | null | undefined,
@@ -175,13 +192,25 @@ export function ruleSourceRanges(
   return ranges;
 }
 
-/** Which layer contributed one merged rule, and its index inside that layer. */
+/**
+ * Which config wrote one merged rule, and its index inside THAT config — the
+ * nested preset when the engine verified one (`writtenBy`), else the direct
+ * extend it arrived through. Both halves come from the same body: citing
+ * `config:best-practices packageRules[726]` for a rule the reader will find at
+ * `packageRules[3]` of `security:minimumReleaseAgeNpm` is two wrong answers.
+ */
 export function ruleOrigin(
   index: number,
   attribution: readonly RuleAttribution[] | null | undefined,
 ): RuleOrigin | undefined {
   const found = attribution?.find((attr) => attr.index === index);
-  return found ? { layer: layerLabel(found.layer), sourceIndex: found.sourceIndex } : undefined;
+  if (!found) {
+    return undefined;
+  }
+  return {
+    layer: layerLabel(ruleOriginLayer(found)),
+    sourceIndex: found.writtenBy?.sourceIndex ?? found.sourceIndex,
+  };
 }
 
 /** The selector keys of a rule, read off the app's own one-line summary so
@@ -192,17 +221,29 @@ function selectorKeys(rule: unknown): string[] {
   return summary.startsWith("(") ? [] : summary.split(" + ");
 }
 
-function digestLine(index: number, rule: unknown, detail: RuleDigestDetail): string {
+/**
+ * One rule's line. `writer` is appended when the rule came from a preset
+ * NESTED below the range's own extend — the range head says
+ * `config:best-practices` for all 731 of them, and this is the only place a
+ * whole-key answer can say which body actually wrote each one.
+ */
+function digestLine(
+  index: number,
+  rule: unknown,
+  detail: RuleDigestDetail,
+  writer: string | undefined,
+): string {
   const writes = ruleWrittenKeys(rule);
   const written = writes.length > 0 ? writes.join(", ") : "(sets nothing)";
+  const from = writer ? ` [from ${writer}]` : "";
   const selectors = selectorKeys(rule);
   const first = selectors[0];
   if (detail === "shape" || first === undefined) {
-    return `${index} ${summarizeRuleSelectors(rule)} → ${written}`;
+    return `${index} ${summarizeRuleSelectors(rule)} → ${written}${from}`;
   }
   const value = previewValue((rule as Record<string, unknown>)[first], 48);
   const more = selectors.length - 1;
-  return `${index} ${first}: ${value}${more > 0 ? ` +${more}` : ""} → ${written}`;
+  return `${index} ${first}: ${value}${more > 0 ? ` +${more}` : ""} → ${written}${from}`;
 }
 
 /** Global, inherited and the repo's own config — the layers a person WROTE,
@@ -257,6 +298,11 @@ export function ruleProvenanceView(
   if (!attribution) {
     return { ...base, attributionNote: ATTRIBUTION_NOTE };
   }
+  const writerByIndex = plan.writers
+    ? new Map(
+        attribution.flatMap((attr) => (attr.writtenBy ? [[attr.index, attr.writtenBy.name]] : [])),
+      )
+    : new Map<number, string>();
   const contributions = ruleSourceRanges(attribution)
     .filter((range) => keepRange(range.kind, source))
     .map((range) => {
@@ -266,13 +312,13 @@ export function ruleProvenanceView(
       }
       const lines: string[] = [];
       for (let index = range.from; index <= range.to; index += 1) {
-        lines.push(digestLine(index, rules[index], detail));
+        lines.push(digestLine(index, rules[index], detail, writerByIndex.get(index)));
       }
       return { ...range, rules: lines };
     });
-  const degraded = contributions.some(
-    (range) => detailFor(range.kind, plan) !== "values" && range.count > 0,
-  );
+  const degraded =
+    contributions.some((range) => detailFor(range.kind, plan) !== "values" && range.count > 0) ||
+    (!plan.writers && attribution.some((attr) => attr.writtenBy));
   return {
     ...base,
     contributions,

--- a/packages/engine/src/trace/description-provenance.ts
+++ b/packages/engine/src/trace/description-provenance.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from "../lib";
 import { getDefaultConfig, internalPresetGroups } from "../renovate-adapter";
 import type { PresetNode, TraceResult } from "./model";
-import { computeRuleProvenance, type ProvenanceLayer } from "./provenance";
+import { computeRuleProvenance, type ProvenanceLayer, type RuleAttribution } from "./provenance";
 import { mergingChildren } from "./tree";
 
 /**
@@ -114,8 +114,9 @@ export interface UnattributedDescription {
 
 /**
  * `packageRules[n].description` is never hoisted to the top level, so it is
- * attributed separately — and only to the LAYER that contributed the rule
- * (which is all `computeRuleProvenance` knows), not to the exact node.
+ * attributed separately — from `computeRuleProvenance` rather than from this
+ * module's own replay, hence the arrival LAYER plus the nested node that wrote
+ * the rule, when that walk could verify one.
  */
 export interface RuleDescriptionAttribution {
   /** 0-based index into the final merged `packageRules` array. */
@@ -123,6 +124,9 @@ export interface RuleDescriptionAttribution {
   /** 0-based index within the contributing layer's own `packageRules` array. */
   sourceIndex: number;
   layer: ProvenanceLayer;
+  /** The nested preset whose own body wrote the rule — see
+   *  {@link RuleAttribution.writtenBy}. */
+  writtenBy?: RuleAttribution["writtenBy"];
   values: string[];
 }
 
@@ -396,10 +400,16 @@ function ruleDescriptions(result: TraceResult): RuleDescriptionAttribution[] {
     return [];
   }
   const out: RuleDescriptionAttribution[] = [];
-  for (const { index, layer, sourceIndex } of attribution) {
+  for (const { index, layer, sourceIndex, writtenBy } of attribution) {
     const values = descriptionsOf(rules[index]);
     if (values.length > 0) {
-      out.push({ ruleIndex: index, sourceIndex, layer, values });
+      out.push({
+        ruleIndex: index,
+        sourceIndex,
+        layer,
+        ...(writtenBy ? { writtenBy } : {}),
+        values,
+      });
     }
   }
   return out;

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -373,10 +373,54 @@ export interface RuleAttribution {
   /** 0-based index of this entry within that layer's OWN `packageRules` array — e.g. the
    *  repo-config index a validator message like `packageRules[1]` refers to, when `layer.kind === "repo"`. */
   sourceIndex: number;
+  /**
+   * The preset NESTED below the direct extend `layer` names whose own body
+   * wrote this rule (`security:minimumReleaseAgeNpm` writing what
+   * `config:best-practices` carries in), with the index the rule has in THAT
+   * body. Present only when the layer is a preset, the writer is not that
+   * direct extend itself, and the subtree replay tiled the extend's
+   * ground-truth array exactly — the same honesty rule
+   * {@link ProvenanceStep.writtenBy} follows: absence over a guess.
+   */
+  writtenBy?: { nodeId: string; name: string; sourceIndex: number };
 }
 
 function ownRuleCount(config: Obj): number {
   return Array.isArray(config.packageRules) ? config.packageRules.length : 0;
+}
+
+/**
+ * Which nested body wrote each rule of a direct extend's slice, by walking the
+ * subtree in `resolveConfigPresets`' own merge order — children first, the
+ * node's own body last, exactly the order `mergeChildConfig` concatenates in.
+ * The visited bodies' `packageRules` therefore tile the extend's resolved
+ * array, and position alone identifies the writer; no value matching involved.
+ *
+ * `undefined` when the tiles don't sum to the extend's ground-truth length (a
+ * `packageRules[n].extends` expanded later would do it) — the layer then keeps
+ * its coarse attribution rather than gaining a wrong leaf.
+ */
+function ruleWriters(
+  node: PresetNode,
+  expected: number,
+): (RuleAttribution["writtenBy"] | undefined)[] | undefined {
+  const writers: (RuleAttribution["writtenBy"] | undefined)[] = [];
+  walkResolutionOrder(node, (visited) => {
+    const input = visited.input;
+    const own = isPlainObject(input) ? input.packageRules : undefined;
+    if (!Array.isArray(own)) {
+      return;
+    }
+    for (let sourceIndex = 0; sourceIndex < own.length; sourceIndex++) {
+      // The direct extend writing its own rule is what the layer already says.
+      writers.push(
+        visited.id === node.id
+          ? undefined
+          : { nodeId: visited.id, name: visited.name, sourceIndex },
+      );
+    }
+  });
+  return writers.length === expected ? writers : undefined;
 }
 
 /**
@@ -408,10 +452,17 @@ export function computeRuleProvenance(result: TraceResult): RuleAttribution[] | 
 
   const attribution: RuleAttribution[] = [];
   let offset = 0;
-  for (const { layer, config } of layers) {
+  for (const { layer, config, node } of layers) {
     const count = ownRuleCount(config);
+    const writers = node ? ruleWriters(node, count) : undefined;
     for (let sourceIndex = 0; sourceIndex < count; sourceIndex++) {
-      attribution.push({ index: offset + sourceIndex, layer, sourceIndex });
+      const writtenBy = writers?.[sourceIndex];
+      attribution.push({
+        index: offset + sourceIndex,
+        layer,
+        sourceIndex,
+        ...(writtenBy ? { writtenBy } : {}),
+      });
     }
     offset += count;
   }

--- a/packages/engine/test/provenance.shimmed.test.ts
+++ b/packages/engine/test/provenance.shimmed.test.ts
@@ -252,3 +252,100 @@ describe("computeRuleProvenance (013)", () => {
     expect(computeRuleProvenance(result)).toBeUndefined();
   });
 });
+
+/**
+ * The nested half of 013: which BODY inside a direct extend's subtree wrote a
+ * merged rule. `config:best-practices` contributes all ~730 rules of a real run
+ * and authors none of them, so a layer-only attribution names a preset that
+ * wrote nothing — the asymmetry `ProvenanceStep.writtenBy` already fixed for
+ * scalar keys.
+ */
+const leafTwoRules = [
+  { matchPackageNames: ["two-a"], automerge: true },
+  { matchPackageNames: ["two-b"], automerge: true },
+];
+
+const nestedPresets = {
+  // The direct extend: two nested bodies, then two rules of its own.
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/umbrella" })]: {
+    extends: ["github>test-org/leaf-one", "github>test-org/leaf-two"],
+    packageRules: [
+      { matchPackageNames: ["own-a"], enabled: false },
+      { matchPackageNames: ["own-b"], enabled: false },
+    ],
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/leaf-one" })]: {
+    packageRules: [{ matchPackageNames: ["one-a"], automerge: true }],
+  },
+  [presetInjectionKey({ presetSource: "github", repo: "test-org/leaf-two" })]: {
+    packageRules: leafTwoRules,
+  },
+};
+
+async function nestedAttribution(content: string): Promise<RuleAttribution[]> {
+  const result = await runPipeline({
+    fileName: "renovate.json",
+    content,
+    injectedPresets: nestedPresets,
+  });
+  expect(result.stageStatus.preset).toBe("ok");
+  return must(computeRuleProvenance(result), "the rule attribution");
+}
+
+/** `<writer>[<index in that writer>]`, or `-` for a rule with no nested writer. */
+function writerRef(attr: RuleAttribution): string {
+  return attr.writtenBy ? `${attr.writtenBy.name}[${attr.writtenBy.sourceIndex}]` : "-";
+}
+
+describe("computeRuleProvenance nested writers", () => {
+  it("names the nested body that wrote each rule, with the index it has THERE", async () => {
+    const attribution = await nestedAttribution(
+      JSON.stringify({
+        extends: ["github>test-org/umbrella"],
+        packageRules: [{ matchPackageNames: ["mine"], enabled: false }],
+      }),
+    );
+    // Resolution order is children first, the node's own body last — the order
+    // `mergeChildConfig` concatenates in — so the merged array tiles as
+    // leaf-one, leaf-two, umbrella's own, then the repo's own.
+    expect(
+      attribution.map((a) => [a.index, attrLayerName(a), a.sourceIndex, writerRef(a)]),
+    ).toEqual([
+      [0, "github>test-org/umbrella", 0, "github>test-org/leaf-one[0]"],
+      [1, "github>test-org/umbrella", 1, "github>test-org/leaf-two[0]"],
+      [2, "github>test-org/umbrella", 2, "github>test-org/leaf-two[1]"],
+      // The direct extend's own rules carry no writer: naming it again is
+      // exactly what `layer` already says.
+      [3, "github>test-org/umbrella", 3, "-"],
+      [4, "github>test-org/umbrella", 4, "-"],
+      [5, "repo", 0, "-"],
+    ]);
+  });
+
+  it("the writer's own index points at the rule a reader would find in that preset", async () => {
+    const attribution = await nestedAttribution(
+      JSON.stringify({ extends: ["github>test-org/umbrella"] }),
+    );
+    const twoB = must(
+      attribution.find((a) => writerRef(a) === "github>test-org/leaf-two[1]"),
+      "the leaf-two[1] attribution",
+    );
+    expect(leafTwoRules[twoB.writtenBy?.sourceIndex ?? -1]).toMatchObject({
+      matchPackageNames: ["two-b"],
+    });
+  });
+
+  it("reports no writer when the extend's own rules are all it has", async () => {
+    const attribution = await nestedAttribution(
+      JSON.stringify({ extends: ["github>test-org/leaf-one"] }),
+    );
+    expect(attribution.map(writerRef)).toEqual(["-"]);
+  });
+
+  it("leaves the repo layer alone — it has no subtree to descend into", async () => {
+    const attribution = await nestedAttribution(
+      JSON.stringify({ packageRules: [{ matchPackageNames: ["mine"], enabled: false }] }),
+    );
+    expect(attribution).toEqual([{ index: 0, layer: { kind: "repo" }, sourceIndex: 0 }]);
+  });
+});

--- a/roadmap/013-rule-identity-and-provenance.md
+++ b/roadmap/013-rule-identity-and-provenance.md
@@ -1,6 +1,31 @@
 # 013 — Rule identity: one numbering, provenance chips, cross-links
 
-Milestone: M5 · Status: done 2026-07-24
+Milestone: M5 · Status: done 2026-07-24 · amended 2026-08-27
+
+> **Amendment (2026-08-27): the chips named the wrong preset.** The
+> attribution below stops at the DIRECT extend, so every one of a
+> `config:best-practices` run's 731 rules wore a `config:best-practices` chip —
+> a preset that writes none of them. The Effective Config tab had not had this
+> problem for scalar keys since `ProvenanceStep.writtenBy`; its own per-rule
+> list had, and the Tests tab had it everywhere (rule rows, merge stops, pin
+> buckets, the preset facet whose one option covered all 731).
+>
+> `RuleAttribution` now carries `writtenBy` — the nested body that wrote the
+> rule, plus the index it has THERE — found by walking the extend's subtree in
+> `walkResolutionOrder` (children first, own body last: the order
+> `mergeChildConfig` concatenates in), so the visited bodies tile the extend's
+> resolved array and position alone identifies the writer. Same honesty rule as
+> the rest of this module: when the tiles don't sum to the ground-truth length,
+> the layer keeps its coarse attribution rather than gaining a wrong leaf.
+>
+> `ruleLayerIndex` resolves to that writer, which is what every "which preset
+> is this rule from" surface reads. The CLI's per-rule citation (`ruleOrigin`)
+> takes both halves from the writing body — `packageRules[0]` of
+> `security:minimumReleaseAgeNpm`, not `packageRules[726]` of an extend whose
+> own body has no rule 726. `ruleSourceRanges` deliberately stays per top-level
+> layer: those ranges are the ~200 bytes of every MCP answer that must survive
+> the byte budget whole, and there are ~700 writing bodies. The writer reaches
+> that view as `[from X]` on the digest lines, which already degrade.
 
 > Implemented as specified. Engine: `computeRuleProvenance` (013) attributes
 > every entry of the merged `finalConfig.packageRules` to its contributing


### PR DESCRIPTION
The Tests tab named a preset that wrote none of the rules it was labelling.

## The bug

`computeRuleProvenance` attributed every merged `packageRules` entry to the **direct extend** it arrived through, never descending into the preset tree. On a `{"extends": ["config:best-practices"]}` config that means all 731 rules wear a `config:best-practices` chip — a preset whose own body writes zero rules.

The Effective Config tab's cascade had not had this problem since `ProvenanceStep.writtenBy`, which is exactly where the asymmetry showed:

| surface | before |
| --- | --- |
| Effective Config cascade (`dependencyDashboard`) | `layer: config:best-practices`, `writtenBy: :dependencyDashboard` ✅ |
| Effective Config per-rule list | `config:best-practices` ❌ |
| Tests tab rule rows / merge stops / pin buckets | `config:best-practices` ❌ |
| Tests tab preset facet | one option, `config:best-practices (731)` ❌ |

The engine already documented the gap, in `description-provenance.ts`: *"attributed separately — and only to the LAYER that contributed the rule (which is all `computeRuleProvenance` knows), not to the exact node."*

## The fix

`RuleAttribution` gains `writtenBy: { nodeId, name, sourceIndex }` — the nested body that wrote the rule, plus the index the rule has in **that** body.

It is recovered by walking each direct extend's subtree with `walkResolutionOrder` (children first, own body last — the order `mergeChildConfig` concatenates in). The visited bodies therefore tile the extend's resolved array exactly, and position alone identifies the writer; no value matching is involved. If the tiles don't sum to the ground-truth length (a `packageRules[n].extends` expanded later would do it), the layer keeps its coarse attribution rather than gaining a wrong leaf — the same honesty rule the rest of the module follows.

**App.** `ruleLayerIndex` resolves to that writer. One change, and every consumer follows: rule rows, merge stops, verdict threads, pin buckets, rule evidence, the preset facet and its counts, plus Effective Config's own per-rule list. The chip's tree jump now lands on the originating node.

**CLI.** Per-rule citations take both halves from the writing body — `packageRules[0]` of `security:minimumReleaseAgeNpm`, not `packageRules[726]` of an extend whose own body has no rule 726.

`ruleSourceRanges` **deliberately stays per top-level layer**: those ranges are the ~200 bytes of every MCP answer that must survive the byte budget whole, and a best-practices run has ~700 distinct writing bodies. The writer reaches that view as `[from X]` on the digest lines, with a new budget rung that drops the marker *before* it ever drops a line — one line per merged rule stays the older promise.

## Verified

Same run as the diagnosis, now correct:

```
#525 → mergeConfidence:age-confidence-badges packageRules[0]
#722 → abandonments:recommended              packageRules[0]
#726 → security:minimumReleaseAgeNpm         packageRules[0]
```

New tests:

- **engine** (`provenance.shimmed.test.ts`) — 4: tiling order, the writer's own index, an extend with only its own rules, the repo layer
- **app unit** (`rule-filters.test.ts`) — 1
- **app shimmed component** (`TestsPanel.shimmed.test.tsx`) — 1: the Tests tab renders the nested leaf and *not* the umbrella extend. The direct regression test.
- **cli** (`rule-provenance.test.ts`) — 2: nested citation, and the writer being dropped before any line is

Two existing MCP tests were updated to the corrected behaviour.

Full gate green: `format`, `lint`, `typecheck`, 1957 unit/integration tests, 127 e2e.
