### PR TITLE
feat(app): pipeline extract phase behind a phase picker

### DIFF
--- a/packages/app/e2e/07-stage-chip-outcomes.spec.ts
+++ b/packages/app/e2e/07-stage-chip-outcomes.spec.ts
@@ -21,6 +21,13 @@ test("the Migrate node shows amber with a delta when it rewrote the config", asy
   // Roadmap 028: the stage rail is the Pipeline tab's stage selector.
   await openTab(page, "pipeline");
 
+  // Roadmap 090: the tab leads with the phase picker, and the stage rail is
+  // what the Config phase — the one selected on arrival — shows.
+  const picker = page.getByRole("radiogroup", { name: "Pipeline phase" });
+  await expect(picker.getByRole("radio")).toHaveCount(4);
+  await expect(picker.locator("button.active .phase-seg-name")).toHaveText("Config");
+  await expect(picker.getByRole("radio", { name: /^Lookup/ })).toBeDisabled();
+
   const migrateNode = page.locator('.stage-rail-btn[data-stage="migrate"]');
   await expect(migrateNode).toBeVisible();
   await expect(migrateNode.locator(".stage-rail-glyph.changed")).toBeVisible();

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -42,6 +42,7 @@ import { usePlatformContext } from "@/app/use-platform-context";
 import { useInheritedConfigLayer } from "@/app/use-inherited-config-layer";
 import { useRepoLoad } from "@/app/use-repo-load";
 import { useRepoDeps } from "@/features/simulator/use-repo-deps";
+import type { PipelinePhase } from "@/features/pipeline/phases";
 import { EMPTY_FORM } from "@/features/simulator/form";
 import { pinShareFields } from "@/features/simulator/pins";
 import { useRepoPicker } from "@/app/use-repo-picker";
@@ -553,18 +554,26 @@ export function App() {
   // Roadmap 078: the loaded repo's extracted dependencies — discovered on
   // demand (the first open of the From-repository tab), reset by a new load.
   const { view: repoDepsView, ensure: ensureRepoDeps } = useRepoDeps(loadedRepo);
-  // Roadmap 089: …and the Dependencies tab is the second door onto the same
-  // discovery. Opening it is what starts one, exactly as opening the
-  // From-repository tab is — the trigger lives HERE rather than in the panel
-  // because every results panel stays MOUNTED (028), so a panel-side effect
-  // would fire for a tab nobody has looked at and spend the rate limit on it.
-  // `ensure` is idempotent per loaded repo, so the two doors never discover
-  // twice.
+  /**
+   * Roadmap 090: which phase the Pipeline tab is showing. Here rather than in
+   * the panel because the phase is half of a discovery trigger (below), and
+   * because a phase the reader picked must survive a re-run — extraction is a
+   * fact about the REPOSITORY, so a new run of the config pipeline does not
+   * invalidate it.
+   */
+  const [pipelinePhase, setPipelinePhase] = useState<PipelinePhase>("config");
+  // Roadmap 089/090: …and the Dependencies tab and the Pipeline tab's Extract
+  // phase are the second and third doors onto the same discovery. Opening one
+  // is what starts it, exactly as opening the From-repository tab is — the
+  // trigger lives HERE rather than in the panel because every results panel
+  // stays MOUNTED (028), so a panel-side effect would fire for a tab nobody has
+  // looked at and spend the rate limit on it. `ensure` is idempotent per loaded
+  // repo, so the three doors never discover twice.
   useEffect(() => {
-    if (tab === "deps") {
+    if (tab === "deps" || (tab === "pipeline" && pipelinePhase === "extract")) {
       ensureRepoDeps();
     }
-  }, [tab, ensureRepoDeps]);
+  }, [tab, pipelinePhase, ensureRepoDeps]);
   // Roadmap 087: the connect panel's one-click reload — grants this session
   // repository ACCESS (the LoadedRepo record discovery runs from) without
   // touching the config the share link installed. It rides the current
@@ -1290,6 +1299,8 @@ export function App() {
       presetCount,
       effectiveKeys: effectiveStats?.keys ?? null,
       onShowRewrites,
+      pipelinePhase,
+      onSelectPipelinePhase: setPipelinePhase,
       selectedStage,
       onSelectStage: setSelectedStage,
       deferredStage,
@@ -1344,6 +1355,7 @@ export function App() {
       presetCount,
       effectiveStats,
       onShowRewrites,
+      pipelinePhase,
       selectedStage,
       deferredStage,
       migrateSteps,
@@ -1387,6 +1399,7 @@ export function App() {
       setSelectedNodeId,
       setMigrationStepIndex,
       setMergeStepIndex,
+      setPipelinePhase,
     ],
   );
 

--- a/packages/app/src/app/ResultsColumn.tsx
+++ b/packages/app/src/app/ResultsColumn.tsx
@@ -88,7 +88,10 @@ export function ResultsColumn({
     onWalkTab,
     backTab,
     onBack,
+    onJumpToTab,
     validateHasErrors,
+    pipelinePhase,
+    onSelectPipelinePhase,
     selectPresetNode,
     focusEditorRepoIndex,
     errorLib,
@@ -272,8 +275,18 @@ export function ResultsColumn({
       ) : (
         <EmptyNote>Nothing to test — the pipeline produced no effective config.</EmptyNote>
       ),
+      // Roadmap 090: the tab leads with the phase picker now. The Config phase
+      // is exactly what this panel always was; the Extract phase draws 087's
+      // repository discovery — the same view the Dependencies tab renders as a
+      // table, here as the three steps that produced it.
       pipeline: (
         <PipelinePanel
+          phase={pipelinePhase}
+          onSelectPhase={onSelectPipelinePhase}
+          extract={repoDeps}
+          repoConnect={repoConnect}
+          onRetryExtract={onLoadRepoDeps}
+          onOpenDependencies={() => onJumpToTab("deps")}
           result={result}
           selectedStage={selectedStage}
           onSelectStage={onSelectStage}
@@ -357,6 +370,9 @@ export function ResultsColumn({
     selectPresetNode,
     focusEditorRepoIndex,
     errorLib,
+    onJumpToTab,
+    pipelinePhase,
+    onSelectPipelinePhase,
     selectedStage,
     onSelectStage,
     deferredStage,

--- a/packages/app/src/app/run-view-context.ts
+++ b/packages/app/src/app/run-view-context.ts
@@ -30,6 +30,7 @@ import type { AuthState } from "@/components/GithubAuthHint";
 import type { ResultsTabDescriptor } from "@/components/ResultsPanel";
 import type { ResultsTabId } from "@/data/results-tabs";
 import type { EffectiveTally } from "@/lib/effective-tally";
+import type { PipelinePhase } from "@/features/pipeline/phases";
 import type { ShareSimulator } from "@/lib/share";
 import type { ErrorTranslationLib } from "@/platform/run";
 import type { SimRequest } from "@/hooks/use-share-link";
@@ -59,6 +60,11 @@ export interface RunView {
   onShowRewrites: () => void;
 
   // —— pipeline ——
+  /** Roadmap 090: which of Renovate's phases the Pipeline tab is showing.
+   *  App's, because opening the Extract phase is what triggers repository
+   *  discovery — and a mounted-but-unseen panel must never trigger it. */
+  pipelinePhase: PipelinePhase;
+  onSelectPipelinePhase: (phase: PipelinePhase) => void;
   selectedStage: StageId;
   onSelectStage: (stage: StageId) => void;
   deferredStage: StageId;

--- a/packages/app/src/components/SegmentedControl.tsx
+++ b/packages/app/src/components/SegmentedControl.tsx
@@ -8,6 +8,11 @@ export interface SegmentedOption<T extends string> {
   label: ReactNode;
   title?: string;
   ariaLabel?: string;
+  /** Roadmap 090: a segment that names a state this app cannot enter — the
+   *  pipeline's Lookup and Update phases, which need the datasource network
+   *  calls the engine deliberately severs. Rendered, because the picker is
+   *  what teaches the sequence, and disabled because nothing is behind it. */
+  disabled?: boolean;
 }
 
 /**
@@ -52,6 +57,7 @@ export function SegmentedControl<T extends string>({
           aria-label={option.ariaLabel}
           title={option.title}
           className={option.value === value ? "active" : undefined}
+          disabled={option.disabled}
           onClick={() => onChange(option.value)}
         >
           {option.label}

--- a/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
+++ b/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
@@ -25,6 +25,8 @@ const EMPTY: RepoDepsView = {
   deps: [],
   fileCount: 0,
   skippedFiles: 0,
+  files: [],
+  managersConsidered: 0,
   truncated: false,
   error: null,
 };

--- a/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
+++ b/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
@@ -97,6 +97,15 @@ describe("DependenciesPanel", () => {
       deps: [DEP],
       fileCount: 1,
       skippedFiles: 2,
+      files: [
+        {
+          path: "Dockerfile",
+          managers: ["dockerfile"],
+          extractedBy: null,
+          depCount: 0,
+          outcome: "no-deps",
+        },
+      ],
     });
 
     expect(
@@ -104,7 +113,29 @@ describe("DependenciesPanel", () => {
     ).toBeTruthy();
     expect(view.getByText("react")).toBeTruthy();
     expect(view.getByText("from acme/webapp")).toBeTruthy();
-    // The honest accounting rides under the table, cap and all.
+    // The honest accounting rides under the table: the files that held nothing,
+    // and the ones the cap left unread.
+    expect(view.container.textContent).toContain("1 matched file did not contain any dependencies");
     expect(view.container.textContent).toContain("2 matched files not read");
+  });
+
+  it("draws no footnote when every matched file was read and contributed", () => {
+    const view = renderPanel({
+      ...EMPTY,
+      status: "ready",
+      repo: "acme/webapp",
+      deps: [DEP],
+      fileCount: 1,
+      files: [
+        {
+          path: "package.json",
+          managers: ["npm"],
+          extractedBy: "npm",
+          depCount: 1,
+          outcome: "extracted",
+        },
+      ],
+    });
+    expect(view.container.querySelector(".data-table-note")).toBeNull();
   });
 });

--- a/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
+++ b/packages/app/src/features/dependencies/DependenciesPanel.test.tsx
@@ -23,8 +23,6 @@ const EMPTY: RepoDepsView = {
   status: "idle",
   repo: "",
   deps: [],
-  fileCount: 0,
-  skippedFiles: 0,
   files: [],
   managersConsidered: 0,
   truncated: false,
@@ -95,15 +93,34 @@ describe("DependenciesPanel", () => {
       status: "ready",
       repo: "acme/webapp",
       deps: [DEP],
-      fileCount: 1,
-      skippedFiles: 2,
       files: [
+        {
+          path: "package.json",
+          managers: ["npm"],
+          extractedBy: "npm",
+          depCount: 1,
+          outcome: "extracted",
+        },
         {
           path: "Dockerfile",
           managers: ["dockerfile"],
           extractedBy: null,
           depCount: 0,
           outcome: "no-deps",
+        },
+        {
+          path: "a/Chart.yaml",
+          managers: ["helmv3"],
+          extractedBy: null,
+          depCount: 0,
+          outcome: "not-read",
+        },
+        {
+          path: "b/Chart.yaml",
+          managers: ["helmv3"],
+          extractedBy: null,
+          depCount: 0,
+          outcome: "not-read",
         },
       ],
     });
@@ -114,7 +131,7 @@ describe("DependenciesPanel", () => {
     expect(view.getByText("react")).toBeTruthy();
     expect(view.getByText("from acme/webapp")).toBeTruthy();
     // The honest accounting rides under the table: the files that held nothing,
-    // and the ones the cap left unread.
+    // and the ones the cap left unread — every count off the same ledger.
     expect(view.container.textContent).toContain("1 matched file did not contain any dependencies");
     expect(view.container.textContent).toContain("2 matched files not read");
   });
@@ -125,7 +142,6 @@ describe("DependenciesPanel", () => {
       status: "ready",
       repo: "acme/webapp",
       deps: [DEP],
-      fileCount: 1,
       files: [
         {
           path: "package.json",

--- a/packages/app/src/features/dependencies/DependenciesPanel.tsx
+++ b/packages/app/src/features/dependencies/DependenciesPanel.tsx
@@ -31,17 +31,22 @@ import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 
 const DEP_NOUN: DataTableNoun = { one: "dependency", many: "dependencies" };
 
-/** What was read, and what honestly was not — the same accounting the
- *  From-repository picker's footnote gives, said once under the table. */
+/** The footnotes the table cannot say itself — matched files that turned out
+ *  to hold nothing, and what honestly was not read at all. Silent when there
+ *  is nothing to report; where the rows came from is the toolbar's note. */
 function DependenciesNote({ view }: { view: RepoDepsView }) {
-  const parts = [`detected because you loaded this config from ${view.repo}`];
+  const emptyFiles = view.files.filter((file) => file.outcome === "no-deps").length;
+  const parts: string[] = [];
+  if (emptyFiles > 0) {
+    parts.push(`${plural(emptyFiles, "matched file")} did not contain any dependencies`);
+  }
   if (view.skippedFiles > 0) {
     parts.push(`${nf.format(view.skippedFiles)} matched files not read`);
   }
   if (view.truncated) {
     parts.push("the repository’s file listing was truncated");
   }
-  return <p className="data-table-note">{parts.join(" · ")}</p>;
+  return parts.length === 0 ? null : <p className="data-table-note">{parts.join(" · ")}</p>;
 }
 
 function DependenciesError({ view, onRetry }: { view: RepoDepsView; onRetry: () => void }) {

--- a/packages/app/src/features/dependencies/DependenciesPanel.tsx
+++ b/packages/app/src/features/dependencies/DependenciesPanel.tsx
@@ -2,6 +2,7 @@ import { DataTable } from "@/components/DataTable";
 import type { DataTableNoun } from "@/components/data-table";
 import { EmptyNote } from "@/components/EmptyNote";
 import { nf, plural } from "@/lib/format";
+import { discoveryCaveats, tallyDiscovery } from "@/lib/discovery-caveats";
 import { RepoConnectPanel } from "@/components/RepoConnectPanel";
 import {
   DEP_COLUMNS,
@@ -32,20 +33,16 @@ import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 const DEP_NOUN: DataTableNoun = { one: "dependency", many: "dependencies" };
 
 /** The footnotes the table cannot say itself — matched files that turned out
- *  to hold nothing, and what honestly was not read at all. Silent when there
- *  is nothing to report; where the rows came from is the toolbar's note. */
+ *  to hold nothing, and the shared caveat clauses every discovery surface
+ *  prints from the same ledger. Silent when there is nothing to report; where
+ *  the rows came from is the toolbar's note. */
 function DependenciesNote({ view }: { view: RepoDepsView }) {
-  const emptyFiles = view.files.filter((file) => file.outcome === "no-deps").length;
+  const empty = tallyDiscovery(view).empty;
   const parts: string[] = [];
-  if (emptyFiles > 0) {
-    parts.push(`${plural(emptyFiles, "matched file")} did not contain any dependencies`);
+  if (empty > 0) {
+    parts.push(`${plural(empty, "matched file")} did not contain any dependencies`);
   }
-  if (view.skippedFiles > 0) {
-    parts.push(`${nf.format(view.skippedFiles)} matched files not read`);
-  }
-  if (view.truncated) {
-    parts.push("the repository’s file listing was truncated");
-  }
+  parts.push(...discoveryCaveats(view));
   return parts.length === 0 ? null : <p className="data-table-note">{parts.join(" · ")}</p>;
 }
 
@@ -104,7 +101,7 @@ export function DependenciesPanel({
         rowNoun={DEP_NOUN}
         filterPlaceholder={`Filter ${nf.format(view.deps.length)} ${
           view.deps.length === 1 ? DEP_NOUN.one : DEP_NOUN.many
-        } across ${plural(view.fileCount, "package file")}…`}
+        } across ${plural(tallyDiscovery(view).extracted, "package file")}…`}
         contextNote={`from ${view.repo}`}
       />
       <DependenciesNote view={view} />

--- a/packages/app/src/features/pipeline/ExtractDepsCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractDepsCard.tsx
@@ -1,0 +1,68 @@
+import { useToggleSet } from "@/hooks/use-toggle-set";
+import { plural } from "@/lib/format";
+import { ExtractDepList, ExtractRow } from "./ExtractRows";
+import { depGroups, type ExtractDepGroup } from "./extract-phase";
+import type { RepoDep, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Extract phase's third card, and the phase's result: every
+ * dependency the walk extracted, grouped by the manager that read it.
+ *
+ * The footer hands the reader on rather than repeating the Dependencies tab:
+ * this card explains WHERE the list came from, that tab is the full searchable
+ * list with the row actions. Switching tabs is the shell's act, so it arrives
+ * as a callback (features never reach into the app layer).
+ */
+
+function depFile(dep: RepoDep): string {
+  return dep.packageFile;
+}
+
+function DepGroupRow({
+  group,
+  open,
+  onToggle,
+}: {
+  group: ExtractDepGroup;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <ExtractRow
+      lead={group.manager}
+      count={plural(group.deps.length, "dep")}
+      open={open}
+      onToggle={onToggle}
+    >
+      <ExtractDepList deps={group.deps} trailing={depFile} />
+    </ExtractRow>
+  );
+}
+
+export function ExtractDepsCard({
+  view,
+  onOpenDependencies,
+}: {
+  view: RepoDepsView;
+  onOpenDependencies: () => void;
+}) {
+  const open = useToggleSet();
+  const groups = depGroups(view);
+  return (
+    <>
+      <ul className="extract-rows">
+        {groups.map((group) => (
+          <DepGroupRow
+            key={group.manager}
+            group={group}
+            open={open.set.has(group.manager)}
+            onToggle={() => open.toggle(group.manager)}
+          />
+        ))}
+      </ul>
+      <button type="button" className="btn-quiet extract-jump" onClick={onOpenDependencies}>
+        Open the Dependencies tab
+      </button>
+    </>
+  );
+}

--- a/packages/app/src/features/pipeline/ExtractDepsCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractDepsCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 import { plural } from "@/lib/format";
 import { ExtractDepList, ExtractRow } from "./ExtractRows";
@@ -47,7 +48,9 @@ export function ExtractDepsCard({
   onOpenDependencies: () => void;
 }) {
   const open = useToggleSet();
-  const groups = depGroups(view);
+  // Derived once per discovery, not once per row toggle — the cap admits
+  // hundreds of files, and expansion state lives in this same component.
+  const groups = useMemo(() => depGroups(view), [view]);
   return (
     <>
       <ul className="extract-rows">

--- a/packages/app/src/features/pipeline/ExtractFilesCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractFilesCard.tsx
@@ -1,0 +1,57 @@
+import { useToggleSet } from "@/hooks/use-toggle-set";
+import { ExtractDepList, ExtractRow } from "./ExtractRows";
+import { type ExtractFileRow, fileDepNote, fileRows } from "./extract-phase";
+import type { RepoDep, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Extract phase's second card: the files discovery actually
+ * READ, and what each of them yielded.
+ *
+ * The managers card above lists every matched file; this one lists the scanned
+ * ones, which is the honest difference the fetch cap makes. A file with no
+ * dependencies still gets a row — a package file Renovate reads and finds
+ * nothing in is a result, not an absence.
+ */
+
+function depManager(dep: RepoDep): string {
+  return dep.manager;
+}
+
+function FileRow({
+  row,
+  open,
+  onToggle,
+}: {
+  row: ExtractFileRow;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <ExtractRow
+      lead={row.file.path}
+      count={fileDepNote(row.file)}
+      note={row.file.managers.join(", ")}
+      open={open}
+      onToggle={onToggle}
+    >
+      <ExtractDepList deps={row.deps} trailing={depManager} />
+    </ExtractRow>
+  );
+}
+
+export function ExtractFilesCard({ view }: { view: RepoDepsView }) {
+  const open = useToggleSet();
+  const rows = fileRows(view);
+  return (
+    <ul className="extract-rows">
+      {rows.map((row) => (
+        <FileRow
+          key={row.file.path}
+          row={row}
+          open={open.set.has(row.file.path)}
+          onToggle={() => open.toggle(row.file.path)}
+        />
+      ))}
+    </ul>
+  );
+}

--- a/packages/app/src/features/pipeline/ExtractFilesCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractFilesCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 import { ExtractDepList, ExtractRow } from "./ExtractRows";
 import { type ExtractFileRow, fileDepNote, fileRows } from "./extract-phase";
@@ -41,7 +42,8 @@ function FileRow({
 
 export function ExtractFilesCard({ view }: { view: RepoDepsView }) {
   const open = useToggleSet();
-  const rows = fileRows(view);
+  // Derived once per discovery, not once per row toggle (see ExtractDepsCard).
+  const rows = useMemo(() => fileRows(view), [view]);
   return (
     <ul className="extract-rows">
       {rows.map((row) => (

--- a/packages/app/src/features/pipeline/ExtractManagersCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractManagersCard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useToggleSet } from "@/hooks/use-toggle-set";
 import { plural } from "@/lib/format";
 import { ExtractNotes, ExtractRow } from "./ExtractRows";
@@ -57,7 +58,9 @@ function ManagerRow({
 
 export function ExtractManagersCard({ view }: { view: RepoDepsView }) {
   const open = useToggleSet();
-  const rows = managerRows(view);
+  // Derived once per discovery, not once per row toggle (see ExtractDepsCard).
+  const rows = useMemo(() => managerRows(view), [view]);
+  const notes = useMemo(() => managerNotes(view), [view]);
   return (
     <>
       <ul className="extract-rows">
@@ -70,7 +73,7 @@ export function ExtractManagersCard({ view }: { view: RepoDepsView }) {
           />
         ))}
       </ul>
-      <ExtractNotes notes={managerNotes(view)} />
+      <ExtractNotes notes={notes} />
     </>
   );
 }

--- a/packages/app/src/features/pipeline/ExtractManagersCard.tsx
+++ b/packages/app/src/features/pipeline/ExtractManagersCard.tsx
@@ -1,0 +1,76 @@
+import { useToggleSet } from "@/hooks/use-toggle-set";
+import { plural } from "@/lib/format";
+import { ExtractNotes, ExtractRow } from "./ExtractRows";
+import {
+  type ExtractManagerRow,
+  fileDepNote,
+  fileDepTone,
+  managerNotes,
+  managerRows,
+} from "./extract-phase";
+import type { RepoDepFile, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Extract phase's first card: which managers claimed which
+ * files.
+ *
+ * Matching is the cheap path-only step, so this covers the WHOLE walk — every
+ * file the tree listing offered, not just the ten discovery went on to fetch.
+ * A file the cap dropped says "not read" rather than "no deps": nobody read
+ * it, so nothing at all is known about what is inside.
+ */
+
+function ManagerFiles({ files }: { files: readonly RepoDepFile[] }) {
+  return (
+    <ul className="extract-sublist">
+      {files.map((file) => (
+        <li key={file.path} className="extract-subrow">
+          <code className="extract-subrow-lead">{file.path}</code>
+          <span className={`extract-subrow-trail ${fileDepTone(file)}`}>{fileDepNote(file)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ManagerRow({
+  row,
+  open,
+  onToggle,
+}: {
+  row: ExtractManagerRow;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <ExtractRow
+      lead={row.manager}
+      count={plural(row.files.length, "file")}
+      note={row.preview}
+      open={open}
+      onToggle={onToggle}
+    >
+      <ManagerFiles files={row.files} />
+    </ExtractRow>
+  );
+}
+
+export function ExtractManagersCard({ view }: { view: RepoDepsView }) {
+  const open = useToggleSet();
+  const rows = managerRows(view);
+  return (
+    <>
+      <ul className="extract-rows">
+        {rows.map((row) => (
+          <ManagerRow
+            key={row.manager}
+            row={row}
+            open={open.set.has(row.manager)}
+            onToggle={() => open.toggle(row.manager)}
+          />
+        ))}
+      </ul>
+      <ExtractNotes notes={managerNotes(view)} />
+    </>
+  );
+}

--- a/packages/app/src/features/pipeline/ExtractPhase.test.tsx
+++ b/packages/app/src/features/pipeline/ExtractPhase.test.tsx
@@ -34,8 +34,6 @@ const EMPTY: RepoDepsView = {
   status: "idle",
   repo: "",
   deps: [],
-  fileCount: 0,
-  skippedFiles: 0,
   files: [],
   managersConsidered: 0,
   truncated: false,
@@ -47,8 +45,6 @@ const READY: RepoDepsView = {
   status: "ready",
   repo: "acme/webapp",
   deps: [dep("react", "package.json", "npm"), dep("node", "Dockerfile", "dockerfile")],
-  fileCount: 2,
-  skippedFiles: 1,
   files: [
     {
       path: "package.json",

--- a/packages/app/src/features/pipeline/ExtractPhase.test.tsx
+++ b/packages/app/src/features/pipeline/ExtractPhase.test.tsx
@@ -1,0 +1,183 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExtractPhase } from "./ExtractPhase";
+import type { RepoConnectOffer, RepoDep, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Extract phase as it is rendered: its four pre-report
+ * states (none of which may be a track of zeros), the node that is selected
+ * first, and what each node's card opens onto.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+const CONNECT: RepoConnectOffer = {
+  suggestion: null,
+  onConnect: () => undefined,
+  onOpenLoad: () => undefined,
+};
+
+function dep(name: string, file: string, manager: string): RepoDep {
+  return {
+    key: `${file}:0:${name}`,
+    depName: name,
+    value: "1.0.0",
+    meta: `${file} · 1.0.0`,
+    manager,
+    packageFile: file,
+    fill: { depName: name, manager, packageFile: file },
+  };
+}
+
+const EMPTY: RepoDepsView = {
+  status: "idle",
+  repo: "",
+  deps: [],
+  fileCount: 0,
+  skippedFiles: 0,
+  files: [],
+  managersConsidered: 0,
+  truncated: false,
+  error: null,
+};
+
+const READY: RepoDepsView = {
+  ...EMPTY,
+  status: "ready",
+  repo: "acme/webapp",
+  deps: [dep("react", "package.json", "npm"), dep("node", "Dockerfile", "dockerfile")],
+  fileCount: 2,
+  skippedFiles: 1,
+  files: [
+    {
+      path: "package.json",
+      managers: ["npm"],
+      extractedBy: "npm",
+      depCount: 1,
+      outcome: "extracted",
+    },
+    {
+      path: "Dockerfile",
+      managers: ["dockerfile"],
+      extractedBy: "dockerfile",
+      depCount: 1,
+      outcome: "extracted",
+    },
+    {
+      path: "docs/package.json",
+      managers: ["npm"],
+      extractedBy: null,
+      depCount: 0,
+      outcome: "not-read",
+    },
+    {
+      path: ".github/workflows/ci.yml",
+      managers: ["github-actions"],
+      extractedBy: null,
+      depCount: 0,
+      outcome: "no-deps",
+    },
+  ],
+  managersConsidered: 100,
+};
+
+function renderPhase(view: RepoDepsView, over: Partial<Parameters<typeof ExtractPhase>[0]> = {}) {
+  return render(
+    <ExtractPhase
+      view={view}
+      connect={CONNECT}
+      onRetry={vi.fn()}
+      onOpenDependencies={vi.fn()}
+      {...over}
+    />,
+  );
+}
+
+describe("ExtractPhase states", () => {
+  it("offers to connect a repository when none is loaded", () => {
+    const onOpenLoad = vi.fn();
+    const view = renderPhase(EMPTY, { connect: { ...CONNECT, onOpenLoad } });
+
+    expect(view.container.textContent).toContain("The repository isn’t loaded in this session");
+    // Above all: no track of zeros claiming a walk that never ran.
+    expect(view.container.querySelector(".stage-rail")).toBeNull();
+  });
+
+  it("says it is reading while discovery runs", () => {
+    const view = renderPhase({ ...EMPTY, status: "loading", repo: "acme/webapp" });
+    expect(view.container.textContent).toContain("Reading acme/webapp’s package files…");
+    expect(view.container.querySelector(".stage-rail")).toBeNull();
+  });
+
+  it("states a failure and offers the retry", () => {
+    const onRetry = vi.fn();
+    const view = renderPhase(
+      { ...EMPTY, status: "error", repo: "acme/webapp", error: "rate limited" },
+      { onRetry },
+    );
+
+    expect(view.container.textContent).toContain("Could not read acme/webapp: rate limited");
+    fireEvent.click(view.getByRole("button", { name: "Try again" }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("says nothing matched rather than drawing an empty track", () => {
+    const view = renderPhase({ ...EMPTY, status: "ready", repo: "acme/webapp" });
+    expect(view.container.textContent).toContain("No package files matched in acme/webapp");
+    expect(view.container.querySelector(".stage-rail")).toBeNull();
+  });
+});
+
+describe("ExtractPhase report", () => {
+  it("opens on the phase's result, with the three steps beside it", () => {
+    const view = renderPhase(READY);
+
+    const nodes = [...view.container.querySelectorAll(".stage-rail-btn")];
+    expect(nodes.map((node) => node.textContent)).toEqual([
+      "Match managers3",
+      "Scan files3 package files",
+      "Extract deps+2",
+    ]);
+    expect(view.container.querySelector(".card-title")?.textContent).toBe(
+      "Extract deps — 2 dependencies from acme/webapp",
+    );
+    // Grouped by the manager that read them, opening onto the deps themselves.
+    fireEvent.click(view.getByRole("button", { name: /npm/ }));
+    expect(view.getByText("react")).toBeTruthy();
+  });
+
+  it("hands the reader on to the Dependencies tab rather than repeating it", () => {
+    const onOpenDependencies = vi.fn();
+    const view = renderPhase(READY, { onOpenDependencies });
+
+    fireEvent.click(view.getByRole("button", { name: "Open the Dependencies tab" }));
+    expect(onOpenDependencies).toHaveBeenCalledOnce();
+  });
+
+  it("shows every matched file under Match managers, unread ones included", () => {
+    const view = renderPhase(READY);
+
+    fireEvent.click(view.getByRole("button", { name: /Match managers/ }));
+    expect(view.container.querySelector(".card-title")?.textContent).toBe(
+      "Match managers — 3 of 100 managers matched files",
+    );
+    fireEvent.click(view.getByRole("button", { name: /npm/ }));
+    expect(view.getByText("docs/package.json")).toBeTruthy();
+    // The cap dropped it, so nothing is claimed about its contents.
+    expect(view.getByText("not read")).toBeTruthy();
+    expect(view.container.textContent).toContain("97 other managers matched no files.");
+  });
+
+  it("lists only the files discovery actually read under Scan files", () => {
+    const view = renderPhase(READY);
+
+    fireEvent.click(view.getByRole("button", { name: /Scan files/ }));
+    expect(view.container.querySelector(".card-title")?.textContent).toBe(
+      "Scan files — 3 package files scanned",
+    );
+    expect(view.queryByText("docs/package.json")).toBeNull();
+    fireEvent.click(view.getByRole("button", { name: /package\.json/ }));
+    expect(view.getByText("react")).toBeTruthy();
+  });
+});

--- a/packages/app/src/features/pipeline/ExtractPhase.tsx
+++ b/packages/app/src/features/pipeline/ExtractPhase.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { EmptyNote } from "@/components/EmptyNote";
+import { RepoConnectPanel } from "@/components/RepoConnectPanel";
+import { ExtractDepsCard } from "./ExtractDepsCard";
+import { ExtractFilesCard } from "./ExtractFilesCard";
+import { ExtractManagersCard } from "./ExtractManagersCard";
+import { ExtractTrack } from "./ExtractTrack";
+import { type ExtractNode, type ExtractNodeId, extractNodes } from "./extract-phase";
+import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Pipeline tab's Extract phase: what Renovate's extraction
+ * did to the loaded repository, as the three steps it actually performs.
+ *
+ * The states before the walk has anything to report are the Dependencies tab's
+ * (089), and for the same reason: "no repository" is an offer, "reading" and
+ * "failed" are statuses, and none of them may be drawn as a track of zeros —
+ * three green nodes reading 0/0/+0 would claim a walk that never ran.
+ *
+ * The Extract-deps node is selected first because it is the phase's RESULT;
+ * the two before it explain how it was arrived at, which is a question a
+ * reader asks second.
+ */
+
+export interface ExtractPhaseProps {
+  view: RepoDepsView;
+  /** What to offer while no repository is loaded — the shell's. */
+  connect: RepoConnectOffer;
+  /** Re-runs discovery after a failure; the FIRST run is the shell's own (it
+   *  fires when this phase becomes the visible one, never on the load). */
+  onRetry: () => void;
+  /** Jumps to the Dependencies tab — the shell owns tab switching. */
+  onOpenDependencies: () => void;
+}
+
+function ExtractCardHeader({ node }: { node: ExtractNode }) {
+  return (
+    <div className="card-title">
+      {node.label}
+      <span className="card-title-hint"> — {node.outcome}</span>
+    </div>
+  );
+}
+
+function ExtractCardBody({
+  node,
+  view,
+  onOpenDependencies,
+}: {
+  node: ExtractNodeId;
+  view: RepoDepsView;
+  onOpenDependencies: () => void;
+}) {
+  if (node === "managers") {
+    return <ExtractManagersCard view={view} />;
+  }
+  if (node === "files") {
+    return <ExtractFilesCard view={view} />;
+  }
+  return <ExtractDepsCard view={view} onOpenDependencies={onOpenDependencies} />;
+}
+
+function ExtractFailure({ view, onRetry }: { view: RepoDepsView; onRetry: () => void }) {
+  return (
+    <div className="extract-status">
+      <p className="sim-empty-guard">
+        Could not read {view.repo}: {view.error}
+      </p>
+      <button type="button" className="btn-quiet" onClick={onRetry}>
+        Try again
+      </button>
+    </div>
+  );
+}
+
+function ExtractReport({
+  view,
+  onOpenDependencies,
+}: {
+  view: RepoDepsView;
+  onOpenDependencies: () => void;
+}) {
+  const [selected, setSelected] = useState<ExtractNodeId>("deps");
+  const nodes = extractNodes(view);
+  const node = nodes.find((candidate) => candidate.id === selected) ?? nodes[0];
+  if (node === undefined) {
+    return null;
+  }
+  return (
+    <>
+      <ExtractTrack nodes={nodes} selected={node.id} onSelect={setSelected} />
+      <div className="card">
+        <ExtractCardHeader node={node} />
+        <ExtractCardBody node={node.id} view={view} onOpenDependencies={onOpenDependencies} />
+      </div>
+    </>
+  );
+}
+
+export function ExtractPhase({ view, connect, onRetry, onOpenDependencies }: ExtractPhaseProps) {
+  if (view.repo === "") {
+    return <RepoConnectPanel offer={connect} />;
+  }
+  if (view.status === "idle" || view.status === "loading") {
+    return <p className="extract-status">Reading {view.repo}’s package files…</p>;
+  }
+  if (view.status === "error") {
+    return <ExtractFailure view={view} onRetry={onRetry} />;
+  }
+  if (view.files.length === 0) {
+    return (
+      <EmptyNote>
+        No package files matched in {view.repo} — none of the managers the browser engine can run
+        claims a file in this repository.
+      </EmptyNote>
+    );
+  }
+  return <ExtractReport view={view} onOpenDependencies={onOpenDependencies} />;
+}

--- a/packages/app/src/features/pipeline/ExtractPhase.tsx
+++ b/packages/app/src/features/pipeline/ExtractPhase.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { EmptyNote } from "@/components/EmptyNote";
 import { RepoConnectPanel } from "@/components/RepoConnectPanel";
 import { ExtractDepsCard } from "./ExtractDepsCard";
@@ -81,7 +81,7 @@ function ExtractReport({
   onOpenDependencies: () => void;
 }) {
   const [selected, setSelected] = useState<ExtractNodeId>("deps");
-  const nodes = extractNodes(view);
+  const nodes = useMemo(() => extractNodes(view), [view]);
   const node = nodes.find((candidate) => candidate.id === selected) ?? nodes[0];
   if (node === undefined) {
     return null;

--- a/packages/app/src/features/pipeline/ExtractRows.tsx
+++ b/packages/app/src/features/pipeline/ExtractRows.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from "react";
+import { Caret } from "@/components/Caret";
+import type { RepoDep } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the parts the Extract phase's three cards are built from: a
+ * disclosure row, a dependency list, and the muted notes under a card.
+ *
+ * One row implementation rather than three near-identical ones: the cards
+ * differ in what a row LEADS with (a manager, a file, a manager again) and in
+ * what it opens onto, not in how a row behaves. The lead is a `<code>` in all
+ * three because all three are identifiers Renovate itself would print.
+ */
+
+export function ExtractRow({
+  lead,
+  count,
+  note,
+  open,
+  onToggle,
+  children,
+}: {
+  lead: string;
+  /** The row's own number — "4 files", "6 deps". */
+  count: string;
+  /** The muted line the collapsed row previews its contents with. */
+  note?: string;
+  open: boolean;
+  onToggle: () => void;
+  /** What the row opens onto; rendered only while open. */
+  children: ReactNode;
+}) {
+  return (
+    <li className={open ? "extract-row open" : "extract-row"}>
+      <button type="button" className="extract-row-head" aria-expanded={open} onClick={onToggle}>
+        <Caret open={open} />
+        <code className="extract-row-lead">{lead}</code>
+        <span className="extract-row-count">{count}</span>
+        <span className="extract-row-note">{note ?? ""}</span>
+      </button>
+      {open ? children : null}
+    </li>
+  );
+}
+
+/** The dependencies an open row lists: the name, what the file says it is at,
+ *  and one trailing fact the card chooses (the manager, or the file). */
+export function ExtractDepList({
+  deps,
+  trailing,
+}: {
+  deps: readonly RepoDep[];
+  trailing: (dep: RepoDep) => string;
+}) {
+  return (
+    <ul className="extract-sublist">
+      {deps.map((dep) => (
+        <li key={dep.key} className="extract-subrow">
+          <code className="extract-subrow-lead">{dep.depName}</code>
+          <span className="extract-subrow-value">{dep.value === "" ? "—" : dep.value}</span>
+          <span className="extract-subrow-trail">{trailing(dep)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** The small print under a card: what the walk did not do. */
+export function ExtractNotes({ notes }: { notes: readonly string[] }) {
+  return (
+    <p className="extract-notes">
+      {notes.map((note) => (
+        <span key={note} className="extract-note-line">
+          {note}
+        </span>
+      ))}
+    </p>
+  );
+}

--- a/packages/app/src/features/pipeline/ExtractTrack.tsx
+++ b/packages/app/src/features/pipeline/ExtractTrack.tsx
@@ -1,0 +1,65 @@
+import type { ExtractNode, ExtractNodeId } from "./extract-phase";
+
+/**
+ * Roadmap 090 — the Extract phase's own three-step track: match managers,
+ * scan files, extract deps.
+ *
+ * Deliberately the stage rail's grammar (a dot on a line, a name, a delta
+ * under it) and deliberately NOT `StageRail` itself: that component is typed
+ * on the engine's `StageId` and reads a `TraceResult` for its glyphs, neither
+ * of which exists here — extraction is not a pipeline stage. What is shared is
+ * what should be: the geometry and the glyph, through the rail's own classes,
+ * so the two tracks cannot drift apart visually.
+ */
+
+function ExtractTrackNode({
+  node,
+  selected,
+  onSelect,
+}: {
+  node: ExtractNode;
+  selected: boolean;
+  onSelect: (id: ExtractNodeId) => void;
+}) {
+  return (
+    <li className="stage-rail-node">
+      <button
+        type="button"
+        className={`stage-rail-btn${selected ? " selected" : ""}`}
+        data-extract-node={node.id}
+        aria-pressed={selected}
+        aria-label={`${node.label}: ${node.outcome}`}
+        onClick={() => onSelect(node.id)}
+      >
+        <span className="stage-rail-glyph clean" aria-hidden="true" />
+        <span className="stage-rail-label">{node.label}</span>
+        <span className={`stage-rail-delta ${node.metaTone}`} aria-hidden="true">
+          {node.meta}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export function ExtractTrack({
+  nodes,
+  selected,
+  onSelect,
+}: {
+  nodes: readonly ExtractNode[];
+  selected: ExtractNodeId;
+  onSelect: (id: ExtractNodeId) => void;
+}) {
+  return (
+    <ol className="stage-rail" aria-label="Extraction steps">
+      {nodes.map((node) => (
+        <ExtractTrackNode
+          key={node.id}
+          node={node}
+          selected={node.id === selected}
+          onSelect={onSelect}
+        />
+      ))}
+    </ol>
+  );
+}

--- a/packages/app/src/features/pipeline/PhasePicker.test.tsx
+++ b/packages/app/src/features/pipeline/PhasePicker.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PhasePicker } from "./PhasePicker";
+import type { RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the phase picker: Renovate's four phases, the two this app
+ * runs, and the counts behind each door.
+ *
+ * The claim under test is the honest one: a phase nothing is behind says so
+ * (and cannot be selected), and a count appears only once the thing that
+ * produces it has reported.
+ */
+
+afterEach(cleanup);
+
+const EMPTY: RepoDepsView = {
+  status: "idle",
+  repo: "",
+  deps: [],
+  fileCount: 0,
+  skippedFiles: 0,
+  files: [],
+  managersConsidered: 0,
+  truncated: false,
+  error: null,
+};
+
+function renderPicker(
+  over: Partial<Parameters<typeof PhasePicker>[0]> = {},
+): ReturnType<typeof render> {
+  return render(
+    <PhasePicker
+      phase="config"
+      onSelectPhase={vi.fn()}
+      effectiveKeys={62}
+      extract={EMPTY}
+      {...over}
+    />,
+  );
+}
+
+describe("PhasePicker", () => {
+  it("names all four phases in Renovate's order, whether or not they run here", () => {
+    const view = renderPicker();
+    const names = [...view.container.querySelectorAll(".phase-seg-name")].map(
+      (node) => node.textContent,
+    );
+    expect(names).toEqual(["Config", "Extract", "Lookup", "Update"]);
+  });
+
+  it("disables the two phases nothing is behind and says why", () => {
+    const view = renderPicker();
+    for (const label of ["Lookup", "Update"]) {
+      const segment = view.getByRole("radio", { name: `${label}, not available yet` });
+      expect((segment as HTMLButtonElement).disabled).toBe(true);
+      expect(segment.getAttribute("title")).toBe("Not available today");
+    }
+  });
+
+  it("counts the effective config's options under Config", () => {
+    const view = renderPicker();
+    expect(view.getByRole("radio", { name: "Config, 62 options" })).toBeTruthy();
+    // …and says nothing at all while the count is still being computed.
+    cleanup();
+    const pending = renderPicker({ effectiveKeys: null });
+    expect(pending.getByRole("radio", { name: "Config" })).toBeTruthy();
+  });
+
+  it("counts the extracted deps only once discovery has reported", () => {
+    const loading = renderPicker({ extract: { ...EMPTY, status: "loading", repo: "acme/webapp" } });
+    expect(loading.getByRole("radio", { name: "Extract, reading…" })).toBeTruthy();
+    cleanup();
+
+    const ready = renderPicker({
+      extract: {
+        ...EMPTY,
+        status: "ready",
+        repo: "acme/webapp",
+        deps: [
+          {
+            key: "package.json:0:react",
+            depName: "react",
+            value: "17.0.0",
+            meta: "package.json · 17.0.0",
+            manager: "npm",
+            packageFile: "package.json",
+            fill: {},
+          },
+        ],
+      },
+    });
+    const segment = ready.getByRole("radio", { name: "Extract, +1 deps" });
+    expect(segment.querySelector(".phase-seg-note.ok")).toBeTruthy();
+  });
+
+  it("reports the phase the reader picked", () => {
+    const onSelectPhase = vi.fn();
+    const view = renderPicker({ onSelectPhase });
+
+    fireEvent.click(view.getByRole("radio", { name: "Extract" }));
+    expect(onSelectPhase).toHaveBeenCalledWith("extract");
+  });
+});

--- a/packages/app/src/features/pipeline/PhasePicker.test.tsx
+++ b/packages/app/src/features/pipeline/PhasePicker.test.tsx
@@ -18,8 +18,6 @@ const EMPTY: RepoDepsView = {
   status: "idle",
   repo: "",
   deps: [],
-  fileCount: 0,
-  skippedFiles: 0,
   files: [],
   managersConsidered: 0,
   truncated: false,

--- a/packages/app/src/features/pipeline/PhasePicker.tsx
+++ b/packages/app/src/features/pipeline/PhasePicker.tsx
@@ -1,0 +1,99 @@
+import { SegmentedControl, type SegmentedOption } from "@/components/SegmentedControl";
+import { nf, plural } from "@/lib/format";
+import {
+  PHASE_UNAVAILABLE_NOTE,
+  PIPELINE_PHASES,
+  type PipelinePhase,
+  type PipelinePhaseDescriptor,
+} from "./phases";
+import type { RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — the Pipeline tab's phase picker: Renovate's four phases as one
+ * segmented control, two of which this app can run.
+ *
+ * The app's own `SegmentedControl` rather than a fourth hand-rolled strip: it
+ * labels a STATE (which phase is on screen), which is what that component is
+ * for, and it carries the radiogroup semantics a home-made row of buttons
+ * always forgets. A segment's subtitle is the count the phase produced, so the
+ * picker also says what is behind each door before it is opened.
+ */
+
+interface PhaseNote {
+  text: string;
+  tone: "muted" | "ok";
+}
+
+/** The subtitle under a segment's name — a real count, or nothing. Never a
+ *  zero standing in for "not measured yet": the Extract segment stays quiet
+ *  until discovery has reported, exactly as the tab badges do. */
+// Not exported: the picker is this file's only consumer, and a helper beside a
+// component is what the fast-refresh rule refuses.
+function phaseNote(
+  phase: PipelinePhase,
+  effectiveKeys: number | null,
+  extract: RepoDepsView,
+): PhaseNote | null {
+  if (phase === "config") {
+    return effectiveKeys === null ? null : { text: plural(effectiveKeys, "option"), tone: "muted" };
+  }
+  if (phase === "extract") {
+    if (extract.status === "ready") {
+      return { text: `+${nf.format(extract.deps.length)} deps`, tone: "ok" };
+    }
+    return extract.status === "loading" ? { text: "reading…", tone: "muted" } : null;
+  }
+  return { text: PHASE_UNAVAILABLE_NOTE, tone: "muted" };
+}
+
+function PhaseLabel({ label, note }: { label: string; note: PhaseNote | null }) {
+  return (
+    <>
+      <span className="phase-seg-name">{label}</span>
+      <span className={note === null ? "phase-seg-note" : `phase-seg-note ${note.tone}`}>
+        {note?.text ?? ""}
+      </span>
+    </>
+  );
+}
+
+function phaseOption(
+  descriptor: PipelinePhaseDescriptor,
+  note: PhaseNote | null,
+): SegmentedOption<PipelinePhase> {
+  return {
+    value: descriptor.id,
+    label: <PhaseLabel label={descriptor.label} note={note} />,
+    // The visible label is two lines; spoken it is one sentence.
+    ariaLabel: note === null ? descriptor.label : `${descriptor.label}, ${note.text}`,
+    title: descriptor.title,
+    disabled: !descriptor.available,
+  };
+}
+
+export function PhasePicker({
+  phase,
+  onSelectPhase,
+  effectiveKeys,
+  extract,
+}: {
+  phase: PipelinePhase;
+  onSelectPhase: (phase: PipelinePhase) => void;
+  /** Keys in the effective config, or null while provenance is still being
+   *  computed — the Config segment's own count. */
+  effectiveKeys: number | null;
+  extract: RepoDepsView;
+}) {
+  const options = PIPELINE_PHASES.map((descriptor) =>
+    phaseOption(descriptor, phaseNote(descriptor.id, effectiveKeys, extract)),
+  );
+  return (
+    <SegmentedControl
+      className="phase-picker"
+      label="Pipeline phase"
+      value={phase}
+      options={options}
+      onChange={onSelectPhase}
+    />
+  );
+}

--- a/packages/app/src/features/pipeline/PipelinePanel.tsx
+++ b/packages/app/src/features/pipeline/PipelinePanel.tsx
@@ -8,8 +8,12 @@ import type { LayerParseResult } from "@/lib/input-schemas";
 import { presetTreeSummary } from "@/lib/preset-tree-stats";
 import { getStageActivity } from "@/lib/stage-activity";
 import { stageHint } from "@/lib/stage-delta";
+import { ExtractPhase } from "./ExtractPhase";
+import { PhasePicker } from "./PhasePicker";
+import type { PipelinePhase } from "./phases";
 import { StageDiff } from "./StageDiff";
 import { StageLayerEditor } from "./StageLayerEditor";
+import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 
 /**
  * The Pipeline tab, as a slice.
@@ -164,33 +168,13 @@ export interface StageLayersProps {
   inheritState: InheritLayerState | null;
 }
 
-export interface PipelinePanelProps extends StageLayersProps {
-  result: TraceResult;
-  /**
-   * The two stage identities are NOT interchangeable, and the split is the
-   * point of this panel's wiring:
-   *
-   * `selectedStage` is what the user just clicked — it drives the rail's
-   * selection and the layer editor, both of which are inputs, and an input that
-   * lags a click by a frame eats the first keystroke typed into it.
-   *
-   * `deferredStage` lags under load (`useDeferredValue` in App) and drives the
-   * expensive renders — the whole-stage diff and the rewrite stepper — so a
-   * click paints the new selection immediately and the heavy body catches up.
-   * `rendering` is exactly the window where the two disagree.
-   */
-  selectedStage: StageId;
-  onSelectStage: (stage: StageId) => void;
-  deferredStage: StageId;
-  effectiveKeys: number | null;
-  migrateSteps: TraceEvent[];
-  migrateStepperMounted: boolean;
-  finalMigrated: unknown;
-  migrationStepIndex: number;
-  onMigrationStepChange: (index: number) => void;
-}
-
-export function PipelinePanel({
+/**
+ * Roadmap 090: the Config phase — everything this tab was before the picker
+ * existed, unchanged and now behind the first segment. Its own component so
+ * `PipelinePanel` is the phase switch and nothing else (and so the card's JSX
+ * keeps its depth under the ratchet).
+ */
+function ConfigPhase({
   result,
   selectedStage,
   onSelectStage,
@@ -208,7 +192,7 @@ export function PipelinePanel({
   globalParse,
   inheritedParse,
   inheritState,
-}: PipelinePanelProps) {
+}: ConfigPhaseProps) {
   return (
     <>
       <StageRail
@@ -252,6 +236,80 @@ export function PipelinePanel({
       {deferredStage === "migrate" && !migrateStepperMounted ? (
         <EmptyNote>No rewrites — this config already uses current option names.</EmptyNote>
       ) : null}
+    </>
+  );
+}
+
+interface ConfigPhaseProps extends StageLayersProps {
+  result: TraceResult;
+  /**
+   * The two stage identities are NOT interchangeable, and the split is the
+   * point of this panel's wiring:
+   *
+   * `selectedStage` is what the user just clicked — it drives the rail's
+   * selection and the layer editor, both of which are inputs, and an input that
+   * lags a click by a frame eats the first keystroke typed into it.
+   *
+   * `deferredStage` lags under load (`useDeferredValue` in App) and drives the
+   * expensive renders — the whole-stage diff and the rewrite stepper — so a
+   * click paints the new selection immediately and the heavy body catches up.
+   * `rendering` is exactly the window where the two disagree.
+   */
+  selectedStage: StageId;
+  onSelectStage: (stage: StageId) => void;
+  deferredStage: StageId;
+  effectiveKeys: number | null;
+  migrateSteps: TraceEvent[];
+  migrateStepperMounted: boolean;
+  finalMigrated: unknown;
+  migrationStepIndex: number;
+  onMigrationStepChange: (index: number) => void;
+}
+
+export interface PipelinePanelProps extends ConfigPhaseProps {
+  /**
+   * Roadmap 090: which of Renovate's phases is on screen. App's state rather
+   * than this panel's, for one reason: opening the Extract phase is what
+   * TRIGGERS repository discovery, and every results panel stays mounted (028)
+   * — a panel-side trigger would fire for a tab nobody has looked at.
+   */
+  phase: PipelinePhase;
+  onSelectPhase: (phase: PipelinePhase) => void;
+  /** The loaded repository's extracted dependencies, and the three things the
+   *  Extract phase does with them that are the shell's, not this tab's. */
+  extract: RepoDepsView;
+  repoConnect: RepoConnectOffer;
+  onRetryExtract: () => void;
+  onOpenDependencies: () => void;
+}
+
+export function PipelinePanel({
+  phase,
+  onSelectPhase,
+  extract,
+  repoConnect,
+  onRetryExtract,
+  onOpenDependencies,
+  ...config
+}: PipelinePanelProps) {
+  return (
+    <>
+      <PhasePicker
+        phase={phase}
+        onSelectPhase={onSelectPhase}
+        effectiveKeys={config.effectiveKeys}
+        extract={extract}
+      />
+      {phase === "extract" ? (
+        <ExtractPhase
+          view={extract}
+          connect={repoConnect}
+          onRetry={onRetryExtract}
+          onOpenDependencies={onOpenDependencies}
+        />
+      ) : (
+        <ConfigPhase {...config} />
+      )}
     </>
   );
 }

--- a/packages/app/src/features/pipeline/extract-phase.test.ts
+++ b/packages/app/src/features/pipeline/extract-phase.test.ts
@@ -45,8 +45,6 @@ const VIEW: RepoDepsView = {
     dep("typescript", "package.json", "npm"),
     dep("node", "Dockerfile", "dockerfile"),
   ],
-  fileCount: 2,
-  skippedFiles: 1,
   files: [
     walkFile("package.json", ["npm"], { extractedBy: "npm", depCount: 2, outcome: "extracted" }),
     walkFile("Dockerfile", ["dockerfile"], {
@@ -142,7 +140,8 @@ describe("managerNotes", () => {
     const notes = managerNotes(VIEW);
 
     expect(notes[0]).toBe("97 other managers matched no files.");
-    expect(notes[1]).toContain("1 matched file was not read");
+    // The shared clause (`lib/discovery-caveats`), sentence-cased by this card.
+    expect(notes[1]).toContain("1 matched file not read");
     // The permanent one: this walk is not config-aware, and says so.
     expect(notes.at(-1)).toContain("enabledManagers and ignorePaths from your merged config");
   });

--- a/packages/app/src/features/pipeline/extract-phase.test.ts
+++ b/packages/app/src/features/pipeline/extract-phase.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+  depGroups,
+  extractNodes,
+  fileDepNote,
+  fileDepTone,
+  fileRows,
+  managerNotes,
+  managerRows,
+  matchedManagerNames,
+  scannedFiles,
+} from "./extract-phase";
+import type { RepoDep, RepoDepFile, RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090 — what the Extract phase is allowed to SAY about a walk.
+ *
+ * The claims under test are honesty claims: a file the fetch cap dropped is
+ * never counted as scanned and never described as empty, the manager
+ * denominator is the walk's own, and the footnotes state the config the walk
+ * does not apply.
+ */
+
+function dep(name: string, file: string, manager: string): RepoDep {
+  return {
+    key: `${file}:0:${name}`,
+    depName: name,
+    value: "1.0.0",
+    meta: `${file} · 1.0.0`,
+    manager,
+    packageFile: file,
+    fill: { depName: name, manager, packageFile: file },
+  };
+}
+
+function walkFile(path: string, managers: string[], over: Partial<RepoDepFile> = {}): RepoDepFile {
+  return { path, managers, extractedBy: null, depCount: 0, outcome: "not-read", ...over };
+}
+
+const VIEW: RepoDepsView = {
+  status: "ready",
+  repo: "acme/webapp",
+  deps: [
+    dep("react", "package.json", "npm"),
+    dep("typescript", "package.json", "npm"),
+    dep("node", "Dockerfile", "dockerfile"),
+  ],
+  fileCount: 2,
+  skippedFiles: 1,
+  files: [
+    walkFile("package.json", ["npm"], { extractedBy: "npm", depCount: 2, outcome: "extracted" }),
+    walkFile("Dockerfile", ["dockerfile"], {
+      extractedBy: "dockerfile",
+      depCount: 1,
+      outcome: "extracted",
+    }),
+    walkFile("docs/package.json", ["npm"]),
+    walkFile(".github/workflows/ci.yml", ["github-actions"], { outcome: "no-deps" }),
+  ],
+  managersConsidered: 100,
+  truncated: false,
+  error: null,
+};
+
+describe("extractNodes", () => {
+  it("counts managers, scanned files and deps, each against what the walk did", () => {
+    const [managers, files, deps] = extractNodes(VIEW);
+
+    expect(managers?.meta).toBe("3");
+    expect(managers?.outcome).toBe("3 of 100 managers matched files");
+    // Three of the four matched files were READ — the fourth is past the cap.
+    expect(files?.meta).toBe("3 package files");
+    expect(files?.outcome).toBe("3 package files scanned");
+    expect(deps?.meta).toBe("+3");
+    expect(deps?.metaTone).toBe("ok");
+    expect(deps?.outcome).toBe("3 dependencies from acme/webapp");
+  });
+
+  it("says one dependency rather than 1 dependencies", () => {
+    const nodes = extractNodes({ ...VIEW, deps: [dep("react", "package.json", "npm")] });
+    expect(nodes[2]?.outcome).toBe("1 dependency from acme/webapp");
+  });
+});
+
+describe("the walk's own rows", () => {
+  it("lists managers most files first, with every claimed file", () => {
+    const rows = managerRows(VIEW);
+
+    expect(rows.map((row) => row.manager)).toEqual(["npm", "dockerfile", "github-actions"]);
+    expect(rows[0]?.files.map((f) => f.path)).toEqual(["package.json", "docs/package.json"]);
+    expect(rows[0]?.preview).toBe("package.json, docs/package.json");
+  });
+
+  it("keeps a file the cap dropped out of the scanned list", () => {
+    expect(scannedFiles(VIEW).map((f) => f.path)).not.toContain("docs/package.json");
+    expect(matchedManagerNames(VIEW)).toContain("npm");
+    expect(fileRows(VIEW).map((row) => row.file.path)).toEqual([
+      "package.json",
+      "Dockerfile",
+      ".github/workflows/ci.yml",
+    ]);
+  });
+
+  it("hands each scanned file the deps that came out of it", () => {
+    const rows = fileRows(VIEW);
+    expect(rows[0]?.deps.map((d) => d.depName)).toEqual(["react", "typescript"]);
+    expect(rows[2]?.deps).toEqual([]);
+  });
+
+  it("never calls an unread file empty", () => {
+    expect(fileDepNote(walkFile("docs/package.json", ["npm"]))).toBe("not read");
+    expect(fileDepNote(walkFile("a.yml", ["x"], { outcome: "no-deps" }))).toBe("no deps");
+    expect(fileDepNote(walkFile("b.json", ["x"], { outcome: "unreadable" }))).toBe(
+      "could not be read",
+    );
+    expect(fileDepNote(walkFile("c.json", ["x"], { outcome: "error" }))).toBe("extraction failed");
+    expect(
+      fileDepNote(
+        walkFile("d.json", ["x"], { outcome: "extracted", depCount: 6, extractedBy: "x" }),
+      ),
+    ).toBe("6 deps");
+  });
+
+  it("tones only a real count as a result", () => {
+    expect(fileDepTone(walkFile("a", ["x"], { outcome: "extracted", depCount: 6 }))).toBe("ok");
+    expect(fileDepTone(walkFile("b", ["x"], { outcome: "extracted", depCount: 0 }))).toBe(
+      "neutral",
+    );
+    expect(fileDepTone(walkFile("c", ["x"]))).toBe("neutral");
+  });
+
+  it("groups the deps by the manager that read them, in extraction order", () => {
+    expect(depGroups(VIEW).map((group) => [group.manager, group.deps.length])).toEqual([
+      ["npm", 2],
+      ["dockerfile", 1],
+    ]);
+  });
+});
+
+describe("managerNotes", () => {
+  it("accounts for the managers that matched nothing and the files nobody read", () => {
+    const notes = managerNotes(VIEW);
+
+    expect(notes[0]).toBe("97 other managers matched no files.");
+    expect(notes[1]).toContain("1 matched file was not read");
+    // The permanent one: this walk is not config-aware, and says so.
+    expect(notes.at(-1)).toContain("enabledManagers and ignorePaths from your merged config");
+  });
+
+  it("drops the counts it has nothing to report, and adds the truncation", () => {
+    const notes = managerNotes({
+      ...VIEW,
+      managersConsidered: 2,
+      files: VIEW.files.slice(0, 2),
+      truncated: true,
+    });
+
+    expect(notes.some((note) => note.includes("other manager"))).toBe(false);
+    expect(notes.some((note) => note.includes("not read"))).toBe(false);
+    expect(notes.some((note) => note.includes("truncated"))).toBe(true);
+  });
+});

--- a/packages/app/src/features/pipeline/extract-phase.ts
+++ b/packages/app/src/features/pipeline/extract-phase.ts
@@ -1,0 +1,207 @@
+/**
+ * Roadmap 090 — the Extract phase's three nodes and the rows behind each of
+ * them, as pure derivations over the discovery record (`RepoDepsView`, filled
+ * by the shell's `useRepoDeps`).
+ *
+ * Everything here is arithmetic over what the walk ACTUALLY did, and the
+ * discipline the file exists to hold is that it may state nothing else. The
+ * walk matches every path in the tree but reads only the first ten (087's
+ * fetch cap), so a matched file the cap dropped is `not-read` — never "no
+ * deps", which would be a claim about bytes nobody fetched. Likewise the
+ * denominator: `managersConsidered` is how many managers the walk asked, not
+ * how many managers Renovate has.
+ *
+ * Pure and DOM-free, so the counts, the ordering and every sentence under a
+ * card are unit-testable without a renderer.
+ */
+import { nf, plural, pluralWord } from "@/lib/format";
+import type { RepoDep, RepoDepFile, RepoDepsView } from "@/types/repo";
+
+export type ExtractNodeId = "managers" | "files" | "deps";
+
+/** The tone a node's meta line wears — the rail's own vocabulary, minus the
+ *  ones extraction cannot produce. */
+export type ExtractNodeTone = "neutral" | "ok";
+
+export interface ExtractNode {
+  id: ExtractNodeId;
+  label: string;
+  /** The glyph-short line under the node's name. */
+  meta: string;
+  metaTone: ExtractNodeTone;
+  /** The card header's sentence when this node is selected — what the step
+   *  came out as, said in full. */
+  outcome: string;
+}
+
+/** English plural for the one irregular noun this phase counts. */
+function dependencies(n: number): string {
+  return `${nf.format(n)} ${n === 1 ? "dependency" : "dependencies"}`;
+}
+
+/** Managers that claimed at least one file, in walk order of first claim. */
+export function matchedManagerNames(view: RepoDepsView): string[] {
+  const names: string[] = [];
+  for (const file of view.files) {
+    for (const manager of file.managers) {
+      if (!names.includes(manager)) {
+        names.push(manager);
+      }
+    }
+  }
+  return names;
+}
+
+/** The files the walk actually READ — everything the cap did not drop. */
+export function scannedFiles(view: RepoDepsView): RepoDepFile[] {
+  return view.files.filter((file) => file.outcome !== "not-read");
+}
+
+/**
+ * The three nodes, always all three: the phase is a fixed sequence, and a
+ * step that found nothing still ran.
+ *
+ * Only the last node's meta is toned — the deps it produced are the phase's
+ * result, which is the one number the rail's `ok` green is for. The custom
+ * managers 063 will add would show as "K + M custom" here; nothing produces a
+ * `custom.` manager today, so the suffix is omitted rather than printed as
+ * "+ 0 custom".
+ */
+export function extractNodes(view: RepoDepsView): ExtractNode[] {
+  const managers = matchedManagerNames(view);
+  const scanned = scannedFiles(view);
+  const repo = view.repo === "" ? "the repository" : view.repo;
+  return [
+    {
+      id: "managers",
+      label: "Match managers",
+      meta: nf.format(managers.length),
+      metaTone: "neutral",
+      outcome: `${managers.length} of ${nf.format(view.managersConsidered)} managers matched files`,
+    },
+    {
+      id: "files",
+      label: "Scan files",
+      meta: plural(scanned.length, "package file"),
+      metaTone: "neutral",
+      outcome: `${plural(scanned.length, "package file")} scanned`,
+    },
+    {
+      id: "deps",
+      label: "Extract deps",
+      meta: `+${nf.format(view.deps.length)}`,
+      metaTone: "ok",
+      outcome: `${dependencies(view.deps.length)} from ${repo}`,
+    },
+  ];
+}
+
+/** One row of the Match-managers card: a manager and the files it claimed. */
+export interface ExtractManagerRow {
+  manager: string;
+  files: RepoDepFile[];
+  /** The muted, ellipsized preview a collapsed row shows. Every path, joined
+   *  — the row's width does the eliding, so nothing is silently dropped. */
+  preview: string;
+}
+
+/** Managers that claimed a file, most files first (name as the tiebreak, so
+ *  the order is stable across runs). */
+export function managerRows(view: RepoDepsView): ExtractManagerRow[] {
+  const rows = matchedManagerNames(view).map((manager) => {
+    const files = view.files.filter((file) => file.managers.includes(manager));
+    return { manager, files, preview: files.map((file) => file.path).join(", ") };
+  });
+  return rows.toSorted(
+    (a, b) => b.files.length - a.files.length || a.manager.localeCompare(b.manager),
+  );
+}
+
+/** What one file of the walk contributed — the count in the manager card's
+ *  expanded list, and the same sentence the files card leads with. */
+export function fileDepNote(file: RepoDepFile): string {
+  if (file.outcome === "not-read") {
+    return "not read";
+  }
+  if (file.outcome === "unreadable") {
+    return "could not be read";
+  }
+  if (file.outcome === "error") {
+    return "extraction failed";
+  }
+  return file.depCount === 0 ? "no deps" : plural(file.depCount, "dep");
+}
+
+/** Whether a file's note is a RESULT (green) or an absence (muted). */
+export function fileDepTone(file: RepoDepFile): ExtractNodeTone {
+  return file.outcome === "extracted" && file.depCount > 0 ? "ok" : "neutral";
+}
+
+/** One row of the Scan-files card: the file, and the deps it produced. */
+export interface ExtractFileRow {
+  file: RepoDepFile;
+  deps: RepoDep[];
+}
+
+export function fileRows(view: RepoDepsView): ExtractFileRow[] {
+  return scannedFiles(view).map((file) => ({
+    file,
+    deps: view.deps.filter((dep) => dep.packageFile === file.path),
+  }));
+}
+
+/** One row of the Extract-deps card: a manager and everything it extracted. */
+export interface ExtractDepGroup {
+  manager: string;
+  deps: RepoDep[];
+}
+
+/** Grouped by the manager that extracted them, in the order extraction
+ *  produced them — the walk's own order, which is the file order. */
+export function depGroups(view: RepoDepsView): ExtractDepGroup[] {
+  const groups = new Map<string, RepoDep[]>();
+  for (const dep of view.deps) {
+    const existing = groups.get(dep.manager);
+    if (existing === undefined) {
+      groups.set(dep.manager, [dep]);
+    } else {
+      existing.push(dep);
+    }
+  }
+  return [...groups].map(([manager, deps]) => ({ manager, deps }));
+}
+
+/**
+ * The Match-managers card's footnotes — the honest accounting of what this
+ * walk is NOT.
+ *
+ * The last one is permanent until the discovery grows a config-aware walk:
+ * `enabledManagers` and `ignorePaths` from the merged config are not applied
+ * to it (only Renovate's own default ignore of `node_modules`/
+ * `bower_components` is), so production Renovate may consider fewer managers
+ * and fewer files than this list shows. Saying so is cheaper than a reader
+ * concluding their `enabledManagers` is being ignored by Renovate too.
+ */
+export function managerNotes(view: RepoDepsView): string[] {
+  const notes: string[] = [];
+  const matched = matchedManagerNames(view).length;
+  const others = view.managersConsidered - matched;
+  if (others > 0) {
+    notes.push(`${plural(others, "other manager")} matched no files.`);
+  }
+  const notRead = view.files.length - scannedFiles(view).length;
+  if (notRead > 0) {
+    notes.push(
+      `${nf.format(notRead)} matched ${pluralWord(notRead, "file")} ` +
+        `${notRead === 1 ? "was" : "were"} not read — discovery caps how many files it fetches.`,
+    );
+  }
+  if (view.truncated) {
+    notes.push("The repository’s file listing was truncated, so the walk did not see every file.");
+  }
+  notes.push(
+    "Renovate’s default ignorePaths (node_modules, bower_components) were applied; " +
+      "enabledManagers and ignorePaths from your merged config were not.",
+  );
+  return notes;
+}

--- a/packages/app/src/features/pipeline/extract-phase.ts
+++ b/packages/app/src/features/pipeline/extract-phase.ts
@@ -14,7 +14,8 @@
  * Pure and DOM-free, so the counts, the ordering and every sentence under a
  * card are unit-testable without a renderer.
  */
-import { nf, plural, pluralWord } from "@/lib/format";
+import { nf, plural } from "@/lib/format";
+import { discoveryCaveats } from "@/lib/discovery-caveats";
 import type { RepoDep, RepoDepFile, RepoDepsView } from "@/types/repo";
 
 export type ExtractNodeId = "managers" | "files" | "deps";
@@ -39,17 +40,28 @@ function dependencies(n: number): string {
   return `${nf.format(n)} ${n === 1 ? "dependency" : "dependencies"}`;
 }
 
-/** Managers that claimed at least one file, in walk order of first claim. */
-export function matchedManagerNames(view: RepoDepsView): string[] {
-  const names: string[] = [];
+/** Every manager's claimed files, keyed in walk order of first claim — the
+ *  ONE pass the manager card's rows, names and notes all read, instead of a
+ *  files×managers rescan per question (the fetch cap admits hundreds of
+ *  files, so the quadratic spellings stopped being free). */
+function filesByManager(view: RepoDepsView): Map<string, RepoDepFile[]> {
+  const claimed = new Map<string, RepoDepFile[]>();
   for (const file of view.files) {
     for (const manager of file.managers) {
-      if (!names.includes(manager)) {
-        names.push(manager);
+      const files = claimed.get(manager);
+      if (files === undefined) {
+        claimed.set(manager, [file]);
+      } else {
+        files.push(file);
       }
     }
   }
-  return names;
+  return claimed;
+}
+
+/** Managers that claimed at least one file, in walk order of first claim. */
+export function matchedManagerNames(view: RepoDepsView): string[] {
+  return [...filesByManager(view).keys()];
 }
 
 /** The files the walk actually READ — everything the cap did not drop. */
@@ -108,8 +120,7 @@ export interface ExtractManagerRow {
 /** Managers that claimed a file, most files first (name as the tiebreak, so
  *  the order is stable across runs). */
 export function managerRows(view: RepoDepsView): ExtractManagerRow[] {
-  const rows = matchedManagerNames(view).map((manager) => {
-    const files = view.files.filter((file) => file.managers.includes(manager));
+  const rows = [...filesByManager(view)].map(([manager, files]) => {
     return { manager, files, preview: files.map((file) => file.path).join(", ") };
   });
   return rows.toSorted(
@@ -144,9 +155,20 @@ export interface ExtractFileRow {
 }
 
 export function fileRows(view: RepoDepsView): ExtractFileRow[] {
+  // One pass over the deps, not one filter per file — same cap arithmetic as
+  // `filesByManager` above.
+  const depsByFile = new Map<string, RepoDep[]>();
+  for (const dep of view.deps) {
+    const deps = depsByFile.get(dep.packageFile);
+    if (deps === undefined) {
+      depsByFile.set(dep.packageFile, [dep]);
+    } else {
+      deps.push(dep);
+    }
+  }
   return scannedFiles(view).map((file) => ({
     file,
-    deps: view.deps.filter((dep) => dep.packageFile === file.path),
+    deps: depsByFile.get(file.path) ?? [],
   }));
 }
 
@@ -189,19 +211,17 @@ export function managerNotes(view: RepoDepsView): string[] {
   if (others > 0) {
     notes.push(`${plural(others, "other manager")} matched no files.`);
   }
-  const notRead = view.files.length - scannedFiles(view).length;
-  if (notRead > 0) {
-    notes.push(
-      `${nf.format(notRead)} matched ${pluralWord(notRead, "file")} ` +
-        `${notRead === 1 ? "was" : "were"} not read — discovery caps how many files it fetches.`,
-    );
-  }
-  if (view.truncated) {
-    notes.push("The repository’s file listing was truncated, so the walk did not see every file.");
-  }
+  // The shared clauses every discovery surface prints (`lib/discovery-caveats`)
+  // — this card only sentence-cases them, so its counts and the footnotes'
+  // are one arithmetic.
+  notes.push(...discoveryCaveats(view).map((clause) => `${sentenceCase(clause)}.`));
   notes.push(
     "Renovate’s default ignorePaths (node_modules, bower_components) were applied; " +
       "enabledManagers and ignorePaths from your merged config were not.",
   );
   return notes;
+}
+
+function sentenceCase(clause: string): string {
+  return clause.charAt(0).toUpperCase() + clause.slice(1);
 }

--- a/packages/app/src/features/pipeline/phases.ts
+++ b/packages/app/src/features/pipeline/phases.ts
@@ -1,0 +1,60 @@
+/**
+ * Roadmap 090 — the Pipeline tab's PHASES: the four steps production Renovate
+ * walks for a repository, of which this app runs two.
+ *
+ * The tab has always shown one of them — the config pipeline (008's stages,
+ * global → merge) — under a name that promised all four. 087 taught the
+ * browser engine to extract a loaded repository's dependencies, which is
+ * Renovate's own second phase, so it becomes the second segment rather than a
+ * second tab: the picker is what teaches the ORDER, and a disabled segment
+ * teaches it as honestly as a live one.
+ *
+ * `lookup` and `update` are rendered and disabled on purpose. Both need live
+ * datasource network calls, which the engine deliberately severs (078's "not
+ * in scope"), so nothing here may pretend otherwise — they carry a muted "not
+ * available yet" and a title saying the same thing.
+ */
+
+export const PIPELINE_PHASE_IDS = ["config", "extract", "lookup", "update"] as const;
+
+export type PipelinePhase = (typeof PIPELINE_PHASE_IDS)[number];
+
+export interface PipelinePhaseDescriptor {
+  id: PipelinePhase;
+  label: string;
+  /** What the phase does, for the segment's `title`. */
+  title: string;
+  /** Whether this app can run it at all. */
+  available: boolean;
+}
+
+export const PIPELINE_PHASES: readonly PipelinePhaseDescriptor[] = [
+  {
+    id: "config",
+    label: "Config",
+    title: "Resolve the configuration — the stages this app runs from your file",
+    available: true,
+  },
+  {
+    id: "extract",
+    label: "Extract",
+    title: "Find the dependencies in the repository's package files",
+    available: true,
+  },
+  {
+    id: "lookup",
+    label: "Lookup",
+    title: "Not available today",
+    available: false,
+  },
+  {
+    id: "update",
+    label: "Update",
+    title: "Not available today",
+    available: false,
+  },
+];
+
+/** What an unavailable segment says instead of a count. Stated once so the
+ *  picker and its test cannot disagree about the promise being made. */
+export const PHASE_UNAVAILABLE_NOTE = "not available yet";

--- a/packages/app/src/features/simulator/RepoDepsTab.tsx
+++ b/packages/app/src/features/simulator/RepoDepsTab.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from "react";
 import { nf } from "@/lib/format";
+import { discoveryCaveats, tallyDiscovery } from "@/lib/discovery-caveats";
 import { filterRepoDeps, hiddenDepFiles, REPO_DEPS_SHOWN, type RepoDraft } from "./repo-deps";
 import type { PinnedTest } from "@/types/simulator";
 import type { RepoDep, RepoDepsView } from "@/types/repo";
@@ -191,17 +192,13 @@ function RepoDepsFootnote({ view, hidden }: { view: RepoDepsView; hidden: readon
     const named = files.slice(0, 4).join(", ") + (files.length > 4 ? ", …" : "");
     parts.push(`… ${nf.format(hidden.length)} more across ${named}`);
   } else {
+    const files = tallyDiscovery(view).extracted;
     parts.push(
-      `${nf.format(view.deps.length)} dependencies across ${nf.format(view.fileCount)} package files`,
+      `${nf.format(view.deps.length)} dependencies across ${nf.format(files)} package files`,
     );
   }
   parts.push(`detected because you loaded this config from ${view.repo}`);
-  if (view.skippedFiles > 0) {
-    parts.push(`${nf.format(view.skippedFiles)} matched files not read`);
-  }
-  if (view.truncated) {
-    parts.push("the repository's file listing was truncated");
-  }
+  parts.push(...discoveryCaveats(view));
   return <p className="pin-repo-note">{parts.join(" · ")}</p>;
 }
 
@@ -273,7 +270,7 @@ export function RepoDepsTab({
       <div className="pin-repo-search">
         <input
           aria-label="Search detected dependencies"
-          placeholder={`Search the ${nf.format(view.deps.length)} dependencies detected across ${nf.format(view.fileCount)} package files…`}
+          placeholder={`Search the ${nf.format(view.deps.length)} dependencies detected across ${nf.format(tallyDiscovery(view).extracted)} package files…`}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -419,8 +419,6 @@ const REPO_DEPS: RepoDepsView = {
       },
     },
   ],
-  fileCount: 2,
-  skippedFiles: 0,
   files: [
     {
       path: "package.json",
@@ -502,7 +500,7 @@ it("caps the list at five rows, counts the tail, and drafts inline under its row
     repoDep("Chart.yaml", "redis", "18.0.0"),
   ];
   const result = await run();
-  const view = render(<Harness result={result} repoDeps={{ ...REPO_DEPS, deps, fileCount: 4 }} />);
+  const view = render(<Harness result={result} repoDeps={{ ...REPO_DEPS, deps }} />);
   fireEvent.click(view.getByRole("tab", { name: "From repository" }));
 
   // Five rows, then the design's tail line naming the hidden rows' files —

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -421,6 +421,23 @@ const REPO_DEPS: RepoDepsView = {
   ],
   fileCount: 2,
   skippedFiles: 0,
+  files: [
+    {
+      path: "package.json",
+      managers: ["npm"],
+      extractedBy: "npm",
+      depCount: 1,
+      outcome: "extracted",
+    },
+    {
+      path: "Dockerfile",
+      managers: ["dockerfile"],
+      extractedBy: "dockerfile",
+      depCount: 1,
+      outcome: "extracted",
+    },
+  ],
+  managersConsidered: 100,
   truncated: false,
   error: null,
 };

--- a/packages/app/src/features/simulator/repo-deps.ts
+++ b/packages/app/src/features/simulator/repo-deps.ts
@@ -21,8 +21,6 @@ export const EMPTY_REPO_DEPS: RepoDepsView = {
   status: "idle",
   repo: "",
   deps: [],
-  fileCount: 0,
-  skippedFiles: 0,
   files: [],
   managersConsidered: 0,
   truncated: false,

--- a/packages/app/src/features/simulator/repo-deps.ts
+++ b/packages/app/src/features/simulator/repo-deps.ts
@@ -23,6 +23,8 @@ export const EMPTY_REPO_DEPS: RepoDepsView = {
   deps: [],
   fileCount: 0,
   skippedFiles: 0,
+  files: [],
+  managersConsidered: 0,
   truncated: false,
   error: null,
 };

--- a/packages/app/src/features/simulator/use-repo-deps.ts
+++ b/packages/app/src/features/simulator/use-repo-deps.ts
@@ -74,29 +74,24 @@ async function discover(repo: LoadedRepo): Promise<RepoDepsView> {
     .toSorted((a, b) => a.depth - b.depth || a.index - b.index)
     .slice(0, MAX_REPO_DEP_FILES)
     .map((entry) => entry.path);
-  let skippedFiles = walk.files.length - taken.length;
   // The file fetches are independent GETs — issued together. Extraction
   // stays sequential below: the engine serializes it (module-level renovate
   // state) against every other engine task.
   const contents = await Promise.all(taken.map((path) => loadRepoFile({ ...request, path }, opts)));
   const deps: RepoDep[] = [];
   // What each READ file turned into, keyed by path; the files nothing is
-  // recorded for are the ones the cap dropped (`not-read` below).
+  // recorded for are the ones the cap dropped (`not-read` below). Every count
+  // a surface prints is derived from this ledger (`lib/discovery-caveats.ts`),
+  // never accumulated beside it.
   const read = new Map<string, Pick<RepoDepFile, "outcome" | "extractedBy" | "depCount">>();
-  let fileCount = 0;
   for (const [index, path] of taken.entries()) {
     const content = contents[index] ?? null;
     if (content === null) {
-      skippedFiles += 1;
       read.set(path, { outcome: "unreadable", extractedBy: null, depCount: 0 });
       continue;
     }
     const outcome = await engine.extractDeps({ fileName: path, content });
     if (!outcome.ok) {
-      // "no deps in this file" is not a skipped file; a real failure is.
-      if (outcome.reason !== "no-deps") {
-        skippedFiles += 1;
-      }
       read.set(path, {
         outcome: outcome.reason === "no-deps" ? "no-deps" : "error",
         extractedBy: null,
@@ -104,7 +99,6 @@ async function discover(repo: LoadedRepo): Promise<RepoDepsView> {
       });
       continue;
     }
-    fileCount += 1;
     const rows = repoDepsOfFile(outcome.file);
     deps.push(...rows);
     read.set(path, {
@@ -122,8 +116,6 @@ async function discover(repo: LoadedRepo): Promise<RepoDepsView> {
     status: "ready",
     repo: repo.repo,
     deps,
-    fileCount,
-    skippedFiles,
     files,
     managersConsidered: walk.managersConsidered,
     truncated: tree.truncated,

--- a/packages/app/src/features/simulator/use-repo-deps.ts
+++ b/packages/app/src/features/simulator/use-repo-deps.ts
@@ -19,12 +19,20 @@ import { useLatestRef } from "@/hooks/use-latest-ref";
 import { loadEngine } from "@/platform/engine-chunk";
 import { loadRepoFile, loadRepoTree } from "@/platform/run";
 import { causedErrorMessage } from "@/lib/errors";
-import type { LoadedRepo, RepoDep, RepoDepsView } from "@/types/repo";
+import type { LoadedRepo, RepoDep, RepoDepFile, RepoDepsView } from "@/types/repo";
 
 /** Every matched file is fetched by default; this is only a runaway backstop
  *  for pathological monorepos (each file is one request, and an anonymous
  *  GitHub session has 60 an hour). The view counts anything it drops. */
 const MAX_REPO_DEP_FILES = 500;
+
+/** A matched file the cap dropped: claimed, never fetched, so nothing at all
+ *  is known about what is inside it. */
+const NOT_READ: Pick<RepoDepFile, "outcome" | "extractedBy" | "depCount"> = {
+  outcome: "not-read",
+  extractedBy: null,
+  depCount: 0,
+};
 
 /** Renovate's own default ignorePaths, applied to the walk. */
 const IGNORED_PATH = /(^|\/)(node_modules|bower_components)\//;
@@ -51,30 +59,36 @@ async function discover(repo: LoadedRepo): Promise<RepoDepsView> {
   const tree = await loadRepoTree(request, opts);
   // One bulk pass over the tree (per-manager, inside the engine) — a
   // per-path scan would rebuild the manager table and its per-pattern debug
-  // strings tens of thousands of times on a large tree.
-  const candidates = engine.matchExtractablePaths(
+  // strings tens of thousands of times on a large tree. It hands back the
+  // ATTRIBUTION (which managers claim each path), which is what the Extract
+  // phase's first node reports on.
+  const walk = engine.matchExtractableManagers(
     tree.paths.filter((path) => !IGNORED_PATH.test(path)),
   );
   // Shallowest first (tree order as the tiebreak) before the cap: GitHub
   // lists the tree lexicographically, so ten `.github/workflows/*.yml`
   // files would otherwise spend the whole budget before `package.json` is
   // even reached.
-  const taken = candidates
-    .map((path, index) => ({ path, index, depth: path.split("/").length }))
+  const taken = walk.files
+    .map((match, index) => ({ path: match.path, index, depth: match.path.split("/").length }))
     .toSorted((a, b) => a.depth - b.depth || a.index - b.index)
     .slice(0, MAX_REPO_DEP_FILES)
     .map((entry) => entry.path);
-  let skippedFiles = candidates.length - taken.length;
+  let skippedFiles = walk.files.length - taken.length;
   // The file fetches are independent GETs — issued together. Extraction
   // stays sequential below: the engine serializes it (module-level renovate
   // state) against every other engine task.
   const contents = await Promise.all(taken.map((path) => loadRepoFile({ ...request, path }, opts)));
   const deps: RepoDep[] = [];
+  // What each READ file turned into, keyed by path; the files nothing is
+  // recorded for are the ones the cap dropped (`not-read` below).
+  const read = new Map<string, Pick<RepoDepFile, "outcome" | "extractedBy" | "depCount">>();
   let fileCount = 0;
   for (const [index, path] of taken.entries()) {
     const content = contents[index] ?? null;
     if (content === null) {
       skippedFiles += 1;
+      read.set(path, { outcome: "unreadable", extractedBy: null, depCount: 0 });
       continue;
     }
     const outcome = await engine.extractDeps({ fileName: path, content });
@@ -83,17 +97,35 @@ async function discover(repo: LoadedRepo): Promise<RepoDepsView> {
       if (outcome.reason !== "no-deps") {
         skippedFiles += 1;
       }
+      read.set(path, {
+        outcome: outcome.reason === "no-deps" ? "no-deps" : "error",
+        extractedBy: null,
+        depCount: 0,
+      });
       continue;
     }
     fileCount += 1;
-    deps.push(...repoDepsOfFile(outcome.file));
+    const rows = repoDepsOfFile(outcome.file);
+    deps.push(...rows);
+    read.set(path, {
+      outcome: "extracted",
+      extractedBy: outcome.file.manager,
+      depCount: rows.length,
+    });
   }
+  const files: RepoDepFile[] = walk.files.map((match) => ({
+    path: match.path,
+    managers: match.managers,
+    ...(read.get(match.path) ?? NOT_READ),
+  }));
   return {
     status: "ready",
     repo: repo.repo,
     deps,
     fileCount,
     skippedFiles,
+    files,
+    managersConsidered: walk.managersConsidered,
     truncated: tree.truncated,
     error: null,
   };

--- a/packages/app/src/lib/discovery-caveats.test.ts
+++ b/packages/app/src/lib/discovery-caveats.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { discoveryCaveats, tallyDiscovery } from "./discovery-caveats";
+import type { RepoDepFile, RepoDepFileOutcome, RepoDepsView } from "@/types/repo";
+
+/**
+ * The shared discovery arithmetic — one pass over the ledger, so the three
+ * surfaces that print these numbers cannot disagree with each other.
+ */
+
+function file(path: string, outcome: RepoDepFileOutcome): RepoDepFile {
+  return { path, managers: ["npm"], extractedBy: null, depCount: 0, outcome };
+}
+
+function view(files: RepoDepFile[], truncated = false): RepoDepsView {
+  return {
+    status: "ready",
+    repo: "acme/webapp",
+    deps: [],
+    files,
+    managersConsidered: 10,
+    truncated,
+    error: null,
+  };
+}
+
+describe("tallyDiscovery", () => {
+  it("counts every outcome, and nothing twice", () => {
+    const tally = tallyDiscovery(
+      view([
+        file("a", "extracted"),
+        file("b", "extracted"),
+        file("c", "no-deps"),
+        file("d", "not-read"),
+        file("e", "unreadable"),
+        file("f", "error"),
+      ]),
+    );
+    expect(tally).toEqual({ extracted: 2, empty: 1, notRead: 1, unreadable: 1, errored: 1 });
+  });
+});
+
+describe("discoveryCaveats", () => {
+  it("stays silent when the walk answered for every matched file", () => {
+    expect(discoveryCaveats(view([file("a", "extracted"), file("b", "no-deps")]))).toEqual([]);
+  });
+
+  it("names each shortfall separately — the cap, the unreadable, the failed", () => {
+    const clauses = discoveryCaveats(
+      view([
+        file("a", "not-read"),
+        file("b", "not-read"),
+        file("c", "unreadable"),
+        file("d", "error"),
+      ]),
+    );
+    expect(clauses).toHaveLength(3);
+    expect(clauses[0]).toContain("2 matched files not read");
+    expect(clauses[1]).toBe("1 matched file could not be read");
+    expect(clauses[2]).toBe("extraction failed for 1 matched file");
+  });
+
+  it("adds the truncation clause when the tree listing was cut short", () => {
+    const clauses = discoveryCaveats(view([], true));
+    expect(clauses).toHaveLength(1);
+    expect(clauses[0]).toContain("truncated");
+  });
+});

--- a/packages/app/src/lib/discovery-caveats.ts
+++ b/packages/app/src/lib/discovery-caveats.ts
@@ -1,0 +1,70 @@
+import { plural } from "@/lib/format";
+import type { RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 090's honest accounting, derived ONCE from the per-file ledger.
+ *
+ * Three surfaces report the same discovery — the Dependencies footnote, the
+ * From-repository footnote and the Extract phase's notes — and each used to
+ * run its own arithmetic over its own pick of counters, which let two tabs
+ * print two different "files not read" totals for one walk. Everything here
+ * is one pass over `view.files`, so a count shown on one surface can never
+ * disagree with the same count on another. Lives in `lib/` because the three
+ * surfaces are three feature slices, and features may not import each other.
+ */
+export interface DiscoveryTally {
+  /** Files whose extraction contributed rows — the "across N package files". */
+  extracted: number;
+  /** Read fine, held no dependencies. */
+  empty: number;
+  /** Never fetched — the fetch cap. */
+  notRead: number;
+  /** Fetched, but the content could not be read. */
+  unreadable: number;
+  /** Read, but the extractor itself failed. */
+  errored: number;
+}
+
+export function tallyDiscovery(view: RepoDepsView): DiscoveryTally {
+  const tally: DiscoveryTally = { extracted: 0, empty: 0, notRead: 0, unreadable: 0, errored: 0 };
+  for (const file of view.files) {
+    if (file.outcome === "extracted") {
+      tally.extracted += 1;
+    } else if (file.outcome === "no-deps") {
+      tally.empty += 1;
+    } else if (file.outcome === "not-read") {
+      tally.notRead += 1;
+    } else if (file.outcome === "unreadable") {
+      tally.unreadable += 1;
+    } else {
+      tally.errored += 1;
+    }
+  }
+  return tally;
+}
+
+/**
+ * The caveat clauses — what the walk honestly did NOT turn into an answer.
+ * Lowercase and unpunctuated so a footnote can join them with " · " and a
+ * notes list can sentence-case them; every surface says the same numbers in
+ * the same words. Empty when the walk answered for every matched file.
+ */
+export function discoveryCaveats(view: RepoDepsView): string[] {
+  const tally = tallyDiscovery(view);
+  const parts: string[] = [];
+  if (tally.notRead > 0) {
+    parts.push(
+      `${plural(tally.notRead, "matched file")} not read — discovery caps how many files it fetches`,
+    );
+  }
+  if (tally.unreadable > 0) {
+    parts.push(`${plural(tally.unreadable, "matched file")} could not be read`);
+  }
+  if (tally.errored > 0) {
+    parts.push(`extraction failed for ${plural(tally.errored, "matched file")}`);
+  }
+  if (view.truncated) {
+    parts.push("the repository’s file listing was truncated — the walk did not see every file");
+  }
+  return parts;
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -30,6 +30,7 @@ import "./styles/15-pins.css";
 import "./styles/16-tabs.css";
 import "./styles/17-build-info.css";
 import "./styles/18-data-table.css";
+import "./styles/19-pipeline-extract.css";
 
 // Roadmap 033: one-time storage migrations run before the App's `useState`
 // initializers read storage — and, unlike their old module-scope home, they

--- a/packages/app/src/styles/19-pipeline-extract.css
+++ b/packages/app/src/styles/19-pipeline-extract.css
@@ -60,11 +60,14 @@
   margin: 0;
 }
 
-/* The rows a card opens onto: a disclosure head, and a sublist under it. */
+/* The rows a card opens onto: a disclosure head, and a sublist under it.
+   `.card` is an unpadded shell (only its title pads itself), so each body
+   piece here carries the title's own 0.75rem side inset — without it the
+   text sits flush against the card border. */
 .extract-rows {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0.35rem 0.75rem;
 }
 
 .extract-row {
@@ -163,11 +166,12 @@
   color: var(--ok);
 }
 
-/* The card's small print: what this walk is not. One line per note. */
+/* The card's small print: what this walk is not. One line per note. The
+   rows' own bottom padding supplies part of the 0.5rem gap above. */
 .extract-notes {
   color: var(--muted);
   font-size: 0.7rem;
-  margin: 0.5rem 0 0;
+  margin: 0.15rem 0.75rem 0.6rem;
 }
 
 .extract-note-line {
@@ -179,5 +183,5 @@
 .extract-jump {
   display: inline-block;
   font-size: 0.75rem;
-  margin-top: 0.5rem;
+  margin: 0.15rem 0.75rem 0.6rem;
 }

--- a/packages/app/src/styles/19-pipeline-extract.css
+++ b/packages/app/src/styles/19-pipeline-extract.css
@@ -1,0 +1,183 @@
+/* Roadmap 090 — the Pipeline tab's phase picker and its Extract phase.
+
+   Appended at the end of the cascade, which is what main.tsx's header
+   sanctions for a new surface: the only selectors here that another file also
+   writes are `.seg button` variants, and those are DELIBERATE overrides of the
+   shared segment metrics (a two-line segment), which have to come after the
+   base to work at equal specificity.
+
+   The track itself has no rules here at all — it wears the stage rail's own
+   classes (08-landing.css), so the two cannot drift apart. What is here is the
+   picker's second line and the phase's rows. */
+
+/* The picker sits above the tab's content and spans it: four phases, one line,
+   each carrying a name and the count behind it. */
+.phase-picker {
+  display: flex;
+  margin: 0 0 0.9rem;
+}
+
+.phase-picker button {
+  flex: 1;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.3rem 0.5rem;
+}
+
+/* A phase this app cannot run (Lookup, Update). Dimmed rather than hidden:
+   the picker is what teaches Renovate's real order, and a gap in the sequence
+   would teach it wrong. */
+.phase-picker button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.phase-seg-name {
+  font-size: 0.8rem;
+}
+
+/* Always rendered, empty or not, so a phase whose count has not arrived does
+   not make the strip jump when it does. */
+.phase-seg-note {
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  min-height: 0.85rem;
+}
+
+.phase-seg-note.muted {
+  color: var(--muted);
+}
+
+.phase-seg-note.ok {
+  color: var(--ok);
+}
+
+/* The states before the walk has anything to report. */
+.extract-status {
+  color: var(--muted);
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+/* The rows a card opens onto: a disclosure head, and a sublist under it. */
+.extract-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.extract-row {
+  border-bottom: 1px solid var(--border);
+}
+
+.extract-row:last-child {
+  border-bottom: none;
+}
+
+.extract-row.open {
+  background: var(--surface);
+}
+
+.extract-row-head {
+  align-items: baseline;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  font: inherit;
+  font-size: 0.8rem;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+  text-align: left;
+  width: 100%;
+}
+
+.extract-row-lead {
+  flex: none;
+  font-family: var(--font-mono);
+}
+
+.extract-row-count {
+  color: var(--muted);
+  flex: none;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+}
+
+/* The collapsed row's preview of what is inside it. It takes the slack and
+   elides — every path is in the DOM, the width decides how much is read. */
+.extract-row-note {
+  color: var(--faint);
+  flex: 1 1 auto;
+  font-size: 0.72rem;
+  min-width: 0;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.extract-sublist {
+  list-style: none;
+  margin: 0 0 0.4rem;
+  padding: 0 0 0 1.4rem;
+}
+
+.extract-subrow {
+  align-items: baseline;
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.5rem;
+  padding: 0.1rem 0;
+}
+
+.extract-subrow-lead {
+  font-family: var(--font-mono);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.extract-subrow-value {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.extract-subrow-trail {
+  color: var(--muted);
+  flex: 1 1 auto;
+  font-size: 0.72rem;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* A per-file count that IS a result reads in the verdict green; an absence
+   ("no deps", "not read") stays muted, because it is not one. */
+.extract-subrow-trail.ok {
+  color: var(--ok);
+}
+
+/* The card's small print: what this walk is not. One line per note. */
+.extract-notes {
+  color: var(--muted);
+  font-size: 0.7rem;
+  margin: 0.5rem 0 0;
+}
+
+.extract-note-line {
+  display: block;
+}
+
+/* `.btn-quiet` is a link inside a sentence and takes no box metrics of its
+   own, so the one that stands alone under the card says so here. */
+.extract-jump {
+  display: inline-block;
+  font-size: 0.75rem;
+  margin-top: 0.5rem;
+}

--- a/packages/app/src/types/repo.ts
+++ b/packages/app/src/types/repo.ts
@@ -53,6 +53,29 @@ export interface RepoDep {
   fill: Partial<FormState>;
 }
 
+/**
+ * Roadmap 090: what became of ONE file the discovery walk matched.
+ *
+ * `not-read` is the fetch cap (and only the cap): the file was claimed and
+ * never fetched, so nothing whatever is known about its contents — which is
+ * exactly what the Extract phase's rows must say instead of "no deps".
+ */
+export type RepoDepFileOutcome = "extracted" | "no-deps" | "not-read" | "unreadable" | "error";
+
+/** One file of the walk: who claimed it, and what came back. */
+export interface RepoDepFile {
+  path: string;
+  /** The extractable managers whose file patterns claim this path — several
+   *  managers legitimately claim one filename. */
+  managers: string[];
+  /** The manager that actually ran (the first extractable match), or null when
+   *  the file was never read or produced nothing. */
+  extractedBy: string | null;
+  /** Named, pinnable dependencies this file contributed. */
+  depCount: number;
+  outcome: RepoDepFileOutcome;
+}
+
 /** What the tab renders — computed by the shell, drawn by the feature. */
 export interface RepoDepsView {
   status: RepoDepsStatus;
@@ -63,6 +86,13 @@ export interface RepoDepsView {
   fileCount: number;
   /** Matched files past the fetch cap, or claimed only by unmapped managers. */
   skippedFiles: number;
+  /** Roadmap 090: every matched file, in walk order — the Extract phase's
+   *  ledger. Matching is the cheap path-only step, so this covers the whole
+   *  walk; the fetch cap only decides which of them were READ. */
+  files: RepoDepFile[];
+  /** Roadmap 090: how many managers the walk asked — the honest denominator
+   *  for "K of N managers matched files". */
+  managersConsidered: number;
   /** GitHub truncates very large trees; the listing says so. */
   truncated: boolean;
   error: string | null;

--- a/packages/app/src/types/repo.ts
+++ b/packages/app/src/types/repo.ts
@@ -82,13 +82,10 @@ export interface RepoDepsView {
   /** `owner/repo` of the loaded repository. */
   repo: string;
   deps: RepoDep[];
-  /** Package files actually extracted. */
-  fileCount: number;
-  /** Matched files past the fetch cap, or claimed only by unmapped managers. */
-  skippedFiles: number;
   /** Roadmap 090: every matched file, in walk order — the Extract phase's
-   *  ledger. Matching is the cheap path-only step, so this covers the whole
-   *  walk; the fetch cap only decides which of them were READ. */
+   *  ledger, and the ONE source every count is derived from
+   *  (`lib/discovery-caveats.ts`). Matching is the cheap path-only step, so
+   *  this covers the whole walk; the fetch cap only decides which were READ. */
   files: RepoDepFile[];
   /** Roadmap 090: how many managers the walk asked — the honest denominator
    *  for "K of N managers matched files". */

--- a/packages/engine/src/extract.ts
+++ b/packages/engine/src/extract.ts
@@ -99,17 +99,42 @@ export function matchManagersForFile(
   });
 }
 
+/** One path a repo walk kept, and the extractable managers that claim it —
+ *  several managers legitimately claim one filename. */
+export interface ExtractableMatch {
+  path: string;
+  /** In upstream's manager order; never empty. */
+  managers: string[];
+}
+
+/** What one walk over a repository's file listing found. */
+export interface ExtractableWalk {
+  /** How many managers the walk ASKED: the extractable ledger minus the
+   *  default-disabled and the pattern-less ones, neither of which a filename
+   *  walk can ever match. The honest denominator for "K of N managers matched
+   *  files". */
+  managersConsidered: number;
+  /** The claimed paths, in input order. */
+  files: ExtractableMatch[];
+}
+
 /**
- * The repo walk's bulk form of the same question: which of these paths does
- * at least one EXTRACTABLE manager claim? One `getMatchingFiles` pass per
- * manager over the whole list — per-path calls would rebuild the manager
- * table, the subset Set and the per-pattern debug strings tens of thousands
- * of times on a large tree. Input order is preserved.
+ * The repo walk's bulk form of `matchManagersForFile`: which EXTRACTABLE
+ * managers claim each of these paths? One `getMatchingFiles` pass per manager
+ * over the whole list — per-path calls would rebuild the manager table, the
+ * subset Set and the per-pattern debug strings tens of thousands of times on a
+ * large tree. Input order is preserved.
+ *
+ * Returns the attribution rather than the bare path list: the walk's own
+ * accounting (roadmap 090's Extract phase) has to say WHICH manager claimed a
+ * file, and recovering that per path afterwards is exactly the per-path scan
+ * this shape exists to avoid.
  */
-export function matchExtractablePaths(paths: readonly string[]): string[] {
+export function matchExtractableManagers(paths: readonly string[]): ExtractableWalk {
   return withCollectorSuppressed(() => {
     const all = [...paths];
-    const matched = new Set<string>();
+    const claims = new Map<string, string[]>();
+    let managersConsidered = 0;
     for (const [manager, config] of Object.entries(managerDefaultConfigs)) {
       if (!(manager in managerExtractors)) {
         continue;
@@ -125,11 +150,24 @@ export function matchExtractablePaths(paths: readonly string[]): string[] {
       if (!patterns || patterns.length === 0) {
         continue;
       }
+      managersConsidered += 1;
       for (const file of getMatchingFiles({ manager, managerFilePatterns: patterns }, all)) {
-        matched.add(file);
+        const claimed = claims.get(file);
+        if (claimed === undefined) {
+          claims.set(file, [manager]);
+        } else {
+          claimed.push(manager);
+        }
       }
     }
-    return paths.filter((path) => matched.has(path));
+    const files: ExtractableMatch[] = [];
+    for (const path of paths) {
+      const managers = claims.get(path);
+      if (managers !== undefined) {
+        files.push({ path, managers });
+      }
+    }
+    return { managersConsidered, files };
   });
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,12 +1,14 @@
 export { runPipeline } from "./pipeline";
 export {
   EXTRACTABLE_MANAGERS,
+  type ExtractableMatch,
+  type ExtractableWalk,
   type ExtractedPackageFile,
   extractDeps,
   type ExtractFile,
   type ExtractOutcome,
   type ExtractRequest,
-  matchExtractablePaths,
+  matchExtractableManagers,
   matchManagersForFile,
 } from "./extract";
 export type { PackageDependency } from "./renovate-adapter";

--- a/packages/engine/test/extract.node.test.ts
+++ b/packages/engine/test/extract.node.test.ts
@@ -10,7 +10,12 @@ import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { extractDeps, matchManagersForFile } from "../src/index";
+import {
+  EXTRACTABLE_MANAGERS,
+  extractDeps,
+  matchExtractableManagers,
+  matchManagersForFile,
+} from "../src/index";
 import { GlobalConfig } from "../src/renovate-adapter";
 import { EXTRACT_CASES, extractFixture, extractSnapshotPath } from "./extract-cases";
 import { must } from "./helpers";
@@ -84,6 +89,31 @@ describe("extractDeps (golden)", () => {
     expect(matchManagersForFile("Dockerfile")).toContain("dockerfile");
     expect(matchManagersForFile(".github/workflows/ci.yml")).toContain("github-actions");
     expect(matchManagersForFile("renovate.json")).not.toContain("npm");
+  });
+
+  it("attributes a repo walk's paths to the managers that claim them", () => {
+    const walk = matchExtractableManagers([
+      "README.md",
+      "package.json",
+      "node_modules/left-pad/package.json",
+      ".github/workflows/ci.yml",
+      "build.gradle",
+    ]);
+    // Input order, and only the paths an EXTRACTABLE manager claims — gradle
+    // matches but is not in the ledger, so `build.gradle` is not walked. The
+    // ignorePaths filter is the caller's, so a vendored manifest still matches.
+    expect(walk.files.map((file) => file.path)).toEqual([
+      "package.json",
+      "node_modules/left-pad/package.json",
+      ".github/workflows/ci.yml",
+    ]);
+    expect(walk.files[0]?.managers).toContain("npm");
+    expect(walk.files[2]?.managers).toContain("github-actions");
+    // The denominator the Extract phase's "K of N managers" quotes: every
+    // manager the walk actually asked, which is more than one and no more
+    // than the ledger.
+    expect(walk.managersConsidered).toBeGreaterThan(1);
+    expect(walk.managersConsidered).toBeLessThanOrEqual(EXTRACTABLE_MANAGERS.length);
   });
 
   it("reports an honest gap for a matched-but-unmapped manager", async () => {

--- a/roadmap/078-dep-proposals-from-extraction.md
+++ b/roadmap/078-dep-proposals-from-extraction.md
@@ -1,7 +1,15 @@
 # 078 — Dependency proposals: extract real deps from a pasted package file
 
-Milestone: M17 · Status: proposed — after 062 (tab taxonomy) and 063 (the
-file-set input this rides on); independent of 064.
+Milestone: M17 · Status: **app scope shipped; CLI scope in flight.**
+[087](087-ghost-row-and-repo-deps.md) built the shims and the engine
+(`extractDeps` over 102 managers) and made the input the LOADED REPOSITORY
+rather than a pasted file-set — read its "Deltas from 078's spec" before this
+document's Scope, which is written against the original plan.
+[089](089-dependencies-tab-and-data-table.md) gave the extracted list its own
+tab, and [090](090-pipeline-extract-phase.md) gave the extraction itself the
+Pipeline tab's Extract phase. **Remaining: `rcd extract`** (the CLI bullet
+below — in flight as the next layer), the pasted `{ path, content }` file-set
+input (still 063's), and custom managers (063 too).
 Feasibility surveyed:
 [2026-08-builtin-extraction-feasibility.md](2026-08-builtin-extraction-feasibility.md)
 

--- a/roadmap/090-pipeline-extract-phase.md
+++ b/roadmap/090-pipeline-extract-phase.md
@@ -1,0 +1,161 @@
+# 090 — The Pipeline tab's Extract phase, behind a phase picker
+
+- Milestone: M21 · Status: done
+- Design: Claude Design project "Renovate Config Debugger", artboards
+  `Extract Phase.dc.html` and `Proposal F - Integrated Shell.dc.html`
+  (pipeline mode)
+
+## The ask
+
+The Pipeline tab has always shown one thing under a name that promises four.
+What it draws is Renovate's **config** pipeline — 008's eight stages, global
+through merge — while production Renovate walks four phases per repository:
+resolve the config, extract the dependencies, look each one up, and decide the
+updates.
+
+[087](087-ghost-row-and-repo-deps.md) shipped the second of those phases as an
+engine (`matchExtractableManagers`, `extractDeps`, the tree walk in
+`use-repo-deps.ts`) and [089](089-dependencies-tab-and-data-table.md) gave its
+RESULT a tab. Neither showed the phase itself: which managers claimed which
+files, which of those files were read, and what came out of each. This item is
+that view, and the picker that puts it in Renovate's own order.
+
+## What shipped
+
+### The phase picker
+
+Four segments at the top of the tab, through the app's own
+`SegmentedControl` (`features/pipeline/PhasePicker.tsx`) — a control that
+labels a STATE, which is exactly what a phase choice is, and which carries the
+radiogroup semantics a hand-rolled row of buttons always forgets.
+
+- **Config** — the tab as it was, unchanged, down to the same DOM: the stage
+  rail, the stage card, the rewrite stepper. Its subtitle is the effective
+  config's option count.
+- **Extract** — the new view. Its subtitle is `+N deps` in the verdict green,
+  and only once discovery has REPORTED: a zero before that would claim the
+  repository has none (089's rule for the tab badges, applied to a segment).
+- **Lookup** and **Update** — rendered, disabled, `title="Not available
+today"`, subtitle "not available yet". Both need the live datasource calls
+  the engine deliberately severs (078's "not in scope"), so the honest thing
+  is to name them and say so. Dropping them would teach the sequence wrong,
+  and enabling them would be a lie with a spinner on it.
+
+`SegmentedControl` grew one optional `disabled` per option for this, which is
+the whole diff to the shared component.
+
+### The Extract phase
+
+A three-node track and one card beneath it, selected by node:
+
+1. **Match managers** — "K of N managers matched files". One row per manager
+   that claimed something, most files first; the collapsed row previews its
+   paths, the open one lists each file with what it yielded.
+2. **Scan files** — "N package files scanned". One row per file discovery
+   actually READ, its dep count and the managers that claim it; open, the deps
+   themselves.
+3. **Extract deps** — "N dependencies from owner/repo", and the node selected
+   first, because it is the phase's result. Grouped by the manager that read
+   them, with a link on to the Dependencies tab rather than a second copy of
+   it.
+
+The track wears the stage rail's own classes (`08-landing.css`) rather than a
+second dot-on-a-line implementation, so the two cannot drift apart visually.
+It is deliberately NOT `StageRail` itself: that component is typed on the
+engine's `StageId` and reads a `TraceResult` for its glyphs, and extraction is
+not a pipeline stage.
+
+### Data honesty
+
+Everything the view states is arithmetic over the discovery record, and the
+record grew exactly what the view needs to be honest:
+
+- **`RepoDepsView.files`** — every matched path, in walk order, with the
+  managers that claim it and what became of it
+  (`extracted` / `no-deps` / `not-read` / `unreadable` / `error`). Matching is
+  the cheap path-only step, so this covers the whole walk; 087's fetch cap of
+  ten only decides which of them were READ. A file the cap dropped says **"not
+  read"**, never "no deps" — that would be a claim about bytes nobody fetched.
+- **`RepoDepsView.managersConsidered`** — how many managers the walk asked
+  (the extractable ledger minus the default-disabled and the pattern-less
+  ones, neither of which a filename walk can match). It is the denominator of
+  "K of N", so the sentence cannot quietly become "K of all of Renovate's".
+- **The footnotes** state what the walk is not: how many managers matched
+  nothing, how many matched files went unread, whether GitHub truncated the
+  listing, and — permanently, until the walk becomes config-aware — that
+  **`enabledManagers` and `ignorePaths` from the merged config are NOT applied
+  to it**. Only Renovate's own default ignore of `node_modules` /
+  `bower_components` is (`use-repo-deps.ts`'s `IGNORED_PATH`). The design
+  sketched those notes as claims that the config HAD applied; the data does
+  not support that, so the sentence is inverted rather than dropped — a reader
+  whose `enabledManagers` is narrow must not conclude Renovate is ignoring it.
+
+The four states before a report are the Dependencies tab's, for the same
+reason: no repository is an offer (`RepoConnectPanel`), reading and failed are
+statuses, and nothing found is a fact. None of them may be drawn as a track of
+zeros.
+
+### The engine hand-off
+
+`matchExtractablePaths` returned bare paths, which meant the attribution the
+first node needs could only be recovered by a per-path re-scan — the exact
+thing that function's one-pass-per-manager shape exists to avoid. It is now
+`matchExtractableManagers`, returning `{ managersConsidered, files: [{ path,
+managers }] }` from the same single pass. Same cost, same order, one caller.
+
+### Wiring
+
+- The phase is **App's state**, not the panel's: opening the Extract phase is
+  what TRIGGERS discovery, and every results panel stays mounted (028), so a
+  panel-side effect would fire for a tab nobody has looked at. App's existing
+  `tab === "deps"` trigger became `tab === "deps" || (tab === "pipeline" &&
+phase === "extract")`; `ensure` is idempotent per loaded repo, so the three
+  doors onto discovery never discover twice.
+- It reaches the panel through the run-view context (086's admission rule: it
+  changes on a selection, never on a keystroke), and `onOpenDependencies` is
+  `jumpToTab("deps")` — the shell owns tab switching, and the jump records the
+  one-step way back like every other cross-tab link.
+- `PipelinePanel` is now the phase switch and nothing else; everything it used
+  to be is `ConfigPhase`, one component down, unchanged.
+
+## Deltas from the artboard
+
+- **The phase is not in the share payload.** Every other pipeline sub-state is
+  (`stage`, `step`), so this was a real choice: the Extract view depends on
+  repository ACCESS the recipient of a link may not have, and a link that
+  opened on it would show the connect panel where the sender saw their
+  extraction. `tab=pipeline` lands on Config, which is the phase every reader
+  can see. Cheap to add later — the codec validates fields independently and
+  `simStep` is the precedent for an additive one.
+- **"K + M custom" is rendered as "K".** 063's custom managers are still
+  unimplemented, so nothing can produce a `custom.`-prefixed manager id today
+  and "+ 0 custom" would be a control panel for a feature that does not exist.
+  The sentence takes the suffix the day the ledger can carry one.
+- **The fetch cap is counted, not named.** The footnote says how many files
+  went unread and that discovery caps its fetches; it does not print "10",
+  because the number belongs to `use-repo-deps.ts` (the app shell) and the
+  feature may not reach for it. Wording the sentence cap-agnostically was
+  cheaper than putting the constant on the view.
+- **No per-file "open in the editor" or row actions.** The artboard's rows are
+  read-only here: the actions on a dependency are the Dependencies tab's
+  (089), and the footer is the one-click way to them.
+
+## Verification
+
+- `features/pipeline/extract-phase.test.ts` (unit) — the three nodes' counts
+  and sentences (including "1 dependency", not "1 dependencies"), manager
+  ordering and its file lists, the scanned/matched split, the per-file note
+  for every outcome (an unread file is never "no deps"), the dep grouping, and
+  the footnotes appearing and disappearing with what they report.
+- `features/pipeline/PhasePicker.test.tsx` (components) — four phases in
+  Renovate's order, the two disabled with their reason, the Config count, the
+  Extract count only once discovery reported, and the selection callback.
+- `features/pipeline/ExtractPhase.test.tsx` (components) — the four pre-report
+  states, none of which draws a track; the default node; each card's header
+  sentence and what it opens onto; the unread file present under Match
+  managers and absent under Scan files; the hand-off to the Dependencies tab.
+- `packages/engine/test/extract.node.test.ts` — the walk's attribution: input
+  order, extractable managers only, and a denominator bounded by the ledger.
+- e2e: `07-stage-chip-outcomes` now asserts the picker leads the tab with
+  Config active and Lookup disabled, before the stage-rail assertions it
+  always made.


### PR DESCRIPTION
The Pipeline tab gains the design's four-phase picker (Config active,
Extract live, Lookup/Update honestly disabled) and the Extract phase's
three-node track: match managers, scan files, extract deps, each with a
drill-down card fed by the repo discovery record. Roadmap 090; closes
roadmap 078's app scope.

Design: Extract Phase.dc.html, Proposal F - Integrated Shell.dc.html

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>