### PR TITLE
feat(cli): rcd extract — headless dependency extraction for one file

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -31,19 +31,20 @@ rules. Everything merged into 34 effective options, 6 of them overridden along
 the way.
 ```
 
-| command      | question it answers                                  |
-| ------------ | ---------------------------------------------------- |
-| `digest`     | what happened in this run, in one paragraph          |
-| `validate`   | would Renovate refuse this config? (exit `2` if so)  |
-| `tree`       | which presets did the config pull in                 |
-| `provenance` | which preset set this option                         |
-| `resolved`   | the merged config Renovate would run with            |
-| `simulate`   | which `packageRules` match a hypothetical dependency |
-| `compare`    | did an edit change behavior                          |
-| `group`      | which groups form from several updates               |
-| `run`        | the whole trace                                      |
-| `docs`       | what an option means, and where it may go            |
-| `mcp`        | all of the above over MCP stdio                      |
+| command      | question it answers                                   |
+| ------------ | ----------------------------------------------------- |
+| `digest`     | what happened in this run, in one paragraph           |
+| `validate`   | would Renovate refuse this config? (exit `2` if so)   |
+| `tree`       | which presets did the config pull in                  |
+| `provenance` | which preset set this option                          |
+| `resolved`   | the merged config Renovate would run with             |
+| `simulate`   | which `packageRules` match a hypothetical dependency  |
+| `compare`    | did an edit change behavior                           |
+| `group`      | which groups form from several updates                |
+| `run`        | the whole trace                                       |
+| `docs`       | what an option means, and where it may go             |
+| `extract`    | which dependencies Renovate would extract from a file |
+| `mcp`        | all of the above over MCP stdio                       |
 
 ```console
 $ rcd validate renovate.json
@@ -54,6 +55,7 @@ $ rcd simulate renovate.json --dep '{"depName":"react","currentValue":"17.0.0","
 $ rcd compare before.json after.json --dep '{"depName":"react"}'
 $ rcd group renovate.json --dep '{"depName":"react","updateType":"minor"}' --dep '{"depName":"react-dom","updateType":"minor"}'
 $ rcd docs minimumReleaseAge
+$ rcd extract package.json
 $ echo '{"extends":["config:recommended"]}' | rcd run --stdin --format json --select status
 ```
 
@@ -108,6 +110,7 @@ The rest belong to one command each.
 |              | `--keys <a,b,…>`             | only these options of `--select final`                                  |
 |              | `--config-scope <which>`     | `full` (default) \| `package-rules`                                     |
 | `docs`       | `--search`                   | list options whose name matches                                         |
+| `extract`    | `--manager <name>`           | force this manager — the only door for a pattern-less manager           |
 
 ### What `docs` answers
 
@@ -518,6 +521,8 @@ inspection chooses the endpoint, the CLI withholds tokens and says so on stderr.
 `rcd mcp` speaks MCP over stdio — the same answers as the subcommands, better
 economics for a session. It takes no arguments and writes nothing but the
 protocol to stdout, so point any MCP-capable client at it as a stdio server.
+`extract` has no MCP tool of its own: the server describes one held config
+run, and file extraction is a different question from any of those tools.
 It speaks the 2026-07-28 protocol and the legacy 2025-era `initialize`
 handshake, chosen per connection.
 

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -133,6 +133,12 @@ export const OPTIONS = {
       "which config keys to report: package-rules (drop the globalOnly options a rule " +
       "cannot reach) | full",
   },
+  manager: {
+    flags: "--manager <name>",
+    description:
+      "force this manager, instead of matching by filename — the only door for a " +
+      "pattern-less manager, and how to pick among several that claim one filename",
+  },
 } as const satisfies Record<string, OptionSpec>;
 
 export type OptionName = keyof typeof OPTIONS;

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { fixture, runCli, runJson } from "../test-harness";
+
+/**
+ * Roadmap 078's CLI half. Fixtures are stored under a name no dependency
+ * scanner reads (`*.fixture`, the engine's own extraction suite convention)
+ * and materialized here under the REAL filename `extract` matches on — a
+ * `package.json` or `build.gradle` living in this repo's own tree would be
+ * indistinguishable from one of its manifests to a scanner walking it.
+ */
+
+let dir: string | null = null;
+
+afterEach(async () => {
+  if (dir !== null) {
+    await rm(dir, { recursive: true, force: true });
+    dir = null;
+  }
+});
+
+async function materialize(fixtureName: string, realName: string): Promise<string> {
+  const content = await readFile(fixture(`extract/${fixtureName}.fixture`), "utf8");
+  dir = await mkdtemp(join(tmpdir(), "rcd-extract-"));
+  const path = join(dir, realName);
+  await writeFile(path, content, "utf8");
+  return path;
+}
+
+describe("extract", () => {
+  test("auto-matches the manager by filename and reports its deps", async () => {
+    const path = await materialize("package.json", "package.json");
+    const run = await runJson<{
+      fileName: string;
+      matchedManagers: string[];
+      results: { ok: boolean; file?: { manager: string; deps: { depName: string }[] } }[];
+    }>(["extract", path, "--format", "json"]);
+    expect(run.code).toBe(0);
+    expect(run.payload.matchedManagers).toContain("npm");
+    expect(run.payload.results).toHaveLength(1);
+    const [result] = run.payload.results;
+    expect(result?.ok).toBe(true);
+    expect(result?.file?.manager).toBe("npm");
+    expect(result?.file?.deps.map((dep) => dep.depName)).toContain("react");
+  });
+
+  test("pretty output lists depName, currentValue, datasource and depType", async () => {
+    const path = await materialize("package.json", "package.json");
+    const run = await runCli(["extract", path]);
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain("npm —");
+    expect(run.stdout).toContain("react");
+    expect(run.stdout).toContain("17.0.0");
+    expect(run.stdout).toContain("npm");
+    expect(run.stdout).toContain("dependencies");
+  });
+
+  test("several managers claiming one filename all run and are all reported", async () => {
+    const path = await materialize("pyproject.toml", "pyproject.toml");
+    const run = await runJson<{
+      matchedManagers: string[];
+      results: { ok: boolean; file?: { manager: string } }[];
+    }>(["extract", path, "--format", "json"]);
+    // pyproject.toml is pep621's, pixi's and poetry's.
+    expect(run.payload.matchedManagers).toEqual(
+      expect.arrayContaining(["pep621", "pixi", "poetry"]),
+    );
+    expect(run.payload.results.length).toBeGreaterThanOrEqual(3);
+    const pep621 = run.payload.results.find((r) => r.ok && r.file?.manager === "pep621");
+    expect(pep621?.ok).toBe(true);
+  });
+
+  test("--manager forces one, the only door for a pattern-less manager", async () => {
+    const path = await materialize("deployment.yaml", "k8s-deployment.yaml");
+    const run = await runJson<{
+      matchedManagers: string[];
+      requestedManager: string;
+      results: { ok: boolean; file?: { manager: string; deps: { depName: string }[] } }[];
+    }>(["extract", path, "--manager", "kubernetes", "--format", "json"]);
+    expect(run.code).toBe(0);
+    // kubernetes ships empty managerFilePatterns — never matched by filename.
+    expect(run.payload.matchedManagers).not.toContain("kubernetes");
+    expect(run.payload.requestedManager).toBe("kubernetes");
+    const [result] = run.payload.results;
+    expect(result?.ok).toBe(true);
+    expect(result?.file?.manager).toBe("kubernetes");
+    expect(result?.file?.deps.map((dep) => dep.depName)).toContain("nginx");
+  });
+
+  test("no manager matches the filename and none was forced", async () => {
+    const path = await materialize("notes.md", "notes.md");
+    const run = await runCli(["extract", path]);
+    expect(run.code).toBe(1);
+    expect(run.stdout).toContain("no manager");
+    expect(run.stdout).toContain("notes.md");
+  });
+
+  test("a matched-but-unmapped manager reports the engine's own gap, not a guess", async () => {
+    const path = await materialize("build.gradle", "build.gradle");
+    const run = await runJson<{
+      matchedManagers: string[];
+      results: { ok: boolean; message?: string }[];
+    }>(["extract", path, "--format", "json"]);
+    expect(run.code).toBe(1);
+    expect(run.payload.matchedManagers).toContain("gradle");
+    expect(run.payload.results[0]?.ok).toBe(false);
+    expect(run.payload.results[0]?.message).toContain("not supported in the browser engine");
+  });
+
+  test("an unreadable file is a clear IO error", async () => {
+    const run = await runCli(["extract", "/no/such/file/package.json"]);
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain("cannot read file");
+  });
+
+  test("no file named is an error", async () => {
+    const run = await runCli(["extract"]);
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain("name a file");
+  });
+
+  test("--help documents the pattern-less-manager door", async () => {
+    const run = await runCli(["extract", "--help"]);
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain("--manager");
+    expect(run.stdout).toContain("pattern-less manager");
+  });
+});

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -1,0 +1,139 @@
+import {
+  EXTRACTABLE_MANAGERS,
+  type ExtractOutcome,
+  extractDeps,
+  matchManagersForFile,
+  type PackageDependency,
+} from "@renovate-config-debugger/engine";
+import { outputFormat, stringOption } from "../args";
+import type { Command } from "../command";
+import { CliError, EXIT_ERROR, EXIT_OK } from "../io";
+import { emitJson, emitLines } from "../output";
+import { readTextFile } from "../run-input";
+
+/**
+ * Roadmap 078's CLI half: "what would Renovate extract from this file?",
+ * headless. Mirrors 087's engine surface exactly — `matchManagersForFile` for
+ * filename detection, `extractDeps` per matched manager — so this command adds
+ * no logic of its own beyond running one over the other and reporting both.
+ *
+ * Several managers can legitimately claim one filename (`pyproject.toml` is
+ * pep621's, pixi's and poetry's): with no `--manager`, every EXTRACTABLE match
+ * runs and gets its own section. `--manager` forces one — the only door for
+ * the eleven pattern-less managers (empty `managerFilePatterns`), and how to
+ * pick among several claimants.
+ */
+
+interface ExtractReport {
+  fileName: string;
+  /** Every manager whose file patterns matched, extractable or not. */
+  matchedManagers: string[];
+  requestedManager?: string;
+  results: ExtractOutcome[];
+}
+
+async function runExtraction(
+  fileName: string,
+  content: string,
+  manager?: string,
+): Promise<ExtractReport> {
+  const matchedManagers = matchManagersForFile(fileName);
+  if (manager) {
+    return {
+      fileName,
+      matchedManagers,
+      requestedManager: manager,
+      results: [await extractDeps({ fileName, content, manager })],
+    };
+  }
+  const extractable = matchedManagers.filter((m) => EXTRACTABLE_MANAGERS.includes(m));
+  if (extractable.length === 0) {
+    // Either nothing matched (`no-manager`) or everything that did is
+    // unmapped (`unsupported-manager`) — one call with no override reports
+    // exactly which, in the engine's own words.
+    return { fileName, matchedManagers, results: [await extractDeps({ fileName, content })] };
+  }
+  const results: ExtractOutcome[] = [];
+  for (const candidate of extractable) {
+    results.push(await extractDeps({ fileName, content, manager: candidate }));
+  }
+  return { fileName, matchedManagers, results };
+}
+
+function depLine(dep: PackageDependency, fileDatasource: string | undefined): string {
+  const name = dep.depName ?? dep.packageName ?? "(unnamed)";
+  const value = dep.currentValue ?? "(no current value)";
+  const datasource = dep.datasource ?? fileDatasource;
+  const bits = [name.padEnd(28), value.padEnd(16), datasource ?? "(no datasource)"];
+  if (dep.depType) {
+    bits.push(dep.depType);
+  }
+  return `    ${bits.join(" ")}`;
+}
+
+function reportLines(report: ExtractReport): string[] {
+  const lines: string[] = [];
+  for (const outcome of report.results) {
+    if (outcome.ok) {
+      const { manager, deps, datasource } = outcome.file;
+      lines.push(
+        `${manager} — ${deps.length} dependenc${deps.length === 1 ? "y" : "ies"} in ${report.fileName}`,
+      );
+      for (const dep of deps) {
+        lines.push(depLine(dep, datasource));
+      }
+    } else {
+      lines.push(`✗ ${outcome.message}`);
+    }
+    lines.push("");
+  }
+  return lines;
+}
+
+/** Whether at least one section actually produced dependencies. */
+function anySucceeded(report: ExtractReport): boolean {
+  return report.results.some((outcome) => outcome.ok);
+}
+
+export const extractCommand: Command = {
+  name: "extract",
+  summary: "which dependencies would Renovate extract from this file?",
+  usage: ["extract <file> [--manager <name>]"],
+  details: [
+    "Reads the file locally and runs Renovate's own extraction, the same code",
+    "path the app's From-repository tab uses — not a guess at the shape of a",
+    "dependency, the real depName/currentValue/datasource/depType.",
+    "",
+    "With no --manager, every manager whose file patterns match the filename",
+    "runs and gets its own section — pyproject.toml is pep621's, pixi's and",
+    "poetry's, and all three are reported. --manager forces one: the only door",
+    "for a pattern-less manager (argocd, kubernetes, tekton, pep723, …), and how",
+    "to pick among several claimants.",
+    "",
+    "Only the curated manager set the browser engine ships runs here; a matched",
+    "manager outside it reports an honest 'not supported' rather than a guess.",
+  ],
+  options: ["manager", "format"],
+  async run(args, io) {
+    const format = outputFormat(args);
+    const file = args.positionals[0];
+    if (!file) {
+      throw new CliError("name a file, e.g. `rcd extract package.json`");
+    }
+    const content = await readTextFile(file, "file");
+    const manager = stringOption(args, "manager");
+    const report = await runExtraction(file, content, manager);
+    const ok = anySucceeded(report);
+
+    if (format === "json") {
+      emitJson(io, report);
+    } else {
+      const lines =
+        report.results.length === 1 && !report.results[0]?.ok
+          ? [`✗ ${report.results[0]?.message}`]
+          : reportLines(report);
+      emitLines(io, lines);
+    }
+    return ok ? EXIT_OK : EXIT_ERROR;
+  },
+};

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -6,6 +6,7 @@ import type { Command } from "./command";
 import { compareCommand } from "./commands/compare";
 import { digestCommand } from "./commands/digest";
 import { docsCommand } from "./commands/docs";
+import { extractCommand } from "./commands/extract";
 import { groupCommand } from "./commands/group";
 import { mcpCommand } from "./commands/mcp";
 import { provenanceCommand } from "./commands/provenance";
@@ -46,6 +47,7 @@ export const COMMANDS: readonly Command[] = [
   compareCommand,
   groupCommand,
   docsCommand,
+  extractCommand,
   mcpCommand,
 ];
 

--- a/packages/cli/test/fixtures/extract/build.gradle.fixture
+++ b/packages/cli/test/fixtures/extract/build.gradle.fixture
@@ -1,0 +1,3 @@
+dependencies {
+  implementation 'org.slf4j:slf4j-api:2.0.13'
+}

--- a/packages/cli/test/fixtures/extract/deployment.yaml.fixture
+++ b/packages/cli/test/fixtures/extract/deployment.yaml.fixture
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: nginx:1.27.0

--- a/packages/cli/test/fixtures/extract/notes.md.fixture
+++ b/packages/cli/test/fixtures/extract/notes.md.fixture
@@ -1,0 +1,3 @@
+# notes
+
+Nothing here looks like a package manifest.

--- a/packages/cli/test/fixtures/extract/package.json.fixture
+++ b/packages/cli/test/fixtures/extract/package.json.fixture
@@ -1,0 +1,10 @@
+{
+  "name": "acme-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "17.0.0"
+  },
+  "devDependencies": {
+    "vitest": "1.0.0"
+  }
+}

--- a/packages/cli/test/fixtures/extract/pyproject.toml.fixture
+++ b/packages/cli/test/fixtures/extract/pyproject.toml.fixture
@@ -1,0 +1,11 @@
+[project]
+name = "acme"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+  "httpx==0.27.0",
+  "pydantic>=2.7",
+]
+
+[project.optional-dependencies]
+dev = ["pytest==8.2.0"]

--- a/roadmap/078-dep-proposals-from-extraction.md
+++ b/roadmap/078-dep-proposals-from-extraction.md
@@ -1,15 +1,15 @@
 # 078 — Dependency proposals: extract real deps from a pasted package file
 
-Milestone: M17 · Status: **app scope shipped; CLI scope in flight.**
+Milestone: M17 · Status: **app and CLI scope shipped.**
 [087](087-ghost-row-and-repo-deps.md) built the shims and the engine
 (`extractDeps` over 102 managers) and made the input the LOADED REPOSITORY
 rather than a pasted file-set — read its "Deltas from 078's spec" before this
 document's Scope, which is written against the original plan.
 [089](089-dependencies-tab-and-data-table.md) gave the extracted list its own
-tab, and [090](090-pipeline-extract-phase.md) gave the extraction itself the
-Pipeline tab's Extract phase. **Remaining: `rcd extract`** (the CLI bullet
-below — in flight as the next layer), the pasted `{ path, content }` file-set
-input (still 063's), and custom managers (063 too).
+tab, [090](090-pipeline-extract-phase.md) gave the extraction itself the
+Pipeline tab's Extract phase, and `rcd extract <file>` (the CLI bullet below)
+shipped as the next layer. **Remaining:** the pasted `{ path, content }`
+file-set input (still 063's) and custom managers (063 too).
 Feasibility surveyed:
 [2026-08-builtin-extraction-feasibility.md](2026-08-builtin-extraction-feasibility.md)
 


### PR DESCRIPTION
Runs the engine's manager matching and extractDeps over a local package
file, one report section per matched manager; --manager forces the
eleven pattern-less managers or picks among filename claimants.
Closes roadmap 078's CLI scope.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>