### PR TITLE
fix(app): stop attesting robots.txt — Cloudflare rewrites it at the edge (roadmap 088)

### DIFF
--- a/packages/app/scripts/build-manifest.mjs
+++ b/packages/app/scripts/build-manifest.mjs
@@ -12,9 +12,10 @@ import process from "node:process";
 import { fileURLToPath } from "node:url";
 
 const MANIFEST = "build-manifest.json";
-// rcd-config.js is runtime deployment config — the Docker entrypoint may
-// overwrite it at container start — so it is deliberately not attested.
-const EXCLUDED = new Set([MANIFEST, "rcd-config.js"]);
+// Edge/runtime-mutable files are deliberately not attested: the Docker
+// entrypoint may overwrite rcd-config.js at container start, and Cloudflare's
+// managed content signals rewrite robots.txt at the edge.
+const EXCLUDED = new Set([MANIFEST, "rcd-config.js", "robots.txt"]);
 
 const dist = fileURLToPath(new URL("../dist", import.meta.url));
 

--- a/roadmap/088-build-provenance.md
+++ b/roadmap/088-build-provenance.md
@@ -31,9 +31,10 @@ Three layers, each independently checkable:
    image excludes `.git`) — every UI anchor then renders nothing, rather than
    an identity nothing can verify.
 2. **The attested files.** `scripts/build-manifest.mjs` hashes every file
-   in `dist/` into `build-manifest.json` (excluding itself, and
-   `rcd-config.js`, which the Docker entrypoint may rewrite at container
-   start), and writes the same digests — manifest included — to
+   in `dist/` into `build-manifest.json` (excluding itself and the
+   edge/runtime-mutable files: `rcd-config.js`, which the Docker entrypoint
+   may rewrite at container start, and `robots.txt`, which Cloudflare's
+   managed content signals rewrite at the edge), and writes the same digests — manifest included — to
    `build-checksums.txt` (next to `dist/`, gitignored: attestation input,
    not deployment payload). CI generates both before the Pages upload and,
    on main, signs the checksums with `actions/attest`


### PR DESCRIPTION
## The finding

Testing the merged attestation (roadmap 088, #268) against the live deployment:

- `gh attestation verify build-manifest.json -R secustor/renovate-config-debugger` **passes** — SLSA provenance v1, 475 subjects, signed by `ci.yml@refs/heads/main` for the exact commit the manifest claims.
- Individual served assets (`index.html`, a JS chunk) also verify with the same command.
- But the served-vs-manifest check (`tools/verify-deployment.ts`) fails on exactly **one** file: `robots.txt`. Cloudflare's managed content signals prepend an AI-crawler block at the edge, so the served bytes can never match the built bytes.

## The fix

Same category as `rcd-config.js` (runtime-mutable, rewritten after the build), same remedy: exclude `robots.txt` from the manifest and the attestation subjects. Roadmap 088 updated to record the ruling.

After this deploys, `mise run verify-build https://renovate.secustor.dev` should pass clean.