### PR TITLE
feat(simulator): auto-split pasted lists into chips

### DIFF
--- a/packages/app/src/features/simulator/MultiValueInput.test.tsx
+++ b/packages/app/src/features/simulator/MultiValueInput.test.tsx
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MultiValueInput } from "./MultiValueInput";
+
+/**
+ * Roadmap 079 follow-up: paste auto-split. Pasting several values at once
+ * (registry URLs, categories, …) should commit one chip per value instead of
+ * dumping the whole blob into the draft as one unsplittable token.
+ */
+
+// vitest runs without `globals`, so RTL's automatic cleanup never registers.
+afterEach(cleanup);
+
+function Harness({ initial = "" }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <MultiValueInput name="registryUrls" label="registryUrls" value={value} onChange={setValue} />
+  );
+}
+
+function paste(input: HTMLElement, text: string) {
+  return fireEvent.paste(input, { clipboardData: { getData: () => text } });
+}
+
+describe("MultiValueInput — paste auto-split", () => {
+  it("splits a comma-separated paste into one chip per value", () => {
+    const view = render(<Harness />);
+    const input = view.getByLabelText("registryUrls");
+
+    paste(input, "https://a.example, https://b.example, https://c.example");
+
+    const chips = [...view.container.querySelectorAll(".sim-chip")].map((c) =>
+      c.firstChild?.textContent?.trim(),
+    );
+    expect(chips).toEqual(["https://a.example", "https://b.example", "https://c.example"]);
+    // The paste was claimed, not inserted as text.
+    expect((input as HTMLInputElement).value).toBe("");
+  });
+
+  it("splits on newlines, semicolons and whitespace runs alike", () => {
+    const view = render(<Harness />);
+    const input = view.getByLabelText("registryUrls");
+
+    paste(input, "a\nb; c   d");
+
+    const chips = [...view.container.querySelectorAll(".sim-chip")].map((c) =>
+      c.firstChild?.textContent?.trim(),
+    );
+    expect(chips).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("lets a single-token paste fall through to default insertion", () => {
+    const view = render(<Harness />);
+    const input = view.getByLabelText("registryUrls");
+
+    const dispatched = paste(input, "https://a.example");
+
+    // Not claimed: fireEvent reports true when the default wasn't prevented.
+    expect(dispatched).toBe(true);
+    expect(view.container.querySelectorAll(".sim-chip")).toHaveLength(0);
+  });
+
+  it("drops empties from a trailing separator without leaving a stray chip", () => {
+    const view = render(<Harness />);
+    const input = view.getByLabelText("registryUrls");
+
+    paste(input, "a, b,");
+
+    const chips = [...view.container.querySelectorAll(".sim-chip")].map((c) =>
+      c.firstChild?.textContent?.trim(),
+    );
+    expect(chips).toEqual(["a", "b"]);
+  });
+
+  it("dedupes within the pasted batch and against already-committed chips", () => {
+    const view = render(<Harness initial="a" />);
+    const input = view.getByLabelText("registryUrls");
+
+    paste(input, "a, b, b, c");
+
+    const chips = [...view.container.querySelectorAll(".sim-chip")].map((c) =>
+      c.firstChild?.textContent?.trim(),
+    );
+    expect(chips).toEqual(["a", "b", "c"]);
+  });
+
+  it("leaves a partially typed draft untouched by a multi-value paste", () => {
+    const view = render(<Harness />);
+    const input = view.getByLabelText("registryUrls") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "still-typing" } });
+    paste(input, "a, b");
+
+    expect(input.value).toBe("still-typing");
+    const chips = [...view.container.querySelectorAll(".sim-chip")].map((c) =>
+      c.firstChild?.textContent?.trim(),
+    );
+    expect(chips).toEqual(["a", "b"]);
+  });
+});

--- a/packages/app/src/features/simulator/MultiValueInput.tsx
+++ b/packages/app/src/features/simulator/MultiValueInput.tsx
@@ -1,5 +1,18 @@
-import { type KeyboardEvent, type ReactNode, useState } from "react";
+import { type ClipboardEvent, type KeyboardEvent, type ReactNode, useState } from "react";
 import { joinValues, splitValues } from "./form";
+
+// Roadmap 079 follow-up: a paste containing any of these reads as several
+// values, not one — comma/semicolon-separated lists and newline- or
+// whitespace-separated lists are both things a user's clipboard holds.
+const PASTE_SEPARATOR = /[,;\s]/;
+const PASTE_SEPARATOR_RUN = /[,;\s]+/;
+
+function splitPastedText(text: string): string[] {
+  return text
+    .split(PASTE_SEPARATOR_RUN)
+    .map((s) => s.trim())
+    .filter((s) => s !== "");
+}
 
 function ValueChip({ value, onRemove }: { value: string; onRemove: () => void }) {
   return (
@@ -62,6 +75,31 @@ export function MultiValueInput({
     setDraft("");
   }
 
+  // The draft is left untouched either way: merging it into a multi-value
+  // paste would need to know whether the paste replaced a selection or landed
+  // mid-word, and a chip editor has no reason to guess at that. A paste with
+  // no separator falls through to the browser's own insertion, which already
+  // does the right thing with a cursor position and a selection; a paste with
+  // one just adds its pieces as chips and leaves whatever was mid-typed alone.
+  function paste(e: ClipboardEvent<HTMLInputElement>) {
+    const text = e.clipboardData.getData("text");
+    if (!PASTE_SEPARATOR.test(text)) {
+      return;
+    }
+    e.preventDefault();
+    const pieces = splitPastedText(text);
+    if (pieces.length === 0) {
+      return;
+    }
+    const next = [...values];
+    for (const piece of pieces) {
+      if (!next.includes(piece)) {
+        next.push(piece);
+      }
+    }
+    onChange(joinValues(next));
+  }
+
   function keyDown(e: KeyboardEvent<HTMLInputElement>) {
     // Roadmap 068's rule, third consumer: ⌘/Ctrl+⏎ is the app's Run chord and
     // must reach the page listener, so only a BARE Enter is claimed here. That
@@ -94,6 +132,7 @@ export function MultiValueInput({
           placeholder={placeholder}
           onChange={(e) => setDraft(e.target.value)}
           onKeyDown={keyDown}
+          onPaste={paste}
           // Committing on blur would silently turn an abandoned half-typed
           // value into a matcher input; the draft simply stays visible instead.
           spellCheck={false}


### PR DESCRIPTION
Pasting several registry URLs (or lockFiles/categories values) into the
multi-value chip input now splits on commas, semicolons and whitespace
runs and commits each piece as a chip in one update, deduped by the
same rule Enter uses. A separator-less paste keeps the browser default.
Roadmap 079 follow-up (design turn 12, chips variant).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>