### PR TITLE
feat(app): say whether a build is the tagged release or a commit after it

### DIFF
--- a/packages/app/src/components/BuildInfo.test.tsx
+++ b/packages/app/src/components/BuildInfo.test.tsx
@@ -14,6 +14,8 @@ const IDENTITY = vi.hoisted(() => ({
   repo: "secustor/renovate-config-debugger",
   commit: "d58538fab3a0000000000000000000000000000f",
   version: "0.2.0",
+  // Deliberately AFTER the tag: the panel's identity line must say so.
+  versionDistance: 3,
   commitTime: "2026-08-25T14:02:33+02:00",
 }));
 
@@ -45,6 +47,9 @@ describe("BuildStamp", () => {
       `https://github.com/${IDENTITY.repo}/commit/${IDENTITY.commit}`,
     );
     expect(panel.textContent).toContain("2026-08-25 12:02 UTC");
+    // The identity line owns exactness: this build sits after the tag, and
+    // the line says so instead of dressing the commit up as the release.
+    expect(panel.querySelector(".build-info-id")?.textContent).toContain("v0.2.0 + 3 commits");
   });
 
   it("defaults to the attestation command and switches to rebuild & diff", () => {

--- a/packages/app/src/components/BuildInfo.test.tsx
+++ b/packages/app/src/components/BuildInfo.test.tsx
@@ -14,8 +14,8 @@ const IDENTITY = vi.hoisted(() => ({
   repo: "secustor/renovate-config-debugger",
   commit: "d58538fab3a0000000000000000000000000000f",
   version: "0.2.0",
-  // Deliberately AFTER the tag: the panel's identity line must say so.
-  versionDistance: 3,
+  // The tag points at the commit — the one case that gets a version at all.
+  versionDistance: 0,
   commitTime: "2026-08-25T14:02:33+02:00",
 }));
 
@@ -47,9 +47,9 @@ describe("BuildStamp", () => {
       `https://github.com/${IDENTITY.repo}/commit/${IDENTITY.commit}`,
     );
     expect(panel.textContent).toContain("2026-08-25 12:02 UTC");
-    // The identity line owns exactness: this build sits after the tag, and
-    // the line says so instead of dressing the commit up as the release.
-    expect(panel.querySelector(".build-info-id")?.textContent).toContain("v0.2.0 + 3 commits");
+    // The identity line names the version because the tag points at this
+    // commit; formatVersion's own tests prove any other build drops it.
+    expect(panel.querySelector(".build-info-id")?.textContent).toContain("v0.2.0 · d58538f");
   });
 
   it("defaults to the attestation command and switches to rebuild & diff", () => {

--- a/packages/app/src/components/BuildInfo.test.tsx
+++ b/packages/app/src/components/BuildInfo.test.tsx
@@ -52,6 +52,17 @@ describe("BuildStamp", () => {
     expect(panel.querySelector(".build-info-id")?.textContent).toContain("v0.2.0 · d58538f");
   });
 
+  it("drops the separator dot along with the version on a non-release build", () => {
+    IDENTITY.versionDistance = 3;
+    try {
+      render(<BuildStamp />);
+      const trigger = screen.getByRole("button", { name: "d58538f" });
+      expect(trigger.textContent?.trim()).toBe("d58538f");
+    } finally {
+      IDENTITY.versionDistance = 0;
+    }
+  });
+
   it("defaults to the attestation command and switches to rebuild & diff", () => {
     render(<BuildStamp />);
     const panel = openPanel(screen.getByRole("button", { name: /d58538f/ }));

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -228,7 +228,7 @@ function BuildStampInner({ info }: { info: BuildIdentity }) {
         aria-controls={open ? panelId : undefined}
         onClick={toggle}
       >
-        · {version ? `${version} ` : ""}
+        {version ? `· ${version} ` : ""}
         {shortCommit(info)}
       </button>
       {open ? (

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -34,8 +34,8 @@ type VerifyTab = (typeof TABS)[number]["id"];
 
 function BuildIdentityLine({ info }: { info: BuildIdentity }) {
   const time = info.commitTime ? formatCommitTime(info.commitTime) : null;
-  // formatVersion says whether this commit IS the tagged release or sits
-  // after it ("v0.5.0" vs "v0.5.0 + 3 commits").
+  // Only a build the tag points at wears a version (formatVersion); any
+  // other commit is identified by its sha alone.
   const version = formatVersion(info);
   return (
     <p className="build-info-id">
@@ -174,10 +174,13 @@ function BuildVerifyLineInner({ info }: { info: BuildIdentity }) {
   const panelId = useId();
   // The committer date's day, as the committer wrote it — %cI's ISO prefix.
   const built = info.commitTime?.slice(0, 10) ?? null;
+  // Every surface names the version through formatVersion: only a build the
+  // tag points at wears one, everything else is its sha.
+  const version = formatVersion(info);
   return (
     <div className="build-info-line">
       <span>
-        debugger {info.version ? `v${info.version} · ` : ""}
+        debugger {version ? `${version} · ` : ""}
         <a href={commitUrl(info)} target="_blank" rel="noreferrer">
           {shortCommit(info)}
         </a>
@@ -213,6 +216,7 @@ export function BuildVerifyLine() {
 function BuildStampInner({ info }: { info: BuildIdentity }) {
   const { open, triggerRef, panelRef, toggle } = useAnchoredPopover(ESCAPE_PRIORITY.popover);
   const panelId = useId();
+  const version = formatVersion(info);
   return (
     <span className="build-info-anchor build-info-stamp-anchor">
       <button
@@ -224,7 +228,7 @@ function BuildStampInner({ info }: { info: BuildIdentity }) {
         aria-controls={open ? panelId : undefined}
         onClick={toggle}
       >
-        · {info.version ? `v${info.version} ` : ""}
+        · {version ? `${version} ` : ""}
         {shortCommit(info)}
       </button>
       {open ? (

--- a/packages/app/src/components/BuildInfo.tsx
+++ b/packages/app/src/components/BuildInfo.tsx
@@ -4,6 +4,7 @@ import {
   type BuildIdentity,
   commitUrl,
   formatCommitTime,
+  formatVersion,
   shortCommit,
   verifyCommands,
 } from "@/lib/build-info";
@@ -33,9 +34,12 @@ type VerifyTab = (typeof TABS)[number]["id"];
 
 function BuildIdentityLine({ info }: { info: BuildIdentity }) {
   const time = info.commitTime ? formatCommitTime(info.commitTime) : null;
+  // formatVersion says whether this commit IS the tagged release or sits
+  // after it ("v0.5.0" vs "v0.5.0 + 3 commits").
+  const version = formatVersion(info);
   return (
     <p className="build-info-id">
-      {info.version ? `v${info.version} · ` : null}
+      {version ? `${version} · ` : null}
       <a href={commitUrl(info)} target="_blank" rel="noreferrer">
         {shortCommit(info)}
       </a>

--- a/packages/app/src/lib/build-info.test.ts
+++ b/packages/app/src/lib/build-info.test.ts
@@ -3,6 +3,7 @@ import {
   type BuildIdentity,
   commitUrl,
   formatCommitTime,
+  formatVersion,
   parseBuildIdentity,
   shortCommit,
   verifyCommands,
@@ -12,6 +13,7 @@ const IDENTITY: BuildIdentity = {
   repo: "secustor/renovate-config-debugger",
   commit: "d58538fab3a0000000000000000000000000000f",
   version: "0.2.0",
+  versionDistance: 0,
   commitTime: "2026-08-25T14:02:33+02:00",
 };
 
@@ -25,6 +27,7 @@ describe("parseBuildIdentity", () => {
       repo: IDENTITY.repo,
       commit: IDENTITY.commit,
       version: null,
+      versionDistance: null,
       commitTime: null,
     });
   });
@@ -48,6 +51,16 @@ describe("the derived display values", () => {
   it("renders the committer date in UTC, or refuses garbage", () => {
     expect(formatCommitTime("2026-08-25T14:02:33+02:00")).toBe("2026-08-25 12:02 UTC");
     expect(formatCommitTime("not a date")).toBeNull();
+  });
+
+  it("says whether the build IS the tagged release or sits after it", () => {
+    expect(formatVersion(IDENTITY)).toBe("v0.2.0");
+    expect(formatVersion({ ...IDENTITY, versionDistance: 3 })).toBe("v0.2.0 + 3 commits");
+    expect(formatVersion({ ...IDENTITY, versionDistance: 1 })).toBe("v0.2.0 + 1 commit");
+    // An unknown distance must not claim exactness IN WORDS — the bare tag is
+    // today's display, no better and no worse.
+    expect(formatVersion({ ...IDENTITY, versionDistance: null })).toBe("v0.2.0");
+    expect(formatVersion({ ...IDENTITY, version: null })).toBeNull();
   });
 });
 

--- a/packages/app/src/lib/build-info.test.ts
+++ b/packages/app/src/lib/build-info.test.ts
@@ -53,13 +53,12 @@ describe("the derived display values", () => {
     expect(formatCommitTime("not a date")).toBeNull();
   });
 
-  it("says whether the build IS the tagged release or sits after it", () => {
+  it("names a version only for the build the tag points at", () => {
     expect(formatVersion(IDENTITY)).toBe("v0.2.0");
-    expect(formatVersion({ ...IDENTITY, versionDistance: 3 })).toBe("v0.2.0 + 3 commits");
-    expect(formatVersion({ ...IDENTITY, versionDistance: 1 })).toBe("v0.2.0 + 1 commit");
-    // An unknown distance must not claim exactness IN WORDS — the bare tag is
-    // today's display, no better and no worse.
-    expect(formatVersion({ ...IDENTITY, versionDistance: null })).toBe("v0.2.0");
+    // A commit after the tag — or one whose distance is unknown — is not the
+    // release, and wears no version at all: its sha is its identity.
+    expect(formatVersion({ ...IDENTITY, versionDistance: 3 })).toBeNull();
+    expect(formatVersion({ ...IDENTITY, versionDistance: null })).toBeNull();
     expect(formatVersion({ ...IDENTITY, version: null })).toBeNull();
   });
 });

--- a/packages/app/src/lib/build-info.ts
+++ b/packages/app/src/lib/build-info.ts
@@ -1,4 +1,5 @@
 import { isPlainObject } from "@/lib/input-schemas";
+import { plural } from "@/lib/format";
 
 /**
  * Roadmap 088 — the build identity behind "verify this build".
@@ -15,14 +16,21 @@ export interface BuildIdentity {
   repo: string;
   /** Full commit SHA the bundle was built from. */
   commit: string;
-  /** Latest release tag at that commit (without the `v`), if any. */
+  /** Latest release tag reachable from that commit (without the `v`), if any. */
   version: string | null;
+  /** Commits between that tag and this commit — 0 means the build IS the
+   *  tagged release; null means the distance is unknown. */
+  versionDistance: number | null;
   /** The commit's committer date (ISO 8601) — shown as "built". */
   commitTime: string | null;
 }
 
 function str(v: unknown): string | null {
   return typeof v === "string" && v !== "" ? v : null;
+}
+
+function count(v: unknown): number | null {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0 ? v : null;
 }
 
 /** Validated read of the injected value — exported for its tests. */
@@ -35,7 +43,13 @@ export function parseBuildIdentity(raw: unknown): BuildIdentity | null {
   if (!repo || !commit) {
     return null;
   }
-  return { repo, commit, version: str(raw.version), commitTime: str(raw.commitTime) };
+  return {
+    repo,
+    commit,
+    version: str(raw.version),
+    versionDistance: count(raw.versionDistance),
+    commitTime: str(raw.commitTime),
+  };
 }
 
 export const BUILD_INFO: BuildIdentity | null =
@@ -43,6 +57,19 @@ export const BUILD_INFO: BuildIdentity | null =
 
 export function shortCommit(info: BuildIdentity): string {
   return info.commit.slice(0, 7);
+}
+
+/** "v0.5.0" only when the commit IS the tagged release, "v0.5.0 + 3 commits"
+ *  when it sits after it — a bare tag must never dress up a later commit as
+ *  the release. An unknown distance shows the bare tag (nothing to count). */
+export function formatVersion(info: BuildIdentity): string | null {
+  if (info.version === null) {
+    return null;
+  }
+  const tag = `v${info.version}`;
+  return info.versionDistance !== null && info.versionDistance > 0
+    ? `${tag} + ${plural(info.versionDistance, "commit")}`
+    : tag;
 }
 
 export function commitUrl(info: BuildIdentity): string {

--- a/packages/app/src/lib/build-info.ts
+++ b/packages/app/src/lib/build-info.ts
@@ -1,5 +1,4 @@
 import { isPlainObject } from "@/lib/input-schemas";
-import { plural } from "@/lib/format";
 
 /**
  * Roadmap 088 — the build identity behind "verify this build".
@@ -59,17 +58,12 @@ export function shortCommit(info: BuildIdentity): string {
   return info.commit.slice(0, 7);
 }
 
-/** "v0.5.0" only when the commit IS the tagged release, "v0.5.0 + 3 commits"
- *  when it sits after it — a bare tag must never dress up a later commit as
- *  the release. An unknown distance shows the bare tag (nothing to count). */
+/** "v0.5.0" only when the tag points AT the built commit; any other build —
+ *  a commit after the tag, or an unknown distance — has no version at all
+ *  and is identified by its sha. A version must never dress up a commit
+ *  that is not the release. */
 export function formatVersion(info: BuildIdentity): string | null {
-  if (info.version === null) {
-    return null;
-  }
-  const tag = `v${info.version}`;
-  return info.versionDistance !== null && info.versionDistance > 0
-    ? `${tag} + ${plural(info.versionDistance, "commit")}`
-    : tag;
+  return info.version !== null && info.versionDistance === 0 ? `v${info.version}` : null;
 }
 
 export function commitUrl(info: BuildIdentity): string {

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -189,6 +189,7 @@ interface BuildIdentity {
   repo: string;
   commit: string | null;
   version: string | null;
+  versionDistance: number | null;
   commitTime: string | null;
 }
 
@@ -210,12 +211,16 @@ function git(...args: string[]): string | null {
  */
 function collectBuildIdentity(): BuildIdentity {
   const commit = process.env.GITHUB_SHA ?? git("rev-parse", "HEAD");
+  // The latest release tag reachable from this commit, plus how many commits
+  // sit between them — `--long` always yields `<tag>-<distance>-g<sha>`, so 0
+  // means the build IS the tagged release. (CI fetches the full history for
+  // this — see ci.yml's build job.)
+  const described = git("describe", "--tags", "--long")?.match(/^(.+)-(\d+)-g[0-9a-f]+$/);
   return {
     repo: process.env.GITHUB_REPOSITORY ?? "secustor/renovate-config-debugger",
     commit,
-    // The latest release tag reachable from this commit (CI fetches the full
-    // history for this — see ci.yml's build job).
-    version: git("describe", "--tags", "--abbrev=0")?.replace(/^v/, "") ?? null,
+    version: described?.[1]?.replace(/^v/, "") ?? null,
+    versionDistance: described?.[2] === undefined ? null : Number(described[2]),
     commitTime: commit ? git("show", "-s", "--format=%cI", commit) : null,
   };
 }


### PR DESCRIPTION
The identity carried only the nearest tag, so a commit after v0.5.0 wore a
bare "v0.5.0" — indistinguishable from the release itself. The build now
records the tag distance (git describe --long), and the panel's identity
line renders "v0.5.0" only at the tagged commit, "v0.5.0 + 3 commits"
after it.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>