### PR TITLE
ci(docker): version-tag and attest release images; latest follows releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,10 @@ jobs:
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          # BuildKit's in-registry SLSA provenance (roadmap 089), max so the
+          # full build args and materials are recorded. `imagetools create`
+          # carries the attestation manifests into the merged list.
+          provenance: mode=max
           outputs: type=image,name=${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }}
           cache-to: type=registry,ref=${{ matrix.image }}:buildcache-${{ steps.platform.outputs.pair }},mode=max,image-manifest=true,oci-mediatypes=true
@@ -352,6 +356,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Roadmap 089: what signs the image attestation, like roadmap 088's for
+      # the Pages bundle.
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -375,22 +383,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # No `latest` here any more (roadmap 089): `latest` follows releases, and
+      # release.yml moves it. A main push gets the rolling `main` plus its
+      # immutable `sha-` tag — the handle the release promotes.
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ matrix.image }}
           tags: |
-            type=raw,value=latest
+            type=raw,value=main
             type=sha,prefix=sha-,format=short
 
-      - name: Create the manifest list and push
+      - id: push
+        name: Create the manifest list and push
         working-directory: ${{ runner.temp }}/digests
         env:
           IMAGE: ${{ matrix.image }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "${IMAGE}@sha256:%s " *)
+          echo "digest=$(docker buildx imagetools inspect "${IMAGE}:${VERSION}" --format '{{.Manifest.Digest}}')" >> "$GITHUB_OUTPUT"
+
+      # The signed statement "this workflow built this image from this commit",
+      # on the digest of the merged manifest list — the digest every tag
+      # (including the release's version tag and `latest`, which are retags of
+      # it) resolves to. `gh attestation verify oci://<image>:<tag> -R
+      # secustor/renovate-config-debugger` checks it, and release.yml does
+      # exactly that before promoting. (actions/attest with no predicate inputs
+      # emits SLSA build provenance — see the roadmap 088 step above.)
+      - name: Attest build provenance (roadmap 089)
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-name: ${{ matrix.image }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
 
       # Fails loudly if a platform is missing from the published list — the one
       # failure mode of this split that a green build job would otherwise hide.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ name: Release
 # Run it with `dry-run` ticked (the default) to see the version and the notes
 # without touching the registry, the tags or main.
 #
+# The docker images are released here too (roadmap 089), but not rebuilt:
+# after semantic-release publishes, the manifest lists CI built, attested and
+# pushed for this exact commit (`:sha-<short>`, ci.yml `docker`/`docker-merge`)
+# are verified against GitHub's attestation service and retagged `<version>`
+# and `latest`. So `latest` follows releases, not merges, and always points at
+# bytes whose provenance checked out.
+#
 # There is NO npm token, here or in the repository secrets. Publishing is
 # authenticated with npm trusted publishing (OIDC): the registry trusts a short
 # lived token minted by GitHub for this job, having been told on npmjs.com which
@@ -41,7 +48,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 30 for the release itself, plus the budget of the wait-for-CI-images
+    # preflight below.
+    timeout-minutes: 45
     permissions:
       # The `v*` tag and the GitHub release. Nothing is committed back to
       # main — a release changes no tracked file (see release.config.mjs).
@@ -54,6 +63,8 @@ jobs:
       # provenance attestation. Without it there is no other credential to fall
       # back to, and the publish fails rather than degrading to something weaker.
       id-token: write
+      # Roadmap 089: retagging the CI-built images `<version>` + `latest`.
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -87,6 +98,32 @@ jobs:
       - name: Smoke-test the published bin
         run: node packages/cli/bin/rcd.mjs validate packages/cli/test/fixtures/clean.json
 
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        if: ${{ !inputs.dry-run }}
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The images this release promotes are the ones ci.yml built and attested
+      # for this exact commit — checked BEFORE anything is stamped or
+      # published, in verify.ts's spirit: a release dispatched moments after a
+      # merge waits for CI's docker jobs here and, if they never deliver, fails
+      # with npm untouched rather than after the version already shipped.
+      - name: Wait for CI's docker images of this commit
+        if: ${{ !inputs.dry-run }}
+        run: |
+          for image in ghcr.io/secustor/renovate-config-debugger ghcr.io/secustor/renovate-config-debugger-oauth-proxy; do
+            ref="${image}:sha-${GITHUB_SHA::7}"
+            for attempt in $(seq 1 30); do
+              docker buildx imagetools inspect "$ref" > /dev/null 2>&1 && continue 2
+              echo "waiting for ${ref} (${attempt}/30)"
+              sleep 30
+            done
+            echo "::error::${ref} was not pushed — did CI's docker jobs run (and pass) for ${GITHUB_SHA}?"
+            exit 1
+          done
+
       # Nothing is pushed to main any more; the only git write left is the
       # `v*` tag semantic-release itself creates, and the job's own token can
       # do that unless a tag ruleset restricts it. The release GitHub App (see
@@ -106,6 +143,7 @@ jobs:
       # would take precedence over the exchange and quietly put a long-lived
       # credential back in the path this workflow exists to remove.
       - name: semantic-release
+        id: release
         env:
           # The app token when the step above ran, the job token otherwise.
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -118,3 +156,22 @@ jobs:
           # step with the tree already stamped.
           RELEASE_DRY_RUN: ${{ inputs.dry-run }}
         run: pnpm exec semantic-release ${{ inputs.dry-run && '--dry-run' || '' }}
+
+      # A promotion, not a rebuild: `imagetools create` from a single manifest
+      # list copies it unchanged, so the version tag and `latest` resolve to
+      # the same digest CI attested — which is why the attestation is verified
+      # against that digest first, and why it keeps covering the new tags.
+      # `version` comes from the exec plugin's successCmd (release.config.mjs)
+      # and is empty when semantic-release found nothing to release.
+      - name: Promote this commit's images to the version tag and latest
+        if: ${{ !inputs.dry-run && steps.release.outputs.version != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          for image in ghcr.io/secustor/renovate-config-debugger ghcr.io/secustor/renovate-config-debugger-oauth-proxy; do
+            ref="${image}:sha-${GITHUB_SHA::7}"
+            gh attestation verify "oci://${ref}" --repo "$GITHUB_REPOSITORY"
+            docker buildx imagetools create -t "${image}:${VERSION}" -t "${image}:latest" "$ref"
+            docker buildx imagetools inspect "${image}:${VERSION}"
+          done

--- a/README.md
+++ b/README.md
@@ -147,10 +147,9 @@ personal-access-token fallback for GitHub Enterprise Server.
 > [!WARNING]
 > Docker setups are experimental at the moment.
 
-Image tags: `latest` and the bare version tags (`0.3.0`, …) are releases —
-`latest` moves only when a release is cut, and both are the exact digests CI
-built and attested for that commit. `main` tracks every merge, and `sha-<short>`
-pins one. Every published digest carries a signed build attestation:
+Images are created for each commit using `sha-<short>` as the tag, on release semver versioned tags are too released with `latest` pointing on the newest semver release. 
+
+To verify the attestation of a semver release use: 
 
 ```bash
 gh attestation verify oci://ghcr.io/secustor/renovate-config-debugger:latest -R secustor/renovate-config-debugger

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ personal-access-token fallback for GitHub Enterprise Server.
 > [!WARNING]
 > Docker setups are experimental at the moment.
 
-Images are created for each commit using `sha-<short>` as the tag, on release semver versioned tags are too released with `latest` pointing on the newest semver release. 
+Images are created for each commit using `sha-<short>` as the tag, on release semver versioned tags are too released with `latest` pointing on the newest semver release.
 
-To verify the attestation of a semver release use: 
+To verify the attestation of a semver release use:
 
 ```bash
 gh attestation verify oci://ghcr.io/secustor/renovate-config-debugger:latest -R secustor/renovate-config-debugger

--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ personal-access-token fallback for GitHub Enterprise Server.
 > [!WARNING]
 > Docker setups are experimental at the moment.
 
+Image tags: `latest` and the bare version tags (`0.3.0`, …) are releases —
+`latest` moves only when a release is cut, and both are the exact digests CI
+built and attested for that commit. `main` tracks every merge, and `sha-<short>`
+pins one. Every published digest carries a signed build attestation:
+
+```bash
+gh attestation verify oci://ghcr.io/secustor/renovate-config-debugger:latest -R secustor/renovate-config-debugger
+```
+
 The app is a static bundle, so hosting it is the one container above. There is
 also [`docker-compose.yml`](docker-compose.yml), a worked example of both
 services with every optional variable present but commented out:

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -106,6 +106,11 @@ export default {
           "RCD_RELEASE=1 pnpm --filter @renovate-config-debugger/cli build",
         ].join(" && "),
         publishCmd: "node tools/release/publish.ts",
+        // Hands the published version to release.yml's docker-promotion step
+        // (roadmap 089). `success` only runs when a release actually shipped;
+        // the guard keeps a local run from tripping over the unset variable.
+        successCmd:
+          'test -z "$GITHUB_OUTPUT" || echo "version=${nextRelease.version}" >> "$GITHUB_OUTPUT"',
       },
     ],
     "@semantic-release/github",

--- a/roadmap/089-docker-release-tags.md
+++ b/roadmap/089-docker-release-tags.md
@@ -1,0 +1,57 @@
+# 089 — Docker release tags: versioned, attested, `latest` follows releases
+
+Milestone: M21 · Status: done.
+
+## The ask
+
+The images had no releases: every main push moved `latest`, no tag ever named
+a version, and nothing signed what a puller got. Give the docker artifacts the
+same release story the npm packages got in 067 — a version tag per release,
+provenance a consumer can verify, and `latest` meaning "latest release", not
+"latest merge".
+
+## The mechanism
+
+**CI builds and attests; the release promotes.** No image is rebuilt at
+release time.
+
+1. **ci.yml `docker`** (unchanged split, roadmap 043) builds each
+   (target × platform) natively and pushes by digest, now with BuildKit
+   provenance at `mode=max` — the in-registry SLSA attestation manifests ride
+   along into the merge.
+2. **ci.yml `docker-merge`** joins the digests into one manifest list tagged
+   `main` + `sha-<short>` — `latest` no longer appears here — and signs the
+   merged list's digest with `actions/attest` (`push-to-registry`), the same
+   action and reasoning as 088's Pages attestation. Every later tag is a retag
+   of this digest, so this one signature covers them all:
+   `gh attestation verify oci://ghcr.io/secustor/renovate-config-debugger:latest
+-R secustor/renovate-config-debugger`.
+3. **release.yml**, after semantic-release publishes, runs
+   `gh attestation verify` against this commit's `sha-` manifest lists and
+   `docker buildx imagetools create -t <version> -t latest` them. A
+   single-source `imagetools create` copies the list byte-identically, so the
+   promoted tags resolve to the digest CI attested. The version crosses from
+   semantic-release to the workflow via an exec-plugin `successCmd` writing
+   `$GITHUB_OUTPUT`; `success` only runs on a real publish, so "nothing to
+   release" cleanly skips the promotion.
+
+## Rulings
+
+- **Retag, not rebuild.** The release ships the digests CI already built and
+  pushed for that exact commit — the docker version of release.yml's "the tree
+  that gets published is this one". A rebuild would double the multi-arch
+  matrix into release.yml and publish bytes nothing had exercised.
+- **The wait is a preflight.** The retag's one dependency — CI's docker jobs
+  having pushed this commit's images — is checked _before_ semantic-release
+  runs (polling up to 15 minutes), in verify.ts's spirit: a release dispatched
+  moments after a merge waits, and one whose CI failed dies with npm and the
+  tags untouched, not half-shipped.
+- **Verification gates the promotion.** `latest` moves only after
+  `gh attestation verify` accepts the digest it will point at; a tampered or
+  unattested image fails the release instead of shipping.
+- **Version tags are npm's, bare** (`0.3.0`, docker convention, no `v`),
+  equal across both images and the npm packages by 067's construction. No
+  rolling major/minor tags while the scheme is 0.x with breaking-in-minor.
+- **Main pushes keep an image**: the rolling `main` tag replaces `latest` for
+  anyone deliberately tracking the edge; `sha-` stays the immutable handle the
+  release promotes.


### PR DESCRIPTION
Roadmap 089 — the docker images get the release story the npm packages got in 067.

## What changes

**CI (`ci.yml`), on every main push**
- `docker` builds now emit BuildKit SLSA provenance at `mode=max`; the attestation manifests ride into the merged list.
- `docker-merge` tags `main` + `sha-<short>` — **no more `latest`** — and signs the merged multi-arch digest with `actions/attest` (`push-to-registry: true`), the same action roadmap 088 uses for the Pages bundle. Every later tag is a retag of this digest, so the one signature covers them all.

**Release (`release.yml`), after semantic-release publishes**
- Verifies the attestation of this commit's CI-built manifest lists (`gh attestation verify oci://…`) and promotes those exact digests to `<version>` + `latest` via `imagetools create` — a retag, not a rebuild: what `latest` serves is byte-for-byte what CI built and attested.
- A preflight waits (up to 15 min) for CI's docker jobs to deliver this commit's images **before** anything is stamped or published, so a race with CI fails with npm untouched.
- The version crosses from semantic-release via a new exec-plugin `successCmd` writing `$GITHUB_OUTPUT`; `success` only fires on a real publish, so "nothing to release" cleanly skips the promotion.

## Consumer-visible
- `latest` now means *latest release*, moving only when a release is cut.
- Bare version tags (`0.3.0`, …) match the npm version by 067's construction.
- `main` is the new rolling edge tag; `sha-<short>` unchanged.
- `gh attestation verify oci://ghcr.io/secustor/renovate-config-debugger:latest -R secustor/renovate-config-debugger` verifies any published tag. README documents this.

Design notes: `roadmap/089-docker-release-tags.md`.

## Verification
- `pnpm lint`, `pnpm format:check`, `pnpm typecheck` green; both workflows YAML-parse.
- The CI half exercises itself on merge; the release half shows on the next `release.yml` dispatch (dry-run skips all docker steps by design).
