### PR TITLE
fix(engine): import custom manager extractors statically

### DIFF
--- a/packages/engine/src/extract.ts
+++ b/packages/engine/src/extract.ts
@@ -432,7 +432,7 @@ async function runCustomExtract(request: ExtractCustomRequest): Promise<ExtractO
   const files = [{ fileName: request.fileName, content: request.content }];
   try {
     return await withSeededFiles<ExtractOutcome>(files, async () => {
-      const extract = await customManagerExtractors[type]();
+      const extract = customManagerExtractors[type];
       // The block itself is the config — that is the whole point of a custom
       // manager. A bad matchStrings pattern THROWS; the catch below owns it.
       const result = await extract(request.content, request.fileName, request.block);

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -66,7 +66,11 @@ export type {
   PackageFileContent,
 } from "renovate/dist/modules/manager/types.js";
 import type { ExtractConfig, PackageFileContent } from "renovate/dist/modules/manager/types.js";
-import type { CustomExtractConfig } from "renovate/dist/modules/manager/custom/regex/index.js";
+import {
+  extractPackageFile as regexExtractPackageFile,
+  type CustomExtractConfig,
+} from "renovate/dist/modules/manager/custom/regex/index.js";
+import { extractPackageFile as jsonataExtractPackageFile } from "renovate/dist/modules/manager/custom/jsonata/index.js";
 
 type ManagerExtractFn = (
   content: string,
@@ -84,16 +88,16 @@ type CustomExtractFn = (
 ) => PackageFileContent | null | Promise<PackageFileContent | null>;
 
 /**
- * The custom managers (roadmap 063), lazy like the map below but deliberately
- * NOT part of it: `managerExtractors`' keys are the built-in ledger
+ * The custom managers (roadmap 063), deliberately NOT part of the lazy map
+ * below: `managerExtractors`' keys are the built-in ledger
  * (EXTRACTABLE_MANAGERS), while these run only from a user's own config block —
- * their patterns and matchStrings ARE the block.
+ * their patterns and matchStrings ARE the block. Static, unlike that map,
+ * because validation.js already imports both eagerly (via custom/api.js), so a
+ * dynamic import cannot split them into their own chunk anyway.
  */
-export const customManagerExtractors: Record<CustomManagerType, () => Promise<CustomExtractFn>> = {
-  regex: async () =>
-    (await import("renovate/dist/modules/manager/custom/regex/index.js")).extractPackageFile,
-  jsonata: async () =>
-    (await import("renovate/dist/modules/manager/custom/jsonata/index.js")).extractPackageFile,
+export const customManagerExtractors: Record<CustomManagerType, CustomExtractFn> = {
+  regex: regexExtractPackageFile,
+  jsonata: jsonataExtractPackageFile,
 };
 
 /**


### PR DESCRIPTION
Fixes the `[INEFFECTIVE_DYNAMIC_IMPORT]` Rollup warning seen in every bundle build (e.g. [release run 33453090443, step 14](https://github.com/secustor/renovate-config-debugger/actions/runs/33453090443/job/99753524270#step:14:420)).

**Why the warning:** `customManagerExtractors` (added in #311) lazy-imported `custom/regex/index.js` and `custom/jsonata/index.js`, but `renovate-adapter.ts` also re-exports `validateConfig` from `config/validation.js`, which statically reaches both modules via `custom/index.js` → `custom/api.js` (upstream builds its custom-manager map eagerly). Since they're in the main static graph anyway, the dynamic import could never split them into their own chunk.

**Fix:** make the map static — `Record<CustomManagerType, CustomExtractFn>` holding the imported functions directly — and drop the thunk call at the one call site in `extract.ts`. No behavior or bundle-size change; the warning is gone from the CLI (and app) builds.