### PR TITLE
fix(deps): update dependency renovate to v44.41.0

### DIFF
--- a/packages/app/src/features/effective-config/BlameLedger.test.tsx
+++ b/packages/app/src/features/effective-config/BlameLedger.test.tsx
@@ -87,7 +87,7 @@ test("marks an approximate drop and hedges its reason", () => {
       {
         value: "Group Jest packages.",
         node: { nodeId: "n5", name: "group:recommended" },
-        reason: "ignore-deps-quirk",
+        reason: "description-override",
         droppedBy: { nodeId: "n6", name: "group:jestPlusTypes" },
         approximate: true,
       },

--- a/packages/app/src/features/effective-config/BlameLedger.tsx
+++ b/packages/app/src/features/effective-config/BlameLedger.tsx
@@ -276,11 +276,11 @@ function DroppedList({
 }
 
 /**
- * The quiet footer. Three Renovate quirks delete a description before it can
+ * The quiet footer. Three Renovate rules remove a description before it can
  * merge (069 PR 1) — including `config:best-practices`' own one-liner — and
  * "my preset's description is missing" is otherwise an unanswerable question.
  * A footnote, so it stays out of the way until the ledger's one reveal asks for
- * it: on a real config the `ignoreDeps: []` mute alone drops 135 sentences.
+ * it: on a real config the `overrideDescription` mute alone drops 140 sentences.
  */
 function DroppedSection({
   dropped,

--- a/packages/app/src/features/effective-config/drop-reasons.test.ts
+++ b/packages/app/src/features/effective-config/drop-reasons.test.ts
@@ -24,7 +24,7 @@ const packageList: DroppedDescription = {
 const muted: DroppedDescription = {
   value: "Group Jest packages.",
   node: { nodeId: "n5", name: "group:jestPlusTypes" },
-  reason: "ignore-deps-quirk",
+  reason: "description-override",
   droppedBy: { nodeId: "n6", name: "group:recommended" },
 };
 
@@ -35,7 +35,7 @@ describe("dropReasonText", () => {
     // The mute names the extending config, because that is the config the
     // reader can change.
     expect(dropReasonText(muted)).toBe(
-      "muted by `group:recommended` — its empty `ignoreDeps` deletes every description it extends",
+      "muted by `group:recommended` — its `overrideDescription` replaces every description it resolved",
     );
   });
 
@@ -63,7 +63,7 @@ test("every reason the engine can report has wording", () => {
   const reasons: DroppedDescriptionReason[] = [
     "wrapper-preset",
     "package-list-preset",
-    "ignore-deps-quirk",
+    "description-override",
   ];
 
   expect(Object.keys(DROP_REASONS).toSorted()).toEqual(reasons.toSorted());

--- a/packages/app/src/features/effective-config/drop-reasons.ts
+++ b/packages/app/src/features/effective-config/drop-reasons.ts
@@ -49,10 +49,10 @@ export const DROP_REASONS: Record<DroppedDescriptionReason, DropReasonWording> =
     label: () => "package-name list",
     why: "Renovate drops the description of a preset that only lists `matchPackageNames`",
   },
-  "ignore-deps-quirk": {
+  "description-override": {
     label: (drop) =>
       `muted by ${drop.droppedBy ? `\`${drop.droppedBy.name}\`` : "the extending config"}`,
-    why: "its empty `ignoreDeps` deletes every description it extends",
+    why: "its `overrideDescription` replaces every description it resolved",
   },
 };
 

--- a/packages/app/src/lib/tree-descriptions.test.ts
+++ b/packages/app/src/lib/tree-descriptions.test.ts
@@ -247,7 +247,7 @@ describe("buildTreeDescriptions — drops", () => {
   const MUTED: DroppedDescription = {
     value: "Group known monorepo packages together.",
     node: { nodeId: "p5", name: "group:monorepos" },
-    reason: "ignore-deps-quirk",
+    reason: "description-override",
     droppedBy: { nodeId: "p4", name: "group:recommended" },
   };
 
@@ -295,6 +295,22 @@ describe("buildTreeDescriptions — drops", () => {
     ]);
     expect(tree.byNodeId.get("p4")?.lines[1]?.note).toBe(muteNoteText(2));
     expect(tree.byNodeId.get("p5")?.lines[0]?.kind).toBe("dropped");
+  });
+
+  test("lets one node be both the author and the muter of the same sentence", () => {
+    // An `overrideDescription` replaces the resolved description of the whole
+    // subtree INCLUDING the overriding node's own sentence, so the node that
+    // pressed the button can be the author of one of the drops.
+    const own: DroppedDescription = {
+      value: "Group known monorepo packages together.",
+      node: { nodeId: "p4", name: "group:recommended" },
+      reason: "description-override",
+      droppedBy: { nodeId: "p4", name: "group:recommended" },
+    };
+    const tree = built(provenance({ entries: [], dropped: [own] }));
+
+    expect(tree.byNodeId.get("p4")?.lines.map((line) => line.kind)).toEqual(["dropped", "mute"]);
+    expect(tree.byNodeId.get("p4")?.lines[1]?.note).toBe(muteNoteText(1));
   });
 
   test("does not attach a mute note to the repo config, which renders no row", () => {
@@ -381,8 +397,8 @@ describe("wording", () => {
   });
 
   test("the mute note and the title count agree with English", () => {
-    expect(muteNoteText(1)).toBe("mutes 1 description below (empty `ignoreDeps`)");
-    expect(muteNoteText(135)).toBe("mutes 135 descriptions below (empty `ignoreDeps`)");
+    expect(muteNoteText(1)).toBe("mutes 1 description below (`overrideDescription`)");
+    expect(muteNoteText(135)).toBe("mutes 135 descriptions below (`overrideDescription`)");
 
     expect(countText(0)).toBe("none contribute descriptions");
     expect(countText(1)).toBe("1 contributes a description");

--- a/packages/app/src/lib/tree-descriptions.ts
+++ b/packages/app/src/lib/tree-descriptions.ts
@@ -50,7 +50,7 @@ export interface PositionMarker {
  * preset's best self-description — so it renders plainly (it simply carries no
  * slot marker), and the drop mechanics stay on the blame ledger's footer,
  * where "where did my description go in the final array" is the question.
- * `mute` — the note on the node that CAUSED such drops (`ignoreDeps: []`).
+ * `mute` — the note on the node that CAUSED such drops (`overrideDescription`).
  */
 export type DescLineKind = "contribution" | "dropped" | "mute";
 
@@ -179,8 +179,10 @@ export function buildTreeDescriptions(provenance: DescriptionProvenance): TreeDe
         ),
       );
     }
-    // …and the mute button that pressed it, which is a different node and the
-    // one a reader would actually remove.
+    // …and the mute button that pressed it — usually a different node, and the
+    // one a reader would actually remove. An `overrideDescription` replaces the
+    // overriding node's OWN sentence too, so the two can be the same node: it
+    // then carries both its dropped line and the note.
     const by = drop.droppedBy;
     if (by && by.nodeId !== ROOT_NODE_ID) {
       mutes.set(by.nodeId, (mutes.get(by.nodeId) ?? 0) + 1);
@@ -265,7 +267,7 @@ export function zipDescLines(facts: NodeDescriptionFacts): DescLineWithMarker[] 
  * lists drops, never their causes, so there is no twin to drift from.
  */
 export function muteNoteText(count: number): string {
-  return `mutes ${plural(count, "description")} below (empty \`ignoreDeps\`)`;
+  return `mutes ${plural(count, "description")} below (\`overrideDescription\`)`;
 }
 
 /** The card title's count — the cue that the tree has descriptions to show. */

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -22,7 +22,7 @@
     "fast-json-patch": "3.1.1",
     "json5": "2.2.3",
     "pathe": "^2.0.3",
-    "renovate": "44.39.1"
+    "renovate": "44.41.0"
   },
   "devDependencies": {
     "typescript": "7.0.2",

--- a/packages/engine/src/lib.ts
+++ b/packages/engine/src/lib.ts
@@ -16,6 +16,19 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 /**
+ * The members of an `allowString` array option, in the form Renovate holds
+ * them: `massageConfig` coerces `"x"` to `["x"]`, but a raw `fetched` preset
+ * body has not been through it. Members are returned untouched, non-strings
+ * included — Renovate only warns about those and keeps them.
+ */
+export function allowStringMembers(value: unknown): unknown[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  return Array.isArray(value) ? value : [];
+}
+
+/**
  * Equality by JSON text. Cheap and exact for the JSON-shaped config values the
  * simulator compares, but ORDER-SENSITIVE: `{a:1,b:2}` and `{b:2,a:1}` compare
  * unequal. Callers that need structural equality use `deepEqual` in

--- a/packages/engine/src/registry-names.generated.ts
+++ b/packages/engine/src/registry-names.generated.ts
@@ -1,7 +1,7 @@
 /**
  * GENERATED FILE — do not hand-edit.
  *
- * Produced by `scripts/generate-registry-names.mjs` from renovate@44.39.1's
+ * Produced by `scripts/generate-registry-names.mjs` from renovate@44.41.0's
  * own datasource/manager registries (`renovate/dist/modules/{datasource,manager}/api.js`).
  * Regenerate with `pnpm --filter @renovate-config-debugger/engine generate:registries`
  * after bumping the `renovate` dependency — see that script's header for why

--- a/packages/engine/src/trace/description-provenance.ts
+++ b/packages/engine/src/trace/description-provenance.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "../lib";
+import { allowStringMembers, isPlainObject } from "../lib";
 import { getDefaultConfig, internalPresetGroups } from "../renovate-adapter";
 import type { PresetNode, TraceResult } from "./model";
 import { computeRuleProvenance, type ProvenanceLayer, type RuleAttribution } from "./provenance";
@@ -20,16 +20,17 @@ import { mergingChildren } from "./tree";
  * tree therefore reproduces the exact index of every string, so two nodes that
  * happen to write the same sentence still attribute to their own node.
  *
- * Three Renovate quirks silently delete descriptions before they ever reach
+ * Three Renovate rules silently remove descriptions before they ever reach
  * the merge — all three are reported in `dropped` rather than left unexplained:
  *
  * - **wrapper-preset** — `getPreset` deletes the description of a preset whose
  *   keys are exactly `{description, extends}` (e.g. `config:best-practices`).
  * - **package-list-preset** — same, for a preset whose keys are a subset of
  *   `{description, matchPackageNames}`.
- * - **ignore-deps-quirk** — a config carrying `ignoreDeps: []` (length zero)
- *   makes `resolveConfigPresets` delete the WHOLE resolved description of every
- *   preset it extends.
+ * - **description-override** — a config carrying a non-empty
+ *   `overrideDescription` makes `resolveConfigPresets` REPLACE the whole
+ *   description it resolved — its subtree's sentences and its own — with that
+ *   override, which the overriding node then owns.
  *
  * The first two happen inside `getPreset`, i.e. before the node's `input` is
  * captured, so they are detected from the node's raw pre-migration body — not
@@ -83,14 +84,14 @@ export interface DescriptionAttribution {
 export type DroppedDescriptionReason =
   | "wrapper-preset"
   | "package-list-preset"
-  | "ignore-deps-quirk";
+  | "description-override";
 
 export interface DroppedDescription {
   value: string;
   /** The node that authored the string. */
   node: DescriptionSource;
   reason: DroppedDescriptionReason;
-  /** `ignore-deps-quirk` only: the extending node whose `ignoreDeps: []` deleted it. */
+  /** `description-override` only: the node whose `overrideDescription` replaced it. */
   droppedBy?: DescriptionSource;
   /**
    * The authoring node is a guess: the drop came out of a subtree that had
@@ -149,21 +150,11 @@ export interface DescriptionProvenance {
 }
 
 /**
- * A config body's `description` as the array Renovate holds. `input`/`resolved`
- * are already massaged (so `allowString` has coerced `"x"` to `["x"]`), but raw
- * `fetched` bodies are not — and a hand-injected preset may be anything — so
- * the string form is still coerced here. Members are returned untouched,
- * non-strings included: they are real positions in the array.
+ * A config body's `description` as the array Renovate holds — members
+ * untouched, non-strings included: they are real positions in the array.
  */
 function descriptionMembersOf(body: unknown): unknown[] {
-  if (!isPlainObject(body)) {
-    return [];
-  }
-  const value = body.description;
-  if (typeof value === "string") {
-    return [value];
-  }
-  return Array.isArray(value) ? value : [];
+  return isPlainObject(body) ? allowStringMembers(body.description) : [];
 }
 
 /**
@@ -180,10 +171,22 @@ function sourceOf(node: PresetNode): DescriptionSource {
   return { nodeId: node.id, name: node.name };
 }
 
-/** Renovate's `inputConfig?.ignoreDeps?.length === 0` guard, on a node's own body. */
-function dropsChildDescriptions(node: PresetNode): boolean {
-  const input = node.input;
-  return isPlainObject(input) && Array.isArray(input.ignoreDeps) && input.ignoreDeps.length === 0;
+/**
+ * A node's own `overrideDescription` members, or undefined when it has none —
+ * Renovate's `config.overrideDescription?.length` guard, read off the node's own
+ * body because a child's override is consumed (and deleted) at the child's own
+ * level and never reaches its parent.
+ *
+ * Members, not strings: the guard is upstream's length check on the raw value,
+ * so `overrideDescription: [42]` overrides too (with a member no preset can be
+ * held responsible for), while `[]` does not.
+ */
+function overrideMembersOf(node: PresetNode): unknown[] | undefined {
+  if (!isPlainObject(node.input)) {
+    return undefined;
+  }
+  const members = allowStringMembers(node.input.overrideDescription);
+  return members.length > 0 ? members : undefined;
 }
 
 /**
@@ -307,34 +310,70 @@ function valuesMatch(contributions: Contribution[], truth: string[]): boolean {
 }
 
 /**
+ * Contributions an `overrideDescription` replaced, recorded as drops rather
+ * than left as an unexplained absence. `fallbackAuthor` names the writer for a
+ * string the walk could not attribute to a node of its own; `overriddenBy` is
+ * the node whose override did it.
+ */
+function divertOverridden(
+  contributions: Contribution[],
+  fallbackAuthor: PresetNode,
+  overriddenBy: PresetNode,
+  dropped: DroppedDescription[],
+): void {
+  for (const contribution of contributions) {
+    dropped.push({
+      value: contribution.value,
+      node: contribution.node ?? sourceOf(fallbackAuthor),
+      reason: "description-override",
+      droppedBy: sourceOf(overriddenBy),
+      // a guessed author stays labelled as a guess once it is a drop
+      ...(contribution.approximate ? { approximate: true } : {}),
+    });
+  }
+}
+
+/**
  * Everything one merging child of `parent` contributes: its own `getPreset`
- * drop, its subtree, and — when `quirk` says the parent carries
- * `ignoreDeps: []` — the diversion of that whole subtree into `dropped`,
+ * drop, its subtree, and — when `overridden` says the parent carries an
+ * `overrideDescription` — the diversion of that whole subtree into `dropped`,
  * leaving nothing to merge. Shared by `walk` and the root level, which differ
  * only in what they do with the returned contributions.
  */
 function processChild(
   parent: PresetNode,
   child: PresetNode,
-  quirk: boolean,
+  overridden: boolean,
   dropped: DroppedDescription[],
 ): WalkResult {
   recordOwnDrop(child, dropped);
   const sub = walk(child, dropped);
-  if (!quirk) {
+  if (!overridden) {
     return sub;
   }
-  for (const contribution of sub.contributions) {
-    dropped.push({
-      value: contribution.value,
-      node: contribution.node ?? sourceOf(child),
-      reason: "ignore-deps-quirk",
-      droppedBy: sourceOf(parent),
-      // a guessed author stays labelled as a guess once it is a drop
-      ...(contribution.approximate ? { approximate: true } : {}),
-    });
-  }
+  divertOverridden(sub.contributions, child, parent, dropped);
   return { contributions: [], degraded: sub.degraded };
+}
+
+/**
+ * The node's OWN contribution: its `description` strings, or — when it carries
+ * an `overrideDescription` — that override, with the description it replaces
+ * (the node's own sentence, on top of the subtree `processChild` already
+ * diverted) recorded as a drop the node itself caused.
+ */
+function ownContributionsOf(
+  node: PresetNode,
+  override: unknown[] | undefined,
+  dropped: DroppedDescription[],
+): Contribution[] {
+  const own = descriptionsOf(node.input).map((value) => ({ value, node: sourceOf(node) }));
+  if (!override) {
+    return own;
+  }
+  divertOverridden(own, node, node, dropped);
+  return override
+    .filter((member): member is string => typeof member === "string")
+    .map((value) => ({ value, node: sourceOf(node) }));
 }
 
 /**
@@ -345,17 +384,15 @@ function processChild(
 function walk(node: PresetNode, dropped: DroppedDescription[]): WalkResult {
   const contributions: Contribution[] = [];
   let degraded = false;
-  const quirk = dropsChildDescriptions(node);
+  const override = overrideMembersOf(node);
 
   for (const child of mergingChildren(node)) {
-    const sub = processChild(node, child, quirk, dropped);
+    const sub = processChild(node, child, override !== undefined, dropped);
     degraded ||= sub.degraded;
     contributions.push(...sub.contributions);
   }
 
-  for (const value of descriptionsOf(node.input)) {
-    contributions.push({ value, node: sourceOf(node) });
-  }
+  contributions.push(...ownContributionsOf(node, override, dropped));
 
   if (node.resolved === undefined) {
     return { contributions, degraded };
@@ -456,12 +493,12 @@ export function computeDescriptionProvenance(
 
   // The root level is walked here rather than through `walk` so that each
   // string keeps the direct-extend layer it arrived through.
-  const rootQuirk = dropsChildDescriptions(root);
+  const rootOverride = overrideMembersOf(root);
   const rootContributions: Contribution[] = [];
   for (const child of mergingChildren(root)) {
-    const sub = processChild(root, child, rootQuirk, dropped);
+    const sub = processChild(root, child, rootOverride !== undefined, dropped);
     degraded ||= sub.degraded;
-    if (rootQuirk) {
+    if (rootOverride) {
       continue;
     }
     layered.push({
@@ -470,10 +507,9 @@ export function computeDescriptionProvenance(
     });
     rootContributions.push(...sub.contributions);
   }
-  const ownContributions: Contribution[] = descriptionsOf(root.input).map((value) => ({
-    value,
-    node: sourceOf(root),
-  }));
+  // A repo-level override owns its strings, so they arrive through the `repo`
+  // layer like any other sentence the root wrote.
+  const ownContributions = ownContributionsOf(root, rootOverride, dropped);
   rootContributions.push(...ownContributions);
   layered.push({ layer: { kind: "repo" }, contributions: ownContributions });
 

--- a/packages/engine/src/trace/provenance.ts
+++ b/packages/engine/src/trace/provenance.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "../lib";
+import { allowStringMembers, isPlainObject } from "../lib";
 import { getDefaultConfig, getOptions, mergeChildConfig } from "../renovate-adapter";
 import type { PresetNode, TraceResult } from "./model";
 import { mergingChildren, walkResolutionOrder } from "./tree";
@@ -93,6 +93,9 @@ interface Layer {
   config: Obj;
   /** The tree node behind a preset layer — what the writer walk descends into. */
   node?: PresetNode;
+  /** Keys this layer REPLACES rather than merges, whatever the option's
+   *  `mergeable` flag says — `overrideDescription` is the only one. */
+  replaces?: ReadonlySet<string>;
 }
 
 /**
@@ -116,14 +119,30 @@ function buildLayers(root: PresetNode, layerConfigs: TraceResult["layerConfigs"]
     });
   }
   const repo = structuredClone(root.input) as Obj;
-  delete repo.extends;
-  delete repo.ignorePresets;
-  layers.push({ layer: { kind: "repo" }, config: repo });
+  // `overrideDescription` is consumed into `description`, replacing everything
+  // the presets appended — so the repo layer contributes it as the OVERWRITE it
+  // is, not as the append `description` normally gets. (Which sentence each
+  // preset lost is 069's ledger, not this chain's.)
+  const override = allowStringMembers(repo.overrideDescription);
+  const replaces = override.length > 0 ? new Set(["description"]) : undefined;
+  if (replaces) {
+    repo.description = override;
+  }
+  for (const key of RESOLUTION_KEYS) {
+    delete repo[key];
+  }
+  layers.push({ layer: { kind: "repo" }, config: repo, ...(replaces ? { replaces } : {}) });
   return layers;
 }
 
-/** Keys consumed by preset resolution itself — never a body's own contribution. */
-const RESOLUTION_KEYS = new Set(["extends", "ignorePresets"]);
+/**
+ * Keys `resolveConfigPresets` consumes and deletes — never a body's own
+ * contribution to a final value, so a chain that showed one would claim a
+ * winner the final config contradicts. `overrideDescription` is consumed into
+ * `description`; where its sentences went is the description ledger's story
+ * (069), not this key's.
+ */
+const RESOLUTION_KEYS = new Set(["extends", "ignorePresets", "overrideDescription"]);
 
 interface KeyWriter {
   /** Last node in resolution order whose own body carries the key — the
@@ -233,9 +252,12 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
   // layer owns.
   let acc: Obj = {};
   let accBase: Obj = {};
-  for (const [layerIndex, { layer, config, node }] of layers.entries()) {
+  for (const [layerIndex, { layer, config, node, replaces }] of layers.entries()) {
     const before = acc;
     const after = mergeChildConfig(structuredClone(before), structuredClone(config)) as Obj;
+    for (const key of replaces ?? []) {
+      after[key] = structuredClone(config[key]);
+    }
     if (layerIndex < baseLayerCount) {
       accBase = after;
     }
@@ -244,7 +266,8 @@ export function computeProvenance(result: TraceResult): Map<string, KeyProvenanc
       const opt = optionMap.get(key);
       const parentVal = before[key];
       const childVal = config[key];
-      const mergeableBranch = Boolean(opt?.mergeable) && Boolean(parentVal) && Boolean(childVal);
+      const mergeableBranch =
+        !replaces?.has(key) && Boolean(opt?.mergeable) && Boolean(parentVal) && Boolean(childVal);
       let action: ProvenanceAction;
       let noop = false;
       if (mergeableBranch) {

--- a/packages/engine/test/__snapshots__/internal-presets.json.final.json
+++ b/packages/engine/test/__snapshots__/internal-presets.json.final.json
@@ -79,6 +79,7 @@
     "Provide a link to octochangelog's improved breakdown for Renovate's changelogs",
     "Disable Renovate Dependency Dashboard creation."
   ],
+  "overrideDescription": [],
   "enabled": true,
   "constraintsFiltering": "none",
   "repositoryCache": "disabled",
@@ -103,7 +104,7 @@
   "customDatasources": {},
   "dockerChildPrefix": "renovate_",
   "dockerCliOptions": null,
-  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.1",
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.3",
   "dockerUser": "12021",
   "composerIgnorePlatformReqs": [],
   "goGetDirs": [

--- a/packages/engine/test/__snapshots__/invalid.json.final.json
+++ b/packages/engine/test/__snapshots__/invalid.json.final.json
@@ -62,6 +62,7 @@
   "presetCachePersistence": false,
   "globalExtends": [],
   "description": [],
+  "overrideDescription": [],
   "enabled": true,
   "constraintsFiltering": "none",
   "repositoryCache": "disabled",
@@ -86,7 +87,7 @@
   "customDatasources": {},
   "dockerChildPrefix": "renovate_",
   "dockerCliOptions": null,
-  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.1",
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.3",
   "dockerUser": "12021",
   "composerIgnorePlatformReqs": [],
   "goGetDirs": [

--- a/packages/engine/test/__snapshots__/legacy-config.json.final.json
+++ b/packages/engine/test/__snapshots__/legacy-config.json.final.json
@@ -62,6 +62,7 @@
   "presetCachePersistence": false,
   "globalExtends": [],
   "description": [],
+  "overrideDescription": [],
   "enabled": true,
   "constraintsFiltering": "none",
   "repositoryCache": "disabled",
@@ -86,7 +87,7 @@
   "customDatasources": {},
   "dockerChildPrefix": "renovate_",
   "dockerCliOptions": null,
-  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.1",
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.3",
   "dockerUser": "12021",
   "composerIgnorePlatformReqs": [],
   "goGetDirs": [

--- a/packages/engine/test/__snapshots__/migration-steps.json.final.json
+++ b/packages/engine/test/__snapshots__/migration-steps.json.final.json
@@ -62,6 +62,7 @@
   "presetCachePersistence": false,
   "globalExtends": [],
   "description": [],
+  "overrideDescription": [],
   "enabled": true,
   "constraintsFiltering": "none",
   "repositoryCache": "disabled",
@@ -86,7 +87,7 @@
   "customDatasources": {},
   "dockerChildPrefix": "renovate_",
   "dockerCliOptions": null,
-  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.1",
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.3",
   "dockerUser": "12021",
   "composerIgnorePlatformReqs": [],
   "goGetDirs": [

--- a/packages/engine/test/__snapshots__/preset-package-rules.json.final.json
+++ b/packages/engine/test/__snapshots__/preset-package-rules.json.final.json
@@ -62,6 +62,7 @@
   "presetCachePersistence": false,
   "globalExtends": [],
   "description": [],
+  "overrideDescription": [],
   "enabled": true,
   "constraintsFiltering": "none",
   "repositoryCache": "disabled",
@@ -86,7 +87,7 @@
   "customDatasources": {},
   "dockerChildPrefix": "renovate_",
   "dockerCliOptions": null,
-  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.1",
+  "dockerSidecarImage": "ghcr.io/renovatebot/base-image:13.89.3",
   "dockerUser": "12021",
   "composerIgnorePlatformReqs": [],
   "goGetDirs": [

--- a/packages/engine/test/description-provenance.node.test.ts
+++ b/packages/engine/test/description-provenance.node.test.ts
@@ -30,23 +30,29 @@ interface NodeSpec {
 
 let counter = 0;
 
-function descriptionsOf(body: Record<string, unknown> | undefined): string[] {
-  const value = body?.description;
+function membersOf(value: unknown): unknown[] {
   if (typeof value === "string") {
     return [value];
   }
-  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+  return Array.isArray(value) ? value : [];
+}
+
+function descriptionsOf(body: Record<string, unknown> | undefined): string[] {
+  return membersOf(body?.description).filter((v): v is string => typeof v === "string");
 }
 
 function build(spec: NodeSpec, id: string): PresetNode {
   const children = (spec.children ?? []).map((child) => build(child, `p${++counter}`));
-  const quirk = Array.isArray(spec.input.ignoreDeps) && spec.input.ignoreDeps.length === 0;
-  const replayed = [
-    ...(quirk
-      ? []
-      : children.flatMap((c) => descriptionsOf(c.resolved as Record<string, unknown>))),
-    ...descriptionsOf(spec.input),
-  ];
+  // Renovate's own order: children then own body, then `overrideDescription`
+  // replacing the lot (members, so a non-string override member survives too).
+  const override = membersOf(spec.input.overrideDescription);
+  const replayed =
+    override.length > 0
+      ? override
+      : [
+          ...children.flatMap((c) => descriptionsOf(c.resolved as Record<string, unknown>)),
+          ...descriptionsOf(spec.input),
+        ];
   return {
     id,
     name: spec.name,
@@ -287,14 +293,14 @@ describe("computeDescriptionProvenance: the drop rules", () => {
     expect(prov.dropped).toEqual([]);
   });
 
-  it("reports every description an extending `ignoreDeps: []` deleted, per authoring node", () => {
+  it("reports every description an `overrideDescription` replaced, per authoring node", () => {
     const prov = provenance({
       name: "(input config)",
       input: {},
       children: [
         {
-          name: "quirky",
-          input: { description: ["quirky-own"], ignoreDeps: [] },
+          name: "muter",
+          input: { description: ["muter-own"], overrideDescription: ["one line"] },
           children: [
             {
               name: "a",
@@ -305,33 +311,59 @@ describe("computeDescriptionProvenance: the drop rules", () => {
         },
       ],
     });
-    // only the extending node's OWN description survives
-    expect(shape(prov)).toEqual([["quirky-own", "quirky", "quirky"]]);
+    // the override replaces the WHOLE resolved description — the subtree's
+    // sentences and the overriding node's own — and is owned by that node
+    expect(shape(prov)).toEqual([["one line", "muter", "muter"]]);
     expect(prov.dropped).toEqual([
       {
         value: "a-child-own",
         node: { nodeId: "p3", name: "a-child" },
-        reason: "ignore-deps-quirk",
-        droppedBy: { nodeId: "p1", name: "quirky" },
+        reason: "description-override",
+        droppedBy: { nodeId: "p1", name: "muter" },
       },
       {
         value: "a-own",
         node: { nodeId: "p2", name: "a" },
-        reason: "ignore-deps-quirk",
-        droppedBy: { nodeId: "p1", name: "quirky" },
+        reason: "description-override",
+        droppedBy: { nodeId: "p1", name: "muter" },
+      },
+      {
+        value: "muter-own",
+        node: { nodeId: "p1", name: "muter" },
+        reason: "description-override",
+        droppedBy: { nodeId: "p1", name: "muter" },
       },
     ]);
     expect(prov.degraded).toBe(false);
   });
 
-  it("keeps a muted subtree's guessed author labelled as a guess", () => {
+  it("ignores an empty `overrideDescription`, as Renovate's length guard does", () => {
     const prov = provenance({
       name: "(input config)",
       input: {},
       children: [
         {
-          name: "quirky",
-          input: { ignoreDeps: [] },
+          name: "not-a-muter",
+          input: { description: ["own"], overrideDescription: [] },
+          children: [{ name: "a", input: { description: ["a-own"] } }],
+        },
+      ],
+    });
+    expect(shape(prov)).toEqual([
+      ["a-own", "a", "not-a-muter"],
+      ["own", "not-a-muter", "not-a-muter"],
+    ]);
+    expect(prov.dropped).toEqual([]);
+  });
+
+  it("keeps an overridden subtree's guessed author labelled as a guess", () => {
+    const prov = provenance({
+      name: "(input config)",
+      input: {},
+      children: [
+        {
+          name: "muter",
+          input: { overrideDescription: ["one line"] },
           children: [
             {
               name: "a",
@@ -344,28 +376,50 @@ describe("computeDescriptionProvenance: the drop rules", () => {
         },
       ],
     });
-    // … and the quirk then diverts that guess into `dropped`, still labelled
+    // … and the override then diverts that guess into `dropped`, still labelled
     expect(prov.dropped).toEqual([
       {
         value: "surprise",
         node: { nodeId: "p2", name: "a" },
-        reason: "ignore-deps-quirk",
-        droppedBy: { nodeId: "p1", name: "quirky" },
+        reason: "description-override",
+        droppedBy: { nodeId: "p1", name: "muter" },
         approximate: true,
       },
     ]);
-    expect(prov.entries).toEqual([]);
+    expect(shape(prov)).toEqual([["one line", "muter", "muter"]]);
     expect(prov.degraded).toBe(true);
   });
 
-  it("applies the `ignoreDeps: []` quirk at the repo level too", () => {
+  it("applies an `overrideDescription` at the repo level too, in its `allowString` form", () => {
     const prov = provenance({
       name: "(input config)",
-      input: { description: ["mine"], ignoreDeps: [] },
+      input: { description: ["mine"], overrideDescription: "what this config does" },
       children: [{ name: "a", input: { description: ["a-own"] } }],
     });
-    expect(shape(prov)).toEqual([["mine", "(input config)", "repo"]]);
-    expect(prov.dropped.map((d) => [d.value, d.droppedBy?.nodeId])).toEqual([["a-own", "root"]]);
+    // the root wrote the override, so it arrives through the `repo` layer
+    expect(shape(prov)).toEqual([["what this config does", "(input config)", "repo"]]);
+    expect(prov.dropped.map((d) => [d.value, d.node.name, d.droppedBy?.nodeId])).toEqual([
+      ["a-own", "a", "root"],
+      ["mine", "(input config)", "root"],
+    ]);
+  });
+
+  it("counts a non-string override member as a real position, attributed to nobody", () => {
+    // `overrideDescription` is `subType: "string"`, but a wrong-typed member is
+    // a warning, not a refusal — and it becomes a member of `description`.
+    const result = traceResult(
+      {
+        name: "(input config)",
+        input: { overrideDescription: ["kept", 42] },
+        children: [{ name: "a", input: { description: ["a-own"] } }],
+      },
+      ["kept", 42],
+    );
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    expect(shape(prov)).toEqual([["kept", "(input config)", "repo"]]);
+    expect(prov.unattributed).toEqual([{ index: 1, value: 42 }]);
+    expect(prov.finalLength).toBe(2);
+    expect(prov.degraded).toBe(false);
   });
 });
 

--- a/packages/engine/test/description-provenance.shimmed.test.ts
+++ b/packages/engine/test/description-provenance.shimmed.test.ts
@@ -25,6 +25,7 @@ const repoConfig = JSON.stringify({
 const DEPENDENCY_DASHBOARD = "Enable Renovate Dependency Dashboard creation.";
 const MONOREPOS = "Group known monorepo packages together.";
 const PIN_DOCKER = "Pin Docker digests.";
+const CURATED_GROUPS = "Use curated list of recommended non-monorepo package groupings.";
 const SEMANTIC_COMMITS =
   "Use semantic commit type `fix` for dependencies and `chore` for all others if semantic commits are in use.";
 
@@ -120,22 +121,44 @@ describe("computeDescriptionProvenance (069)", () => {
     expect(prov.dropped.some((d) => values.has(d.value))).toBe(false);
   });
 
-  it("reports the descriptions group:recommended's `ignoreDeps: []` silently deletes", async () => {
+  it("reports the descriptions an `overrideDescription` replaced, per authoring node", async () => {
     const { prov } = await attribution();
-    const quirk = prov.dropped.filter((d) => d.reason === "ignore-deps-quirk");
-    // group:recommended carries `ignoreDeps: []`, which deletes the resolved
+    const overridden = prov.dropped.filter((d) => d.reason === "description-override");
+    // group:recommended's one-line `overrideDescription` replaces the resolved
     // description of every one of its ~130 sub-groups — and it is not alone:
-    // `replacements:all` and `workarounds:all` use the same trick to keep
+    // `replacements:all` and `workarounds:all` use the same option to keep
     // their hundreds of member presets out of the top-level description.
-    expect(quirk.length).toBeGreaterThan(100);
-    expect(new Set(quirk.map((d) => d.droppedBy?.name))).toEqual(
+    expect(overridden.length).toBeGreaterThan(100);
+    expect(new Set(overridden.map((d) => d.droppedBy?.name))).toEqual(
       new Set(["group:recommended", "replacements:all", "workarounds:all"]),
     );
     const nodeJs = must(
-      quirk.find((d) => d.node.name === "group:nodeJs"),
+      overridden.find((d) => d.node.name === "group:nodeJs"),
       "the group:nodeJs drop",
     );
     expect(nodeJs.value).toContain("Node.js");
+    expect(nodeJs.droppedBy?.name).toBe("group:recommended");
+    expect(nodeJs.approximate).toBeUndefined();
+  });
+
+  it("attributes the surviving override to the node that wrote it", async () => {
+    const { prov } = await attribution();
+    // the sentence that replaced those ~130: group:recommended's own, arriving
+    // through the top-level extend that pulled the preset in
+    const curated = must(
+      prov.entries.find((e) => e.value === CURATED_GROUPS),
+      `the "${CURATED_GROUPS}" entry`,
+    );
+    expect(curated.node?.name).toBe("group:recommended");
+    expect(via(curated)).toBe("config:best-practices");
+    expect(curated.approximate).toBeUndefined();
+    // group:monorepos is the same shape one level up: an override on a preset
+    // extended directly, where the writing node IS the top-level layer
+    const monorepos = must(
+      prov.entries.find((e) => e.value === MONOREPOS),
+      "the monorepos entry",
+    );
+    expect(monorepos.node?.name).toBe("group:monorepos");
   });
 
   it("finds the same drops on a repeated run, despite Renovate mutating its own preset table", async () => {
@@ -180,6 +203,30 @@ describe("computeDescriptionProvenance (069)", () => {
       ["Our house rules.", "repo"],
     ]);
     expect(prov.entries[1]?.node?.nodeId).toBe("root");
+  });
+
+  it("replaces a repo config's whole resolved description with its own override", async () => {
+    const result = await runResult(
+      JSON.stringify({
+        extends: [":dependencyDashboard"],
+        description: "Our house rules.",
+        overrideDescription: "What this config does, in one line.",
+      }),
+    );
+    const prov = must(computeDescriptionProvenance(result), "the description provenance");
+    // Renovate replaces the resolved array — the preset's sentence AND the
+    // repo's own — with the override, and deletes `overrideDescription` itself
+    expect(result.finalConfig?.description).toEqual(["What this config does, in one line."]);
+    expect(prov.entries.map((e) => [e.value, via(e)])).toEqual([
+      ["What this config does, in one line.", "repo"],
+    ]);
+    expect(prov.entries[0]?.node?.nodeId).toBe("root");
+    expect(prov.degraded).toBe(false);
+    // both replaced sentences are accounted for, each still credited to its author
+    expect(prov.dropped.map((d) => [d.value, d.node.name, d.reason, d.droppedBy?.name])).toEqual([
+      [DEPENDENCY_DASHBOARD, ":dependencyDashboard", "description-override", "(input config)"],
+      ["Our house rules.", "(input config)", "description-override", "(input config)"],
+    ]);
   });
 
   it("indexes against a final array Renovate let a non-string into", async () => {

--- a/packages/engine/test/provenance.shimmed.test.ts
+++ b/packages/engine/test/provenance.shimmed.test.ts
@@ -20,6 +20,7 @@ import { must } from "./helpers";
 
 const injectedPresets = {
   [presetInjectionKey({ presetSource: "github", repo: "test-org/preset-a" })]: {
+    description: "Preset A bumps ranges.",
     rangeStrategy: "bump",
     addLabels: ["a"],
     packageRules: [{ matchPackageNames: ["left-pad"], enabled: false }],
@@ -43,6 +44,7 @@ const injectedPresets = {
 
 const repoConfig = JSON.stringify({
   extends: ["github>test-org/preset-a", "github>test-org/preset-b", "github>test-org/wrapper"],
+  overrideDescription: "What this config does.",
   automerge: false,
   packageRules: [{ matchDepTypes: ["devDependencies"], extends: ["github>test-org/nested-rule"] }],
 });
@@ -160,6 +162,40 @@ describe("computeProvenance", () => {
     for (const s of range.chain) {
       expect(s.writtenBy).toBeUndefined();
     }
+  });
+
+  it("(h) leaves out a key preset resolution consumes rather than merges", async () => {
+    // `overrideDescription` is folded into `description` and deleted, so the
+    // repo body carries a value the final config does not: a repo step here
+    // would name a winner the final value contradicts — the round-trip
+    // invariant below is the general form of that claim. Where the sentences
+    // went is `computeDescriptionProvenance`'s answer, not this one's.
+    const prov = await provenance();
+    const override = must(
+      prov.get("overrideDescription"),
+      "the 'overrideDescription' provenance entry",
+    );
+    expect(override.finalValue).toEqual([]);
+    expect(override.isDefaultOnly).toBe(true);
+    expect(override.chain.map((s) => layerName(s.layer))).toEqual(["defaults"]);
+  });
+
+  it("(i) records a repo `overrideDescription` as the overwrite of `description` it is", async () => {
+    const prov = await provenance();
+    const description = must(prov.get("description"), "the 'description' provenance entry");
+    expect(description.finalValue).toEqual(["What this config does."]);
+    expect(description.isDefaultOnly).toBe(false);
+    // `description` is a mergeable array — every other layer APPENDS to it —
+    // but the override replaces the lot, so the verb has to be the honest one
+    // and the preset's sentence has to read as the losing value it is.
+    expect(
+      description.chain
+        .filter((s) => s.layer.kind !== "defaults")
+        .map((s) => [layerName(s.layer), s.action, s.after]),
+    ).toEqual([
+      ["github>test-org/preset-a", "set", ["Preset A bumps ranges."]],
+      ["repo", "overwrite", ["What this config does."]],
+    ]);
   });
 
   it("holds the round-trip property: every key's last step reproduces the final value", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       renovate:
-        specifier: 44.39.1
-        version: 44.39.1(supports-color@10.2.2)(typanion@3.14.0)
+        specifier: 44.41.0
+        version: 44.41.0(supports-color@10.2.2)(typanion@3.14.0)
     devDependencies:
       typescript:
         specifier: 7.0.2
@@ -4742,8 +4742,8 @@ packages:
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
 
-  renovate@44.39.1:
-    resolution: {integrity: sha512-cdzyHKPYYpT3PP1drOi8RyOgiWqKkGAq7hCYrpoJ8Ul+nKEye/GLg4Mu77l0wqyCKkcNHHZpJPdd48A79E3fyg==}
+  renovate@44.41.0:
+    resolution: {integrity: sha512-U7pgZfrwVFotkI1grHq1qGGaR+Ckw6NbrwYUB1lytC+eZl4E7w7sj/PQkx2qfLfdyyi/NyfmuEL/UthrXld64g==}
     engines: {node: ^24.11.0, pnpm: ^11.0.0}
     hasBin: true
 
@@ -10261,7 +10261,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  renovate@44.39.1(supports-color@10.2.2)(typanion@3.14.0):
+  renovate@44.41.0(supports-color@10.2.2)(typanion@3.14.0):
     dependencies:
       '@aws-sdk/client-codecommit': 3.1095.0
       '@aws-sdk/client-ec2': 3.1095.0

--- a/roadmap/069-description-provenance.md
+++ b/roadmap/069-description-provenance.md
@@ -113,13 +113,13 @@ desynchronise the indices of everything after it. The UI is expected to render
 
 ## The drop rules
 
-Three places delete a description before it can merge. All three are reported in
+Three places remove a description before it can merge. All three are reported in
 `dropped` (`{ value, node, reason, droppedBy?, approximate? }`) rather than left
 as an unexplained absence, because "why isn't my preset's description showing
 up" is one of the questions this feature exists to answer. `approximate` carries
 the same meaning it has on an entry, and for the same reason: a subtree that had
-already degraded to its enclosing node can then be muted by the quirk below, and
-the guessed author must stay labelled as a guess once it becomes a drop. The two
+already degraded to its enclosing node can then be muted by the override below,
+and the guessed author must stay labelled as a guess once it becomes a drop. The two
 `getPreset` drops are read off a pristine body and are never approximate.
 
 - **`wrapper-preset`** — `getPreset` deletes the description of any preset whose
@@ -128,13 +128,17 @@ the guessed author must stay labelled as a guess once it becomes a drop. The two
   own one-line summaries never reach the config that extends them.
 - **`package-list-preset`** — same, for a preset whose keys are a subset of
   `{description, matchPackageNames}`. This is most of the `packages:` group.
-- **`ignore-deps-quirk`** — `resolveConfigPresets` deletes the ENTIRE resolved
-  description of a preset when the extending config carries `ignoreDeps: []`
-  (length zero). Three internal presets use this deliberately, as a mute button:
-  `group:recommended`, `replacements:all` and `workarounds:all` would otherwise
-  each contribute a hundred-plus sentences. `droppedBy` names the extending
-  node; the `node` on each entry is still the preset that authored the sentence,
-  because the walk attributes the subtree first and diverts it afterwards.
+- **`description-override`** — `resolveConfigPresets` REPLACES the entire
+  resolved description of a config — its subtree's sentences and its own — with
+  its `overrideDescription`, when that option is non-empty. Three internal
+  presets use it deliberately, as a mute button: `group:recommended`,
+  `replacements:all` and `workarounds:all` would otherwise each contribute a
+  hundred-plus sentences, and `group:monorepos` collapses its own. `droppedBy`
+  names the overriding node; the `node` on each entry is still the preset that
+  authored the sentence, because the walk attributes the subtree first and
+  diverts it afterwards. The override itself is an ordinary contribution of the
+  node that wrote it (Renovate deletes the key, so only the `description` it
+  became reaches the final config).
 
 The first two happen inside `getPreset`, i.e. **before** the body the trace
 records as `input`, so they are detected — not predicted — by comparing the raw
@@ -206,7 +210,7 @@ offline (internal presets need no network):
   case value matching would get wrong, and it is not exotic: it is what happens
   whenever someone adds a preset that `config:recommended` already contains.
 - 2 wrapper-preset drops (`config:best-practices`, `config:recommended`) and
-  135 `ignore-deps-quirk` drops from the three mute-button presets.
+  140 `description-override` drops from the three mute-button presets.
 
 ## The 5-PR plan
 
@@ -240,7 +244,8 @@ offline (internal presets need no network):
 - `test/description-provenance.shimmed.test.ts` — the real fixture above:
   full-array attribution and ordering, the two known leaf attributions, both
   duplicates with their `viaTopLevel` and `duplicateOfIndex`, the wrapper-preset
-  drops, the `ignoreDeps: []` drops with their three `droppedBy` presets, a
+  drops, the `overrideDescription` drops with their three `droppedBy` presets
+  and the surviving override attributed to the node that wrote it, a
   repo-config's own description landing last on the root node, a config whose
   `description` holds a number (Renovate warns and keeps it) proving the reported
   indices are positions in the real array, and — the regression guard for the
@@ -340,6 +345,33 @@ the wrong file would be worse than naming none.
 - `src/features/simulator/RuleRow.test.tsx`, `RuleEvidenceCard.test.tsx` and
   `rule-evidence.test.ts` — the quote where it belongs (outside the head button,
   above the clause evidence), and only on a matched, described rule.
+
+## Addendum — 2026-08-27: the mute button is `overrideDescription` now
+
+Renovate 44.41.0 ([#45400](https://github.com/renovatebot/renovate/pull/45400))
+added an `overrideDescription` option and moved the three mute-button presets
+onto it, deleting the `ignoreDeps: []` branch from `resolveConfigPresets`. The
+third drop rule is that option, not the quirk, and `ignore-deps-quirk` is gone
+rather than kept: the quirk no longer fires upstream, so detecting it would
+report drops Renovate does not make.
+
+The shape of the feature is unchanged — the final array of the reference fixture
+is byte-identical, the counts are the same, and `droppedBy` still names the node
+that pressed the button. Two things the swap does change: an override replaces
+the overriding node's OWN description too (the quirk kept it), so a node can
+appear as both the author and the `droppedBy` of one drop; and the surviving
+sentence is a contribution like any other, attributed to the node whose
+`overrideDescription` wrote it.
+
+The KEY provenance (005) needed the option too, in two places. It is consumed by
+`resolveConfigPresets` and deleted, like `extends` and `ignorePresets`, so it
+joins `RESOLUTION_KEYS` — a chain saying "your repo set `overrideDescription:
+[…]`" would name a winner the final `[]` contradicts. And a repo-level override
+does reach the final config, as `description`: the repo layer contributes it as
+an OVERWRITE of a normally-appending key (`Layer.replaces`), which is both what
+Renovate did and the surprising part worth naming. The round-trip invariant —
+every key's last step reproduces its final value — is what catches either half
+being missing.
 
 ## Addendum — 2026-08-23: `writtenBy`, the same honesty rule for a KEY
 

--- a/roadmap/081-standard-preset-names-and-hovers.md
+++ b/roadmap/081-standard-preset-names-and-hovers.md
@@ -237,8 +237,8 @@ tree's origin framing), and a descendant-selector size override
   the section's rows carry the tokens.
 
 - **`drop-reasons.ts` keeps its embedded `<code>`.** One of its three reasons
-  reads "muted by \`X\` — its empty `ignoreDeps` deletes every description it
-  extends": a preset name mid-clause in an explanatory sentence assembled by a
+  reads "muted by \`X\` — its `overrideDescription` replaces every description
+  it resolved": a preset name mid-clause in an explanatory sentence assembled by a
   wording module (which also owns the `≈` hedge and the label/why split, and is
   rendered through `CodeText`). Splitting that sentence into JSX to tokenise one
   name would move presentation into the wording layer — the opposite of the


### PR DESCRIPTION
Supersedes #252, which could not update its own artifacts — see #279 for why.

44.41.0 adds the `overrideDescription` option ([renovatebot/renovate#45400](https://github.com/renovatebot/renovate/pull/45400))
and moves the three mute-button presets (`group:recommended`,
`replacements:all`, `workarounds:all`) onto it, deleting the `ignoreDeps: []`
branch from `resolveConfigPresets`.

**069's description ledger** modelled that quirk, so it models the option
instead: `ignore-deps-quirk` is replaced by `description-override`, which
credits the surviving sentence to the node whose `overrideDescription` wrote it
and reports every sentence it replaced — including the overriding node's own,
which the quirk used to keep. The reference fixture is otherwise unchanged: the
same 24 strings, the same 135 drops, the same three `droppedBy` presets.

**005's key provenance** needed it too: `overrideDescription` is consumed and
deleted like `extends`, so it joins `RESOLUTION_KEYS` — before this, a config
carrying one produced `winner: repo … final: []`. And a repo-level override
does reach the final config, as `description`: the repo layer now contributes
it as the overwrite of a normally-appending key that it is. The round-trip
invariant (every key's last step reproduces its final value) is what caught
both halves.

Tests: the two new drop rules end to end against the real preset tree, the
walk's rules in isolation (own description replaced, empty override ignored,
`allowString` form, non-string member, the approximate-author case), the app's
wording and the same-node author/muter case, and the two provenance cases
above. Full suite green, including e2e.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
