### PR TITLE
feat(app): seed two starter pins from the config's own rules

### DIFF
--- a/packages/app/e2e/04-simulator.spec.ts
+++ b/packages/app/e2e/04-simulator.spec.ts
@@ -5,7 +5,14 @@ import {
   MERGE_STEPS_CONFIG,
   PACKAGE_RULES_CONFIG,
 } from "./fixtures";
-import { drawer, openSimulator, simulateQuickFill, tabButton } from "./helpers";
+import {
+  clearStarterPins,
+  drawer,
+  openSimulator,
+  openTab,
+  simulateQuickFill,
+  tabButton,
+} from "./helpers";
 
 /**
  * Journey 4 — the packageRules simulator. After a run whose config has a
@@ -101,6 +108,10 @@ test("focusing a pre-filled simulator field selects its content so typing replac
  */
 test("pinning from the detail view adds a standing test without leaving it", async ({ page }) => {
   await page.goto(await encodeShareFragment({ config: PACKAGE_RULES_CONFIG }));
+  // Roadmap 091: this config's own rule seeds a starter pin, and the count
+  // below is about the pin this test makes — so the starter goes first.
+  await openTab(page, "tests");
+  await clearStarterPins(page);
 
   const simulator = await openSimulator(page);
   await simulateQuickFill(simulator, "GitHub Action");

--- a/packages/app/e2e/11-tabbed-shell.spec.ts
+++ b/packages/app/e2e/11-tabbed-shell.spec.ts
@@ -8,6 +8,7 @@ import {
   SEMANTIC_COMMITS_CONFIG,
 } from "./fixtures";
 import {
+  clearStarterPins,
   effectivePresetChip,
   must,
   openMigrateStage,
@@ -437,6 +438,10 @@ test("a share link naming a retired tab lands on the tab that replaced it", asyn
   );
   await expect(resultsPanel(page)).toBeVisible({ timeout: 30_000 });
   await expect(tabButton(page, "tests")).toHaveAttribute("aria-selected", "true");
+  // Roadmap 091: this config's own rule seeds a starter pin — the alias's
+  // subject is WHICH tab the link lands on, so the list it lands on is cleared
+  // back to the state this assertion was written for.
+  await clearStarterPins(page);
   await expect(tabPanel(page, "tests")).toContainText("No tests pinned yet");
 
   // `rewrites` — Pipeline, AND the migrate stage, or the stepper the sender was

--- a/packages/app/e2e/21-pinned-tests.spec.ts
+++ b/packages/app/e2e/21-pinned-tests.spec.ts
@@ -1,6 +1,12 @@
 import { expect, type Page, test } from "@playwright/test";
 import { encodeShareFragment, MERGE_STEPS_CONFIG, PACKAGE_RULES_CONFIG } from "./fixtures";
-import { openTab, runAndAwaitResult, setEditorContent, tabButton } from "./helpers";
+import {
+  clearStarterPins,
+  openTab,
+  runAndAwaitResult,
+  setEditorContent,
+  tabButton,
+} from "./helpers";
 
 /**
  * Roadmap 075 (v2, iteration 6) — the Tests tab as pinned dependency tests.
@@ -27,6 +33,10 @@ async function pinLodash(page: Page): Promise<void> {
 test("pinning a dependency checks it against the run, and every run after it", async ({ page }) => {
   await page.goto(await encodeShareFragment({ config: PACKAGE_RULES_CONFIG }));
   await openTab(page, "tests");
+  // Roadmap 091: this config's own rule seeds a starter pin. The subject here
+  // is the reader's OWN pin and the loop around it, so the starter goes first
+  // — its own behaviour is the test below.
+  await clearStarterPins(page);
 
   // The tab opens on the list: the empty state says what a pin is, and the
   // Add-a-test form is already open below it (Proposal F).
@@ -125,4 +135,42 @@ test("a pin opens in the full simulator, pre-filled, and the way back is one cli
 
   await page.getByRole("button", { name: "← Back to tests" }).click();
   await expect(page.locator(".pin-card")).toHaveCount(1);
+});
+
+/**
+ * Roadmap 091 — the starter pins. The Tests pane the landing transition docks
+ * in answers "now what?" by example: up to two descriptors derived from the
+ * config's OWN rules, marked as derived, and removable like anything else —
+ * permanently, because a starter that came back after a run would be the
+ * "magic" 075 refused.
+ */
+test("a config's own rules seed a starter pin, marked, and removing it is final", async ({
+  page,
+}) => {
+  await page.goto(await encodeShareFragment({ config: PACKAGE_RULES_CONFIG }));
+  await openTab(page, "tests");
+
+  // The config's one rule matches lodash on minor/patch, so the starter IS a
+  // lodash minor — and it is checked against the run like any pin.
+  const card = page.locator(".pin-card");
+  await expect(card).toHaveCount(1);
+  await expect(card).toContainText("lodash");
+  await expect(card.locator(".pin-starter")).toContainText("starter");
+  await expect(card.locator(".pin-summary")).toContainText("automerge ✓");
+  // With something in the list, the empty state's explainer stands down.
+  await expect(page.locator("#panel-tests")).not.toContainText("No tests pinned yet");
+
+  // A re-run re-checks it, exactly like a pin the reader made.
+  await runAndAwaitResult(page);
+  await openTab(page, "tests");
+  await expect(card.locator(".pin-summary")).toContainText("automerge ✓");
+
+  // The ordinary unpin removes it — and the run after that does not seed it
+  // again: deleting a starter is an answer, not a refresh.
+  await page.getByRole("button", { name: "Remove the pinned test for lodash" }).click();
+  await expect(card).toHaveCount(0);
+  await runAndAwaitResult(page);
+  await openTab(page, "tests");
+  await expect(card).toHaveCount(0);
+  await expect(page.locator("#panel-tests")).toContainText("No tests pinned yet");
 });

--- a/packages/app/e2e/helpers.ts
+++ b/packages/app/e2e/helpers.ts
@@ -206,6 +206,27 @@ export async function effectivePresetChip(page: Page): Promise<Locator> {
  *
  * Returns the simulator card, since every caller's next line asks it something.
  */
+/**
+ * Roadmap 091: removes the STARTER pins the shell seeds into an otherwise
+ * empty Tests tab (up to two, derived from the config's own `packageRules`),
+ * so a spec whose subject is the empty list — or its own pin, counted — sees
+ * the list it was written for.
+ *
+ * Waits for at least one starter first: seeding lands a beat after the run
+ * (it waits on the rule provenance), and a `toHaveCount(0)` that ran before it
+ * would pass and then be falsified. Every caller's config has own rules that
+ * derive one, which is why the wait is safe to make unconditional. Removal
+ * sticks for the session — the seeding latch — so one call is enough.
+ */
+export async function clearStarterPins(page: Page): Promise<void> {
+  const starters = page.locator(".pin-card", { has: page.locator(".pin-starter") });
+  await expect(starters.first()).toBeVisible();
+  for (let remaining = await starters.count(); remaining > 0; remaining--) {
+    await starters.first().locator(".pin-remove").click();
+  }
+  await expect(starters).toHaveCount(0);
+}
+
 export async function openSimulator(page: Page): Promise<Locator> {
   await openTab(page, "tests");
   const panel = tabPanel(page, "tests");

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -50,6 +50,7 @@ import { useRunSummary } from "@/app/use-run-summary";
 import { usePanelStats } from "@/app/use-panel-stats";
 import { usePinnedRun } from "@/app/use-pinned-run";
 import { useResultsTab } from "@/app/use-results-tab";
+import { useStarterPins } from "@/app/use-starter-pins";
 import { useShareLink } from "@/hooks/use-share-link";
 import type { RunInputs } from "@/lib/run-inputs";
 import { createRunQueue, type RunQueue } from "@/lib/run-queue";
@@ -234,7 +235,8 @@ export function App() {
    * the tab strip's count is one of the numbers `useRunSummary` assembles. The
    * evaluation itself is the panel's (`usePinnedTests`), keyed on the run.
    */
-  const { pins, addPin, removePin, setPinsFromShare, pinsAsShareFields } = usePinnedRun();
+  const { pins, addPin, removePin, seedStarterPins, setPinsFromShare, pinsAsShareFields } =
+    usePinnedRun();
   // Roadmap 028/069/083: the counts the results panels report back up (the
   // Effective tab's key tally, the Overview tab's behavior count) and the
   // ledger signal that goes the other way — as one hook, because a new run
@@ -330,6 +332,12 @@ export function App() {
   // owned by `useResultsTab` because arriving at a rule is a tab switch.)
   const configEditorRef = useRef<ConfigEditorHandle>(null);
   const ruleProvenance = useRuleProvenance(result);
+  // Roadmap 091: the first settled run seeds up to two starter pins from the
+  // reader's OWN rules (provenance is what makes "own" a fact), so the Tests
+  // pane the landing transition docks in has something to answer with. Once,
+  // and never over a reader who has pinned anything themselves — the latch is
+  // `usePinnedRun`'s.
+  useStarterPins({ result, ruleProvenance, seedStarterPins });
   /**
    * Roadmap 075 (iteration 3): the header's `N rewrites` link. The Rewrites tab
    * retired into Pipeline's migrate stage, so "show me the rewrites" is two

--- a/packages/app/src/app/use-pinned-run.test.tsx
+++ b/packages/app/src/app/use-pinned-run.test.tsx
@@ -1,0 +1,109 @@
+import { act, cleanup, render } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { EMPTY_FORM } from "@/features/simulator/form";
+import { type PinnedRun, usePinnedRun } from "./use-pinned-run";
+import type { FormState } from "@/types/simulator";
+
+/**
+ * Roadmap 091: the starter-pin latch. Seeding happens at most once per session
+ * and never over a reader who has touched the list — what counts as a touch IS
+ * the behaviour, so the ledger of touches is tested as one.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+/** The hook's API, hoisted out of the render so a test can drive it. */
+let held: PinnedRun | null = null;
+
+function Harness() {
+  const api = usePinnedRun();
+  // Written from an effect, never during render (`react/globals`); `render`
+  // and `act` both flush effects, so every read below sees the latest.
+  useEffect(() => {
+    held = api;
+  }, [api]);
+  return null;
+}
+
+function mount(): PinnedRun {
+  held = null;
+  render(<Harness />);
+  if (!held) {
+    throw new Error("the harness did not render");
+  }
+  return held;
+}
+
+/** The hook after the last committed render — `mount()`'s value holds the
+ *  stable callbacks, this holds the current list. */
+function current(): PinnedRun {
+  if (!held) {
+    throw new Error("the harness did not render");
+  }
+  return held;
+}
+
+function form(packageName: string): FormState {
+  return { ...EMPTY_FORM, manager: "npm", packageName, currentValue: "1.0.0", newValue: "1.1.0" };
+}
+
+function names(): string[] {
+  return current().pins.map((pin) => pin.form.packageName);
+}
+
+describe("usePinnedRun starter seeding", () => {
+  it("seeds marked starters into an untouched list, once", () => {
+    const api = mount();
+    act(() => api.seedStarterPins([form("react"), form("lodash")]));
+    expect(names()).toStrictEqual(["react", "lodash"]);
+    expect(current().pins.every((pin) => pin.starter === true)).toBe(true);
+
+    act(() => api.seedStarterPins([form("vue")]));
+    expect(names()).toStrictEqual(["react", "lodash"]);
+  });
+
+  it("does not seed after the reader has pinned, or removed, anything", () => {
+    const api = mount();
+    act(() => api.addPin(form("react")));
+    act(() => api.removePin(current().pins[0]?.id ?? ""));
+    expect(names()).toStrictEqual([]);
+    // The list is empty again, but it is not UNTOUCHED — the reader deleted
+    // that pin, and a starter arriving in its place would undo the gesture.
+    act(() => api.seedStarterPins([form("lodash")]));
+    expect(names()).toStrictEqual([]);
+  });
+
+  it("trips the latch even when a run derived nothing", () => {
+    const api = mount();
+    act(() => api.seedStarterPins([]));
+    act(() => api.seedStarterPins([form("react")]));
+    expect(names()).toStrictEqual([]);
+  });
+
+  it("stands down for a link that carried pins", () => {
+    const api = mount();
+    act(() => api.setPinsFromShare([{ packageName: "react", manager: "npm" }]));
+    act(() => api.seedStarterPins([form("lodash")]));
+    expect(names()).toStrictEqual(["react"]);
+    expect(current().pins.some((pin) => pin.starter === true)).toBe(false);
+  });
+
+  it("still seeds for a link that carried none — that is someone else's config", () => {
+    const api = mount();
+    act(() => api.setPinsFromShare([]));
+    act(() => api.seedStarterPins([form("lodash")]));
+    expect(names()).toStrictEqual(["lodash"]);
+  });
+
+  it("leaves starters out of the share link", () => {
+    const api = mount();
+    act(() => api.seedStarterPins([form("react")]));
+    act(() => api.addPin(form("lodash")));
+    expect(names()).toStrictEqual(["react", "lodash"]);
+    expect(current().pinsAsShareFields()).toStrictEqual([
+      { manager: "npm", packageName: "lodash", currentValue: "1.0.0", newValue: "1.1.0" },
+    ]);
+  });
+});

--- a/packages/app/src/app/use-pinned-run.ts
+++ b/packages/app/src/app/use-pinned-run.ts
@@ -33,6 +33,13 @@ export interface PinnedRun {
   pins: PinnedTest[];
   addPin: (form: FormState) => void;
   removePin: (id: string) => void;
+  /**
+   * Roadmap 091: the starter pins, seeded once. Called by `useStarterPins` on
+   * the first settled run — with the descriptors it derived, or with none when
+   * it derived none. Either way the latch trips, so this fires at most once
+   * per session and a reader who deletes a starter never sees it return.
+   */
+  seedStarterPins: (forms: FormState[]) => void;
   /** The decode side: a link's descriptors, with ids minted here. */
   setPinsFromShare: (shared: Record<string, string>[]) => void;
   /**
@@ -47,8 +54,16 @@ export function usePinnedRun(): PinnedRun {
   const [pins, setPins] = useState<PinnedTest[]>([]);
   const pinSeqRef = useRef(0);
   const nextPinId = useCallback(() => `pin-${++pinSeqRef.current}`, []);
+  /**
+   * Roadmap 091: the seeding latch — true once the list has been touched by
+   * anything at all: a pin made, a pin removed, a link's pins installed, or
+   * the one seeding itself. A ref, not state: it gates a decision taken inside
+   * a callback, and a re-render is neither needed nor wanted when it flips.
+   */
+  const pinsTouchedRef = useRef(false);
   const addPin = useCallback(
     (form: FormState) => {
+      pinsTouchedRef.current = true;
       // Roadmap 080: the detail view's pin leaves the form on screen, so a
       // repeated click reaches here with the same descriptor — an identical
       // test is a no-op, not a second row.
@@ -61,12 +76,41 @@ export function usePinnedRun(): PinnedRun {
     [nextPinId],
   );
   const removePin = useCallback((id: string) => {
+    pinsTouchedRef.current = true;
     setPins((prev) => prev.filter((pin) => pin.id !== id));
   }, []);
+  // Roadmap 091: seeded, never authored — so it happens only into a list
+  // nothing has touched yet, and it is itself a touch.
+  const seedStarterPins = useCallback(
+    (forms: FormState[]) => {
+      if (pinsTouchedRef.current) {
+        return;
+      }
+      pinsTouchedRef.current = true;
+      if (forms.length === 0) {
+        return;
+      }
+      setPins((prev) =>
+        prev.length > 0
+          ? prev
+          : forms.slice(0, MAX_PINS).map((form) => ({ id: nextPinId(), form, starter: true })),
+      );
+    },
+    [nextPinId],
+  );
   // Roadmap 075 (iteration 6): the link's pins, with ids minted here.
   const setPinsFromShare = useCallback(
     (shared: Record<string, string>[]) => {
-      setPins(pinsFromShareFields(shared, nextPinId));
+      const installed = pinsFromShareFields(shared, nextPinId);
+      // Roadmap 091: every link arrival calls this, with `[]` when the link
+      // carried no pins — only one that actually INSTALLS pins is a list the
+      // reader was handed, and only that one may stop the starters. A link
+      // without pins is someone else's config on this reader's screen, which
+      // is exactly the case the starters were written for.
+      if (installed.length > 0) {
+        pinsTouchedRef.current = true;
+      }
+      setPins(installed);
     },
     [nextPinId],
   );
@@ -74,7 +118,16 @@ export function usePinnedRun(): PinnedRun {
   // tests OF — a link that reproduces the run without them reproduces the wrong
   // screen. Descriptors only (the same fields `sim.form` carries), so this adds
   // no new class of data to a link.
-  const pinsAsShareFields = useCallback(() => pins.map((pin) => pinShareFields(pin.form)), [pins]);
+  //
+  // Roadmap 091: starters are left behind. They are not the sharer's tests —
+  // they are what this app made up from the config the link already carries,
+  // so the opener's own first run derives them again, from their own rules,
+  // marked as starters there too. Sharing them would hand someone else's
+  // reader two authored-looking pins nobody wrote.
+  const pinsAsShareFields = useCallback(
+    () => pins.filter((pin) => pin.starter !== true).map((pin) => pinShareFields(pin.form)),
+    [pins],
+  );
 
-  return { pins, addPin, removePin, setPinsFromShare, pinsAsShareFields };
+  return { pins, addPin, removePin, seedStarterPins, setPinsFromShare, pinsAsShareFields };
 }

--- a/packages/app/src/app/use-starter-pins.test.tsx
+++ b/packages/app/src/app/use-starter-pins.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RuleAttribution, TraceResult } from "@renovate-config-debugger/engine";
+import { useStarterPins } from "./use-starter-pins";
+import type { FormState } from "@/types/simulator";
+
+/**
+ * Roadmap 091: the seeding trigger. What a starter IS lives in
+ * `features/simulator/starter-pins.test.ts`; this covers the two decisions the
+ * shell makes — WHOSE rules are derived from (the repo config's, by
+ * provenance), and WHEN the attempt happens (never while provenance is still
+ * computing, once when it lands either way).
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+/** The reader's own rule first, a preset's second — the run merges them into
+ *  one array and only provenance can tell them apart. */
+const RULES = [
+  { matchManagers: ["npm"], matchUpdateTypes: ["minor"], groupName: "npm minor" },
+  { matchManagers: ["nuget"], automerge: true },
+];
+
+const RESULT = { finalConfig: { packageRules: RULES } } as unknown as TraceResult;
+
+const PROVENANCE = [
+  { index: 0, layer: { kind: "repo" }, sourceIndex: 0 },
+  { index: 1, layer: { kind: "preset", name: "config:recommended" }, sourceIndex: 0 },
+] as unknown as RuleAttribution[];
+
+function Harness({
+  result,
+  ruleProvenance,
+  seedStarterPins,
+}: {
+  result: TraceResult | null;
+  ruleProvenance: RuleAttribution[] | null | undefined;
+  seedStarterPins: (forms: FormState[]) => void;
+}) {
+  useStarterPins({ result, ruleProvenance, seedStarterPins });
+  return null;
+}
+
+describe("useStarterPins", () => {
+  it("derives from the reader's own rules only, once provenance lands", () => {
+    const seed = vi.fn();
+    const { rerender } = render(
+      <Harness result={RESULT} ruleProvenance={undefined} seedStarterPins={seed} />,
+    );
+    // Still computing: an attempt now would trip the latch on a half-answer.
+    expect(seed).not.toHaveBeenCalled();
+
+    rerender(<Harness result={RESULT} ruleProvenance={PROVENANCE} seedStarterPins={seed} />);
+    expect(seed).toHaveBeenCalledTimes(1);
+    const forms = seed.mock.calls[0]?.[0] as FormState[];
+    // The preset's nuget rule is not the reader's, so it is not demonstrated.
+    expect(forms.map((form) => form.manager)).toStrictEqual(["npm"]);
+    expect(forms[0]?.updateType).toBe("minor");
+  });
+
+  it("attempts — and so trips the latch — even when provenance is unavailable", () => {
+    const seed = vi.fn();
+    render(<Harness result={RESULT} ruleProvenance={null} seedStarterPins={seed} />);
+    expect(seed).toHaveBeenCalledWith([]);
+  });
+
+  it("does nothing before a run has produced a config", () => {
+    const seed = vi.fn();
+    render(<Harness result={null} ruleProvenance={PROVENANCE} seedStarterPins={seed} />);
+    expect(seed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/app/use-starter-pins.ts
+++ b/packages/app/src/app/use-starter-pins.ts
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import type { RuleAttribution, TraceResult } from "@renovate-config-debugger/engine";
+import { deriveStarterPins } from "@/features/simulator/starter-pins";
+import type { FormState } from "@/types/simulator";
+
+/**
+ * Roadmap 091 — WHEN the starter pins are seeded. (WHAT they are is
+ * `features/simulator/starter-pins.ts`; the shell computes, the feature
+ * draws.)
+ *
+ * The design's landing transition ends with the Tests pane sliding in, and the
+ * pane's whole promise — "these are the updates I care about, tell me when an
+ * edit changes what happens to them" — reads as an instruction manual when the
+ * list under it is empty. So the FIRST run that settles seeds up to two
+ * descriptors derived from the reader's own rules, and nothing after it does:
+ * the latch inside `usePinnedRun` trips here whether or not anything was
+ * derived, so a reader who deletes them, or who was already pinning, is never
+ * seeded over.
+ *
+ * "Their own rules" is provenance's answer, not a guess: the resolved
+ * `packageRules` are filtered to the entries the REPO config contributed
+ * (roadmap 013's `computeRuleProvenance`), because a starter derived from
+ * `config:best-practices` would demonstrate a decision the reader never made.
+ * Provenance is a per-run promise, so the effect waits for it — `undefined` is
+ * "still computing", `null` is "unavailable", and only the second one is an
+ * answer (no rules to derive from, latch tripped, empty state stays).
+ */
+export function useStarterPins({
+  result,
+  ruleProvenance,
+  seedStarterPins,
+}: {
+  result: TraceResult | null;
+  ruleProvenance: RuleAttribution[] | null | undefined;
+  seedStarterPins: (forms: FormState[]) => void;
+}): void {
+  useEffect(() => {
+    const rules = result?.finalConfig?.packageRules;
+    if (!result?.finalConfig || ruleProvenance === undefined) {
+      return;
+    }
+    if (ruleProvenance === null || !Array.isArray(rules)) {
+      seedStarterPins([]);
+      return;
+    }
+    const own = new Set(
+      ruleProvenance.filter((entry) => entry.layer.kind === "repo").map((entry) => entry.index),
+    );
+    seedStarterPins(deriveStarterPins((rules as unknown[]).filter((_, index) => own.has(index))));
+  }, [result, ruleProvenance, seedStarterPins]);
+}

--- a/packages/app/src/features/simulator/EmptyTestsCard.tsx
+++ b/packages/app/src/features/simulator/EmptyTestsCard.tsx
@@ -5,8 +5,11 @@ import type { FormState } from "@/types/simulator";
  * The design's empty state (Proposal F / "Skip Reason Funnel", `state:
  * empty`): a dashed card that says what a pin is, points at the Add-a-test
  * card below, and offers the quick-fill descriptors as "common cases" —
- * clicking one seeds the form rather than pinning, because no pin is ever
- * created for the reader (075 iteration 6). Everything goes through the SEED
+ * clicking one seeds the form rather than pinning, because a chip is an offer
+ * (075 iteration 6; the shell's own starter pins, roadmap 091, are the one
+ * thing that fills the list unasked — and they wear a chip saying so, which is
+ * why this card is on screen at all only when they derived nothing).
+ * Everything goes through the SEED
  * channel: since the ghost rework the card below may be collapsed, and the
  * seed is what opens it and moves focus into the form once it has rendered —
  * a direct DOM focus from here would query a form that is not on screen yet.

--- a/packages/app/src/features/simulator/PinCard.tsx
+++ b/packages/app/src/features/simulator/PinCard.tsx
@@ -51,6 +51,7 @@ function PinCardHead({
           context={pinContext(pin.form, outcome?.updateType ?? "")}
           summary={outcome ? headSummary(outcome) : null}
           pending={evaluation ? "not checked" : "checking…"}
+          starter={pin.starter === true}
         />
       </button>
       <button

--- a/packages/app/src/features/simulator/PinHeadRow.test.tsx
+++ b/packages/app/src/features/simulator/PinHeadRow.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PinHeadRow } from "./PinHeadRow";
+
+/**
+ * Roadmap 091: a seeded pin has to LOOK seeded. The chip is the only thing
+ * that distinguishes a starter from a test the reader wrote, and its title is
+ * where the invitation to replace it lives — a pin nobody made, wearing
+ * nothing, would read as a test the reader forgot writing.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+describe("PinHeadRow", () => {
+  it("marks a starter, and says what it is for", () => {
+    const view = render(
+      <PinHeadRow
+        check={{ status: "pending" }}
+        name="lodash"
+        context="4.17.20 → 4.18.0 · npm · minor"
+        summary="1 rule matched"
+        starter={true}
+      />,
+    );
+    const chip = view.container.querySelector(".pin-starter");
+    expect(chip?.textContent).toBe("starter");
+    expect(chip?.getAttribute("title")).toContain("packageRules");
+  });
+
+  it("says nothing on a pin the reader made", () => {
+    const view = render(
+      <PinHeadRow
+        check={{ status: "pending" }}
+        name="lodash"
+        context="4.17.20 → 4.18.0 · npm · minor"
+        summary="1 rule matched"
+      />,
+    );
+    expect(view.container.querySelector(".pin-starter")).toBeNull();
+    expect(view.container.querySelector(".pin-name")?.textContent).toBe("lodash");
+  });
+});

--- a/packages/app/src/features/simulator/PinHeadRow.tsx
+++ b/packages/app/src/features/simulator/PinHeadRow.tsx
@@ -18,6 +18,7 @@ export function PinHeadRow({
   context,
   summary,
   pending,
+  starter = false,
 }: {
   check: PinCheck;
   name: string;
@@ -27,11 +28,19 @@ export function PinHeadRow({
   summary: string | null;
   /** What stands in for the sentence while `summary` is null. */
   pending?: string;
+  /** Roadmap 091: this descriptor was derived from the reader's own rules, not
+   *  written by them — said on the row, since it is the row's own claim. */
+  starter?: boolean;
 }) {
   return (
     <>
       <span className={`pin-dot ${dotTone(check)}`} title={dotTitle(check)} />
       <span className="pin-name">{name}</span>
+      {starter ? (
+        <span className="pin-starter" title="Derived from your packageRules — swap in a real one">
+          starter
+        </span>
+      ) : null}
       <span className="pin-meta">{context}</span>
       {summary === null ? (
         <span className="pin-pending">{pending}</span>

--- a/packages/app/src/features/simulator/PinHeadRow.tsx
+++ b/packages/app/src/features/simulator/PinHeadRow.tsx
@@ -37,7 +37,10 @@ export function PinHeadRow({
       <span className={`pin-dot ${dotTone(check)}`} title={dotTitle(check)} />
       <span className="pin-name">{name}</span>
       {starter ? (
-        <span className="pin-starter" title="Derived from your packageRules — swap in a real one">
+        <span
+          className="pill pill-count pin-starter"
+          title="Derived from your packageRules — swap in a real one"
+        >
           starter
         </span>
       ) : null}

--- a/packages/app/src/features/simulator/PinsView.tsx
+++ b/packages/app/src/features/simulator/PinsView.tsx
@@ -19,9 +19,12 @@ import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
  * ("N pinned · R rules evaluated per test, in merge order" — with the merge
  * law on the right), the funnel card per pin, and the Add-a-test card at the
  * foot — the design's GHOST row once pins exist, open only while a pin is
- * being made (082 revisited alongside 078). No pin is ever created for the
- * reader: the empty state says what a pin is and seeds the form, and the
- * detail view (one dependency, the full analysis) is one quiet link away from
+ * being made (082 revisited alongside 078). No pin is created for the reader
+ * from inside this view — the empty state says what a pin is and seeds the
+ * FORM, never the list (the two starter pins roadmap 091 seeds once per
+ * session are the shell's, wear a chip saying so, and are unpinned like any
+ * other) — and the detail view (one dependency, the full analysis) is one
+ * quiet link away from
  * every card that HAS a dependency to hand it — roadmap 080 closed the
  * descriptor-less door.
  */

--- a/packages/app/src/features/simulator/starter-pins.test.ts
+++ b/packages/app/src/features/simulator/starter-pins.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { deriveStarterPins, nextVersion, starterFormForRule } from "./starter-pins";
+import { EMPTY_FORM, toDescriptor } from "./form";
+
+/**
+ * Roadmap 091: a starter pin has one job — FIRE the rule it was derived from.
+ * So the tests are about the two halves of that promise: the descriptor
+ * carries what the rule matches on, and a rule whose matchers cannot be
+ * satisfied exactly produces nothing at all rather than a near miss.
+ */
+
+describe("starterFormForRule", () => {
+  it("builds the design's pair from a manager+updateType rule and a bare updateType rule", () => {
+    const grouped = starterFormForRule({
+      matchManagers: ["npm"],
+      matchUpdateTypes: ["minor"],
+      groupName: "npm minor",
+    });
+    expect(grouped?.manager).toBe("npm");
+    expect(grouped?.updateType).toBe("minor");
+    // The version move implies the type it claims: 4.17.20 → 4.18.0.
+    expect(grouped?.currentValue).toBe("4.17.20");
+    expect(grouped?.newValue).toBe("4.18.0");
+
+    const automerged = starterFormForRule({ matchUpdateTypes: ["patch"], automerge: true });
+    // No ecosystem named — the app's own npm quick-fill, whose pair already IS
+    // a patch, so nothing is synthesized.
+    expect(automerged?.manager).toBe("npm");
+    expect(automerged?.updateType).toBe("patch");
+    expect(automerged?.newValue).toBe("4.17.21");
+  });
+
+  it("names the rule's own package, depType and datasource", () => {
+    const form = starterFormForRule({
+      matchPackageNames: ["@types/node"],
+      matchDepTypes: ["devDependencies"],
+      matchDatasources: ["npm"],
+    });
+    expect(form?.packageName).toBe("@types/node");
+    expect(form?.depType).toBe("devDependencies");
+    expect(form?.datasource).toBe("npm");
+    // A datasource with a manager we know how to pair it with keeps the pair.
+    expect(form?.manager).toBe("npm");
+  });
+
+  it("uses a neutral package for a manager it holds no sample for", () => {
+    const form = starterFormForRule({ matchManagers: ["gradle"] });
+    expect(form?.manager).toBe("gradle");
+    expect(form?.packageName).toBe("example-package");
+    expect(form?.currentValue).toBe("1.2.3");
+    expect(form?.newValue).toBe("1.3.0");
+  });
+
+  it("carries a descriptor the simulator can actually run", () => {
+    const form = starterFormForRule({ matchManagers: ["dockerfile"] });
+    expect(form).not.toBeNull();
+    const descriptor = toDescriptor(form ?? EMPTY_FORM);
+    expect(descriptor.manager).toBe("dockerfile");
+    expect(descriptor.updateType).toBe("major");
+    expect(descriptor.currentValue).toBeDefined();
+    expect(descriptor.newValue).toBeDefined();
+  });
+
+  it("skips rules whose matchers cannot be satisfied synthetically", () => {
+    // A matcher with no form field to satisfy it.
+    expect(starterFormForRule({ matchCurrentVersion: ">=1.0.0", automerge: true })).toBeNull();
+    expect(starterFormForRule({ matchSourceUrls: ["https://github.com/a/b"] })).toBeNull();
+    // Satisfiable matcher, unsatisfiable VALUE: a pattern describes a set, and
+    // a starter has to be a member of it.
+    expect(starterFormForRule({ matchPackageNames: ["@types/**"] })).toBeNull();
+    expect(starterFormForRule({ matchPackageNames: ["/^react/"] })).toBeNull();
+    expect(starterFormForRule({ matchManagers: ["!npm"] })).toBeNull();
+    // An update type no version pair implies.
+    expect(starterFormForRule({ matchUpdateTypes: ["lockFileMaintenance"] })).toBeNull();
+    // A datasource with no manager to pair it with.
+    expect(starterFormForRule({ matchDatasources: ["crate"] })).toBeNull();
+    // Nothing to demonstrate: a rule with no matchers fires on everything.
+    expect(starterFormForRule({ automerge: true })).toBeNull();
+    // Not a rule at all.
+    expect(starterFormForRule("nonsense")).toBeNull();
+    expect(starterFormForRule({ matchManagers: [7] })).toBeNull();
+  });
+
+  it("skips an update type the named ecosystem's versions cannot express", () => {
+    // `20-alpine` has no minor segment, and inventing one invents a tag.
+    expect(
+      starterFormForRule({ matchManagers: ["dockerfile"], matchUpdateTypes: ["minor"] }),
+    ).toBeNull();
+  });
+});
+
+describe("nextVersion", () => {
+  it("moves the segment the update type names and resets what is below it", () => {
+    expect(nextVersion("4.17.20", "major")).toBe("5.0.0");
+    expect(nextVersion("4.17.20", "minor")).toBe("4.18.0");
+    expect(nextVersion("4.17.20", "patch")).toBe("4.17.21");
+    // A single segment can still move a major, suffix intact.
+    expect(nextVersion("20-alpine", "major")).toBe("21-alpine");
+  });
+
+  it("returns null rather than inventing a segment", () => {
+    expect(nextVersion("20-alpine", "minor")).toBeNull();
+    expect(nextVersion("1.2", "patch")).toBeNull();
+    expect(nextVersion("latest", "major")).toBeNull();
+  });
+});
+
+describe("deriveStarterPins", () => {
+  it("takes at most two, from distinct rules", () => {
+    const forms = deriveStarterPins([
+      { matchManagers: ["npm"], matchUpdateTypes: ["minor"], groupName: "npm minor" },
+      { matchUpdateTypes: ["patch"], automerge: true },
+      { matchManagers: ["dockerfile"], pinDigests: true },
+    ]);
+    expect(forms).toHaveLength(2);
+    expect(forms.map((form) => form.updateType)).toStrictEqual(["minor", "patch"]);
+  });
+
+  it("does not pin the same descriptor twice", () => {
+    const forms = deriveStarterPins([
+      { matchManagers: ["npm"], matchUpdateTypes: ["minor"] },
+      { matchManagers: ["npm"], matchUpdateTypes: ["minor"], automerge: true },
+      { matchManagers: ["nuget"] },
+    ]);
+    expect(forms).toHaveLength(2);
+    expect(forms[1]?.manager).toBe("nuget");
+  });
+
+  it("derives nothing from rules it cannot satisfy — the empty state stays", () => {
+    expect(deriveStarterPins([])).toStrictEqual([]);
+    expect(deriveStarterPins([{ matchCurrentVersion: "1.x" }, { automerge: true }])).toStrictEqual(
+      [],
+    );
+  });
+});

--- a/packages/app/src/features/simulator/starter-pins.ts
+++ b/packages/app/src/features/simulator/starter-pins.ts
@@ -1,0 +1,242 @@
+import { EMPTY_FORM, QUICK_FILLS } from "./form";
+import { isPlainObject } from "@/lib/input-schemas";
+import { samePinForm } from "./pins";
+import type { FormState } from "@/types/simulator";
+
+/**
+ * Roadmap 091 — the starter pins: up to two descriptors derived from the
+ * reader's OWN `packageRules`, seeded once when the Tests tab would otherwise
+ * open empty.
+ *
+ * The empty state says what a pin is; a starter shows one. Each is built to
+ * FIRE one of the rules the reader wrote — `matchManagers: ["npm"]` +
+ * `matchUpdateTypes: ["minor"]` becomes an npm minor update, so the card that
+ * lands says "grouped: npm minor" in the reader's own words rather than in
+ * ours.
+ *
+ * The one rule this file obeys: **never guess.** A descriptor is synthesized
+ * only when every matcher on the rule can be satisfied exactly; a rule
+ * carrying anything else (`matchCurrentVersion` ranges, `matchSourceUrls`,
+ * a glob-only `matchPackageNames`) is skipped rather than approximated,
+ * because a starter that does NOT fire the rule it was derived from teaches
+ * the reader something false.
+ *
+ * Pure and DOM-free — the app layer decides WHEN to seed (`use-starter-pins`),
+ * this decides what.
+ */
+
+/** Two, as the design draws it: enough to show the grammar, few enough that
+ *  the reader's own first pin is still the point of the tab. */
+export const MAX_STARTER_PINS = 2;
+
+/**
+ * The matchers a synthetic descriptor can satisfy exactly. Every other
+ * `match*` key disqualifies its rule — the list is the honesty guarantee, so
+ * it grows only when a matcher gains a field the form can actually set.
+ */
+const SATISFIABLE_MATCHERS = new Set([
+  "matchManagers",
+  "matchDatasources",
+  "matchPackageNames",
+  "matchDepNames",
+  "matchDepTypes",
+  "matchUpdateTypes",
+]);
+
+/** The update types a version pair can express. `pin`/`digest`/… are real
+ *  types, but nothing in a two-version descriptor implies them. */
+const SYNTHESIZABLE_UPDATE_TYPES = ["major", "minor", "patch"];
+
+/** What a descriptor looks like when the rule names a manager we hold no
+ *  sample for: a neutral package on a clean semver base. */
+const NEUTRAL_SAMPLE: Partial<FormState> = {
+  packageName: "example-package",
+  currentValue: "1.2.3",
+  newValue: "1.3.0",
+  updateType: "minor",
+};
+
+/** A rule that names no ecosystem at all (`matchUpdateTypes: ["patch"]` and
+ *  nothing else) still has to become a recognizable update; npm is the app's
+ *  own first quick-fill, so it is the one the reader has already seen. */
+function defaultSample(): Partial<FormState> {
+  return QUICK_FILLS.find(({ fill }) => fill.manager === "npm")?.fill ?? NEUTRAL_SAMPLE;
+}
+
+function ruleOf(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}
+
+/** A matcher's values, as strings — null when it isn't a list of them (a
+ *  matcher we cannot read is a matcher we cannot satisfy). */
+function matcherValues(value: unknown): string[] | null {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) {
+    return null;
+  }
+  return value as string[];
+}
+
+/**
+ * The first value that names ONE thing: not a negation (`!x`), not a regex
+ * (`/x/`), not a glob (`@types/**`). Renovate's own matcher grammar — a
+ * pattern describes a set, and a starter has to be a member of it, which only
+ * a literal guarantees.
+ */
+function firstLiteral(values: string[] | null): string | null {
+  if (values === null) {
+    return null;
+  }
+  return values.find((v) => v !== "" && !/[*?[\]{}]/.test(v) && !/^[!/]/.test(v)) ?? null;
+}
+
+/** The quick-fill that already describes this ecosystem — the samples are the
+ *  app's, not a second table that could drift from them. */
+function sampleFor(manager: string | null, datasource: string | null): Partial<FormState> | null {
+  if (manager !== null) {
+    return QUICK_FILLS.find(({ fill }) => fill.manager === manager)?.fill ?? null;
+  }
+  if (datasource !== null) {
+    return QUICK_FILLS.find(({ fill }) => fill.datasource === datasource)?.fill ?? null;
+  }
+  return null;
+}
+
+function bumpNumericPrefix(segment: string): string | null {
+  const digits = /^\d+/.exec(segment);
+  if (!digits) {
+    return null;
+  }
+  return `${Number(digits[0]) + 1}${segment.slice(digits[0].length)}`;
+}
+
+/**
+ * The other end of a version move of the asked-for kind, or null when this
+ * version cannot express one — `20-alpine` has no minor to bump, and inventing
+ * `20.1-alpine` would be a tag that does not exist.
+ */
+export function nextVersion(current: string, updateType: string): string | null {
+  const parts = current.split(".");
+  const index = updateType === "major" ? 0 : updateType === "minor" ? 1 : 2;
+  if (index >= parts.length) {
+    return null;
+  }
+  const head = parts.slice(0, index);
+  const bumped = bumpNumericPrefix(parts[index] ?? "");
+  if (bumped === null || head.some((part) => !/^\d+$/.test(part))) {
+    return null;
+  }
+  // Everything below the bumped position resets, which is what a version move
+  // of that kind actually looks like.
+  const tail = parts.slice(index + 1).map(() => "0");
+  return [...head, bumped, ...tail].join(".");
+}
+
+/**
+ * One rule → one descriptor that fires it, or null when it cannot be built.
+ * Exported for the tests; the seeding path goes through `deriveStarterPins`.
+ */
+export function starterFormForRule(value: unknown): FormState | null {
+  const rule = ruleOf(value);
+  if (rule === null) {
+    return null;
+  }
+  const matchers = Object.keys(rule).filter((key) => key.startsWith("match"));
+  // Nothing to demonstrate: a rule with no matchers fires on every update, so
+  // whatever else gets pinned already exercises it.
+  if (matchers.length === 0 || matchers.some((key) => !SATISFIABLE_MATCHERS.has(key))) {
+    return null;
+  }
+
+  const manager = "matchManagers" in rule ? firstLiteral(matcherValues(rule.matchManagers)) : null;
+  const datasource =
+    "matchDatasources" in rule ? firstLiteral(matcherValues(rule.matchDatasources)) : null;
+  if (
+    ("matchManagers" in rule && manager === null) ||
+    ("matchDatasources" in rule && datasource === null)
+  ) {
+    return null;
+  }
+  const sample = sampleFor(manager, datasource);
+  // A datasource with no manager we can pair it with is the case the doc names
+  // explicitly: a descriptor naming only a datasource is not an update anyone
+  // recognizes, and guessing the manager would guess the match.
+  if (sample === null && manager === null && datasource !== null) {
+    return null;
+  }
+  const base = sample ?? (manager === null ? defaultSample() : NEUTRAL_SAMPLE);
+
+  const packageName =
+    ("matchPackageNames" in rule ? firstLiteral(matcherValues(rule.matchPackageNames)) : null) ??
+    ("matchDepNames" in rule ? firstLiteral(matcherValues(rule.matchDepNames)) : null);
+  const depName = "matchDepNames" in rule ? firstLiteral(matcherValues(rule.matchDepNames)) : null;
+  const depType = "matchDepTypes" in rule ? firstLiteral(matcherValues(rule.matchDepTypes)) : null;
+  for (const [key, named] of [
+    ["matchPackageNames", packageName],
+    ["matchDepNames", depName],
+    ["matchDepTypes", depType],
+  ] as const) {
+    if (key in rule && named === null) {
+      return null;
+    }
+  }
+
+  const asked = "matchUpdateTypes" in rule ? matcherValues(rule.matchUpdateTypes) : null;
+  const updateType =
+    "matchUpdateTypes" in rule
+      ? (asked?.find((type) => SYNTHESIZABLE_UPDATE_TYPES.includes(type)) ?? null)
+      : (base.updateType ?? null);
+  if (updateType === null) {
+    return null;
+  }
+  const currentValue = base.currentValue ?? "";
+  // The sample's own pair when it is already the asked-for kind (`lodash
+  // 4.17.20 → 4.17.21` IS a patch), a synthesized one otherwise.
+  const newValue =
+    updateType === base.updateType
+      ? (base.newValue ?? "")
+      : (nextVersion(currentValue, updateType) ?? "");
+  if (currentValue === "" || newValue === "") {
+    return null;
+  }
+
+  return {
+    ...EMPTY_FORM,
+    manager: manager ?? base.manager ?? "",
+    datasource: datasource ?? base.datasource ?? "",
+    packageFile: base.packageFile ?? "",
+    packageName: packageName ?? base.packageName ?? "",
+    depName: depName ?? "",
+    depType: depType ?? base.depType ?? "",
+    versioning: base.versioning ?? "",
+    currentValue,
+    newValue,
+    updateType,
+  };
+}
+
+/**
+ * The starter pins for a run: at most {@link MAX_STARTER_PINS} descriptors,
+ * one per rule, in the order the rules merged.
+ *
+ * `rules` are the reader's OWN entries of the resolved `packageRules` — the
+ * caller filters by provenance, because a starter derived from a preset's rule
+ * would demonstrate a decision the reader did not make.
+ */
+export function deriveStarterPins(rules: readonly unknown[]): FormState[] {
+  const forms: FormState[] = [];
+  for (const rule of rules) {
+    if (forms.length >= MAX_STARTER_PINS) {
+      break;
+    }
+    const form = starterFormForRule(rule);
+    // Two rules can describe the same update (`matchManagers: ["npm"]` twice
+    // over); the second one adds a row that says nothing new.
+    if (form !== null && !forms.some((existing) => samePinForm(existing, form))) {
+      forms.push(form);
+    }
+  }
+  return forms;
+}

--- a/packages/app/src/styles/15-pins.css
+++ b/packages/app/src/styles/15-pins.css
@@ -153,6 +153,20 @@
   white-space: nowrap;
 }
 
+/* Roadmap 091: the seeded pin's own chip. Muted and outlined — a starter is a
+   suggestion the app made, so it must never read as a status the run
+   reported (the dot beside it is the only thing on this row that does). */
+.pin-starter {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  color: var(--faint);
+  flex: none;
+  font-size: 0.65rem;
+  line-height: 1.5;
+  padding: 0 0.35rem;
+  text-transform: lowercase;
+}
+
 .pin-meta,
 .pin-pending {
   color: var(--muted);

--- a/packages/app/src/styles/15-pins.css
+++ b/packages/app/src/styles/15-pins.css
@@ -156,14 +156,11 @@
 /* Roadmap 091: the seeded pin's own chip. Muted and outlined — a starter is a
    suggestion the app made, so it must never read as a status the run
    reported (the dot beside it is the only thing on this row that does). */
+/* The chip IS the app's `.pill pill-count` (03-presets.css); this adds only
+   the quieter ink and the row-flexbox behavior. */
 .pin-starter {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-pill);
   color: var(--faint);
   flex: none;
-  font-size: 0.65rem;
-  line-height: 1.5;
-  padding: 0 0.35rem;
   text-transform: lowercase;
 }
 

--- a/packages/app/src/types/simulator.ts
+++ b/packages/app/src/types/simulator.ts
@@ -50,4 +50,11 @@ export interface PinnedTest {
    */
   id: string;
   form: FormState;
+  /**
+   * Roadmap 091: this pin was SEEDED from the reader's own `packageRules`, not
+   * authored — the card wears a "starter" chip and the link leaves it behind
+   * (the opener's own config seeds their own). Absent on every pin a reader or
+   * a link made, which is the majority, so it stays optional.
+   */
+  starter?: boolean;
 }

--- a/roadmap/075-v2-integrated-shell.md
+++ b/roadmap/075-v2-integrated-shell.md
@@ -87,7 +87,11 @@ commit on `feat/v2`:
   tokens.
 - The advanced zone (008/045 layers, host tokens) keeps its behavior; it
   moves with the editor pane.
-- **No seeded pins.** The Landing Transition mock shows a Tests tab that
+- **No seeded pins.**
+  _(Reversed later: [091](091-starter-pins.md) shipped two STARTER pins,
+  derived from the reader's own `packageRules`, marked as such and seeded once
+  — the ruling below stands as the record of what that reversal had to
+  answer.)_ The Landing Transition mock shows a Tests tab that
   already has pins in it; iteration 6 deliberately ships an empty list with an
   explainer instead. A pin the user did not ask for is a test they did not
   write, and every run would then re-check a descriptor they never chose —

--- a/roadmap/091-starter-pins.md
+++ b/roadmap/091-starter-pins.md
@@ -1,0 +1,174 @@
+# 091 — Starter pins, derived from the config's own rules
+
+Milestone: M21 · Status: done · Design: Claude Design project "Renovate Config
+Debugger", artboard `Landing Transition.dc.html`, Turn 5 / beat 5a
+("Settled") · Revisits one [075](075-v2-integrated-shell.md) non-goal.
+
+## The ask
+
+The landing transition's last beat: the run settles, the shell docks, "the
+Tests pane slides in with two starter pins derived from the config's own
+rules". The pane's promise — _these are the updates I care about, tell me when
+an edit changes what happens to them_ — reads as an instruction manual when
+the list under it is empty, and the empty state answers "what is a pin"
+without answering "now what". A starter answers it by example, in the reader's
+own vocabulary: for
+`packageRules: [{matchManagers:["npm"], matchUpdateTypes:["minor"], groupName:"npm minor"}, {matchUpdateTypes:["patch"], automerge:true}]`
+the two cards that land say _grouped: npm minor_ and _automerge ✓_ — the
+reader's own rules, firing, with nothing typed.
+
+## 075's non-goal, revisited
+
+[075](075-v2-integrated-shell.md) listed **"No seeded pins"** as an explicit
+non-goal, and the owner has now adopted the design's beat. The reversal has to
+answer 075's two reasons, and does:
+
+- _"A pin the user did not ask for is a test they did not write."_ True, so it
+  never claims to be one: the row wears a muted `starter` chip whose title is
+  "Derived from your packageRules — swap in a real one". It is an offer with a
+  verdict attached, not a test attributed to the reader.
+- _"Every run would then re-check a descriptor they never chose."_ Only while
+  they keep it. The × that removes a pin removes a starter (no special
+  dismissal was built, deliberately), and removal is permanent for the
+  session — the latch below is what makes deleting a starter stick.
+
+The rest of 075's ruling stands: no expectation model (a starter records a
+descriptor, not an assertion), and the ghost row is still the offer for
+everything else. Neither [080](080-tests-succeed-the-simulator.md) nor
+[082](082-final-tab-specs-deltas.md) ruled on seeded pins — 080 closed the
+descriptor-LESS door into the detail view (a starter arrives with a
+descriptor, so it is on the right side of that test) and 082's pin rulings are
+about the Add-a-test card, not the list.
+
+## Derivation (`features/simulator/starter-pins.ts`)
+
+Input: the entries of the run's **resolved** `packageRules` that the REPO
+config contributed — `computeRuleProvenance` (013) filtered to
+`layer.kind === "repo"`. Resolved, because that is the array the simulator
+evaluates against; filtered, because a starter derived from
+`config:best-practices` would demonstrate a decision the reader never made.
+
+One rule → one descriptor, under one law: **never guess.** A descriptor is
+synthesized only when every matcher on the rule can be satisfied exactly; a
+starter that does not fire the rule it came from teaches something false.
+
+- **Satisfiable matchers** — `matchManagers`, `matchDatasources`,
+  `matchPackageNames`, `matchDepNames`, `matchDepTypes`, `matchUpdateTypes`.
+  Any other `match*` key on the rule (`matchCurrentVersion`,
+  `matchSourceUrls`, `matchFileNames`, `matchRepositories`, …) disqualifies
+  it. The allowlist is the honesty guarantee; it grows only when a matcher
+  gains a form field that can satisfy it.
+- **Values must be literal** — `react` yes; `@types/**`, `/^react/` and
+  `!npm` no. A pattern describes a set and a starter has to be a member of it,
+  which only a literal guarantees.
+- **The ecosystem comes from the app's own quick-fills** (`QUICK_FILLS`), not
+  a second sample table that could drift from them: `matchManagers: ["npm"]`
+  becomes lodash in `package.json`, `dockerfile` becomes `node`, and so on. A
+  rule naming only a datasource is paired with the manager of the quick-fill
+  that carries it; one that cannot be paired (`matchDatasources: ["crate"]`)
+  is skipped rather than pinned as a manager-less descriptor. A rule naming a
+  manager we hold no sample for keeps the manager and takes a neutral
+  `example-package 1.2.3`. A rule naming no ecosystem at all takes npm — the
+  first quick-fill, the one the reader has already seen.
+- **The version move implies the update type.** `matchUpdateTypes` picks the
+  first of major/minor/patch it names; the sample's own pair is reused when it
+  is already that kind (`4.17.20 → 4.17.21` IS a patch), otherwise the pair is
+  synthesized by moving that segment and resetting what is below it
+  (`4.17.20 → 4.18.0`). A version that cannot express the move is a skip, not
+  an invention: `20-alpine` has no minor, so
+  `{matchManagers:["dockerfile"], matchUpdateTypes:["minor"]}` yields nothing.
+  An update type no version pair implies (`lockFileMaintenance`, `pin`,
+  `digest`, …) is a skip for the same reason.
+- **A rule with no matchers is skipped** — it fires on every update, so
+  whatever else lands already exercises it, and a descriptor for it would be
+  arbitrary.
+- **Two, from distinct rules, deduplicated** — rules are walked in merge
+  order, identical descriptors (two rules that describe the same update)
+  collapse, and the first two survivors win. Zero is a normal outcome: no own
+  rules, or none satisfiable, means no starters and the existing empty state
+  stays exactly as it was.
+
+## Seeding, and the latch (`app/use-starter-pins.ts` + `use-pinned-run.ts`)
+
+The shell computes, the feature draws: the derivation is the simulator
+slice's, the decision to seed is the app layer's, next to the run-settle
+handling it belongs with.
+
+Seeding is attempted **once**, on the first run that settles with a
+`finalConfig` and resolved rule provenance (`undefined` is "still computing"
+and waits; `null` is "unavailable" and counts as an attempt that derived
+nothing). It happens only into a list **nothing has touched** — the latch
+(`pinsTouchedRef`, inside `usePinnedRun`) trips on:
+
+- a pin added, by any channel;
+- a pin removed — this is the one that makes deletion stick: the list is empty
+  again but it is not untouched, and re-seeding would undo the gesture;
+- a share link that **installed** pins;
+- the seeding itself, whether or not it derived anything.
+
+Consequences, stated: editing the config and re-running never re-seeds; a
+reader who keeps the starters has them re-evaluated on every run like any pin
+(they go through `addPin`'s own list, so `usePinnedTests` cannot tell them
+apart, which is the point); and a link that carried no pins does NOT trip the
+latch — that is someone else's config on this reader's screen, which is
+precisely the case the starters were written for.
+
+## The share-link ruling: starters are left behind
+
+`pinsAsShareFields` filters `starter` pins out of the payload. They are not
+the sharer's tests — they are what this app made up from the config the link
+already carries — so the opener's own first run derives them again, from the
+same rules, marked as starters there too. Sharing them would hand someone
+else's reader two authored-looking pins nobody wrote, and would then need a
+rule for what the flag means on arrival. The alternative (share them as plain
+pins) loses the chip and gains the exact confusion 075 objected to, one
+session removed. The `starter` flag therefore never enters the codec: nothing
+in `share.ts` changes, and a link built from a starters-only session simply
+carries no `pins` — which the opener's own seeding fills in.
+
+## Deltas
+
+- `types/simulator.ts` — `PinnedTest.starter?: boolean` (optional: absent on
+  every pin a reader or a link made).
+- `features/simulator/starter-pins.ts` — the derivation, pure and DOM-free.
+- `app/use-starter-pins.ts` — when to seed; consumes `useRuleProvenance`,
+  which App already mounts for the message cross-links, so no second replay.
+- `app/use-pinned-run.ts` — `seedStarterPins`, the latch, and the share
+  filter.
+- `PinHeadRow`/`PinCard` — the `starter` chip, on the pin row's head beside
+  the name. `.pin-starter` is muted and outlined (tokens only): a starter is a
+  suggestion the app made, so it must never read as a status the run reported
+  — the dot beside it is the only thing on that row that does.
+- `PinsView` / `EmptyTestsCard` doc comments: "no pin is ever created for the
+  reader" was 075's rule and is now qualified rather than deleted.
+
+## Verification
+
+- `features/simulator/starter-pins.test.ts` — the design's two rules produce
+  the design's two pins; the rule's own package/depType/datasource are
+  carried; the neutral fallback; the skip list (unsatisfiable matcher,
+  glob/regex/negated value, unpairable datasource, non-version update type,
+  matcher-less rule, non-object); `nextVersion`'s moves and its refusals; and
+  `deriveStarterPins`' two-max, distinct-rules, dedupe and empty cases.
+- `app/use-pinned-run.test.tsx` — the latch ledger: seeds once into an
+  untouched list with `starter: true`; no seeding after an add or a remove;
+  an empty derivation still trips it; a link with pins stands the seeding
+  down and a link without pins does not; starters are absent from
+  `pinsAsShareFields`.
+- `app/use-starter-pins.test.tsx` — the trigger's own two decisions: a
+  preset's rule is not derived from (provenance filter), nothing is attempted
+  while provenance is `undefined`, and an unavailable (`null`) provenance
+  still counts as the one attempt.
+- `features/simulator/PinHeadRow.test.tsx` — the chip and its title on a
+  starter, nothing on a pin the reader made.
+- The existing `TestsPanel.shimmed.test.tsx` is untouched: it drives the panel
+  with App's pins as props, and seeding is above it.
+- e2e `21-pinned-tests.spec.ts` gains the whole loop in a real browser: the
+  starter appears for `PACKAGE_RULES_CONFIG`, wears the chip, carries the
+  run's own verdict (`automerge ✓`), survives a re-run, and does NOT come back
+  after the × plus another run. Three specs whose subject is the empty list or
+  their own pin's count clear it first through a new
+  `clearStarterPins(page)` helper (04-simulator, 11-tabbed-shell's tab-alias
+  case, 21's first case) — the helper waits for the starter before removing
+  it, so a `toHaveCount(0)` cannot pass ahead of the seeding. Full suite green
+  (129).


### PR DESCRIPTION
The landing transition's settled beat: a first run with an empty Tests
pane derives up to two descriptors that fire the user's own repo-layer
packageRules, pins them marked 'starter', and never re-seeds once pins
were touched. Starters stay out of share links. Roadmap 091; reverses
075's no-seeded-pins non-goal, noted there.

Design: Landing Transition.dc.html (Turn 5, settled beat)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>