### PR TITLE
feat(app): hover copy affordance on inline preset-name tokens

### DIFF
--- a/packages/app/src/components/LayerSource.test.tsx
+++ b/packages/app/src/components/LayerSource.test.tsx
@@ -103,7 +103,9 @@ test("wraps the cell only when the caller asks for one", () => {
   cleanup();
 
   // The cascade step spreads its token, the verb and its badges across one head
-  // row, so there is no cell to wrap.
+  // row, so there is no cell to wrap — only `PresetName`'s own hover-copy wrap
+  // sits around the token, not a second cell of `LayerSource`'s own.
   const bare = render(<LayerSource preset={{ name: "a", nodeId: "n1" }} />);
-  expect(bare.container.firstElementChild?.className).toBe("preset-token");
+  expect(bare.container.firstElementChild?.className).toBe("preset-name-wrap");
+  expect(bare.container.querySelector(".preset-token")).not.toBeNull();
 });

--- a/packages/app/src/components/LayerSource.tsx
+++ b/packages/app/src/components/LayerSource.tsx
@@ -86,6 +86,10 @@ export function LayerSource({
           onClick={
             nodeId !== undefined && onSelectPreset ? () => onSelectPreset(nodeId) : undefined
           }
+          // The root node's "(input config)" label is not a preset — nothing
+          // extends it, so there is nothing sensible to paste from a copy of
+          // it. Same gate the jump above already uses for the same reason.
+          showCopy={nodeId !== undefined}
         />
       ) : layer ? (
         <ProvenanceChip layer={layer} onSelectPreset={onSelectPreset} />

--- a/packages/app/src/components/PresetName.test.tsx
+++ b/packages/app/src/components/PresetName.test.tsx
@@ -1,5 +1,5 @@
 import type { PresetNode } from "@renovate-config-debugger/engine";
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ROOT_NODE_ID } from "@/lib/preset-tree-stats";
 import { HOVER_INTENT_DELAY_MS } from "./hover-gate";
@@ -37,7 +37,12 @@ const GROUP = node("p3", "group:monorepos", [DEEP]);
 const RECOMMENDED = node("p1", "config:recommended", [node("p2", ":dependencyDashboard"), GROUP]);
 const TREE = node(ROOT_NODE_ID, "(your config)", [RECOMMENDED]);
 
-function renderToken(props: { name: string; nodeId?: string; onClick?: () => void }) {
+function renderToken(props: {
+  name: string;
+  nodeId?: string;
+  onClick?: () => void;
+  showCopy?: boolean;
+}) {
   const onSelectPreset = vi.fn();
   const view = render(
     <PresetReferenceProvider value={{ root: TREE, onSelectPreset }}>
@@ -45,6 +50,19 @@ function renderToken(props: { name: string; nodeId?: string; onClick?: () => voi
     </PresetReferenceProvider>,
   );
   return { ...view, onSelectPreset };
+}
+
+function stubClipboard(): string[] {
+  const writes: string[] = [];
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: {
+      writeText: async (text: string) => {
+        writes.push(text);
+      },
+    },
+  });
+  return writes;
 }
 
 /** A genuine pointer hover: the move gate wants a `mousemove`, and 081's
@@ -174,5 +192,56 @@ describe("the standard hover card", () => {
     fireEvent.focus(getByRole("button", { name: "github>acme/private" }));
 
     expect(card()).toBeNull();
+  });
+});
+
+describe("the hover-copy affordance", () => {
+  // Real timers here: the shared `CopyButton`'s own copied-state timing is
+  // already pinned in `CopyButton.test.tsx`, and driving its async clipboard
+  // write plus its transient-state flush through fake timers (needed by the
+  // hover-intent tests above) would fight `waitFor`'s own polling.
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("copies the full name and flips to the shared copied state for 1.5s", async () => {
+    const writes = stubClipboard();
+    const { getByRole } = renderToken({ name: "github>acme/renovate-config:security" });
+
+    await act(async () => {
+      fireEvent.click(getByRole("button", { name: "Copy preset name" }));
+    });
+
+    expect(writes).toEqual(["github>acme/renovate-config:security"]);
+    await waitFor(() => {
+      expect(getByRole("button", { name: "Copy preset name" }).className).toContain("copied");
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1600));
+    });
+    expect(getByRole("button", { name: "Copy preset name" }).className).not.toContain("copied");
+  });
+
+  it("does not trigger the token's own click behavior", async () => {
+    stubClipboard();
+    const onClick = vi.fn();
+    const { getByRole } = renderToken({ name: "config:recommended", nodeId: "p1", onClick });
+
+    await act(async () => {
+      fireEvent.click(getByRole("button", { name: "Copy preset name" }));
+    });
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("is off where the caller says the token sits inside another button", () => {
+    const { queryByRole } = renderToken({
+      name: "config:recommended",
+      nodeId: "p1",
+      showCopy: false,
+    });
+
+    expect(queryByRole("button", { name: "Copy preset name" })).toBeNull();
   });
 });

--- a/packages/app/src/components/PresetName.tsx
+++ b/packages/app/src/components/PresetName.tsx
@@ -1,5 +1,6 @@
 import { useMemo, type ReactNode } from "react";
 import { presetReferenceFacts } from "@/lib/preset-reference";
+import { CopyButton } from "./CopyButton";
 import { HoverCardAnchor, type HoverCardHandlers } from "./hover-card";
 import { HOVER_INTENT_DELAY_MS } from "./hover-gate";
 import { usePresetReference } from "./preset-reference-context";
@@ -50,6 +51,15 @@ export interface PresetNameProps {
    * previews (the detail panel's own heading).
    */
   noCard?: boolean;
+  /**
+   * The shell-wide hover-copy affordance (Review-steps turn 17, variant 17a):
+   * one copy icon, on every inline value, everywhere. On by default; a caller
+   * turns it off only where the token renders INSIDE another element's own
+   * `<button>` — the ledger card header's toggle, a family row's toggle —
+   * where a second button would be invalid HTML nested inside the first, and
+   * the click would double as that button's whole-surface activation.
+   */
+  showCopy?: boolean;
 }
 
 /**
@@ -85,7 +95,41 @@ function PresetToken({
   );
 }
 
-export function PresetName({ name, nodeId, onClick, heading, noCard }: PresetNameProps) {
+/**
+ * The hover-revealed copy icon beside a token. Absolutely positioned (CSS) so
+ * it reserves no layout space while hidden — a dense ledger or tree row must
+ * not reflow when the pointer arrives — and stays in the tab order so a
+ * keyboard user who focuses it sees it too, via `:focus-within` on the wrap
+ * rather than `:hover` alone.
+ *
+ * It copies the FULL `name` — the string the config actually writes, never a
+ * truncated display form — and the click is stopped from bubbling past this
+ * slot: the token's own `onClick` is a sibling, not a parent, so it is never
+ * at risk here, but a caller that goes on to embed the pair inside some other
+ * clickable row stays safe by construction rather than by convention.
+ */
+function PresetNameCopy({ name }: { name: string }) {
+  return (
+    // oxlint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions -- not a control itself, just a stop on the one real button inside it: it keeps a copy click from bubbling into some future ancestor row's own `onClick`, which is exactly why it carries no role or keyboard contract of its own.
+    <span className="preset-name-copy-slot" onClick={(e) => e.stopPropagation()}>
+      <CopyButton
+        className="preset-name-copy"
+        iconOnly
+        label="Copy preset name"
+        getText={() => name}
+      />
+    </span>
+  );
+}
+
+export function PresetName({
+  name,
+  nodeId,
+  onClick,
+  heading,
+  noCard,
+  showCopy = true,
+}: PresetNameProps) {
   const { root, onSelectPreset } = usePresetReference();
   // Cheap (the walk behind it is cached on the tree object), but it runs on
   // every render of every token on screen, and the ledger puts dozens on one
@@ -99,10 +143,20 @@ export function PresetName({ name, nodeId, onClick, heading, noCard }: PresetNam
     <PresetToken name={name} onClick={onClick} heading={heading} handlers={handlers} />
   );
 
+  const wrap = (inner: ReactNode): ReactNode =>
+    showCopy ? (
+      <span className="preset-name-wrap">
+        {inner}
+        <PresetNameCopy name={name} />
+      </span>
+    ) : (
+      inner
+    );
+
   if (!facts) {
-    return token();
+    return wrap(token());
   }
-  return (
+  return wrap(
     <HoverCardAnchor
       className="preset-ref-card"
       width={CARD_WIDTH}
@@ -111,6 +165,6 @@ export function PresetName({ name, nodeId, onClick, heading, noCard }: PresetNam
       card={<PresetReferenceCard facts={facts} onSelect={onSelectPreset} />}
     >
       {token}
-    </HoverCardAnchor>
+    </HoverCardAnchor>,
   );
 }

--- a/packages/app/src/features/presets/LedgerCard.tsx
+++ b/packages/app/src/features/presets/LedgerCard.tsx
@@ -46,8 +46,9 @@ function LedgerCardToggle({
   return (
     <button type="button" className="ledger-head-toggle" aria-expanded={open} onClick={onToggle}>
       <Caret open={open} />
-      {/* Inert: this token lives inside the header's own toggle button. */}
-      <PresetName name={source.name} nodeId={source.nodeId} />
+      {/* Inert: this token lives inside the header's own toggle button — a
+          nested button would be invalid HTML, so the copy affordance is off. */}
+      <PresetName name={source.name} nodeId={source.nodeId} showCopy={false} />
       <SourcePill source={source} />
       <span className="ledger-head-counts">
         {source.failed

--- a/packages/app/src/features/presets/LedgerFamilies.tsx
+++ b/packages/app/src/features/presets/LedgerFamilies.tsx
@@ -78,8 +78,9 @@ function FamilyRow({
       >
         <Caret open={expanded} />
         {/* Inert inside the row's own toggle — a nested button is invalid
-            HTML, and the row already activates on click. */}
-        <PresetName name={family.name} nodeId={family.nodeId} />
+            HTML, and the row already activates on click. Same reason the
+            copy affordance is off: a second button here nests just the same. */}
+        <PresetName name={family.name} nodeId={family.nodeId} showCopy={false} />
         <span className="ledger-family-note">{family.note ?? ""}</span>
         <FamilyBar rules={family.rules} max={max} />
         <span className="ledger-family-count">{plural(family.rules, "rule")}</span>

--- a/packages/app/src/styles/02-controls.css
+++ b/packages/app/src/styles/02-controls.css
@@ -255,6 +255,38 @@ button.preset-token:focus-visible {
   word-break: break-all;
 }
 
+/* The shell-wide hover-copy affordance (Review-steps turn 17, variant 17a),
+   on the one inline value that was still missing it. Absolutely positioned so
+   it reserves no space while hidden — a ledger or tree row must not reflow
+   when the pointer arrives — and revealed on `:focus-within` as well as
+   `:hover`, so a keyboard user tabbing onto the icon finds it visible rather
+   than an invisible control with a name. */
+.preset-name-wrap {
+  display: inline-flex;
+  position: relative;
+}
+
+.preset-name-copy-slot {
+  display: inline-flex;
+  left: 100%;
+  margin-left: 0.15rem;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.preset-name-wrap:hover .preset-name-copy-slot,
+.preset-name-wrap:focus-within .preset-name-copy-slot {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.copy-btn.preset-name-copy {
+  padding: 0.1rem 0.3rem;
+}
+
 /* ---------- the standard preset hover card (roadmap 081) ----------
    Behind every token: the "via" chain that reaches this preset, what it drags
    in, and the way into the tree. Rides the shared `.option-card` popover plane

--- a/roadmap/081-standard-preset-names-and-hovers.md
+++ b/roadmap/081-standard-preset-names-and-hovers.md
@@ -291,3 +291,15 @@ and click-through included — and nothing else. Non-preset writers keep their
 `ProvenanceChip`. `viaNoteRef` and its test died with the note;
 `duplicateNoteText`'s "X resolves it again" stays, because a repeat's cell has
 no writer token whose hover could carry that fact.
+
+## Addendum — 2026-08-31: the token grew the shell-wide hover-copy affordance
+
+Review-steps turn 17 (variant 17a) put one copy affordance on every inline
+value shell-wide; the preset token was the one still missing it. `PresetName`
+now renders the shared `CopyButton` beside the token, hover/focus-revealed and
+positioned absolutely so it costs no layout in a dense ledger or tree row, and
+it always copies the full `extends` string rather than whatever the token
+displays. A `showCopy` prop (default on) turns it off at the two sites where
+the token already sits inside another element's own `<button>` — the ledger
+card header's toggle and a family row's toggle — where a second button would
+nest invalid HTML inside the first.


### PR DESCRIPTION
The last inline value missing the shell's one copy standard (design
turn 17, 17a): a keyboard-reachable clipboard icon revealed on
hover/focus beside every preset token, copying the full extends string;
suppressed where the token nests inside another control. 081 addendum.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>