### PR TITLE
refactor: sweep V findings (60, verified twice)

### DIFF
--- a/.claude/skills/persona-test/SKILL.md
+++ b/.claude/skills/persona-test/SKILL.md
@@ -102,7 +102,7 @@ token   = base64url( deflate-raw( utf8( JSON.stringify(payload) ) ) )   // no pa
 url     = `http://localhost:<port>/?s=<unique>#config=${token}`
 ```
 
-— the exact wire format `packages/app/src/share.ts` decodes. The generator
+— the exact wire format `packages/app/src/lib/share.ts` decodes. The generator
 reads the pinned Renovate version straight from
 `packages/engine/package.json`, so it always matches the build you just
 served; only pass `--renovate` explicitly if you need to deviate.

--- a/.claude/skills/persona-test/generate-links.mjs
+++ b/.claude/skills/persona-test/generate-links.mjs
@@ -2,7 +2,7 @@
 /**
  * Roadmap 019 — share-link generator for persona-test scenarios.
  *
- * Produces a URL in the exact wire format `packages/app/src/share.ts` reads:
+ * Produces a URL in the exact wire format `packages/app/src/lib/share.ts` reads:
  *   payload {v:2, renovate, config, fileName, c} → JSON → UTF-8 →
  *   deflate-raw (CompressionStream) → base64url (no padding), placed after
  *   `#config=`. `c` is the 027 integrity tag (config checksum).
@@ -219,7 +219,7 @@ function bytesToBase64url(bytes) {
 }
 
 /** Roadmap 027 integrity tag — must stay byte-for-byte identical to
- *  `configChecksum` in packages/app/src/share.ts (32-bit FNV-1a, base36). */
+ *  `configChecksum` in packages/app/src/lib/share.ts (32-bit FNV-1a, base36). */
 function configChecksum(config) {
   let h = 0x811c9dc5;
   for (let i = 0; i < config.length; i++) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,9 @@ jobs:
         # `vite dev` serves renovate's transitive deps raw (no CJS interop),
         # a regime neither the Node tests nor the production build exercise.
         run: pnpm --filter @renovate-config-debugger/app check:dev-graph
-      - name: House lint rule specs (tools/)
+      # Every `tools/**/*.spec.ts`: `tools/` is not a workspace package, so the
+      # per-package steps above never reach them.
+      - name: Repo-level specs (tools/)
         run: pnpm test:tools
 
   build:

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -819,13 +819,15 @@
         // app-only; see the CLI block below. The file that DEFINES them is
         // exempt in the helper bank.
         "rcd/prefer-plural": "error",
-        // Sweep IV, both app-only because their homes are: `jsonSnippet` lives
-        // in `@/lib/value-preview` and does not resolve from the CLI or the
-        // engine, and `use-lookup-accessors` names `@/data/*` accessors whose
-        // engine namesakes (`shims/repo-config.ts:207`/`:245` and
-        // `shims/presets/host-transport.ts:55`) are its only three false
-        // positives tree-wide — app-only removes all three structurally.
+        // Sweep IV. `use-json-snippet` is app-only because its home is:
+        // `jsonSnippet` lives in `@/lib/value-preview` and does not resolve
+        // from the CLI or the engine.
         "rcd/use-json-snippet": "error",
+        // Sweep V moved `use-lookup-accessors`' home to `ownValue` in
+        // `engine/src/is.ts`, so it is no longer app-only — the engine block
+        // below enables it too. `host-transport.ts:55`, one of the three
+        // engine sites this rule used to be scoped away from, is an `ownValue`
+        // CALL now; `shims/repo-config.ts` is the single exemption left.
         "rcd/use-lookup-accessors": "error"
       }
     },
@@ -854,7 +856,10 @@
     // old `no-unguarded-json-stringify` kept the engine out because
     // `shims/repo-config.ts` stringified under a guard the rule could not see;
     // under the helper design that call is just `jsonDocument(value)` and the
-    // reason is gone. Only the two verbatim upstream ports are exempt, below.
+    // reason is gone. Three engine files are exempt below, each from ONE rule:
+    // the two verbatim upstream ports (`renovate-deps.ts`, `migration.ts`) from
+    // `prefer-is-helpers`, and — since sweep V put `use-lookup-accessors` in
+    // this block — `shims/repo-config.ts` from that rule alone.
     {
       "files": ["packages/engine/src/**"],
       "excludeFiles": [
@@ -864,7 +869,13 @@
       ],
       "rules": {
         "rcd/prefer-is-helpers": "error",
-        "rcd/use-json-helpers": "error"
+        "rcd/use-json-helpers": "error",
+        // Sweep V: the engine is in scope here for the same reason as the two
+        // above — the home moved into `src/is.ts` (`ownValue(table, key)`), so
+        // an import is always `./is`. Both of this sweep's own defects
+        // (40d7e954: `resolvers[platform]`, `managerExtractors[manager]`) were
+        // in this tree.
+        "rcd/use-lookup-accessors": "error"
       }
     },
     // ---- …and the e2e specs -------------------------------------------------
@@ -904,6 +915,29 @@
       "files": ["packages/**"],
       "rules": {
         "rcd/comment-cites-what-exists": "error"
+      }
+    },
+    // ---- …and every test that hand-copies part of an enumeration ------------
+    // Sweep V: test trees only, where a restatement of a registry stands in for
+    // coverage — finding 29 looped six of the seven `RESULTS_TAB_IDS` under the
+    // title "accepts every real tab id", and the CLI's two bin suites listed six
+    // of twelve commands. The repo measures identically clean repo-wide, so the
+    // scope buys no precision today; it keeps the message TRUE of every site the
+    // rule can reach and structurally excludes a future production subset that
+    // is deliberately partial (the `use-json-snippet`/`use-goto-app-helper`
+    // scoping precedent). No exemption is needed even inside the glob: the
+    // registry DEFINITIONS are complete lists, and a complete list is out of
+    // shape by the proper-subset condition.
+    {
+      "files": [
+        "packages/**/*.test.ts",
+        "packages/**/*.test.tsx",
+        "packages/cli/test/**",
+        "packages/engine/test/**",
+        "packages/app/e2e/*.spec.ts"
+      ],
+      "rules": {
+        "rcd/complete-enumeration-restatement": "error"
       }
     },
     // ---- …and the files that ARE the helper ---------------------------------
@@ -976,15 +1010,15 @@
       "files": ["packages/app/src/lib/value-preview.ts"],
       "rules": { "rcd/use-json-snippet": "off" }
     },
-    // The two `Object.hasOwn`-guarded accessor bodies, exempted BY PATH rather
-    // than by an AST carve-out: the guard and the read need not be adjacent, so
-    // the rule must not try to recognise the guarded shape.
+    // Sweep V: `use-lookup-accessors`' one remaining exemption, and the only
+    // live hit tree-wide. `repo-config.ts:207`/`:245` index a
+    // `Record<HostPlatform, string>` with a `platform: RepoPlatform` (=
+    // `HostPlatform`, :35) union — total by construction, behind a
+    // `req.endpoint || …` where a `string | undefined` would not typecheck.
+    // (The two app accessor bodies exempted here before are `ownValue(...)`
+    // calls now, so they are out of shape and their overrides are gone.)
     {
-      "files": ["packages/app/src/data/platform-endpoints.ts"],
-      "rules": { "rcd/use-lookup-accessors": "off" }
-    },
-    {
-      "files": ["packages/app/src/data/host-tokens.ts"],
+      "files": ["packages/engine/src/shims/repo-config.ts"],
       "rules": { "rcd/use-lookup-accessors": "off" }
     },
     // ---- …and the one type-aware rule that is off everywhere but here -------

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -376,8 +376,10 @@
                 // `/schema`, `/simulate-missing-inputs`) or through
                 // `loadEngine()`. `/is` and `/json` are the two this ban sends
                 // most authors to; every banner subpath is a zero-import file
-                // precisely so reaching it from the ENTRY chunk is free, which
-                // `engine/test/import-free-subpaths.node.test.ts` keeps true.
+                // precisely so reaching it from the ENTRY chunk is free, and
+                // `/simulate-missing-inputs` — which has imports — stays
+                // Renovate-free across its whole closure. Both are kept true by
+                // `engine/test/import-free-subpaths.node.test.ts`.
                 "group": ["@renovate-config-debugger/engine"],
                 "allowTypeImports": true,
                 "message": "Value-importing the engine ROOT statically pulls the whole Renovate graph into this chunk — use a narrow subpath export, or load it at runtime through platform/engine-chunk.ts (`loadEngine()`). Type-only imports are fine."
@@ -887,16 +889,19 @@
     },
     // ---- …and every comment that cites a file or a symbol's home ------------
     // `comment-cites-what-exists` resolves citations against the real tree.
-    // Test files are deliberately NOT excluded (unlike every helper rule): a
-    // test docblock citing its sibling suite is exactly the citation this
-    // guards, and one of the three defects it landed with is in a
+    // Everything under `packages/` is in scope — `src`, every test tree, `e2e`,
+    // `scripts` — because an enumeration of trees is the mechanism that let the
+    // CLI's and the worker's suites drift out of it. Test files are deliberately
+    // NOT excluded (unlike every helper rule): a test docblock citing its
+    // sibling suite is exactly the citation this guards, and one of the three
+    // defects it landed with is in a
     // `.shimmed.test.tsx`. `tools/**` is deliberately OUT and must stay out — a
     // rule header there keeps a past-tense census of WHAT WAS IN THE TREE (see
     // `prefer-is-helpers`), naming symbols and files the sweep deleted on
     // purpose; that is the rule's single false positive on the whole tree, and
     // this scope removes it structurally rather than by heuristic.
     {
-      "files": ["packages/*/src/**", "packages/engine/test/**", "packages/app/e2e/**"],
+      "files": ["packages/**"],
       "rules": {
         "rcd/comment-cites-what-exists": "error"
       }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,11 +22,16 @@ there rather than being backported.
 - Configs never leave the browser except for the preset fetches they
   themselves declare; those go browser → host API directly, with nothing
   proxying configs or presets.
-- Tokens (OAuth or personal access token) live in `sessionStorage`/memory
-  only and are cleared when the tab closes.
+- Access tokens (OAuth or personal access token) live in
+  `sessionStorage`/memory and are cleared when the tab closes. Where a
+  deployment enables the worker's `REFRESH_COOKIE` — as the public one does —
+  the refresh token lives in an `HttpOnly` cookie scoped to the worker mount,
+  so the session survives a closed tab; `localStorage` still holds no secret.
+  The full table is in [docs/Auth-Flow.md](docs/Auth-Flow.md).
 - Share links carry state in the URL fragment only, never a token.
-- `packages/oauth-worker` does nothing but the OAuth `code → token` exchange;
-  it never sees a config, a preset, or an API request.
+- `packages/oauth-worker` does nothing but the OAuth `code → token` /
+  `refresh_token → token` exchange and the `POST /logout` that drops the
+  refresh cookie; it never sees a config, a preset, or an API request.
 
 Reports about any of the above guarantees not holding, or about the
 `oauth-worker` itself, are especially welcome.

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -568,7 +568,9 @@ export function App() {
   // trigger lives HERE rather than in the panel because every results panel
   // stays MOUNTED (028), so a panel-side effect would fire for a tab nobody has
   // looked at and spend the rate limit on it. `ensure` is idempotent per loaded
-  // repo, so the three doors never discover twice.
+  // repo, so the three doors never discover twice — and its IDENTITY moves with
+  // the repo+customManagers pair, which is what re-fires this effect for a tab
+  // that was already open when the key changed.
   useEffect(() => {
     if (tab === "deps" || (tab === "pipeline" && pipelinePhase === "extract")) {
       ensureRepoDeps();
@@ -966,7 +968,7 @@ export function App() {
       // dropping it on `<body>`.
       focusTab("problems", ticket);
       const n = next.errors.length;
-      showToast(`Fix applied — re-ran: ${n === 0 ? "0 errors" : plural(n, "error")}`);
+      showToast(`Fix applied — re-ran: ${plural(n, "error")}`);
     }
   }
 
@@ -1359,6 +1361,7 @@ export function App() {
       hostTokens={hostTokens}
       customHostRules={customHostRules}
       onShowPipelineLayers={onShowPipelineLayers}
+      suppressTokens={untrustedGuard !== null}
     />
   );
 

--- a/packages/app/src/app/AppShellHeader.tsx
+++ b/packages/app/src/app/AppShellHeader.tsx
@@ -85,17 +85,25 @@ function DigestLinks({
         onOpen={onShowRewrites}
       />
       <span aria-hidden="true">·</span>
-      <DigestLink count={presets} label="presets" onOpen={() => onJump("presets")} />
+      <DigestLink
+        count={presets}
+        label={pluralWord(presets, "preset")}
+        onOpen={() => onJump("presets")}
+      />
       {effectiveKeys === null ? null : <span aria-hidden="true">·</span>}
       {effectiveKeys === null ? null : (
         <DigestLink
           count={effectiveKeys}
-          label="effective options"
+          label={pluralWord(effectiveKeys, "effective option")}
           onOpen={() => onJump("effective")}
         />
       )}
       <span aria-hidden="true">·</span>
-      <DigestLink count={problems} label="problems" onOpen={() => onJump("problems")} />
+      <DigestLink
+        count={problems}
+        label={pluralWord(problems, "problem")}
+        onOpen={() => onJump("problems")}
+      />
     </div>
   );
 }

--- a/packages/app/src/app/ConfigColumn.tsx
+++ b/packages/app/src/app/ConfigColumn.tsx
@@ -240,8 +240,10 @@ export function ConfigColumn({
           all about the shortcut they had just pressed. The wrapper is always
           mounted for the reason the run's live region is: a region announces a
           CHANGE to something the reader is already watching. Empty, it renders
-          nothing and takes no space; the paragraph and its margins still come
-          and go with the message.
+          nothing; the desktop split collapses the flex gap it would otherwise
+          spend (`10-messages-tabs.css`, the `:empty` rule beside `.config-col`'s
+          flex block). The paragraph and its margins still come and go with the
+          message.
 
           The other half of "a CHANGE" is the sender's: raising the identical
           message twice — a repo load that fails the same way twice — is one

--- a/packages/app/src/app/use-focus-landing.ts
+++ b/packages/app/src/app/use-focus-landing.ts
@@ -52,10 +52,11 @@ export interface FocusLanding {
  * is hidden or removed, and it is where Safari leaves it after a click on a
  * button.
  *
- * Exported since the ninth 068 review for App's `gestureWantsResultsLanding`,
- * which asks the same question of the same DOM — it had spelled the collapse
- * out a second time, and both spellings have to agree for a ticket's `from` and
- * "who is holding focus now" to be comparable at all.
+ * Exported since the ninth 068 review for `useKeyboardLandings`'
+ * `gestureWantsResultsLanding` (`app/use-keyboard-landings.ts`), which asks the
+ * same question of the same DOM — it had spelled the collapse out a second
+ * time, and both spellings have to agree for a ticket's `from` and "who is
+ * holding focus now" to be comparable at all.
  */
 export function focusHolder(): Element | null {
   const active = document.activeElement;

--- a/packages/app/src/app/use-oauth-session.ts
+++ b/packages/app/src/app/use-oauth-session.ts
@@ -73,9 +73,9 @@ export function useOAuthSession(): OAuthSession {
     setAuthUser(null);
   }, []);
 
-  // A sibling tab's broadcast changes the session outside any React event —
-  // its refresh signs this tab in, its sign-out tears this tab down — so the
-  // chip re-reads the module state when one lands.
+  // The session changes outside any React event — a sibling's refresh or
+  // sign-out, and this tab's own internal sign-out on an expired or revoked
+  // grant — so the chip re-reads the module state when one lands.
   useEffect(() => {
     if (!OAUTH_CONFIG) {
       return;

--- a/packages/app/src/components/JsonDiff.tsx
+++ b/packages/app/src/components/JsonDiff.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useMemo, useState, useTransition } from "react";
 import { Diff, getChangeKey, Hunk, parseDiff } from "react-diff-view";
 import { jsonFile } from "@renovate-config-debugger/engine/json";
 import { useDiffOptionHover } from "./option-docs-hooks";
-import { nf } from "@/lib/format";
+import { nf, plural } from "@/lib/format";
 import { buildJsonPatch } from "@/lib/json-patch";
 import { CopyButton } from "./CopyButton";
 import { SegmentedControl, type SegmentedOption } from "./SegmentedControl";
@@ -221,7 +221,7 @@ export function JsonDiff({ before, after, names, title }: Props) {
             className="btn-secondary accent-text"
             onClick={() => startTransition(() => setShowAllRequested(true))}
           >
-            Show all {nf.format(stat.total)} lines
+            Show all {plural(stat.total, "line")}
           </button>
         </div>
       )}

--- a/packages/app/src/components/MessagesPanel.shimmed.test.tsx
+++ b/packages/app/src/components/MessagesPanel.shimmed.test.tsx
@@ -116,7 +116,8 @@ it("renders a suggested edit as a unified diff behind one primary Apply button",
 });
 
 /** The library is `null` until the engine chunk has loaded. The card must still
- *  render the message — degrading to "no explanation yet", never to nothing. */
+ *  render the raw message alone — no explanation, no fix and no claim that there
+ *  is none — degrading exactly as `ErrorTranslationView` does. */
 it("renders the raw message before the translation library has loaded", async () => {
   const result = await panelFor(JSON.stringify({ automerge: "yes" }));
   const view = render(
@@ -127,4 +128,6 @@ it("renders the raw message before the translation library has loaded", async ()
   expect(card?.textContent).toContain("should be boolean");
   expect(card?.querySelector(".problem-key")).toBeNull();
   expect(card?.querySelector(".problem-docs")).toBeNull();
+  expect(card?.querySelector(".problem-nofix")).toBeNull();
+  expect(card?.querySelector(".problem-body")).toBeNull();
 });

--- a/packages/app/src/components/ProblemCard.tsx
+++ b/packages/app/src/components/ProblemCard.tsx
@@ -130,16 +130,25 @@ function ProblemFix({
 }
 
 /** Everything below the message: the explanation when 014 knows one, and
- *  either the fix or the honest note that there isn't one. */
+ *  either the fix or the honest note that there isn't one — and nothing at all
+ *  until the library has answered, so the note is never a claim about an
+ *  unloaded library. For that window the card wears the same shape
+ *  `PresetProblemCard` ships — message flush to the bottom border, since the
+ *  card's bottom padding lives on `.problem-body`. */
 function ProblemBody({
   explanation,
   fix,
+  libReady,
   onApplyFix,
 }: {
   explanation?: string;
   fix: ErrorFixResult | null;
+  libReady: boolean;
   onApplyFix?: (fix: ErrorFixResult) => void;
 }) {
+  if (!libReady) {
+    return null;
+  }
   return (
     <div className="problem-body">
       {explanation ? <p className="problem-explain">{explanation}</p> : null}
@@ -207,6 +216,7 @@ export function ProblemCard({
       <ProblemBody
         explanation={translated?.explanation}
         fix={translated?.fix ?? null}
+        libReady={errorLib !== null}
         onApplyFix={onApplyFix}
       />
     </li>

--- a/packages/app/src/components/ShortcutSheet.tsx
+++ b/packages/app/src/components/ShortcutSheet.tsx
@@ -22,7 +22,8 @@ import { type ShortcutRow, type ShortcutSection, shortcutSheet } from "@/lib/sho
  * does not reach a document- or window-level listener, so the sheet declares
  * that a modal owns the keyboard for as long as it is up (see
  * `claimModalKeyboard`, which the ladder and the 016 Home/End page scroll both
- * read), the same way every other page-level key is gated on App's `keysLive`.
+ * read), the same way every other page-level key is gated on `keysLive`
+ * (`app/use-keyboard-landings.ts`).
  * Home/End matter here in particular: these rows overflow the sheet's own
  * `max-height` box, so they are the keys that scroll it.
  */

--- a/packages/app/src/components/StageRail.tsx
+++ b/packages/app/src/components/StageRail.tsx
@@ -194,8 +194,8 @@ function PreviewNode({
  *  list while a run is in flight. Paced narration, not measurement — the
  *  engine reports nothing until it is finished. The design's pace: quick
  *  enough that the whole walk fits in the moment before the shell docks in.
- *  An uninterrupted walk is 1.28 s at this pace; App's `LANDING_WALK_CAP_MS`
- *  (use-landing-walk.ts) must stay comfortably above it. */
+ *  An uninterrupted walk is 1.28 s at this pace; `LANDING_WALK_CAP_MS`
+ *  (`app/use-landing-walk.ts`) must stay comfortably above it. */
 const RUNNING_STEP_MS = 160;
 
 /** The last column. The run's own completion is what lights it, and by then

--- a/packages/app/src/components/rule-framing.tsx
+++ b/packages/app/src/components/rule-framing.tsx
@@ -134,26 +134,18 @@ function FramingBreakdown({ framing, showCopy }: { framing: RuleFramingData; sho
  * "713 (713 from your config)" both say the count twice and add nothing. When
  * one source covers every rule, say "all" instead.
  */
-function CompactBreakdown({
-  framing,
-  total,
-  showCopy,
-}: {
-  framing: RuleFramingData;
-  total: number;
-  showCopy?: boolean;
-}) {
+function CompactBreakdown({ framing, total }: { framing: RuleFramingData; total: number }) {
   if (framing.own === total && !framing.top) {
     return "all from your config";
   }
   if (framing.own === 0 && framing.top && framing.top.count === total) {
     return (
       <>
-        all pulled in by <ContributorLabel top={framing.top} showCopy={showCopy} />
+        all pulled in by <ContributorLabel top={framing.top} />
       </>
     );
   }
-  return <FramingBreakdown framing={framing} showCopy={showCopy} />;
+  return <FramingBreakdown framing={framing} />;
 }
 
 /**

--- a/packages/app/src/data/glossary-data.ts
+++ b/packages/app/src/data/glossary-data.ts
@@ -249,7 +249,7 @@ export const GLOSSARY = {
   presetRollup: {
     name: "collapsed subtree totals",
     plain:
-      "Unique presets and packageRules contributed by this subtree's descendants, hidden while it is collapsed. Expand the row to see them individually.",
+      "Resolved presets and packageRules below this node, hidden while it is collapsed. Counted per occurrence — a preset that recurs in this subtree counts each time — so this can exceed the headline preset total above, which counts each name once. Expand the row to see them individually.",
   },
   keyOverridden: {
     name: "overridden",

--- a/packages/app/src/data/host-tokens.ts
+++ b/packages/app/src/data/host-tokens.ts
@@ -6,6 +6,7 @@
  * run.ts (which must stay engine-chunk-light) imports it too.
  */
 import type { PresetTokenKey, RepoPlatform } from "@renovate-config-debugger/engine";
+import { ownValue } from "@renovate-config-debugger/engine/is";
 
 export interface HostTokenDescriptor {
   /** Stable id, also the token's field prefix in the engine's PresetAuth. */
@@ -111,5 +112,5 @@ const HOST_PLATFORM: Readonly<Record<string, RepoPlatform>> = Object.fromEntries
 /** The platform serving a HOST that may be any string — the own-key guard is
  *  what keeps a pasted `constructor/repo` from reporting a known host. */
 export function platformForHost(host: string): RepoPlatform | undefined {
-  return Object.hasOwn(HOST_PLATFORM, host) ? HOST_PLATFORM[host] : undefined;
+  return ownValue(HOST_PLATFORM, host);
 }

--- a/packages/app/src/data/host-tokens.ts
+++ b/packages/app/src/data/host-tokens.ts
@@ -101,8 +101,10 @@ export function isTreeListingPlatform(value: string): value is RepoPlatform {
 }
 
 /** Known public hosts → the platform that serves their repos, from the same
- *  one table (`host` is documented there as the canonical host of that id). */
-export const HOST_PLATFORM: Readonly<Record<string, RepoPlatform>> = Object.fromEntries(
+ *  one table (`host` is documented there as the canonical host of that id).
+ *  Private: reached only through `platformForHost`, whose own-key guard is
+ *  the point. */
+const HOST_PLATFORM: Readonly<Record<string, RepoPlatform>> = Object.fromEntries(
   HOST_TOKENS.map((descriptor) => [descriptor.host, descriptor.id]),
 );
 

--- a/packages/app/src/data/platform-endpoints.ts
+++ b/packages/app/src/data/platform-endpoints.ts
@@ -9,6 +9,7 @@
  * share.ts can be decided — and unit-tested — against the very same defaults
  * the platform <select> renders, with no React in the way.
  */
+import { ownValue } from "@renovate-config-debugger/engine/is";
 
 /** The platform a fresh session starts on, and the one a share link that names
  *  none is read against. Here rather than re-typed per consumer: the codec's
@@ -46,5 +47,5 @@ export const PLATFORMS = Object.keys(PLATFORM_ENDPOINTS);
  *  own-key guard is what keeps a share link naming `constructor` from
  *  resolving to `Object.prototype`'s member instead of an endpoint. */
 export function defaultEndpointFor(platform: string): string | undefined {
-  return Object.hasOwn(PLATFORM_ENDPOINTS, platform) ? PLATFORM_ENDPOINTS[platform] : undefined;
+  return ownValue(PLATFORM_ENDPOINTS, platform);
 }

--- a/packages/app/src/data/platform-endpoints.ts
+++ b/packages/app/src/data/platform-endpoints.ts
@@ -22,8 +22,10 @@ export const DEFAULT_ENDPOINT = "https://api.github.com";
 
 /** Platforms that resolve `local>` in the browser, with their default endpoint.
  *  An empty endpoint means "not fetched in the browser" (a real Renovate run
- *  reaches it; this app never does). Second copy of the list
- *  `engine/test/local-preset-platforms.node.test.ts` guards — update both. */
+ *  reaches it; this app never does). A deliberate subset of the ids the engine
+ *  shim classifies (`local` excluded — it can never serve a preset); nothing
+ *  asserts the two agree, so a Renovate bump that adds a platform (caught by
+ *  `engine/test/local-preset-platforms.node.test.ts`) needs an entry here too. */
 export const PLATFORM_ENDPOINTS: Record<string, string> = {
   github: DEFAULT_ENDPOINT,
   gitlab: "https://gitlab.com/api/v4",

--- a/packages/app/src/features/editor/AdvancedZone.tsx
+++ b/packages/app/src/features/editor/AdvancedZone.tsx
@@ -70,6 +70,9 @@ export interface AdvancedZoneProps {
    *  zone is shell-only (ConfigColumn renders it once a result exists), so the
    *  pipeline it points at is always there. */
   onShowPipelineLayers: () => void;
+  /** While the untrusted-endpoint guard stands every run is executed with
+   *  tokens suppressed, so the collapsed line may not claim one is in force. */
+  suppressTokens: boolean;
 }
 
 /** The panel's opening line (Proposal F verbatim): what the drawer is FOR, and
@@ -122,6 +125,7 @@ export function AdvancedZone({
   hostTokens,
   customHostRules,
   onShowPipelineLayers,
+  suppressTokens,
 }: AdvancedZoneProps) {
   const line = credentialsLine({
     tokens: hostTokens,
@@ -129,6 +133,7 @@ export function AdvancedZone({
     platform: displayPlatform,
     endpoint: displayEndpoint,
     customHostCount: customHostRules.rules.length,
+    suppressTokens,
   });
   return (
     <details

--- a/packages/app/src/features/editor/HostRows.tsx
+++ b/packages/app/src/features/editor/HostRows.tsx
@@ -38,6 +38,7 @@ function HostTokenInput({ host }: { host: HostTokenField }) {
  *  "a token, or no token" but 009's three-way (signed in / can sign in / PAT
  *  only). Its own component so each branch is a flat list of controls. */
 function GithubRowActions({
+  host,
   oauthConfigured,
   signedIn,
   avatarUrl,
@@ -48,6 +49,7 @@ function GithubRowActions({
   onClearToken,
   onRevealToken,
 }: {
+  host: string;
   oauthConfigured: boolean;
   signedIn: boolean;
   /** See Props.authUser — the signed-in row names who, when it can. */
@@ -84,7 +86,13 @@ function GithubRowActions({
       ) : null}
       {tokenValid ? <span className="host-ok">token ✓</span> : null}
       {tokenSet ? (
-        <button type="button" className="host-remove" title="Remove token" onClick={onClearToken}>
+        <button
+          type="button"
+          className="host-remove"
+          title="Remove token"
+          aria-label={`Remove the token for ${host}`}
+          onClick={onClearToken}
+        >
           ✕
         </button>
       ) : null}
@@ -127,6 +135,7 @@ export function GithubHostRow({
         <code className="host-name">{host.host}</code>
         {isPlatform ? <span className="pill pill-count host-kind">platform</span> : null}
         <GithubRowActions
+          host={host.host}
           oauthConfigured={oauthConfigured}
           signedIn={signedIn}
           avatarUrl={avatarUrl}
@@ -184,7 +193,13 @@ function HostRow({
       <span className="pill pill-count host-kind">{kind}</span>
       <span className="host-row-actions">
         {tokenValid ? <span className="host-ok">token ✓</span> : null}
-        <button type="button" className="host-remove" title="Remove host" onClick={onRemove}>
+        <button
+          type="button"
+          className="host-remove"
+          title="Remove host"
+          aria-label={`Remove ${host}`}
+          onClick={onRemove}
+        >
           ✕
         </button>
       </span>

--- a/packages/app/src/features/editor/credentials-summary.test.ts
+++ b/packages/app/src/features/editor/credentials-summary.test.ts
@@ -21,6 +21,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com anonymous");
   });
@@ -33,6 +34,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com anonymous");
   });
@@ -45,6 +47,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://ghe.example/api/v3",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("ghe.example anonymous");
   });
@@ -57,6 +60,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com ✓");
   });
@@ -69,6 +73,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com ✓");
   });
@@ -84,6 +89,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com anonymous · +2");
   });
@@ -96,6 +102,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "gitlab",
         endpoint: "",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("gitlab.com ✓ · +1");
   });
@@ -116,8 +123,40 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 0,
+        suppressTokens: false,
       }),
     ).toBe("github.com anonymous");
+  });
+
+  it("withholds the tick while the untrusted-endpoint guard suppresses tokens", () => {
+    // The guard runs every request without a token, so a signed-in session
+    // pointed at the untrusted host authenticates against nothing.
+    expect(
+      credentialsLine({
+        tokens: withToken("github", "ghp_x"),
+        signedIn: true,
+        platform: "github",
+        endpoint: "https://ghe.example/api/v3",
+        customHostCount: 0,
+        suppressTokens: true,
+      }),
+    ).toBe("ghe.example anonymous");
+  });
+
+  it("keeps the +N tail under suppression — those hosts still hold tokens", () => {
+    const tokens = NONE.map((token) =>
+      token.id === "gitlab" || token.id === "gitea" ? { ...token, value: "t" } : token,
+    );
+    expect(
+      credentialsLine({
+        tokens,
+        signedIn: true,
+        platform: "github",
+        endpoint: "https://ghe.example/api/v3",
+        customHostCount: 1,
+        suppressTokens: true,
+      }),
+    ).toBe("ghe.example anonymous · +3");
   });
 
   it("counts custom host rules toward the +N tail", () => {
@@ -128,6 +167,7 @@ describe("credentialsLine (roadmap 076/077, Proposal F)", () => {
         platform: "github",
         endpoint: "https://api.github.com",
         customHostCount: 1,
+        suppressTokens: false,
       }),
     ).toBe("github.com anonymous · +1");
   });

--- a/packages/app/src/features/editor/credentials-summary.ts
+++ b/packages/app/src/features/editor/credentials-summary.ts
@@ -5,9 +5,10 @@
  * The design's grammar is `⟨host⟩ ✓` / `⟨host⟩ anonymous`, plus ` · +N` when
  * other hosts carry tokens too: the line names the host this session's
  * platform context points at and states — positively, never as "the count is
- * zero" — whether the session can authenticate against it. Pure, and its own
- * module, because "carrying a credential" is not a fact the markup should be
- * re-deciding inline.
+ * zero" — whether the session can authenticate against it. The ✓/anonymous
+ * choice is about the credential in force for the NEXT run, not the inventory
+ * in storage. Pure, and its own module, because "carrying a credential" is not
+ * a fact the markup should be re-deciding inline.
  */
 import { defaultEndpointFor } from "@/data/platform-endpoints";
 import type { HostTokenId } from "@/data/host-tokens";
@@ -26,6 +27,9 @@ export interface CredentialsInput {
    *  are credentials for hosts the four-row table does not name, so they can
    *  never BE the primary host — they only ever add to the ` · +N` tail. */
   customHostCount: number;
+  /** Security 2026-07-25: while the untrusted-endpoint guard stands the run
+   *  carries no token to ANY host, so the line must not claim one. */
+  suppressTokens: boolean;
 }
 
 /** The endpoint field is empty (platform default in force) or literally the
@@ -59,8 +63,9 @@ export function credentialsLine(input: CredentialsInput): string {
   // save an invalid token, so the line must not claim one authenticates.
   const primaryValue = primary?.value ?? "";
   const primaryAuthed =
-    (input.platform === "github" && input.signedIn) ||
-    (primaryValue !== "" && isValidToken(primaryValue));
+    !input.suppressTokens &&
+    ((input.platform === "github" && input.signedIn) ||
+      (primaryValue !== "" && isValidToken(primaryValue)));
   let extras = input.customHostCount;
   for (const token of input.tokens) {
     if (token.id === input.platform) {

--- a/packages/app/src/features/effective-config/EffectiveConfig.tsx
+++ b/packages/app/src/features/effective-config/EffectiveConfig.tsx
@@ -15,7 +15,7 @@ import {
   effectiveTableRows,
   isEffectiveView,
 } from "./effective-rows";
-import { nf } from "@/lib/format";
+import { plural } from "@/lib/format";
 import { ResolvedJsonView } from "./ResolvedJsonView";
 import { useProvenance, useResolvedConfig } from "./use-effective-derivations";
 import { useRuleProvenance } from "@/hooks/rule-provenance";
@@ -285,7 +285,7 @@ export const EffectiveConfig = memo(function EffectiveConfig({
       />
       {view === "keys" ? (
         <p className="data-table-note">
-          {nf.format(entries.length)} options in the config Renovate runs · hover any key for
+          {plural(entries.length, "option")} in the config Renovate runs · hover any key for
           Renovate’s docs · defaults have no cascade — only the default ever touched them
         </p>
       ) : null}

--- a/packages/app/src/features/pipeline/PhasePicker.test.tsx
+++ b/packages/app/src/features/pipeline/PhasePicker.test.tsx
@@ -71,7 +71,7 @@ describe("PhasePicker", () => {
         ],
       },
     });
-    const segment = ready.getByRole("radio", { name: "Extract, +1 deps" });
+    const segment = ready.getByRole("radio", { name: "Extract, +1 dep" });
     expect(segment.querySelector(".phase-seg-note.ok")).toBeTruthy();
   });
 

--- a/packages/app/src/features/pipeline/PhasePicker.tsx
+++ b/packages/app/src/features/pipeline/PhasePicker.tsx
@@ -1,5 +1,5 @@
 import { SegmentedControl, type SegmentedOption } from "@/components/SegmentedControl";
-import { nf, plural } from "@/lib/format";
+import { plural } from "@/lib/format";
 import {
   PHASE_UNAVAILABLE_NOTE,
   PIPELINE_PHASES,
@@ -39,7 +39,7 @@ function phaseNote(
   }
   if (phase === "extract") {
     if (extract.status === "ready") {
-      return { text: `+${nf.format(extract.deps.length)} deps`, tone: "ok" };
+      return { text: `+${plural(extract.deps.length, "dep")}`, tone: "ok" };
     }
     return extract.status === "loading" ? { text: "reading…", tone: "muted" } : null;
   }

--- a/packages/app/src/features/pipeline/PipelinePanel.test.tsx
+++ b/packages/app/src/features/pipeline/PipelinePanel.test.tsx
@@ -1,0 +1,70 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+// jsdom has no `matchMedia`, and the rail's `prefersReducedMotion` calls it on mount.
+import { stubMatchMedia } from "@tools/test/jsdom-stubs";
+import { CONNECT_OFFER, EMPTY_VIEW } from "@tools/test/repo-deps";
+import { traceResult } from "@tools/test/trace-result";
+import type { StageStatus } from "@renovate-config-debugger/engine";
+import { PipelinePanel } from "./PipelinePanel";
+
+/**
+ * The migrate stage card's empty note is a CLAIM about the config ("already
+ * uses current option names"), so it may only be made for a migrate that ran
+ * and rewrote nothing — a skipped or errored stage has no steps either, and
+ * StageDiff is saying the opposite two rows above it.
+ */
+
+function renderMigrate(migrate: StageStatus) {
+  const result = traceResult({ stageStatus: { ...traceResult().stageStatus, migrate } });
+  return render(
+    <PipelinePanel
+      phase="config"
+      onSelectPhase={vi.fn()}
+      extract={EMPTY_VIEW}
+      repoConnect={CONNECT_OFFER}
+      onRetryExtract={vi.fn()}
+      onOpenDependencies={vi.fn()}
+      result={result}
+      selectedStage="migrate"
+      onSelectStage={vi.fn()}
+      deferredStage="migrate"
+      effectiveKeys={0}
+      migrateSteps={[]}
+      migrateStepperMounted={false}
+      finalMigrated={undefined}
+      migrationStepIndex={0}
+      onMigrationStepChange={vi.fn()}
+      globalText=""
+      onGlobalTextChange={vi.fn()}
+      inheritedText=""
+      onInheritedTextChange={vi.fn()}
+      globalParse={{}}
+      inheritedParse={{}}
+      inheritState={null}
+    />,
+  );
+}
+
+const NOTE = "already uses current option names";
+
+describe("the migrate stage's no-rewrites note", () => {
+  beforeEach(() => {
+    stubMatchMedia(false);
+  });
+
+  it("is made for a migrate that ran and rewrote nothing", () => {
+    const view = renderMigrate("ok");
+    expect(view.container.textContent).toContain(NOTE);
+  });
+
+  it("is withheld when the stage was skipped because parsing failed", () => {
+    const view = renderMigrate("skipped");
+    expect(view.container.textContent).not.toContain(NOTE);
+    expect(view.container.textContent).toContain("skipped");
+  });
+
+  it("is withheld when the stage itself errored", () => {
+    const view = renderMigrate("error");
+    expect(view.container.textContent).not.toContain(NOTE);
+  });
+});

--- a/packages/app/src/features/pipeline/PipelinePanel.tsx
+++ b/packages/app/src/features/pipeline/PipelinePanel.tsx
@@ -233,7 +233,11 @@ function ConfigPhase({
           onIndexChange={onMigrationStepChange}
         />
       ) : null}
-      {deferredStage === "migrate" && !migrateStepperMounted ? (
+      {/* Only for a migrate that actually ran clean: a skipped or errored stage
+          has StageDiff's own message above, and this note would contradict it. */}
+      {deferredStage === "migrate" &&
+      !migrateStepperMounted &&
+      result.stageStatus.migrate === "ok" ? (
         <EmptyNote>No rewrites — this config already uses current option names.</EmptyNote>
       ) : null}
     </>

--- a/packages/app/src/features/pipeline/extract-phase.ts
+++ b/packages/app/src/features/pipeline/extract-phase.ts
@@ -137,7 +137,7 @@ export function extractNodes(view: RepoDepsView): ExtractNode[] {
  */
 function managersOutcome(view: RepoDepsView): string {
   const { builtIn } = matchedManagerCounts(view);
-  const base = `${nf.format(builtIn)} of ${nf.format(view.managersConsidered)} managers matched files`;
+  const base = `${nf.format(builtIn)} of ${plural(view.managersConsidered, "manager")} matched files`;
   if (view.customManagersConsidered === 0) {
     return base;
   }

--- a/packages/app/src/features/presets/OriginFraming.tsx
+++ b/packages/app/src/features/presets/OriginFraming.tsx
@@ -2,7 +2,7 @@ import type { PresetNode } from "@renovate-config-debugger/engine";
 import type { TreeStats } from "@/lib/preset-tree-stats";
 import { Term } from "@/components/glossary";
 import { PresetName } from "@/components/PresetName";
-import { nf, plural, pluralWord } from "@/lib/format";
+import { nf, plural } from "@/lib/format";
 
 /**
  * Roadmap 016: honest origin framing for the headline preset count (persona
@@ -36,8 +36,8 @@ export function OriginFraming({ root, stats }: { root: PresetNode; stats: TreeSt
     return (
       <p className="origin-framing">
         Your <Term id="extends">extends</Term> entry{" "}
-        <PresetName name={onlyRoot.name} nodeId={onlyRoot.id} /> expands to {nf.format(total)}{" "}
-        {pluralWord(total, "preset")}.
+        <PresetName name={onlyRoot.name} nodeId={onlyRoot.id} /> expands to{" "}
+        {plural(total, "preset")}.
       </p>
     );
   }

--- a/packages/app/src/features/presets/TreeRow.tsx
+++ b/packages/app/src/features/presets/TreeRow.tsx
@@ -4,7 +4,7 @@ import type { NodeStats } from "@/lib/preset-tree-stats";
 import { Explained, ExplainedText } from "@/components/glossary";
 import { type HoverCardHandlers, HoverCardAnchor } from "@/components/hover-card";
 import { GLOSSARY } from "@/data/glossary-data";
-import { nf, plural } from "@/lib/format";
+import { plural } from "@/lib/format";
 import { presetTreeNameClass } from "@/lib/preset-row-dom";
 import type { NodeDescriptionFacts } from "@/lib/tree-descriptions";
 import { NodeDescriptionCard } from "./NodeDescriptions";
@@ -39,8 +39,8 @@ function ContributionBadges({ stats, collapsed }: { stats: NodeStats; collapsed:
       ) : null}
       {collapsed && (stats.descResolved > 0 || stats.descRules > 0) ? (
         <ExplainedText entry={GLOSSARY.presetRollup} className="badge rollup explained">
-          {stats.descResolved > 0 ? `· ${nf.format(stats.descResolved)} presets ` : ""}
-          {stats.descRules > 0 ? `· ${nf.format(stats.descRules)} rules` : ""}
+          {stats.descResolved > 0 ? `· ${plural(stats.descResolved, "preset")} ` : ""}
+          {stats.descRules > 0 ? `· ${plural(stats.descRules, "rule")}` : ""}
         </ExplainedText>
       ) : null}
     </>

--- a/packages/app/src/features/session/use-session-menu.ts
+++ b/packages/app/src/features/session/use-session-menu.ts
@@ -15,11 +15,12 @@ import { useAnchoredPopover } from "@/hooks/use-anchored-popover";
  * them unreachable. While this panel is up, focus is inside it or on the
  * trigger — anywhere else closes it in the same event that moved it.
  *
- * - `defaultPrevented`: the two surfaces that claim Escape are CodeMirror and
- *   the repo-load form, and focus reaching either has already closed the menu.
- *   Nothing the panel itself renders claims the key — its items are buttons
- *   and `ThemeSwitch`'s radios, with no key handler between them — and no
- *   registry shortcut binds Escape.
+ * - The claimed press: CodeMirror claims by `preventDefault` (the flag the
+ *   ladder reads), the repo-load form by `stopPropagation` (the press never
+ *   reaches the ladder at all — see escape-stack.ts's two-spellings paragraph);
+ *   focus reaching either has already closed the menu. Nothing the panel itself
+ *   renders claims the key — its items are buttons and `ThemeSwitch`'s radios,
+ *   with no key handler between them — and no registry shortcut binds Escape.
  * - The combobox yield: `mayOwnNativePopup` is the simulator's two `<input
  *   list>` fields, which are two panels away from this one.
  * - `modalKeyboardOwned()`: `?` is exempt from the overlay gate, so the sheet

--- a/packages/app/src/features/simulator/AddTestBox.tsx
+++ b/packages/app/src/features/simulator/AddTestBox.tsx
@@ -593,7 +593,7 @@ export function AddTestBox({
     <DescriptorActions
       className="pin-new-actions"
       formId={PIN_FORM_ID}
-      submitLabel="Simulate"
+      submitLabel={simulating ? "Simulating…" : "Simulate"}
       submitDisabled={simulating || !result.finalConfig}
       atLimit={atLimit}
       onPin={() => pin()}

--- a/packages/app/src/features/simulator/PinCard.tsx
+++ b/packages/app/src/features/simulator/PinCard.tsx
@@ -5,7 +5,7 @@ import { Caret } from "@/components/Caret";
 import { OpenInSimulatorLink } from "./OpenInSimulatorLink";
 import { PinBucketList } from "./PinBucketList";
 import { PinHeadRow } from "./PinHeadRow";
-import { pinContext, pinName } from "./pins";
+import { pinContext, pinDepName, pinName, pinSubject } from "./pins";
 import { PinProbe } from "./PinProbe";
 import { type CrossLinks, PinFailedSection, PinMatchedSection } from "./PinRuleSections";
 import type { RuleDescriptionNote } from "./rule-descriptions";
@@ -50,7 +50,6 @@ function PinCardHead({
           name={name}
           context={pinContext(pin.form, outcome?.updateType ?? "")}
           summary={outcome ? headSummary(outcome) : null}
-          pending={evaluation ? "not checked" : "checking…"}
           starter={pin.starter === true}
         />
       </button>
@@ -152,7 +151,7 @@ export function PinCard({
   const outcome = useMemo(
     () =>
       evaluation?.sim
-        ? buildPinOutcome(evaluation.sim, layerByIndex, attribution, pinName(pin.form))
+        ? buildPinOutcome(evaluation.sim, layerByIndex, attribution, pinDepName(pin.form))
         : null,
     [evaluation, layerByIndex, attribution, pin],
   );
@@ -173,13 +172,7 @@ export function PinCard({
           layerByIndex={layerByIndex}
           descriptions={descriptions}
           ruleBodies={ruleBodies}
-          subject={[
-            pinName(pin.form),
-            pin.form.manager.trim() || pin.form.datasource.trim(),
-            outcome?.updateType ?? pin.form.updateType,
-          ]
-            .filter((part) => part !== "")
-            .join(" · ")}
+          subject={pinSubject(pin.form, outcome?.updateType ?? "")}
           links={links}
           onOpenInSimulator={onOpenInSimulator}
         />

--- a/packages/app/src/features/simulator/PinHeadRow.test.tsx
+++ b/packages/app/src/features/simulator/PinHeadRow.test.tsx
@@ -37,4 +37,34 @@ describe("PinHeadRow", () => {
     expect(view.container.querySelector(".pin-starter")).toBeNull();
     expect(view.container.querySelector(".pin-name")?.textContent).toBe("lodash");
   });
+
+  // A pin whose simulation threw used to read "not checked" — the one wording
+  // indistinguishable from a pin that never ran.
+  it("says a failed check could not be checked, and carries the message", () => {
+    const view = render(
+      <PinHeadRow
+        check={{ status: "failed", error: "boom" }}
+        name="lodash"
+        context="4.17.20 → 4.18.0 · minor"
+        summary={null}
+      />,
+    );
+    const pending = view.container.querySelector(".pin-pending");
+    expect(pending?.textContent).toBe("could not be checked");
+    expect(pending?.getAttribute("title")).toBe("boom");
+  });
+
+  it("says a pin that has not run yet is still checking", () => {
+    const view = render(
+      <PinHeadRow
+        check={{ status: "pending" }}
+        name="lodash"
+        context="4.17.20 → 4.18.0 · minor"
+        summary={null}
+      />,
+    );
+    const pending = view.container.querySelector(".pin-pending");
+    expect(pending?.textContent).toBe("checking…");
+    expect(pending?.getAttribute("title")).toBeNull();
+  });
 });

--- a/packages/app/src/features/simulator/PinHeadRow.tsx
+++ b/packages/app/src/features/simulator/PinHeadRow.tsx
@@ -17,7 +17,6 @@ export function PinHeadRow({
   name,
   context,
   summary,
-  pending,
   starter = false,
 }: {
   check: PinCheck;
@@ -26,8 +25,6 @@ export function PinHeadRow({
   context: string;
   /** The outcome sentence, or null when there is no outcome yet. */
   summary: string | null;
-  /** What stands in for the sentence while `summary` is null. */
-  pending?: string;
   /** Roadmap 091: this descriptor was derived from the reader's own rules, not
    *  written by them — said on the row, since it is the row's own claim. */
   starter?: boolean;
@@ -46,7 +43,9 @@ export function PinHeadRow({
       ) : null}
       <span className="pin-meta">{context}</span>
       {summary === null ? (
-        <span className="pin-pending">{pending}</span>
+        <span className="pin-pending" title={check.status === "failed" ? check.error : undefined}>
+          {check.status === "failed" ? "could not be checked" : "checking…"}
+        </span>
       ) : (
         <span className="pin-summary">{summary}</span>
       )}

--- a/packages/app/src/features/simulator/PinsView.tsx
+++ b/packages/app/src/features/simulator/PinsView.tsx
@@ -5,7 +5,7 @@ import type {
   RuleAttribution,
   TraceResult,
 } from "@renovate-config-debugger/engine";
-import { nf } from "@/lib/format";
+import { plural } from "@/lib/format";
 import { AddTestBox } from "./AddTestBox";
 import { EmptyTestsCard } from "./EmptyTestsCard";
 import { PinCard } from "./PinCard";
@@ -71,7 +71,7 @@ function PinsSummary({
         <strong>{count}</strong> pinned
         {ruleCount === undefined
           ? " — re-checked on every run"
-          : ` · ${nf.format(ruleCount)} rules evaluated per test, in merge order`}
+          : ` · ${plural(ruleCount, "rule")} evaluated per test, in merge order`}
       </span>
     );
   return (

--- a/packages/app/src/features/simulator/RepoDepsTab.tsx
+++ b/packages/app/src/features/simulator/RepoDepsTab.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from "react";
-import { nf } from "@/lib/format";
+import { countNoun, type DataTableNoun } from "@/components/data-table";
+import { nf, plural } from "@/lib/format";
 import { discoveryCaveats, tallyDiscovery } from "@/lib/discovery-caveats";
 import { filterRepoDeps, hiddenDepFiles, REPO_DEPS_SHOWN, type RepoDraft } from "./repo-deps";
 import type { PinnedTest } from "@/types/simulator";
@@ -37,6 +38,8 @@ function pinnedAs(pins: readonly PinnedTest[], dep: RepoDep): string | null {
   return hit.form.updateType === "" ? "pinned" : hit.form.updateType;
 }
 
+const DEP_NOUN: DataTableNoun = { one: "dependency", many: "dependencies" };
+
 const QUICK_TYPES = ["patch", "minor", "major"] as const;
 
 function RepoDepRow({
@@ -60,7 +63,13 @@ function RepoDepRow({
       ) : showQuickPins ? (
         <span className="pin-repo-quick">
           {QUICK_TYPES.map((type) => (
-            <button key={type} type="button" className="btn-chip" onClick={() => onQuickPin(type)}>
+            <button
+              key={type}
+              type="button"
+              className="btn-chip"
+              aria-label={`Draft a ${type} update of ${dep.depName}`}
+              onClick={() => onQuickPin(type)}
+            >
               {type}
             </button>
           ))}
@@ -193,9 +202,7 @@ function RepoDepsFootnote({ view, hidden }: { view: RepoDepsView; hidden: readon
     parts.push(`… ${nf.format(hidden.length)} more across ${named}`);
   } else {
     const files = tallyDiscovery(view).extracted;
-    parts.push(
-      `${nf.format(view.deps.length)} dependencies across ${nf.format(files)} package files`,
-    );
+    parts.push(`${countNoun(view.deps.length, DEP_NOUN)} across ${plural(files, "package file")}`);
   }
   parts.push(`detected because you loaded this config from ${view.repo}`);
   parts.push(...discoveryCaveats(view));
@@ -255,7 +262,7 @@ export function RepoDepsTab({
       <div className="pin-repo-search">
         <input
           aria-label="Search detected dependencies"
-          placeholder={`Search the ${nf.format(view.deps.length)} dependencies detected across ${nf.format(tallyDiscovery(view).extracted)} package files…`}
+          placeholder={`Search the ${countNoun(view.deps.length, DEP_NOUN)} detected across ${plural(tallyDiscovery(view).extracted, "package file")}…`}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -418,7 +418,7 @@ it("offers the loaded repo's dependencies and pins one from the picker (078)", a
   }
 
   // Quick-pin names the update TYPE; the draft is where the next version goes.
-  fireEvent.click(within(row).getByRole("button", { name: "patch" }));
+  fireEvent.click(within(row).getByRole("button", { name: "Draft a patch update of typescript" }));
   fireEvent.change(view.getByLabelText("newValue", { exact: true }), {
     target: { value: "5.9.0" },
   });
@@ -430,7 +430,9 @@ it("offers the loaded repo's dependencies and pins one from the picker (078)", a
   });
   // …and the row now wears the standing pin's badge instead of quick-pins.
   expect(view.container.textContent).toContain("pinned · patch");
-  expect(within(row).queryByRole("button", { name: "patch" })).toBeNull();
+  expect(
+    within(row).queryByRole("button", { name: "Draft a patch update of typescript" }),
+  ).toBeNull();
 
   // The search row narrows by file too (scoped to the list — the pin card
   // above it now names typescript as well).
@@ -479,7 +481,7 @@ it("caps the list at five rows, counts the tail, and drafts inline under its row
   if (!row) {
     throw new Error("the node row is missing");
   }
-  fireEvent.click(within(row).getByRole("button", { name: "patch" }));
+  fireEvent.click(within(row).getByRole("button", { name: "Draft a patch update of node" }));
   const holder = row.nextElementSibling;
   expect(holder?.className).toBe("pin-repo-draft-row");
   expect(holder?.querySelector(".pin-repo-draft")).not.toBeNull();

--- a/packages/app/src/features/simulator/pin-outcome.test.ts
+++ b/packages/app/src/features/simulator/pin-outcome.test.ts
@@ -132,6 +132,40 @@ describe("what a matched rule wrote, against the merge steps", () => {
     expect(second?.conflictNote).toBe("Applied later — its groupName wins over packageRules[0].");
   });
 
+  // Three writers of one key: the note must name the LAST earlier stop — the
+  // value rule 2 replaced was rule 1's, never rule 0's.
+  test("a surviving write names the last earlier stop it beat, not the first", () => {
+    const rules = [0, 1, 2].map((i) => rule(i, "matched", [clause("matched")]));
+    const steps: MergeStep[] = [
+      {
+        kind: "rule",
+        ruleIndex: 0,
+        before: {},
+        after: {},
+        merged: [{ key: "groupName", after: "a" }],
+      },
+      {
+        kind: "rule",
+        ruleIndex: 1,
+        before: {},
+        after: {},
+        merged: [{ key: "groupName", before: "a", after: "b" }],
+      },
+      {
+        kind: "rule",
+        ruleIndex: 2,
+        before: {},
+        after: {},
+        merged: [{ key: "groupName", before: "b", after: "c" }],
+      },
+    ];
+    const outcome = buildPinOutcome(simulation(rules, {}, "minor", steps), layers([]), null);
+    expect(outcome.matched[2]?.wroteSummary).toBe("groupName · wins");
+    expect(outcome.matched[2]?.conflictNote).toBe(
+      "Applied later — its groupName wins over packageRules[1].",
+    );
+  });
+
   test("a matched rule that merged nothing says so", () => {
     const outcome = buildPinOutcome(
       simulation([rule(0, "matched", [clause("matched")])]),
@@ -210,6 +244,22 @@ describe("the rules a card names and the ones it buckets", () => {
     expect(bucketed).toBe(RULES.length - outcome.matched.length - outcome.failed.length);
     // The header count is total minus matched — the named failures included.
     expect(outcome.skippedCount).toBe(RULES.length - outcome.matched.length);
+  });
+
+  // `matchBaseBranches` is the registry's one -ches plural; a naive `s$` strip
+  // printed "base branche" straight into the bucket's reason line.
+  test("singularizes a sibilant selector for the axis reason", () => {
+    const outcome = buildPinOutcome(
+      simulation([
+        rule(0, "no-match", [
+          clause("no-match", "matchBaseBranches", ["next"], { baseBranch: "main" }),
+        ]),
+      ]),
+      layers([]),
+      null,
+    );
+    const bucket = outcome.buckets.find((b) => b.id === "other-axis");
+    expect(bucket?.reason).toBe("matcher on a different axis (base branch)");
   });
 
   test("without provenance nothing is anyone's own, and the remainder is one axis bucket", () => {

--- a/packages/app/src/features/simulator/pin-outcome.ts
+++ b/packages/app/src/features/simulator/pin-outcome.ts
@@ -221,7 +221,8 @@ function buildWrites(
       ? `${first.key} · ${first.survived ? "wins" : "overridden below"}`
       : `${writes.length} keys · ${survived.length === writes.length ? "win" : `${survived.length} win`}`;
   // The note states the conflict this rule is part of, if any: who rewrote its
-  // keys, or — when everything survived — whose earlier write it rewrote.
+  // keys, or — when everything survived — whose LAST earlier write it rewrote
+  // (before that one, the value on the table is not the one this rule replaced).
   const lost = writes.find((w) => !w.survived);
   if (lost?.overriddenBy !== undefined) {
     return {
@@ -232,7 +233,7 @@ function buildWrites(
   }
   const beaten = mergeSteps
     .slice(0, stopIndex)
-    .find((earlier) => earlier.merged.some((m) => writes.some((w) => w.key === m.key)));
+    .findLast((earlier) => earlier.merged.some((m) => writes.some((w) => w.key === m.key)));
   if (beaten) {
     const key = writes.find((w) => beaten.merged.some((m) => m.key === w.key));
     return {
@@ -290,8 +291,12 @@ function failingClauseNote(rule: RuleEvaluation): string {
 function clauseAxis(key: string): string {
   const stripped = key.replace(/^match/, "").replace(/^exclude/, "");
   const spaced = stripped.replace(/([a-z])([A-Z])/g, "$1 $2").toLowerCase();
-  // The registry's plural keys name the axis in the singular.
-  return spaced.replace(/ies$/, "y").replace(/s$/, "");
+  // The registry's plural keys name the axis in the singular; the sibilant step
+  // is why `matchBaseBranches` does not come out as "base branche".
+  return spaced
+    .replace(/ies$/, "y")
+    .replace(/(ch|sh|s|x|z)es$/, "$1")
+    .replace(/s$/, "");
 }
 
 function failingAxis(rule: RuleEvaluation): string | undefined {
@@ -515,8 +520,9 @@ export function buildPinOutcome(
   sim: SimulationResult,
   layerByIndex: Map<number, ProvenanceLayer>,
   attribution: RuleAttribution[] | null | undefined,
-  /** What the funnel calls the dependency — for the replacements bucket's
-   *  "{dep} hasn't been renamed" reason. */
+  /** The dependency's RAW name (`pinDepName`, not `pinName`) — for the
+   *  replacements bucket's "{dep} hasn't been renamed" reason; `""` means the
+   *  form names no package, and the bucket drops the name from the sentence. */
   depName = "",
 ): PinOutcome {
   const matched: PinMatchedRule[] = [];

--- a/packages/app/src/features/simulator/pins.test.ts
+++ b/packages/app/src/features/simulator/pins.test.ts
@@ -7,9 +7,11 @@ import { EMPTY_FORM } from "./form";
 import {
   MAX_PINS,
   pinContext,
+  pinDepName,
   pinFormFromShareFields,
   pinName,
   pinsFromShareFields,
+  pinSubject,
   samePinForm,
 } from "./pins";
 import { pinShareFields } from "./pins";
@@ -70,6 +72,22 @@ describe("how a pin names itself", () => {
     expect(pinName({ ...EMPTY_FORM, packageName: "react", depName: "react-dom" })).toBe("react");
     expect(pinName({ ...EMPTY_FORM, depName: "react-dom" })).toBe("react-dom");
     expect(pinName(EMPTY_FORM)).toBe("(no package name)");
+  });
+
+  // The placeholder is display only: a derivation given it would print
+  // "(no package name) hasn’t been renamed" in the replacements bucket.
+  test("the raw name a derivation takes is empty when the form names neither field", () => {
+    expect(pinDepName({ ...EMPTY_FORM, packageName: "react", depName: "react-dom" })).toBe("react");
+    expect(pinDepName({ ...EMPTY_FORM, depName: "react-dom" })).toBe("react-dom");
+    expect(pinDepName(EMPTY_FORM)).toBe("");
+  });
+
+  test("the probe's subject leads with the name and falls back on a blank run type", () => {
+    const form = { ...EMPTY_FORM, depName: "react", manager: "npm", updateType: "patch" };
+    expect(pinSubject(form, "minor")).toBe("react · npm · minor");
+    // Falsy, not nullish: an empty flattened updateType keeps the stored one,
+    // so the body prose and the card header agree.
+    expect(pinSubject(form, "  ")).toBe("react · npm · patch");
   });
 
   test("the muted line prefers the run's own updateType over the stored one", () => {

--- a/packages/app/src/features/simulator/pins.ts
+++ b/packages/app/src/features/simulator/pins.ts
@@ -84,13 +84,21 @@ export function pinsFromShareFields(
   return pins;
 }
 
+/** The dependency's own name, or `""` when the form names neither field —
+ *  what a derivation gets, before any display placeholder. */
+export function pinDepName(form: FormState): string {
+  return form.packageName.trim() || form.depName.trim();
+}
+
 /**
  * What the card's header calls the pin — the same pair the simulator's stale
  * banner names a run by (`packageName` falling back to `depName`), because they
  * are the same descriptor and a reader must be able to tell one from the other.
+ * Display only: derivations take {@link pinDepName}, whose `""` says the form
+ * names no package at all.
  */
 export function pinName(form: FormState): string {
-  return form.packageName.trim() || form.depName.trim() || "(no package name)";
+  return pinDepName(form) || "(no package name)";
 }
 
 /**
@@ -106,7 +114,29 @@ export function pinContext(form: FormState, effectiveUpdateType: string): string
   const current = form.currentValue.trim();
   const next = form.newValue.trim();
   const move = current !== "" && next !== "" ? `${current} → ${next}` : current || next;
-  const source = form.manager.trim() || form.datasource.trim();
-  const updateType = effectiveUpdateType.trim() || form.updateType.trim();
-  return [move, source, updateType].filter((part) => part !== "").join(" · ");
+  return [move, pinSource(form), pinUpdateType(form, effectiveUpdateType)]
+    .filter((part) => part !== "")
+    .join(" · ");
+}
+
+/**
+ * The prose subject the probe reads back as "Why it matched X" — `react ·
+ * npm · minor`: name first and no version move, unlike {@link pinContext}'s
+ * move-first header line. Same source and update-type fallbacks as that one.
+ */
+export function pinSubject(form: FormState, effectiveUpdateType: string): string {
+  return [pinName(form), pinSource(form), pinUpdateType(form, effectiveUpdateType)]
+    .filter((part) => part !== "")
+    .join(" · ");
+}
+
+/** A descriptor that names only one of the two still has to read as something. */
+function pinSource(form: FormState): string {
+  return form.manager.trim() || form.datasource.trim();
+}
+
+/** The EFFECTIVE type from the evaluation when there is one — a derived type is
+ *  what actually drove the run. */
+function pinUpdateType(form: FormState, effectiveUpdateType: string): string {
+  return effectiveUpdateType.trim() || form.updateType.trim();
 }

--- a/packages/app/src/features/simulator/use-one-off-simulation.ts
+++ b/packages/app/src/features/simulator/use-one-off-simulation.ts
@@ -7,7 +7,7 @@ import type {
 import type { FormState } from "@/types/simulator";
 import { errorMessage } from "@/lib/errors";
 import { buildPinOutcome, type PinOutcome } from "./pin-outcome";
-import { pinName } from "./pins";
+import { pinDepName } from "./pins";
 import { runSimulation } from "./run-simulation";
 
 /**
@@ -46,7 +46,7 @@ export interface OneOffSimulation {
   /** The last failure, or null — a run that threw says so, and clears `oneOff`
    *  so it says it INSTEAD of a verdict. Same staleness check as `oneOff`. */
   error: OneOffError | null;
-  /** In flight. The submit control reads this to disable itself. */
+  /** In flight. The submit control reads this to disable and relabel itself. */
   simulating: boolean;
   /** Run the form once against the current result. A no-op while one is in
    *  flight, or when the form does not pass the caller's guard. */
@@ -83,7 +83,7 @@ export function useOneOffSimulation(host: OneOffSimulationHost): OneOffSimulatio
       const snapshot = { ...form };
       runSimulation(finalConfig, snapshot, updateTypeTouched)
         .then(({ sim, effectiveUpdateType: ranType }) => {
-          const outcome = buildPinOutcome(sim, layerByIndex, attribution, pinName(snapshot));
+          const outcome = buildPinOutcome(sim, layerByIndex, attribution, pinDepName(snapshot));
           setOneOff({ result, form: snapshot, outcome, effectiveUpdateType: ranType });
           return undefined;
         })

--- a/packages/app/src/features/simulator/use-repo-deps.test.tsx
+++ b/packages/app/src/features/simulator/use-repo-deps.test.tsx
@@ -1,0 +1,90 @@
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, expect, it, vi } from "vitest";
+import { type CustomManagerBlocks, type RepoDeps, useRepoDeps } from "./use-repo-deps";
+import { EMPTY_REPO_DEPS } from "./repo-deps";
+import type { LoadedRepo } from "@/types/repo";
+
+/**
+ * The invalidation half of discovery: `ensure`'s IDENTITY is what re-fires the
+ * shell's effect (its other deps are only which tab is open), so a callback
+ * that outlived the discovery key left an already-open Dependencies tab or
+ * Extract phase stranded on "Reading …'s package files…" forever.
+ */
+
+const { loadEngine, loadRepoTree, loadRepoFile } = vi.hoisted(() => ({
+  loadEngine: vi.fn(),
+  loadRepoTree: vi.fn(),
+  loadRepoFile: vi.fn(),
+}));
+vi.mock("@/platform/engine-chunk", () => ({ loadEngine }));
+vi.mock("@/platform/run", () => ({ loadRepoTree, loadRepoFile }));
+
+const REPO: LoadedRepo = { platform: "github", repo: "acme/app", suppressTokens: false };
+
+/** The hook's latest return, published from an effect rather than from render
+ *  (`react(globals)`) — which is also when the assertions read it. */
+const seen: RepoDeps = { ensure: () => undefined, view: EMPTY_REPO_DEPS };
+
+function Harness({ customManagers }: { customManagers: CustomManagerBlocks }) {
+  const deps = useRepoDeps(REPO, customManagers);
+  useEffect(() => {
+    seen.ensure = deps.ensure;
+    seen.view = deps.view;
+  });
+  return null;
+}
+
+beforeEach(() => {
+  seen.ensure = () => undefined;
+  seen.view = EMPTY_REPO_DEPS;
+  loadRepoTree.mockReset();
+  loadRepoTree.mockResolvedValue({ paths: [], truncated: false });
+  loadEngine.mockReset();
+  loadEngine.mockResolvedValue({
+    matchExtractableManagers: () => ({
+      files: [],
+      managersConsidered: 3,
+      customManagersConsidered: 0,
+    }),
+  });
+});
+
+it("re-fires discovery when the custom-manager key changes under an open tab", async () => {
+  const view = render(<Harness customManagers={[]} />);
+  const first = seen.ensure;
+  await act(async () => {
+    first();
+  });
+  expect(seen.view.status).toBe("ready");
+  expect(loadRepoTree).toHaveBeenCalledTimes(1);
+
+  // A run whose blocks differ walks a different repository: the report on
+  // screen stops being the displayed view…
+  view.rerender(<Harness customManagers={[{ customType: "regex" }]} />);
+  await act(async () => undefined);
+  expect(seen.view.status).toBe("idle");
+  // …and the callback the shell's effect depends on moved with it, which is
+  // the only thing that asks for the new walk.
+  expect(seen.ensure).not.toBe(first);
+  await act(async () => {
+    seen.ensure();
+  });
+  expect(loadRepoTree).toHaveBeenCalledTimes(2);
+  expect(seen.view.status).toBe("ready");
+});
+
+it("keeps ensure stable while the key does not move, so the doors never discover twice", async () => {
+  const view = render(<Harness customManagers={[]} />);
+  const first = seen.ensure;
+  await act(async () => {
+    first();
+  });
+  view.rerender(<Harness customManagers={[]} />);
+  await act(async () => undefined);
+  expect(seen.ensure).toBe(first);
+  await act(async () => {
+    seen.ensure();
+  });
+  expect(loadRepoTree).toHaveBeenCalledTimes(1);
+});

--- a/packages/app/src/features/simulator/use-repo-deps.ts
+++ b/packages/app/src/features/simulator/use-repo-deps.ts
@@ -15,6 +15,11 @@
  * stops being the displayed view), so nothing here writes state during render —
  * and a superseded discovery's late settlement is dropped by attempt token, so
  * it can never clobber the fresh view.
+ *
+ * `ensure`'s IDENTITY is keyed to that discovery key, deliberately: the shell's
+ * doors fire it from an effect whose only other deps are which tab is open, so
+ * a stable callback would leave an already-open tab on the idle fallback
+ * forever.
  */
 import { useCallback, useMemo, useRef, useState } from "react";
 import { jsonText } from "@renovate-config-debugger/engine/json";
@@ -274,17 +279,18 @@ export function useRepoDeps(
   // Read the same way as the repo: the on-open trigger must walk with the
   // blocks the CURRENT run resolved, never a closure's stale set.
   const latestCustom = useLatestRef(customManagers);
+  const currentKey = listableRepo === null ? null : discoveryKey(listableRepo, customManagers);
 
+  // Keyed on `currentKey` deliberately (see the header): the callback closes
+  // over the very key `view` compares against, so its identity is what tells an
+  // already-open door that the report it is waiting for is a different one.
   const ensure = useCallback(() => {
     const repo = latestRepo.current;
-    if (repo === null) {
+    if (repo === null || currentKey === null || startedFor.current === currentKey) {
       return;
     }
     const blocks = latestCustom.current;
-    const key = discoveryKey(repo, blocks);
-    if (startedFor.current === key) {
-      return;
-    }
+    const key = currentKey;
     startedFor.current = key;
     const token = ++attempt.current;
     setState({ key, view: { ...EMPTY_REPO_DEPS, status: "loading", repo: repo.repo } });
@@ -314,13 +320,12 @@ export function useRepoDeps(
           },
         });
       });
-  }, [latestRepo, latestCustom]);
+  }, [latestRepo, latestCustom, currentKey]);
 
   // The repo label rides on the view even before discovery ran — `repo` being
   // set is what enables the tab that TRIGGERS discovery. Memoized so the
   // run-view provider's identity only moves on a load or an async report.
   const repoName = listableRepo?.repo ?? "";
-  const currentKey = listableRepo === null ? null : discoveryKey(listableRepo, customManagers);
   const view = useMemo(() => {
     const base = state !== null && state.key === currentKey ? state.view : EMPTY_REPO_DEPS;
     return base.repo === repoName ? base : { ...base, repo: repoName };

--- a/packages/app/src/hooks/scroll-ergonomics.ts
+++ b/packages/app/src/hooks/scroll-ergonomics.ts
@@ -83,8 +83,8 @@ export function useHomeEndPageScroll(): void {
       // dialog, the sheet's remaining rows stayed unreachable by a key the
       // sheet itself prints, and closing it revealed a page jumped to the
       // bottom. This is the gate `useShortcut` and `useTabDigits` get from
-      // App's `keysLive`; this hook takes no props, so it asks the ladder's
-      // own modal flag instead of growing a second one.
+      // `keysLive` (`app/use-keyboard-landings.ts`); this hook takes no props,
+      // so it asks the ladder's own modal flag instead of growing a second one.
       if (modalKeyboardOwned()) {
         return;
       }

--- a/packages/app/src/lib/consumed-blocks.test.ts
+++ b/packages/app/src/lib/consumed-blocks.test.ts
@@ -1,6 +1,6 @@
-import type { SimulationResult } from "@renovate-config-debugger/engine";
+import type { RuleAttribution, SimulationResult } from "@renovate-config-debugger/engine";
 import { describe, expect, test } from "vitest";
-import { simResult } from "@tools/test/simulation";
+import { ruleEval, simResult } from "@tools/test/simulation";
 import { appliedUpdateTypeBlock, consumedAuthoredBlocks } from "./consumed-blocks";
 
 /**
@@ -12,6 +12,18 @@ import { appliedUpdateTypeBlock, consumedAuthoredBlocks } from "./consumed-block
  */
 function simFixture(flattened: Partial<SimulationResult["flattened"]> = {}): SimulationResult {
   return simResult({ flattened: { merged: [], blocks: {}, authoredBlocks: [], ...flattened } });
+}
+
+/** One matched rule set the `major` block, so the attribution chip is unambiguous. */
+function simWithMajorSetter(): SimulationResult {
+  return simResult({
+    rules: [{ ...ruleEval(0, "matched"), merged: [{ key: "major", after: { automerge: false } }] }],
+    flattened: {
+      merged: [],
+      blocks: { major: { automerge: false } },
+      authoredBlocks: ["major"],
+    },
+  });
 }
 
 describe("appliedUpdateTypeBlock", () => {
@@ -66,5 +78,32 @@ describe("consumedAuthoredBlocks", () => {
     expect(consumedAuthoredBlocks(sim, null)).toEqual([
       { key: "major", keys: ["automerge"], layer: undefined },
     ]);
+  });
+});
+
+describe("the attribution chip's layer", () => {
+  const directExtend = { kind: "preset", nodeId: "n1", name: "config:best-practices" } as const;
+
+  test("credits the ORIGINATING preset body, not the direct extend it arrived through", () => {
+    const attribution: RuleAttribution[] = [
+      {
+        index: 0,
+        layer: directExtend,
+        sourceIndex: 0,
+        writtenBy: { nodeId: "n2", name: "security:minimumReleaseAgeNpm", sourceIndex: 0 },
+      },
+    ];
+    expect(consumedAuthoredBlocks(simWithMajorSetter(), attribution)[0]?.layer).toEqual({
+      kind: "preset",
+      nodeId: "n2",
+      name: "security:minimumReleaseAgeNpm",
+    });
+  });
+
+  test("falls back to the direct extend when the engine verified no writer", () => {
+    const attribution: RuleAttribution[] = [{ index: 0, layer: directExtend, sourceIndex: 0 }];
+    expect(consumedAuthoredBlocks(simWithMajorSetter(), attribution)[0]?.layer).toEqual(
+      directExtend,
+    );
   });
 });

--- a/packages/app/src/lib/consumed-blocks.ts
+++ b/packages/app/src/lib/consumed-blocks.ts
@@ -3,6 +3,7 @@ import type {
   RuleAttribution,
   SimulationResult,
 } from "@renovate-config-debugger/engine";
+import { ruleOriginLayer } from "./rule-filters";
 
 /**
  * Roadmap 047: an update-type block the USER authored (per the engine's
@@ -28,6 +29,10 @@ export interface ConsumedBlock {
  * to the whole block: only when EXACTLY ONE matched rule merged that key, and
  * only when that rule traces to a preset. A block that came from the base
  * config, or one several rules touched, is left uncredited rather than guessed.
+ *
+ * The preset credited is the ORIGINATING body, via `ruleOriginLayer`
+ * (rule-filters.ts) — the nested preset that wrote the rule, not the direct
+ * extend it arrived through.
  */
 function blockSourceLayer(
   sim: SimulationResult,
@@ -41,7 +46,8 @@ function blockSourceLayer(
     return undefined;
   }
   const attribution = ruleAttribution?.find((a) => a.index === setters[0]?.index);
-  return attribution?.layer.kind === "preset" ? attribution.layer : undefined;
+  const origin = attribution ? ruleOriginLayer(attribution) : undefined;
+  return origin?.kind === "preset" ? origin : undefined;
 }
 
 export function consumedAuthoredBlocks(

--- a/packages/app/src/lib/escape-stack.test.ts
+++ b/packages/app/src/lib/escape-stack.test.ts
@@ -229,8 +229,9 @@ describe("overlay keyboard ownership", () => {
 
   it("is not the modal question", () => {
     // A modal takes the keyboard through `claimModalKeyboard`, and the bare
-    // keys are switched off by App's `keysLive` while the sheet is up. Nothing
-    // is layered over the page here, and this query must not pretend otherwise.
+    // keys are switched off by `keysLive` (`app/use-keyboard-landings.ts`)
+    // while the sheet is up. Nothing is layered over the page here, and this
+    // query must not pretend otherwise.
     const release = modal();
     expect(overlayKeyboardOwned()).toBe(false);
     release();

--- a/packages/app/src/lib/escape-stack.ts
+++ b/packages/app/src/lib/escape-stack.ts
@@ -171,8 +171,9 @@ function topLayer(): EscapeLayer | undefined {
  * than the confusion it prevents.
  *
  * Modal surfaces are NOT counted here: they are `modalKeyboardOwned()`, and the
- * bare keys are already switched off while the `?` sheet is up (App's
- * `keysLive`, which is what the sheet's own `enabled` flags read).
+ * bare keys are already switched off while the `?` sheet is up (`keysLive` in
+ * `app/use-keyboard-landings.ts`, which is what the sheet's own `enabled` flags
+ * read).
  *
  * What a layer of these two ranks owes in return, since this is the only thing
  * that reads the rank and it has no way to check: it must not outlive the

--- a/packages/app/src/lib/headless.ts
+++ b/packages/app/src/lib/headless.ts
@@ -31,7 +31,7 @@ export {
 } from "./consumed-blocks";
 export { effectiveTally, isOverridden, multiContribBadgeKind } from "./effective-tally";
 export { nf, plural } from "./format";
-export { parseLayerJson } from "./input-schemas";
+export { isValidConfigObject, parseLayerJson } from "./input-schemas";
 export { crossRuleIndex, ruleIndexInMessage, type RuleMessageIndexKind } from "./rule-cross-index";
 export {
   filterRulesBySource,

--- a/packages/app/src/lib/input-schemas.test.ts
+++ b/packages/app/src/lib/input-schemas.test.ts
@@ -555,7 +555,15 @@ describe("stageIdSchema / resultsTabIdSchema", () => {
     expect(stageIdSchema.safeParse("bogus").success).toBe(false);
   });
   test("accepts every real tab id", () => {
-    for (const tab of ["overview", "tests", "pipeline", "presets", "effective", "problems"]) {
+    for (const tab of [
+      "overview",
+      "tests",
+      "pipeline",
+      "presets",
+      "effective",
+      "deps",
+      "problems",
+    ]) {
       expect(resultsTabIdSchema.safeParse(tab).success).toBe(true);
     }
   });

--- a/packages/app/src/lib/input-schemas.ts
+++ b/packages/app/src/lib/input-schemas.ts
@@ -15,7 +15,7 @@
  * schemes in endpoint fields reaching a `fetch`, header injection via tokens,
  * and type confusion crashing or misdirecting downstream code. These two
  * modules are the one place all of that gets checked; callers (share.ts,
- * App.tsx, oauth.ts, PresetTree.tsx) replace their ad hoc checks with these.
+ * App.tsx, oauth.ts, PresetDetail.tsx) replace their ad hoc checks with these.
  *
  * Everything here is a BOUNDARY rule — this app's threat model, with no second
  * copy anywhere. Plain type checks are not: `isPlainObject` and friends come
@@ -302,8 +302,9 @@ export interface LayerParseResult {
  * own error text verbatim (unchanged — the field's error message has always
  * been "Not valid JSON: <native message>", no translation layer to preserve
  * here). A value that parses but isn't usable keeps the EXACT existing
- * string `"must be a JSON object"` so the two `layer-editor-error` render
- * sites (App.tsx) and anything depending on that text keep reading the same
+ * string `"must be a JSON object"` so the `parse.error` row in
+ * `features/pipeline/StageLayerEditor.tsx` (rendered once per layer by
+ * `PipelinePanel`) and anything depending on that text keep reading the same
  * way — now covering the pollution case too (a `__proto__`/`constructor`/
  * `prototype` key anywhere in the layer, including nested `packageRules[n]`,
  * is rejected with the same message rather than silently reaching a merge).
@@ -326,7 +327,8 @@ export function parseLayerJson(text: string): LayerParseResult {
 }
 
 // ---------------------------------------------------------------------------
-// Repo-load input (use-repo-load's `parseRepoRef` result, before request building)
+// Repo-load input (`lib/repo-reference.ts`'s `parseRepoReference` result, as
+// use-repo-load holds it, before request building)
 // ---------------------------------------------------------------------------
 
 const MAX_REPO_REF_LENGTH = 512;
@@ -364,8 +366,8 @@ export function isValidRepoRefPart(value: string): boolean {
  *  optional `:port` — a self-hosted reference like `gitea.example.com:3000/o/r`
  *  must keep reaching the "Unknown host … set its endpoint under Advanced
  *  options" guidance rather than the generic "not a repo reference" refusal.
- *  The host never composes a URL (it only looks up `data/host-tokens`'
- *  `HOST_PLATFORM`). */
+ *  The host never composes a URL (it only reaches `data/host-tokens`'
+ *  `platformForHost`). */
 export function isValidRepoHost(value: string): boolean {
   if (value.length > MAX_REPO_REF_LENGTH) {
     return false;

--- a/packages/app/src/lib/rule-verdict.ts
+++ b/packages/app/src/lib/rule-verdict.ts
@@ -36,7 +36,9 @@
  * Renovate. `.oxlintrc.json` bans the root spelling under
  * `packages/app/src/**` so it cannot come back, and
  * `src/oxlint-boundaries.test.ts` keeps that ban from being dropped by an
- * override that forgets to restate it.
+ * override that forgets to restate it. The half that ban does not cover — the
+ * subpath's own closure staying Renovate-free — is
+ * `engine/test/import-free-subpaths.node.test.ts`.
  */
 export {
   hasEvaluationError,

--- a/packages/app/src/lib/verdict-sentence.test.ts
+++ b/packages/app/src/lib/verdict-sentence.test.ts
@@ -96,6 +96,35 @@ describe("buildVerdictSegments", () => {
     );
   });
 
+  test("the credited preset is the body that WROTE the rule, not the extend it came through", () => {
+    const sim = simFixture(
+      {},
+      {
+        flattened: { merged: [], blocks: { minor: { automerge: true } }, authoredBlocks: [] },
+        rules: [
+          {
+            index: 5,
+            verdict: "matched",
+            clauses: [],
+            notes: [],
+            merged: [{ key: "minor", after: { automerge: true } }],
+          },
+        ],
+      },
+    );
+    const attribution: RuleAttribution[] = [
+      {
+        index: 5,
+        sourceIndex: 0,
+        layer: { kind: "preset", nodeId: "n1", name: "config:best-practices" },
+        writtenBy: { nodeId: "n2", name: ":automergeMinor", sourceIndex: 0 },
+      },
+    ];
+    expect(verdictText(buildVerdictSegments(sim, "major", [], attribution))).toContain(
+      "from `:automergeMinor`",
+    );
+  });
+
   test("scoped automerge without a traceable source stays uncredited", () => {
     const sim = simFixture(
       {},

--- a/packages/app/src/lib/verdict-sentence.ts
+++ b/packages/app/src/lib/verdict-sentence.ts
@@ -2,6 +2,7 @@ import type { RuleAttribution, SimulationResult } from "@renovate-config-debugge
 import { isNonEmptyString, isPlainObject, isString } from "@renovate-config-debugger/engine/is";
 import { jsonText } from "@renovate-config-debugger/engine/json";
 import { pluralWord } from "./format";
+import { ruleOriginLayer } from "./rule-filters";
 import { isFailingClause } from "./rule-verdict";
 
 /** A config value in a plain-language sentence: `[a, b]`, `"x"`, `42`. */
@@ -41,6 +42,9 @@ function isNoopSchedule(schedule: unknown[]): boolean {
  * the preset that rule came from, for the verdict sentence's "from
  * `:automergeMinor`" attribution. Best-effort from data the simulator and
  * `computeRuleProvenance` already compute; no new provenance tracking.
+ *
+ * The preset named is the ORIGINATING body, via `ruleOriginLayer`
+ * (rule-filters.ts) — not the direct extend the rule arrived through.
  */
 function automergeScopeSource(
   sim: SimulationResult,
@@ -58,7 +62,8 @@ function automergeScopeSource(
     return undefined;
   }
   const attribution = ruleAttribution?.find((a) => a.index === rule.index);
-  return attribution?.layer.kind === "preset" ? attribution.layer.name : undefined;
+  const origin = attribution ? ruleOriginLayer(attribution) : undefined;
+  return origin?.kind === "preset" ? origin.name : undefined;
 }
 
 /**

--- a/packages/app/src/platform/analytics.init.test.tsx
+++ b/packages/app/src/platform/analytics.init.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { initAnalytics } from "./analytics";
+
+/**
+ * The WIRING half of roadmap 053: `initAnalytics` itself, which
+ * `analytics.config.test.ts` (node-env, pure functions) cannot reach. The one
+ * line that keeps the share fragment and the OAuth `?code=` out of Google —
+ * `gtag("config", id, { page_location })` — is only observable through the
+ * `dataLayer` this suite reads, so dropping that third argument must fail here.
+ *
+ * `.tsx` for the jsdom "components" project: it needs a DOM, not React.
+ */
+
+const GTAG_SRC = 'script[src*="googletagmanager"]';
+
+function trackWith(measurementId: string): void {
+  globalThis.__RCD_ANALYTICS__ = { measurementId };
+}
+
+/** The `config` call's arguments — gtag pushes `arguments` objects, so the
+ *  entries are indexed, never spread. */
+function configCall(): Record<number, unknown> | undefined {
+  return (window.dataLayer ?? [])
+    .map((entry) => entry as Record<number, unknown>)
+    .find((entry) => entry[0] === "config");
+}
+
+afterEach(() => {
+  globalThis.__RCD_ANALYTICS__ = undefined;
+  window.dataLayer = undefined;
+  for (const script of document.head.querySelectorAll(GTAG_SRC)) {
+    script.remove();
+  }
+  // jsdom keeps the URL across tests; `replaceState` is the only way to set it
+  // without a "Not implemented: navigation" error.
+  window.history.replaceState(null, "", "/");
+});
+
+describe("initAnalytics", () => {
+  test("reports the bare page, never the OAuth code or the share fragment", () => {
+    trackWith("G-TEST123");
+    window.history.replaceState(null, "", "/?code=abc123#config=eJy");
+
+    initAnalytics();
+
+    const pageLocation = configCall()?.[2] as { page_location?: string } | undefined;
+    expect(pageLocation?.page_location).toBe(`${window.location.origin}/`);
+    expect(pageLocation?.page_location).not.toContain("#");
+    expect(pageLocation?.page_location).not.toContain("?");
+  });
+
+  test("without an id nothing is loaded and nothing is queued", () => {
+    initAnalytics();
+
+    expect(window.dataLayer).toBeUndefined();
+    expect(document.head.querySelector(GTAG_SRC)).toBeNull();
+  });
+});

--- a/packages/app/src/platform/oauth.session.test.ts
+++ b/packages/app/src/platform/oauth.session.test.ts
@@ -191,6 +191,20 @@ describe("getValidToken (cookie-session refresh)", () => {
     expect(local.map.has(COOKIE_SESSION_KEY)).toBe(false);
     expect(fetchCalls(`${WORKER_URL}/logout`)).toHaveLength(1);
   });
+
+  test("a definitive rejection notifies THIS tab, not only the siblings", async () => {
+    seedExpiredCookieSession();
+    setRefreshResponse(() => jsonResponse({ error: "bad_refresh_token" }, 400));
+    const { getValidToken, onSessionBroadcast } = await freshOAuth();
+    let notified = 0;
+    onSessionBroadcast(() => {
+      notified += 1;
+    });
+
+    await getValidToken();
+    // Without this the tab whose session died keeps rendering "signed in".
+    expect(notified).toBe(1);
+  });
 });
 
 describe("signOut", () => {
@@ -203,6 +217,20 @@ describe("signOut", () => {
     const [, init] = fetchCalls(`${WORKER_URL}/logout`)[0] ?? [];
     expect(init?.method).toBe("POST");
     expect(init?.credentials).toBe("include");
+  });
+
+  test("notifies this tab's own listeners, with the session already gone", async () => {
+    local.map.set(COOKIE_SESSION_KEY, String(Date.now() + 60_000));
+    const { signOut, isSignedIn, onSessionBroadcast } = await freshOAuth();
+    const seen: boolean[] = [];
+    onSessionBroadcast(() => {
+      seen.push(isSignedIn());
+    });
+
+    signOut();
+    // Reading false FROM INSIDE the listener is the invariant: the teardown
+    // (memLoaded included) completes before anyone is told.
+    expect(seen).toEqual([false]);
   });
 
   test("a failing /logout never surfaces (sign-out is synchronous and total)", async () => {

--- a/packages/app/src/platform/oauth.ts
+++ b/packages/app/src/platform/oauth.ts
@@ -368,9 +368,10 @@ function receiveBroadcast(data: unknown): void {
 
 const sessionListeners = new Set<() => void>();
 
-/** Cross-tab session changes land outside any React event (a sibling's
- *  refresh signing this tab in, its sign-out tearing this tab down), so the
- *  UI layer subscribes here and re-reads `isSignedIn()`/`getStoredUser()`.
+/** Session changes that land outside any React event — a sibling's refresh
+ *  signing this tab in or its sign-out tearing this tab down, and this tab's
+ *  own internal `signOut()` (an expired or revoked grant) — so the UI layer
+ *  subscribes here and re-reads `isSignedIn()`/`getStoredUser()`.
  *  Returns the unsubscribe. */
 export function onSessionBroadcast(listener: () => void): () => void {
   sessionListeners.add(listener);
@@ -859,6 +860,10 @@ export async function getValidToken(): Promise<string | null> {
  * server-side lifetime, which the dropped marker already stops the app from
  * using. `postWorker` is deliberately NOT reused: it expects a token JSON
  * body and throws on anything that isn't one.
+ *
+ * Notifies THIS tab's session listeners too, last: the internal callers
+ * (an expired grant, a definitive `/refresh` rejection) leave no React event
+ * behind, and a sibling already learns through the broadcast.
  */
 export function signOut(): void {
   clearLocalSession();
@@ -871,6 +876,7 @@ export function signOut(): void {
       () => {},
     );
   }
+  notifySessionChanged();
 }
 
 /** This tab's session teardown alone — what a sibling's "signout" broadcast

--- a/packages/app/src/platform/run.ts
+++ b/packages/app/src/platform/run.ts
@@ -40,7 +40,9 @@ function sessionToken(key: string): string | undefined {
   return value !== null && isValidToken(value) ? value : undefined;
 }
 
-export interface RunOptions {
+/** What a run may ask of its CREDENTIALS — App.tsx's own `RunOptions` is the
+ *  caller-side shape, and forwards its `suppressTokens` into this one. */
+export interface RunAuthOptions {
   /**
    * Security 2026-07-25: run with NO credentials at all. Set while an
    * `UntrustedEndpointGuard` stands — a share link pointed the platform
@@ -62,7 +64,7 @@ export interface RunOptions {
  * 076's custom credential rows ride along in the same object as `hostRules`,
  * so the `suppressTokens` overwrite below covers them too.
  */
-function applyAuth(engine: Engine, oauthToken: string | null, opts?: RunOptions): void {
+function applyAuth(engine: Engine, oauthToken: string | null, opts?: RunAuthOptions): void {
   if (opts?.suppressTokens) {
     // Overwrite (never just skip): `setPresetAuth` replaces module state a
     // PREVIOUS run may have populated, so this is what actually guarantees no
@@ -124,7 +126,7 @@ function makeAuthRefreshHandler(engine: Engine): AuthRefreshHandler {
  * exactly as before, no refresh request leaves the browser for a run that
  * must not use credentials, and no revoked-token recovery may re-attach one.
  */
-async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
+async function engineWithAuth(opts?: RunAuthOptions): Promise<Engine> {
   const [engine, oauthToken] = await Promise.all([
     loadEngine(),
     opts?.suppressTokens ? null : getValidToken(),
@@ -138,7 +140,7 @@ async function engineWithAuth(opts?: RunOptions): Promise<Engine> {
  * `loadEngine` keeps the heavy renovate chunk out of the initial page load;
  * Vite code-splits it automatically behind that call.
  */
-export async function run(input: PipelineInput, opts?: RunOptions): Promise<TraceResult> {
+export async function run(input: PipelineInput, opts?: RunAuthOptions): Promise<TraceResult> {
   const engine = await engineWithAuth(opts);
   return engine.runPipeline(input);
 }
@@ -198,7 +200,7 @@ export async function extractPackageJsonConfig(raw: string): Promise<string | nu
  *  a share link chose must not carry credentials either. */
 export async function loadRepoConfig(
   req: RepoConfigRequest,
-  opts?: RunOptions,
+  opts?: RunAuthOptions,
 ): Promise<RepoConfigResult> {
   const engine = await engineWithAuth(opts);
   return engine.fetchRepoConfig(req);
@@ -210,7 +212,7 @@ export async function loadRepoConfig(
  *  it follows did. */
 export async function loadRepoFile(
   req: RepoFileRequest,
-  opts?: RunOptions,
+  opts?: RunAuthOptions,
 ): Promise<string | null> {
   const engine = await engineWithAuth(opts);
   return engine.fetchRepoFile(req);
@@ -222,7 +224,7 @@ export async function loadRepoFile(
  *  load it follows did. */
 export async function loadRepoTree(
   req: RepoTreeRequest,
-  opts?: RunOptions,
+  opts?: RunAuthOptions,
 ): Promise<RepoTreeResult> {
   const engine = await engineWithAuth(opts);
   return engine.fetchRepoTree(req);

--- a/packages/app/src/styles/10-messages-tabs.css
+++ b/packages/app/src/styles/10-messages-tabs.css
@@ -634,6 +634,14 @@
     gap: 0.75rem;
   }
 
+  /* ConfigColumn's always-mounted live regions: empty, neither may spend one of
+     the column's flex gaps. Never `display: none` — a hidden region cannot
+     announce (same trade as `.pin-add-panel > [role="alert"]:empty`). */
+  .app-split.has-results > .config-col > [role="alert"]:empty,
+  .app-split.has-results > .config-col > [role="status"]:empty {
+    margin-block: -0.375rem;
+  }
+
   .app-split.has-results .editor-shell {
     display: flex;
     flex: 1 1 auto;

--- a/packages/app/src/styles/13-effective.css
+++ b/packages/app/src/styles/13-effective.css
@@ -2,7 +2,7 @@
    ORDER IS LOAD-BEARING: main.tsx imports these numbered files in sequence,
    preserving the original file's cascade byte-for-byte; the couplings that
    depend on that order are listed there.
-   This file: the effective config's blame ledger and point-of-contact attribution (069). */
+   This file: the effective config's blame ledger and point-of-contact attribution (069), and the headless note at the foot of the page (060, `components/HeadlessNote.tsx`). */
 
 /* ---------- 069 PR 3: the description row's blame ledger ----------
 

--- a/packages/app/src/styles/16-tabs.css
+++ b/packages/app/src/styles/16-tabs.css
@@ -7,12 +7,13 @@
    across the cascade for it (`.pin-add-tabs .tab`) — a second, unrelated
    surface styling a primitive out of a feature's stylesheet.
 
-   WHY THIS FILE IS LAST, not up with 01-shell / 02-controls where a primitive
-   belongs by rights: the numbering encodes the pre-split `index.css` cascade
-   byte-for-byte (see main.tsx), so renumbering thirteen files to slot this in
-   would put the documented equal-specificity couplings at risk for a purely
-   cosmetic gain — it would move 10 above 01 (`main.app-shell`) or 03 above 02
-   (`.seg button`). Appending is the move main.tsx's own header sanctions.
+   WHY THIS FILE WAS APPENDED rather than renumbered up with 01-shell /
+   02-controls where a primitive belongs by rights: the numbering encodes the
+   pre-split `index.css` cascade byte-for-byte (see main.tsx), so renumbering
+   thirteen files to slot this in would put the documented equal-specificity
+   couplings at risk for a purely cosmetic gain — it would move 10 above 01
+   (`main.app-shell`) or 03 above 02 (`.seg button`). Appending is the move
+   main.tsx's own header sanctions.
 
    Verified safe before moving: the only rules outside this block that target
    `.tab` or `.tab-bar` are `15-pins.css`'s `.pin-add-tabs .tab` and

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -335,6 +335,8 @@ adding an entry to the array a rule matches on rewrites that rule's selector
 text — and the parenthetical says WHICH kind of rewrite it was, so
 `clause-added` never reads as a pattern replacement.
 
+</details>
+
 ### Reading the comparison JSON
 
 `--format json` and the MCP `compare_simulations` answer carry the same object.
@@ -483,8 +485,6 @@ re-embed all of it on both sides. An append is now stated as what it appended
 (`{"collapsed": "append", "beforeLength": 22, "afterLength": 24, "added": […]}`)
 — a replacement still shows both sides, and the full array is one
 `rcd provenance renovate.json description` away.
-
-</details>
 
 ## Exit codes
 

--- a/packages/cli/bin/io.mjs
+++ b/packages/cli/bin/io.mjs
@@ -36,6 +36,10 @@ export function processIo() {
  * truncated the answer, so it is reported and sets a nonzero exit code — which
  * both bins preserve (`… = (await main(…)) || process.exitCode`), since the
  * event normally arrives while main is still awaited.
+ *
+ * `test/bin.test.ts`'s "a peer that stops reading is not a crash" covers the
+ * EPIPE arm only; the non-EPIPE arm above, and the exit code it sets, are
+ * still unasserted.
  */
 function guardStdio() {
   if (process.stderr.listenerCount("error") === 0) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,6 +26,7 @@
   },
   "files": [
     "bin",
+    "!bin/rcd-dev.mjs",
     "dist",
     "LICENSE",
     "README.md"

--- a/packages/cli/src/commands/compare.test.ts
+++ b/packages/cli/src/commands/compare.test.ts
@@ -232,6 +232,24 @@ describe("compare", () => {
       { key: "labels", reason: "identical" },
     ]);
   });
+
+  /** Pretty used to print no Config-delta section at all for a withheld key,
+   *  so a global-only or identical key read as "nothing differed". */
+  test("pretty names the withheld keys and why, not just the JSON answer", async () => {
+    const run = await runCli([
+      "compare",
+      fixture("clean.json"),
+      fixture("grouped.json"),
+      "--dep",
+      '{"depName":"react","packageName":"react"}',
+      "--keys",
+      "groupName,onboardingConfig,labels",
+    ]);
+    expect(run.code).toBe(0);
+    expect(run.stdout).toContain("onboardingConfig — global-only");
+    expect(run.stdout).toContain("--config-scope full");
+    expect(run.stdout).toContain("labels — identical");
+  });
 });
 
 /**

--- a/packages/cli/src/commands/compare.ts
+++ b/packages/cli/src/commands/compare.ts
@@ -13,7 +13,12 @@ import {
   wouldRefuse,
 } from "../run-input";
 import { readDependency } from "../dep";
-import { deltaLine, parseConfigScope, parseKeys } from "../projections/config-view";
+import {
+  deltaLine,
+  parseConfigScope,
+  parseKeys,
+  type WithheldKey,
+} from "../projections/config-view";
 import { parseCompareDetail, type ProjectedComparison } from "../projections/simulate";
 import { askCompare } from "../questions/compare";
 import { askSimulation } from "../questions/simulate";
@@ -103,6 +108,26 @@ function identityLines(comparison: ProjectedComparison): string[] {
   ];
 }
 
+const WITHHELD_REASON: Record<WithheldKey["reason"], string> = {
+  "global-only": "global-only (no packageRule can reach it; `--config-scope full` carries it)",
+  identical: "identical (both sides carry it, nothing differed)",
+  absent: "absent (neither side's per-dependency config has it)",
+};
+
+/** The `--keys` names the delta above does not carry, and why: a withheld key
+ *  that prints nothing is indistinguishable from one that did not differ. */
+function withheldLines(comparison: ProjectedComparison): string[] {
+  const withheld = comparison.configView.withheld;
+  if (!withheld || withheld.length === 0) {
+    return [];
+  }
+  return [
+    "",
+    "Requested keys not in the delta above:",
+    ...withheld.map((entry) => `  ${entry.key} — ${WITHHELD_REASON[entry.reason]}`),
+  ];
+}
+
 export const compareCommand: Command = {
   name: "compare",
   summary: "A/B two simulations: prove an edit changed (or didn't change) behavior",
@@ -125,10 +150,11 @@ export const compareCommand: Command = {
     "The key delta is reported at `--config-scope package-rules` (the globalOnly",
     "options no rule can reach are dropped) and `--keys a,b` narrows it further.",
     "Neither touches the verdict: `summary` states what the comparison found",
-    "over the WHOLE delta, and `configView.withheld` names every requested key",
-    "the answer does not carry, with why — `identical` (both sides carry it,",
-    "nothing differs), `absent` (neither side's per-dependency config has it; a",
-    "rule that did not match contributes nothing), or `global-only`.",
+    "over the WHOLE delta, and every requested key the answer does not carry is",
+    "named with why — `identical` (both sides carry it, nothing differs),",
+    "`absent` (neither side's per-dependency config has it; a rule that did not",
+    "match contributes nothing), or `global-only`. In JSON that is",
+    "`configView.withheld`; pretty output lists the same keys under the delta.",
     "",
     "`--detail verdict` (the default) answers with the claim and its evidence,",
     "and states the identity axis as counts; `--detail rules` restores the rule",
@@ -235,6 +261,7 @@ export const compareCommand: Command = {
         ...(comparison.configDelta.length > 0
           ? ["", "Config delta:", ...comparison.configDelta.map((d) => `  ${deltaLine(d)}`)]
           : []),
+        ...withheldLines(comparison),
         ...identityLines(comparison),
         ...(refusal ? ["", refusal] : []),
       ]);

--- a/packages/cli/src/commands/docs.test.ts
+++ b/packages/cli/src/commands/docs.test.ts
@@ -64,4 +64,13 @@ describe("docs", () => {
     expect(run.code).toBe(1);
     expect(run.stderr).toContain("--search");
   });
+
+  /** A second option name used to be dropped in silence, so `docs a b`
+   *  answered about `a` alone and exited 0 — the first name read as the answer. */
+  test("a second option name is an error naming it, not a silently answered first", async () => {
+    const run = await runCli(["docs", "packageRules", "matchDepNames"]);
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain("does not take");
+    expect(run.stderr).toContain("matchDepNames");
+  });
 });

--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -5,6 +5,7 @@ import { CliError, EXIT_OK } from "../io";
 import { emitJson, emitLines } from "../output";
 import { optionDocLines } from "../projections/option-doc";
 import { askOptionDocs } from "../questions/option-docs";
+import { rejectExtraPositionals } from "../run-input";
 
 /**
  * Renovate's own option metadata, for the exact pinned version — so an agent
@@ -26,6 +27,7 @@ export const docsCommand: Command = {
   options: ["search", "format"],
   run(args, io) {
     const format = outputFormat(args);
+    rejectExtraPositionals(args, "docs", 0);
     const query = args.positionals[0];
     if (!query) {
       throw new CliError("name an option, e.g. `rcd docs packageRules`");

--- a/packages/cli/src/commands/extract.test.ts
+++ b/packages/cli/src/commands/extract.test.ts
@@ -121,6 +121,16 @@ describe("extract", () => {
     expect(run.stderr).toContain("name a file");
   });
 
+  /** A second file used to be dropped in silence, so the exit code reported
+   *  the first file's extraction over one that was never read. */
+  test("a second file is an error naming it, not a silent one-file extraction", async () => {
+    const path = await materialize("package.json", "package.json");
+    const run = await runCli(["extract", path, "other/package.json"]);
+    expect(run.code).toBe(1);
+    expect(run.stderr).toContain("does not take");
+    expect(run.stderr).toContain("other/package.json");
+  });
+
   test("--help documents the pattern-less-manager door", async () => {
     const run = await runCli(["extract", "--help"]);
     expect(run.code).toBe(0);

--- a/packages/cli/src/commands/extract.ts
+++ b/packages/cli/src/commands/extract.ts
@@ -4,7 +4,7 @@ import type { Command } from "../command";
 import { CliError, EXIT_ERROR, EXIT_OK } from "../io";
 import { emitJson, emitLines } from "../output";
 import { anySucceeded, askExtraction, type ExtractReport } from "../questions/extract";
-import { readTextFile } from "../run-input";
+import { readTextFile, rejectExtraPositionals } from "../run-input";
 
 /**
  * Roadmap 078's CLI half: "what would Renovate extract from this file?",
@@ -67,6 +67,7 @@ export const extractCommand: Command = {
   options: ["manager", "format"],
   async run(args, io) {
     const format = outputFormat(args);
+    rejectExtraPositionals(args, "extract", 0);
     const file = args.positionals[0];
     if (!file) {
       throw new CliError("name a file, e.g. `rcd extract package.json`");

--- a/packages/cli/src/mcp/server.test.ts
+++ b/packages/cli/src/mcp/server.test.ts
@@ -300,6 +300,20 @@ describe("run_config", () => {
     expect(note).not.toContain("platformOverride: true");
     expect(note).not.toContain("--trust-endpoints");
   });
+
+  /** The layer guard the CLI's `--global-config` has always had: the record
+   *  schema drops a TOP-LEVEL `__proto__`, so the case that reached the
+   *  pipeline over MCP alone is a nested one. `JSON.parse`, not a literal — a
+   *  literal cannot express an own `__proto__` data property (roadmap 030). */
+  test("a polluted config layer is rejected here as it is on the CLI", async () => {
+    await expect(
+      call("run_config", {
+        fileName: "renovate.json",
+        content: CONFIG,
+        globalConfig: JSON.parse('{"packageRules":[{"__proto__":{"x":1}}]}') as unknown,
+      }),
+    ).rejects.toThrow(/globalConfig must be a JSON object/);
+  });
 });
 
 describe("credential isolation", () => {

--- a/packages/cli/src/mcp/server.ts
+++ b/packages/cli/src/mcp/server.ts
@@ -6,6 +6,7 @@ import {
   optionsSourceUrl,
   type ResolvedConfigMode,
   renovateVersion,
+  type RuleAttribution,
   runPipeline,
   type SimulationResult,
   type TraceResult,
@@ -228,6 +229,7 @@ const DEP = z
     datasource: z.string().optional(),
     manager: z.string().optional(),
     depType: z.string().optional(),
+    depTypes: z.array(z.string()).optional(),
     packageFile: z.string().optional(),
     currentValue: z.string().optional(),
     currentVersion: z.string().optional(),
@@ -350,19 +352,36 @@ const CONFIG_SCOPE = z
       "one produced it, in `configView`.",
   );
 
+/** One attribution per held run, not one per message: computing it walks the
+ *  whole preset tree (~1,076 nodes on a `config:recommended` run), and most
+ *  messages never name a `packageRules[N]`. The box is load-bearing —
+ *  `computeRuleProvenance` legitimately answers `undefined`, and a bare
+ *  truthiness memo would re-walk the tree per message for exactly those runs. */
+const ruleAttributions = new WeakMap<TraceResult, { value: RuleAttribution[] | undefined }>();
+
+function ruleAttributionOf(result: TraceResult): RuleAttribution[] | undefined {
+  let entry = ruleAttributions.get(result);
+  if (!entry) {
+    entry = { value: computeRuleProvenance(result) };
+    ruleAttributions.set(result, entry);
+  }
+  return entry.value;
+}
+
 /**
  * The `packageRules[N]` cross-link for one of a run's own messages, or nothing.
  *
  * Two guards, both roadmap 071: the message must come from the `validate`
  * stage — the global and inherited layers validate their own documents into
  * the same `errors`/`warnings` arrays, and their indexes address a different
- * array — and the run must be attributable at all.
+ * array — and the run must be attributable at all. The attribution itself is
+ * memoized per run, since this is called once per message.
  */
 function ruleLinkOf(run: HeldRun, message: ValidationMessage): RuleCrossLink | undefined {
   if (!repoStageMessage(run.result, message)) {
     return undefined;
   }
-  return ruleCrossLink(message, "repo", computeRuleProvenance(run.result));
+  return ruleCrossLink(message, "repo", ruleAttributionOf(run.result));
 }
 
 /** Each validator message with the position `explain_message` addresses it by.

--- a/packages/cli/src/questions/pipeline.ts
+++ b/packages/cli/src/questions/pipeline.ts
@@ -1,4 +1,6 @@
+import { isValidConfigObject } from "@renovate-config-debugger/app/headless";
 import type { PipelineInput, PresetAuth } from "@renovate-config-debugger/engine";
+import { CliError } from "../io";
 
 /**
  * `src/questions/` — the transport-neutral layer between the engine and the
@@ -34,6 +36,21 @@ export interface PipelineInputSpec {
   platformOverride?: boolean | undefined;
 }
 
+/** The layer guard both transports share. It runs AFTER a schema, not instead
+ *  of one: zod's record parse already drops a top-level `__proto__` (see
+ *  `findPollutedPath`), so what this catches is nested `packageRules[n]`
+ *  pollution — which the CLI's `parseLayerJson` rejects and MCP's
+ *  `z.record(z.string(), z.unknown())` lets through. */
+function checkedLayer(
+  layer: Record<string, unknown> | undefined,
+  which: string,
+): Record<string, unknown> | undefined {
+  if (layer !== undefined && !isValidConfigObject(layer)) {
+    throw new CliError(`${which} must be a JSON object`);
+  }
+  return layer;
+}
+
 /**
  * The optional halves of a `PipelineInput` are OMITTED rather than set to
  * `undefined`: the engine distinguishes "no global config layer" from "a
@@ -41,12 +58,14 @@ export interface PipelineInputSpec {
  * of `{ platform: undefined }` is not the same input as one without the key.
  */
 export function buildPipelineInput(spec: PipelineInputSpec): PipelineInput {
+  const globalConfig = checkedLayer(spec.globalConfig, "globalConfig");
+  const inheritedConfig = checkedLayer(spec.inheritedConfig, "inheritedConfig");
   return {
     fileName: spec.fileName,
     content: spec.content,
     presetAuth: spec.presetAuth,
-    ...(spec.globalConfig ? { globalConfig: spec.globalConfig } : {}),
-    ...(spec.inheritedConfig ? { inheritedConfig: spec.inheritedConfig } : {}),
+    ...(globalConfig ? { globalConfig } : {}),
+    ...(inheritedConfig ? { inheritedConfig } : {}),
     ...(spec.platform ? { platform: spec.platform } : {}),
     ...(spec.endpoint ? { endpoint: spec.endpoint } : {}),
     ...(spec.platformOverride ? { platformOverride: true } : {}),

--- a/packages/cli/src/run-input.ts
+++ b/packages/cli/src/run-input.ts
@@ -259,7 +259,8 @@ export function takeInputFile(args: ParsedArgs): { file?: string; rest: string[]
  * validate a.json b.json` used to validate `a.json` alone and exit `0`, and a
  * second `provenance` key was silently dropped, which read as "the first key's
  * chain is the whole answer". `allowed` counts what the command takes BESIDES
- * the config file — the same `rest` {@link takeInputFile} hands it.
+ * its input positional (the config file, an option name for `docs`, or the
+ * manifest for `extract`), the same `rest` {@link takeInputFile} hands it.
  */
 export function rejectExtraPositionals(args: ParsedArgs, command: string, allowed: number): void {
   const { rest } = takeInputFile(args);

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -20,9 +20,11 @@ import { fixture } from "./harness";
  * behavior of the commands is asserted in-process and only the seams the bin
  * owns are asserted here.
  *
- * The dev runner is the target, not the published `bin/rcd.mjs`: that one
- * needs `dist/main.js`, which the test job never builds — and the artifact
- * itself is already proven by the `bundle` project's parity suite.
+ * The dev runner is the target, not the published `bin/rcd.mjs`: that one needs
+ * `dist/main.js`, which the test job never builds. So nothing here proves the
+ * built artifact — its own dispatch and help live in
+ * `test/bundle/cli-surface.test.ts`, which is the only regime that sees
+ * `ssr.noExternal: true` output.
  */
 
 const BIN = fileURLToPath(new URL("../bin/rcd-dev.mjs", import.meta.url));
@@ -120,6 +122,29 @@ describe("bin/rcd-dev.mjs", () => {
     expect(run.stdout.length).toBeGreaterThan(64 * 1024);
     const result = JSON.parse(run.stdout) as { finalConfig: { extends?: string[] } };
     expect(result.finalConfig).toBeTypeOf("object");
+  }, 120_000);
+
+  test("a peer that stops reading is not a crash", async () => {
+    // `rcd … | head`: the same over-64-KB answer, with the read end closed
+    // mid-write. Without `bin/io.mjs`'s `guardStdio`, the failed write is an
+    // uncaught exception — so the absence of the crash IS the assertion.
+    const child = spawn(
+      process.execPath,
+      [BIN, "run", "--stdin", "--select", "final", "--format", "json"],
+      { cwd: CLI_DIR, env: CHILD_ENV, stdio: ["pipe", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.stdout.once("data", () => child.stdout.destroy());
+    child.stdin.end('{"extends":["config:recommended"]}');
+
+    const [code] = (await once(child, "exit")) as [number | null, string | null];
+    expect(code).toBe(0);
+    expect(stderr).not.toContain("Unhandled 'error' event");
+    expect(stderr).not.toContain("EPIPE");
   }, 120_000);
 });
 

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
+import { COMMANDS } from "../src/main";
 import { fixture } from "./harness";
 
 /**
@@ -80,7 +81,10 @@ describe("bin/rcd-dev.mjs", () => {
     const run = await runBin(["--help"]);
     expect(run.code).toBe(0);
     expect(run.stderr).toBe("");
-    for (const name of ["validate", "digest", "run", "simulate", "compare", "docs"]) {
+    // Over the registry, never a copy of it: the hand-written list this
+    // replaced named six of the twelve commands, so half the help screen was
+    // unasserted here for as long as it stood.
+    for (const name of COMMANDS.map((command) => command.name)) {
       expect(run.stdout).toContain(name);
     }
   });

--- a/packages/cli/test/bundle/cli-surface.test.ts
+++ b/packages/cli/test/bundle/cli-surface.test.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import { readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
@@ -53,7 +54,13 @@ function runBin(args: string[]): Promise<BinRun> {
   });
 }
 
-const COMMANDS = ["validate", "digest", "run", "simulate", "compare", "docs"];
+// The registry as a directory listing, not an import: this project's aliases
+// point `../src/…` at the built bundle on purpose, so the source's own idea of
+// which commands exist has to cross the build boundary some other way. The
+// hand-written list this replaced named six of the twelve.
+const COMMANDS = readdirSync(new URL("../../src/commands/", import.meta.url))
+  .filter((file) => file.endsWith(".ts") && !file.endsWith(".test.ts"))
+  .map((file) => file.slice(0, -".ts".length));
 
 describe("bin/rcd.mjs", () => {
   test("--help writes the command list to stdout and exits 0", async () => {

--- a/packages/cli/test/bundle/cli-surface.test.ts
+++ b/packages/cli/test/bundle/cli-surface.test.ts
@@ -1,0 +1,82 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Dispatch and help, from the PUBLISHED bin.
+ *
+ * This is the only regime that sees `ssr.noExternal: true` output, so it is the
+ * only one that can catch a divergence the inlining introduces: commander reads
+ * `stripVTControlCharacters` from `node:util`, which the shim plugin answers
+ * with `packages/engine/src/shims/node-util-stub.cjs` in the build pipeline
+ * too — a missing export there turns every help screen into a crash while
+ * `test/bin.test.ts` (the dev runner, unbundled) stays green.
+ *
+ * Cheap enough for a child per case: no command here resolves a preset.
+ */
+
+const BIN = fileURLToPath(new URL("../../bin/rcd.mjs", import.meta.url));
+const CLI_DIR = fileURLToPath(new URL("../..", import.meta.url));
+
+// Same reason as `test/bin.test.ts`: the bin hands the REAL environment to
+// `main`, and no assertion may depend on the session that runs the suite.
+const CHILD_ENV: Record<string, string | undefined> = { ...process.env };
+for (const key of Object.keys(CHILD_ENV)) {
+  if (key === "CLAUDECODE" || key.startsWith("RCD_") || key.endsWith("_TOKEN")) {
+    delete CHILD_ENV[key];
+  }
+}
+
+interface BinRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function runBin(args: string[]): Promise<BinRun> {
+  return new Promise<BinRun>((resolve, reject) => {
+    const child = execFile(
+      process.execPath,
+      [BIN, ...args],
+      { cwd: CLI_DIR, env: CHILD_ENV, maxBuffer: 8 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (!error) {
+          resolve({ code: 0, stdout, stderr });
+        } else if (typeof error.code === "number") {
+          resolve({ code: error.code, stdout, stderr });
+        } else {
+          reject(error);
+        }
+      },
+    );
+    child.stdin?.end("");
+  });
+}
+
+const COMMANDS = ["validate", "digest", "run", "simulate", "compare", "docs"];
+
+describe("bin/rcd.mjs", () => {
+  test("--help writes the command list to stdout and exits 0", async () => {
+    const run = await runBin(["--help"]);
+    expect(run.code).toBe(0);
+    expect(run.stderr).toBe("");
+    for (const name of COMMANDS) {
+      expect(run.stdout).toContain(name);
+    }
+  }, 60_000);
+
+  test("no arguments prints the same command list rather than crashing", async () => {
+    const run = await runBin([]);
+    expect(run.code).toBe(0);
+    for (const name of COMMANDS) {
+      expect(run.stdout).toContain(name);
+    }
+  }, 60_000);
+
+  test("a subcommand's own --help exits 0", async () => {
+    const run = await runBin(["digest", "--help"]);
+    expect(run.code).toBe(0);
+    expect(run.stderr).toBe("");
+    expect(run.stdout).toContain("digest");
+  }, 60_000);
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -27,6 +27,8 @@ const bundledEngine = fileURLToPath(new URL("./dist/engine-surface.js", import.m
  *   `test/bundle/` holds the suites that drive the built artifact directly —
  *   the subdirectory is what keeps them out of the "cli" project's
  *   `test/*.test.ts` glob, so `pnpm test` never fails for a missing `dist/`.
+ *   Those cover the bin's own build-only divergences (help, dispatch, the MCP
+ *   transport), which the inlining can break with every `src/` suite green.
  */
 export default defineConfig({
   test: {

--- a/packages/engine/src/error-fix-text.ts
+++ b/packages/engine/src/error-fix-text.ts
@@ -151,8 +151,6 @@ function scanValue(text: string, start: number): number | null {
     return skipString(text, start);
   }
   if (c === "{" || c === "[") {
-    const open = c;
-    const close = c === "{" ? "}" : "]";
     let depth = 1;
     let i = start + 1;
     while (i < text.length && depth > 0) {
@@ -166,18 +164,8 @@ function scanValue(text: string, start: number): number | null {
         i = skipString(text, i);
         continue;
       }
-      if (ch === open) {
-        depth++;
-        i++;
-        continue;
-      }
-      if (ch === close) {
-        depth--;
-        i++;
-        continue;
-      }
-      // A differing bracket type inside (object containing an array, etc.)
-      // also needs depth tracking so its own close doesn't unbalance ours.
+      // One depth counter across both bracket types: a nested array inside our
+      // object (or vice versa) must not unbalance us.
       if (ch === "{" || ch === "[") {
         depth++;
         i++;

--- a/packages/engine/src/extract.ts
+++ b/packages/engine/src/extract.ts
@@ -16,7 +16,7 @@
  * matches their `managerFilePatterns` too, and `extractCustomDeps` runs one
  * block over one file with the block itself as the extractor's config.
  */
-import { isString } from "./is";
+import { isString, ownValue } from "./is";
 import { enqueueEngineTask } from "./pipeline";
 import {
   customManagerExtractors,
@@ -351,9 +351,7 @@ async function runExtract(request: ExtractRequest): Promise<ExtractOutcome> {
   }
   // Own-key only: a caller-supplied `constructor`/`__proto__` must report "not
   // supported" rather than reach a prototype member and throw.
-  const loadExtractor = Object.hasOwn(managerExtractors, manager)
-    ? managerExtractors[manager]
-    : undefined;
+  const loadExtractor = ownValue(managerExtractors, manager);
   if (loadExtractor === undefined) {
     return {
       ok: false,

--- a/packages/engine/src/extract.ts
+++ b/packages/engine/src/extract.ts
@@ -349,7 +349,11 @@ async function runExtract(request: ExtractRequest): Promise<ExtractOutcome> {
             "not supported in the browser engine",
         };
   }
-  const loadExtractor = managerExtractors[manager];
+  // Own-key only: a caller-supplied `constructor`/`__proto__` must report "not
+  // supported" rather than reach a prototype member and throw.
+  const loadExtractor = Object.hasOwn(managerExtractors, manager)
+    ? managerExtractors[manager]
+    : undefined;
   if (loadExtractor === undefined) {
     return {
       ok: false,

--- a/packages/engine/src/is.test.ts
+++ b/packages/engine/src/is.test.ts
@@ -8,6 +8,7 @@ import {
   isString,
   isStringArray,
   isTruthy,
+  ownValue,
 } from "./is";
 
 describe("isString", () => {
@@ -106,5 +107,28 @@ describe("isTruthy", () => {
     const mixed: (string | undefined)[] = ["a", undefined, "b"];
     const kept: string[] = mixed.filter(isTruthy);
     expect(kept).toEqual(["a", "b"]);
+  });
+});
+
+describe("ownValue", () => {
+  it("reads an own key and answers undefined for a missing one", () => {
+    const table = { github: "https://api.github.com/", gitea: "" };
+    expect(ownValue(table, "github")).toBe("https://api.github.com/");
+    expect(ownValue(table, "gitea")).toBe("");
+    expect(ownValue(table, "bitbucket")).toBeUndefined();
+  });
+
+  /** The defect it exists for: a bare `table[key]` answers a FUNCTION here. */
+  it("answers undefined for every Object.prototype member name", () => {
+    const table: Record<string, string> = { github: "https://api.github.com/" };
+    for (const key of ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"]) {
+      expect(ownValue(table, key)).toBeUndefined();
+    }
+  });
+
+  it("reads a null-prototype table the same way", () => {
+    const table: Record<string, number> = Object.assign(Object.create(null), { a: 1 });
+    expect(ownValue(table, "a")).toBe(1);
+    expect(ownValue(table, "b")).toBeUndefined();
   });
 });

--- a/packages/engine/src/is.ts
+++ b/packages/engine/src/is.ts
@@ -9,8 +9,8 @@
  * holds it to that. It is reachable from the app through the `./is` subpath
  * and therefore from the entry chunk, which must never pull the Renovate graph
  * onto a static import path (see `contracts.ts`, `.oxlintrc.json`'s
- * engine-root ban). Predicates only, so the subpath's whole runtime cost is
- * this file.
+ * engine-root ban). Predicates plus the one own-key read that follows from
+ * them (`ownValue`), so the subpath's whole runtime cost is this file.
  *
  * Not a separate workspace package, deliberately — the same reasoning
  * `contracts.ts` states: the app already depends on the engine and the CLI
@@ -78,4 +78,14 @@ type Falsy = false | 0 | 0n | "" | null | undefined;
  *  narrow — `Boolean` leaves the result `(T | undefined)[]`. */
 export function isTruthy<T>(value: T | Falsy): value is T {
   return Boolean(value);
+}
+
+/** One value out of a lookup table BY OWN KEY — `Object.hasOwn` first, so a
+ *  key the user supplied (`constructor`, `toString`, `__proto__`) answers
+ *  `undefined` instead of an `Object.prototype` member. The predicates' own
+ *  corollary: they narrow a value, this narrows a KEY. Three packages had
+ *  this ternary hand-spelled five times; `rcd/use-lookup-accessors` keeps
+ *  them here. */
+export function ownValue<T>(table: Readonly<Record<string, T>>, key: string): T | undefined {
+  return Object.hasOwn(table, key) ? table[key] : undefined;
 }

--- a/packages/engine/src/shims/http.ts
+++ b/packages/engine/src/shims/http.ts
@@ -1,10 +1,12 @@
 /**
  * Browser stub for renovate's got-backed http stack (roadmap 078): mapped over
- * util/http/got.js, util/http/http.js, util/http/index.js AND
- * util/http/gitlab.js. Manager extract files import datasource CLASSES just to
- * read their static `.id`, and those classes reach `Http`/`HttpBase`/
- * `RequestError` at module scope — without this stub any manager import drags
- * the Node-only `got` stack (and its node:stream/timers deps) into the graph.
+ * util/http/got.js, util/http/http.js, util/http/index.js, util/http/gitlab.js
+ * AND util/http/keep-alive.js (that last for its module-scope agentkeepalive
+ * construction, not for the got class surface). Manager extract files import
+ * datasource CLASSES just to read their static `.id`, and those classes reach
+ * `Http`/`HttpBase`/`RequestError` at module scope — without this stub any
+ * manager import drags the Node-only `got` stack (and its node:stream/timers
+ * deps) into the graph.
  *
  * Extraction never performs a request; every method that would throws.
  */

--- a/packages/engine/src/shims/node-util-stub.cjs
+++ b/packages/engine/src/shims/node-util-stub.cjs
@@ -1,5 +1,7 @@
 /**
- * Minimal `node:util` stand-in for the dep prebundle (roadmap 087).
+ * Minimal `node:util` stand-in for the dep prebundle (roadmap 087) — and, under
+ * the CLI's `ssr.noExternal: true` build, for every inlined `node:util` consumer
+ * in the shipped bundle, commander's help renderer included.
  *
  * The npm-extraction graph (find-packages and friends) calls
  * `util.promisify(fs.something)` at module scope. With fs stubbed empty (see
@@ -20,8 +22,19 @@ function promisify(original) {
   };
 }
 
+// Node's own ANSI/VT pattern. commander strips escapes to measure help column
+// widths, so a missing export breaks `--help` in the built CLI and nowhere else.
+const ansi = new RegExp(
+  "[\\u001B\\u009B][[\\]()#;?]*" +
+    "(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*" +
+    "|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)" +
+    "|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))",
+  "g",
+);
+
 module.exports = {
   promisify,
+  stripVTControlCharacters: (str) => String(str).replace(ansi, ""),
   debuglog: () => () => {},
   deprecate: (fn) => fn,
   format: (...args) => args.map(String).join(" "),

--- a/packages/engine/src/shims/presets/host-transport.ts
+++ b/packages/engine/src/shims/presets/host-transport.ts
@@ -27,6 +27,7 @@
  */
 import { getAuthRefreshHandler, resolveAuthToken } from "../../auth";
 import { AUTH_OR_RATE_LIMIT_HINT, NETWORK_OR_CORS_HINT } from "../../contracts";
+import { ownValue } from "../../is";
 import { ExternalHostError, fetchPreset } from "../renovate-internals";
 import { encodePathSegments } from "../url-path";
 import { getInjectedPreset } from "./injection";
@@ -51,9 +52,7 @@ export const PLATFORM_ENDPOINTS: Record<HostPlatform, string> = {
  *  self-hosted platform Renovate knows and this tool has no fetcher for
  *  simply has none. */
 export function defaultEndpointFor(platform: string): string | undefined {
-  return Object.hasOwn(PLATFORM_ENDPOINTS, platform)
-    ? PLATFORM_ENDPOINTS[platform as HostPlatform]
-    : undefined;
+  return ownValue(PLATFORM_ENDPOINTS, platform);
 }
 
 /**

--- a/packages/engine/src/shims/presets/local.ts
+++ b/packages/engine/src/shims/presets/local.ts
@@ -24,10 +24,11 @@ interface Resolver {
   ): Promise<Record<string, unknown> | null>;
 }
 
+// The three classifications below are a hand-port of upstream `getResolver`'s
+// switch; `test/local-preset-platforms.node.test.ts` fails when a bump adds a
+// platform.
 const resolvers: Record<string, Resolver> = { github, gitlab, gitea, forgejo };
 
-// The three sets below are a hand-port of upstream `getResolver`'s switch;
-// `test/local-preset-platforms.node.test.ts` fails when a bump adds a platform.
 // Reachable only via a real Renovate run (their platform APIs have no browser
 // fetcher — either no CORS or no prefix of their own in this tool).
 const RUN_ONLY = new Set(["azure", "bitbucket", "bitbucket-server", "gerrit"]);
@@ -38,7 +39,10 @@ export const getPreset = makeInjectableGetPreset("local", (repo, presetName, pre
   const platform = (GlobalConfig.get("platform") as string | undefined) ?? "github";
   const endpoint = GlobalConfig.get("endpoint") as string | undefined;
 
-  const resolver = resolvers[platform];
+  // Own-key lookup, not a bare bracket read: a `platform` of `constructor` /
+  // `toString` would otherwise hand back an Object.prototype member instead of
+  // falling through to the honest message below (twin: `defaultEndpointFor`).
+  const resolver = Object.hasOwn(resolvers, platform) ? resolvers[platform] : undefined;
   if (resolver) {
     return resolver.getPresetFromEndpoint(repo, presetName, presetPath, endpoint, tag);
   }

--- a/packages/engine/src/shims/presets/local.ts
+++ b/packages/engine/src/shims/presets/local.ts
@@ -7,6 +7,7 @@
  * unchanged from Renovate's; only the underlying transports are the browser
  * shims.
  */
+import { ownValue } from "../../is";
 import { GlobalConfig } from "../../renovate-adapter";
 import * as forgejo from "./forgejo";
 import * as gitea from "./gitea";
@@ -41,8 +42,8 @@ export const getPreset = makeInjectableGetPreset("local", (repo, presetName, pre
 
   // Own-key lookup, not a bare bracket read: a `platform` of `constructor` /
   // `toString` would otherwise hand back an Object.prototype member instead of
-  // falling through to the honest message below (twin: `defaultEndpointFor`).
-  const resolver = Object.hasOwn(resolvers, platform) ? resolvers[platform] : undefined;
+  // falling through to the honest message below.
+  const resolver = ownValue(resolvers, platform);
   if (resolver) {
     return resolver.getPresetFromEndpoint(repo, presetName, presetPath, endpoint, tag);
   }

--- a/packages/engine/src/shims/vite-plugin-renovate-shims.ts
+++ b/packages/engine/src/shims/vite-plugin-renovate-shims.ts
@@ -199,9 +199,13 @@ export function renovateShims(): Plugin {
       // and the npm-extraction chunk throws at module init (graceful-fs's
       // polyfills read the bare `process.cwd`, fast-glob calls `os.cpus()`)
       // — the exact crashes the stubs exist to prevent in dev. Scoped by
-      // importer to third-party code, matching the prebundle's blast radius:
-      // first-party sources and the Node regimes' externalized deps keep the
-      // real modules.
+      // importer to third-party code, which is WIDER than the prebundle's blast
+      // radius: under the CLI's `ssr.noExternal: true` build it also catches
+      // that package's own runtime deps (commander reads
+      // `stripVTControlCharacters` from node:util), so the stubs must export a
+      // superset of the node:util/os surface any bundled dep names — a gap is
+      // a crash in the shipped bundle only. First-party sources and the Node
+      // regimes' EXTERNALIZED deps keep the real modules.
       if (importer !== undefined && importer.includes("node_modules")) {
         const stub = nodeStub(source);
         if (stub) {

--- a/packages/engine/src/simulate-missing-inputs.ts
+++ b/packages/engine/src/simulate-missing-inputs.ts
@@ -31,8 +31,9 @@ import { countNoun } from "./text";
  * That property is why it also has its own `exports` subpath. The app's
  * `lib/rule-verdict.ts` re-exports the predicates below, and reaching them
  * through the root barrel put the entire Renovate graph on the static path of
- * the app's results chunk. Keep the import list above as it is — a value import
- * of anything Renovate-touching here would silently re-weld it.
+ * the app's results chunk. `test/import-free-subpaths.node.test.ts` walks this
+ * module's value-import closure and fails on the first non-relative specifier,
+ * so the invariant is enforced rather than asked for.
  *
  * The app has a narrower cousin, `buildNoInputCaveat`
  * (`lib/verdict-sentence.ts`), which counts only REPO-config rules via

--- a/packages/engine/src/simulate-package-rules.ts
+++ b/packages/engine/src/simulate-package-rules.ts
@@ -67,6 +67,8 @@ export interface DependencyDescriptor {
   /** Defaults to `packageName` when omitted. */
   depName?: string;
   depType?: string;
+  /** Read only when depType is unset — upstream DepTypesMatcher prefers depType. */
+  depTypes?: string[];
   packageFile?: string;
   lockFiles?: string[];
   currentValue?: string;
@@ -93,12 +95,13 @@ export interface DependencyDescriptor {
  * is the invariant: a new descriptor field is a compile error here, never a key
  * the unknown-key note starts mislabeling.
  */
-const DESCRIPTOR_KEY_SET = {
+export const DESCRIPTOR_KEY_SET = {
   manager: true,
   datasource: true,
   packageName: true,
   depName: true,
   depType: true,
+  depTypes: true,
   packageFile: true,
   lockFiles: true,
   currentValue: true,
@@ -311,7 +314,7 @@ interface MatcherDescriptor {
  * by position. Must stay aligned with the upstream registry
  * (`lib/util/package-rules/matchers.ts`) — length-checked at runtime.
  */
-const MATCHER_TABLE: readonly MatcherDescriptor[] = [
+export const MATCHER_TABLE: readonly MatcherDescriptor[] = [
   { key: "matchConfidence", inputFields: ["mergeConfidenceLevel"] },
   { key: "matchRepositories", inputFields: ["repository"] },
   { key: "matchBaseBranches", inputFields: ["baseBranch"] },

--- a/packages/engine/test/extract.node.test.ts
+++ b/packages/engine/test/extract.node.test.ts
@@ -133,6 +133,20 @@ describe("extractDeps (golden)", () => {
     expect(outcome.message).toContain("not supported in the browser engine");
   });
 
+  it("reports not-supported for a prototype-named manager", async () => {
+    const outcome = await extractDeps({
+      fileName: "package.json",
+      content: "{}",
+      manager: "constructor",
+    });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) {
+      return;
+    }
+    expect(outcome.reason).toBe("unsupported-manager");
+    expect(outcome.message).toContain("not supported in the browser engine");
+  });
+
   it("reports no-manager for a file nothing claims", async () => {
     const outcome = await extractDeps({ fileName: "notes.md", content: "# notes\n" });
     expect(outcome.ok).toBe(false);

--- a/packages/engine/test/import-free-subpaths.node.test.ts
+++ b/packages/engine/test/import-free-subpaths.node.test.ts
@@ -4,22 +4,33 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * `contracts.ts`, `is.ts`, `json.ts` and `text-scan.ts` each carry a "WHY THIS
- * MODULE HAS NO IMPORTS" banner, and `.oxlintrc.json`'s engine-root ban sends
- * the app to `/is` and `/json` from its ENTRY chunk on the strength of it.
- * Until now the banner WAS the mechanism: one `import { deepEqual } from
- * "./lib"` would weld whatever that file reaches onto the entry chunk,
- * silently — the dev-graph check crawls through the dynamic seam by design and
- * the entry-size report has no threshold.
+ * The engine subpaths the app imports STATICALLY, and the two different
+ * properties that make each one safe to put on a static chunk.
  *
- * The guarded set is discovered from the banner, not hand-listed, so a further
- * banner file in `src/` is covered on arrival; the identity assertion is the
- * floor that stops a broken scan from passing having found nothing.
+ * 1. Import-free by banner — `contracts.ts`, `is.ts`, `json.ts` and
+ *    `text-scan.ts` each carry a "WHY THIS MODULE HAS NO IMPORTS" banner, and
+ *    `.oxlintrc.json`'s engine-root ban sends the app to `/is` and `/json`
+ *    from its ENTRY chunk on the strength of it. Until now the banner WAS the
+ *    mechanism: one `import { deepEqual } from "./lib"` would weld whatever
+ *    that file reaches onto the entry chunk, silently — the dev-graph check
+ *    crawls through the dynamic seam by design and the entry-size report has
+ *    no threshold. The guarded set is discovered from the banner, not
+ *    hand-listed, so a further banner file in `src/` is covered on arrival;
+ *    the identity assertion is the floor that stops a broken scan from passing
+ *    having found nothing.
+ * 2. Renovate-free by CLOSURE — `simulate-missing-inputs.ts` has imports and
+ *    no banner, so the first property cannot cover it, yet the app reaches it
+ *    statically (`ResultsColumn -> TestsPanel -> rule-filters -> rule-verdict`).
+ *    Its edge to `simulate-package-rules` is `import type` today and one
+ *    keyword from re-welding the whole Renovate graph, so the second describe
+ *    walks the VALUE-import closure rather than the direct imports: that also
+ *    covers `text.ts`, which is import-free but carries no banner.
  *
- * `import type` is allowed: it is erased before a bundler sees it, which is
- * why the engine-root ban itself carries `allowTypeImports`. An all-type
- * import cannot hide as the inline form here — `typescript/no-import-type-
- * side-effects` requires it be written `import type`.
+ * `import type` is allowed in both: it is erased before a bundler sees it,
+ * which is why the engine-root ban itself carries `allowTypeImports`. An
+ * all-type import cannot hide as the inline form here —
+ * `typescript/no-import-type-side-effects` requires it be written `import
+ * type`.
  */
 
 const BANNER = "WHY THIS MODULE HAS NO IMPORTS";
@@ -62,5 +73,74 @@ describe("the import-free engine subpaths", () => {
       [...source.matchAll(pattern)].map(([match]) => match.trim()),
     );
     expect(offenders).toEqual([]);
+  });
+});
+
+/** The statically-imported subpath whose guarantee is closure-shaped. Its
+ *  runtime graph is what a static app chunk pays for on every load. */
+const RENOVATE_FREE_ENTRY = "simulate-missing-inputs.ts";
+
+/** Specifiers of the value imports in one already-comment-stripped source. */
+function valueImports(source: string): string[] {
+  const specifiers: string[] = [];
+  for (const pattern of [FROM_IMPORT, SIDE_EFFECT_IMPORT]) {
+    for (const [match] of source.matchAll(pattern)) {
+      const found = /["']([^"']+)["']\s*$/.exec(match.trim());
+      if (found?.[1] !== undefined) {
+        specifiers.push(found[1]);
+      }
+    }
+  }
+  return specifiers;
+}
+
+interface Closure {
+  /** `src/`-relative names, sorted — every module the entry pulls at runtime. */
+  visited: string[];
+  /** Non-relative specifiers anywhere in the closure. Any of them is an
+   *  offender: the guaranteed property is "reaches nothing but engine prose",
+   *  not merely "does not name renovate". */
+  bare: string[];
+  /** `import(`/`require(` anywhere in the closure — no specifier to follow. */
+  called: string[];
+}
+
+function valueClosure(entry: string): Closure {
+  const visited = new Set<string>();
+  const bare: string[] = [];
+  const called: string[] = [];
+  const queue = [entry];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (name === undefined || visited.has(name)) {
+      continue;
+    }
+    visited.add(name);
+    const source = stripComments(readFileSync(join(SRC, name), "utf8"));
+    called.push(...[...source.matchAll(CALLED_IMPORT)].map(([match]) => `${name}: ${match}`));
+    for (const specifier of valueImports(source)) {
+      if (specifier.startsWith(".")) {
+        queue.push(`${join(dirname(name), specifier)}.ts`);
+      } else {
+        bare.push(`${name}: ${specifier}`);
+      }
+    }
+  }
+  return { visited: [...visited].toSorted(), bare, called };
+}
+
+describe("the Renovate-free engine subpath /simulate-missing-inputs", () => {
+  const closure = valueClosure(RENOVATE_FREE_ENTRY);
+
+  it("value-imports nothing outside the engine's own relative graph", () => {
+    expect(closure.bare).toEqual([]);
+  });
+
+  it("pulls in no module at runtime anywhere in its closure", () => {
+    expect(closure.called).toEqual([]);
+  });
+
+  it("is exactly the three prose/JSON modules the app's results chunk pays for", () => {
+    expect(closure.visited).toEqual(["json.ts", "simulate-missing-inputs.ts", "text.ts"]);
   });
 });

--- a/packages/engine/test/local-preset-platforms.node.test.ts
+++ b/packages/engine/test/local-preset-platforms.node.test.ts
@@ -4,8 +4,8 @@
  * platform fails here instead of shipping an `Unknown platform` message
  * Renovate itself would never print. Re-bucketing an id upstream is not caught
  * — this only asserts that some classification happened, never which one. The
- * dropdown in `packages/app/src/data/platform-endpoints.ts` is the second copy
- * of this list.
+ * app's dropdown (`packages/app/src/data/platform-endpoints.ts`) is a subset of
+ * these ids and is NOT checked here — a new platform belongs there too.
  *
  * It lives here, not beside `local.ts`, because the real platform registry is a
  * `renovate/dist` deep import, which `.oxlintrc.json` fences out of `src/`.
@@ -62,5 +62,13 @@ describe("the local preset resolver's platform sets", () => {
       }
     }
     expect(unclassified).toEqual([]);
+  });
+
+  it("classifies a prototype-member platform name as unknown, not a resolver", async () => {
+    // The cast IS the test: `constructor` is exactly the value the type system
+    // cannot produce but a share link's `platform` can carry at runtime.
+    const { fetched, outcome } = await classify("constructor" as PlatformId);
+    expect(fetched).toBe(false);
+    expect(outcome).toMatch(/Unknown platform 'constructor'/);
   });
 });

--- a/packages/engine/test/repo-config.shimmed.test.ts
+++ b/packages/engine/test/repo-config.shimmed.test.ts
@@ -381,6 +381,15 @@ describe("extractPackageJsonConfig", () => {
     );
   });
 
+  // The array branch is deliberate (see repo-config.ts): an array `renovate`
+  // key is invalid config, but re-serializing it is how the caller's validator
+  // gets to say so — and how the repo-picker badge still reads "has a config".
+  it("re-serializes an array value instead of dropping it", () => {
+    expect(extractPackageJsonConfig('{"renovate":["config:recommended"]}')).toBe(
+      JSON.stringify(["config:recommended"], null, 2),
+    );
+  });
+
   it("returns null for a missing key, a scalar value, or unparseable JSON", () => {
     expect(extractPackageJsonConfig('{"name":"x"}')).toBeNull();
     expect(extractPackageJsonConfig('{"renovate":5}')).toBeNull();

--- a/packages/engine/test/simulate-package-rules.node.test.ts
+++ b/packages/engine/test/simulate-package-rules.node.test.ts
@@ -8,6 +8,7 @@ import { applyPackageRules } from "renovate/dist/util/package-rules/index.js";
 import { describe, expect, it } from "vitest";
 import type { DependencyDescriptor } from "../src/index";
 import { runPipeline, simulatePackageRules } from "../src/index";
+import { DESCRIPTOR_KEY_SET, MATCHER_TABLE } from "../src/simulate-package-rules";
 import { must, npmDep, oracleFlatten, oracleInput } from "./helpers";
 
 describe("simulatePackageRules (golden)", () => {
@@ -267,5 +268,31 @@ describe("simulatePackageRules with a `group:` preset extended inside a rule (go
       expect(simulated.finalDependencyConfig.minimumGroupSize).toBe(5);
       expect(simulated.finalDependencyConfig.groupName).toBeUndefined();
     }
+  });
+});
+
+describe("the descriptor's key set (golden)", () => {
+  // The `satisfies` in the module covers descriptor growth; this covers the
+  // other direction — a matcher input field the descriptor never declared.
+  it("covers every input field the matcher table reads", () => {
+    const unknown = MATCHER_TABLE.flatMap((entry) => entry.inputFields).filter(
+      (field) => !Object.prototype.hasOwnProperty.call(DESCRIPTOR_KEY_SET, field),
+    );
+    expect(unknown).toEqual([]);
+  });
+
+  it("does not call `depTypes` an ignored key — the matcher reads it", async () => {
+    const config = { packageRules: [{ matchDepTypes: ["devDependencies"], labels: ["dev"] }] };
+    const dep: DependencyDescriptor = {
+      manager: "npm",
+      datasource: "npm",
+      packageName: "lodash",
+      depTypes: ["devDependencies"],
+    };
+    const simulated = await simulatePackageRules({ config, dep });
+    expect(simulated.notes.filter((note) => note.includes("ignored"))).toEqual([]);
+    expect(must(simulated.rules[0], "the matchDepTypes rule").verdict).toBe("matched");
+    const oracle = await applyPackageRules(oracleInput(config, dep));
+    expect(simulated.rawFinalConfig).toEqual(oracle);
   });
 });

--- a/roadmap/013-rule-identity-and-provenance.md
+++ b/roadmap/013-rule-identity-and-provenance.md
@@ -26,6 +26,12 @@ Milestone: M5 · Status: done 2026-07-24 · amended 2026-08-27
 > layer: those ranges are the ~200 bytes of every MCP answer that must survive
 > the byte budget whole, and there are ~700 writing bodies. The writer reaches
 > that view as `[from X]` on the digest lines, which already degrade.
+>
+> Completed 2026-09-02: the two verdict-card surfaces that still read
+> `attribution.layer` directly — `verdict-sentence.ts`'s "from `<preset>`"
+> parenthetical (and therefore `rcd simulate`'s sentence) and
+> `consumed-blocks.ts`'s attribution chip — now go through `ruleOriginLayer`
+> like the rest.
 
 > Implemented as specified. Engine: `computeRuleProvenance` (013) attributes
 > every entry of the merged `finalConfig.packageRules` to its contributing

--- a/roadmap/089-dependencies-tab-and-data-table.md
+++ b/roadmap/089-dependencies-tab-and-data-table.md
@@ -110,7 +110,9 @@ Two consequences worth recording:
   results panel stays MOUNTED (028), so a panel-side effect would fire for a
   tab nobody has looked at and spend the rate limit on it. App runs
   `ensureRepoDeps()` when `tab === "deps"`; `ensure` is idempotent per loaded
-  repo, so the doors onto the same discovery never discover twice. (Two at the
+  repo, so the doors onto the same discovery never discover twice, and its
+  identity moves with that repo (plus 093's custom-manager blocks), so a tab
+  that was already open re-discovers when the key changes. (Two at the
   time of writing — this tab and the Tests tab's From-repository view; 090's
   Extract phase is the third, and App's effect gained its condition there.)
 

--- a/roadmap/090-pipeline-extract-phase.md
+++ b/roadmap/090-pipeline-extract-phase.md
@@ -112,7 +112,8 @@ managers }] }` from the same single pass. Same cost, same order, one caller.
   panel-side effect would fire for a tab nobody has looked at. App's existing
   `tab === "deps"` trigger became `tab === "deps" || (tab === "pipeline" &&
 phase === "extract")`; `ensure` is idempotent per loaded repo, so the three
-  doors onto discovery never discover twice.
+  doors onto discovery never discover twice — and its identity is keyed to that
+  repo, so a phase left open re-discovers when a new load changes the key.
 - It reaches the panel through the run-view context (086's admission rule: it
   changes on a selection, never on a keystroke), and `onOpenDependencies` is
   `jumpToTab("deps")` — the shell owns tab switching, and the jump records the

--- a/skills/debug-renovate-config/SKILL.md
+++ b/skills/debug-renovate-config/SKILL.md
@@ -166,7 +166,11 @@ point it at a manifest and it prints the rows Renovate's managers extract.
 
 `validate` exits **2** when Renovate would refuse the config and **1** on an
 infrastructure error, so it works as a check in CI or a hook without a wrapper.
-(Every subcommand that runs the pipeline uses the same exit codes.)
+The other pipeline subcommands use the same codes, with two exceptions:
+`compare` exits **0** whenever the comparison itself ran, even over a config
+Renovate would refuse — the refusal is reported on the output instead — and
+`extract` exits **1** when no manager section produced dependencies, which is
+its verdict rather than a failure.
 
 ## Things worth not re-learning
 

--- a/tools/agents/hooks/readme.md
+++ b/tools/agents/hooks/readme.md
@@ -46,7 +46,10 @@ blocks the stop if any fail, handing back the tail of the failing output.
   takes minutes — running it stays a deliberate step
   (`pnpm --filter @renovate-config-debugger/app build` then `… test:e2e`).
 
-Markdown-only changes skip everything, since none of the checks read prose.
+Markdown-only changes skip everything, since none of the checks read prose —
+except the handful of docs `tools/docs/privacy-claims.spec.ts` pins to the
+worker config. Those are not exempt: they run the always-checks and
+`pnpm test:tools`, but none of the package suites.
 
 Two things keep it from getting in the way:
 

--- a/tools/agents/hooks/stop-check.ts
+++ b/tools/agents/hooks/stop-check.ts
@@ -29,6 +29,14 @@ type PackageName = (typeof PACKAGES)[number];
 const GROUPS = [...PACKAGES, "tools"] as const;
 type CheckGroup = (typeof GROUPS)[number];
 
+/** The files `tools/docs/privacy-claims.spec.ts` reads — keep in sync with it. */
+const DOC_CLAIM_INPUTS = new Set([
+  "README.md",
+  "SECURITY.md",
+  "docs/GitHub-App-Access.md",
+  "packages/oauth-worker/wrangler.jsonc",
+]);
+
 function filter(pkg: PackageName, script: string): string[] {
   return ["--filter", `@renovate-config-debugger/${pkg}`, script];
 }
@@ -54,8 +62,12 @@ const TESTS: Record<CheckGroup, Check[]> = {
   tools: [{ id: "tools specs", args: ["test:tools"] }],
 };
 
-/** Files no check here reads — prose only, so a docs edit shouldn't cost 30s. */
+/** Prose no check here reads, so a docs edit shouldn't cost 30s — except the
+ *  docs `tools/docs/privacy-claims.spec.ts` pins to the worker config. */
 function isCovered(file: string): boolean {
+  if (DOC_CLAIM_INPUTS.has(file)) {
+    return true;
+  }
   return !(file.endsWith(".md") || file.startsWith("docs/") || file.startsWith("roadmap/"));
 }
 
@@ -65,7 +77,14 @@ function isCovered(file: string): boolean {
 function affectedGroups(files: string[]): Set<CheckGroup> {
   const affected = new Set<CheckGroup>();
   for (const file of files) {
-    if (file.startsWith("packages/engine/")) {
+    if (DOC_CLAIM_INPUTS.has(file)) {
+      // Ahead of the root-level catch-all: a README edit runs the guard that
+      // reads it, not the whole matrix.
+      affected.add("tools");
+      if (file.startsWith("packages/oauth-worker/")) {
+        affected.add("oauth-worker");
+      }
+    } else if (file.startsWith("packages/engine/")) {
       affected.add("engine").add("app").add("cli");
     } else if (file.startsWith("packages/app/")) {
       affected.add("app").add("cli");

--- a/tools/agents/hooks/utils/git.spec.ts
+++ b/tools/agents/hooks/utils/git.spec.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getWorkingSet } from "./git.ts";
+
+/**
+ * `getWorkingSet` decides whether the Stop hook runs any check at all: an empty
+ * set exits the hook before lint, typecheck or a single suite (`stop-check.ts`).
+ * So a change git reports must never be filtered out of it — a branch whose only
+ * change is a deletion is exactly the case that would end green while red.
+ */
+let repo: string;
+
+// The developer's own git config must not reach this repo: `commit.gpgsign`,
+// `core.hooksPath` or `init.templateDir` would fail the setup below.
+const env = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null", GIT_CONFIG_SYSTEM: "/dev/null" };
+
+function run(...args: string[]): void {
+  execFileSync("git", args, { cwd: repo, stdio: "ignore", env });
+}
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "rcd-working-set-"));
+  run("init", "--initial-branch", "main");
+  run("config", "user.email", "hooks@example.test");
+  run("config", "user.name", "hooks");
+  for (const name of ["kept.ts", "removed.ts", "moved.ts"]) {
+    writeFileSync(join(repo, name), "export const x = 1;\n");
+  }
+  run("add", ".");
+  run("commit", "-m", "base");
+  // No origin/main and no upstream, so the base ref is HEAD and "changed"
+  // narrows to "uncommitted" — the shape `getBaseRef` documents.
+  run("rm", "removed.ts");
+  run("mv", "moved.ts", "renamed.ts");
+  writeFileSync(join(repo, "kept.ts"), "export const x = 2;\n");
+  writeFileSync(join(repo, "added.ts"), "export const y = 3;\n");
+});
+
+afterAll(() => {
+  rmSync(repo, { recursive: true, force: true });
+});
+
+describe("getWorkingSet", () => {
+  it("reports deletions and both halves of a rename, not just added paths", async () => {
+    const { files } = await getWorkingSet(repo);
+    expect(files.toSorted()).toEqual([
+      "added.ts",
+      "kept.ts",
+      "moved.ts",
+      "removed.ts",
+      "renamed.ts",
+    ]);
+  });
+});

--- a/tools/agents/hooks/utils/git.ts
+++ b/tools/agents/hooks/utils/git.ts
@@ -56,7 +56,9 @@ export interface WorkingSet {
 
 export async function getWorkingSet(root: string): Promise<WorkingSet> {
   const base = await getBaseRef(root);
-  const tracked = lines(await git(["diff", "--name-only", "--diff-filter=ACMR", base], root));
+  // No `--diff-filter`, and renames off: a deletion and BOTH halves of a move
+  // have to reach the set, which only ever string-matches these paths.
+  const tracked = lines(await git(["diff", "--name-only", "--no-renames", base], root));
   // `git diff` only sees files git already knows about, so a brand-new source
   // file — the case where running the tests matters most — is invisible to it.
   const untracked = lines(await git(["ls-files", "--others", "--exclude-standard"], root));

--- a/tools/docs/privacy-claims.spec.ts
+++ b/tools/docs/privacy-claims.spec.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
  * The public deployment ships roadmap 065's cookie mode, so the refresh token
  * outlives the tab. A user-facing doc that promises "closing the tab clears
  * every token" is then a privacy claim the deployment contradicts, which is
- * what this pins: the two shipped docs against whichever mode the Worker
+ * what this pins: the three shipped docs against whichever mode the Worker
  * config declares.
  */
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -27,7 +27,7 @@ const cookieModeShipped =
   );
 
 describe("the privacy docs match the deployed worker", () => {
-  it.each(["README.md", "docs/GitHub-App-Access.md"])(
+  it.each(["README.md", "docs/GitHub-App-Access.md", "SECURITY.md"])(
     "%s describes the refresh token the way the worker stores it, and points at the table",
     (path) => {
       const text = read(path);

--- a/tools/lint/repo-root.ts
+++ b/tools/lint/repo-root.ts
@@ -1,0 +1,30 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * The repo root, for the two house rules that read the tree:
+ * `comment-cites-what-exists` resolves citations against the real files, and
+ * `complete-enumeration-restatement` scrapes its registries out of them.
+ *
+ * It lives here rather than in either rule because a second copy of a helper
+ * that has a home is the exact class three rules of this plugin
+ * (`prefer-is-helpers`, `use-json-helpers`, `use-json-snippet`) were landed to
+ * prevent — the plugin does not get to exempt itself. Memoized once per lint
+ * process, so the two rules share ONE walk rather than one each.
+ */
+let cached: string | undefined;
+export function repoRoot(): string {
+  if (cached !== undefined) {
+    return cached;
+  }
+  let dir = import.meta.dirname;
+  while (!existsSync(join(dir, "pnpm-workspace.yaml"))) {
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error("tools/lint/repo-root.ts: no pnpm-workspace.yaml above the lint plugin");
+    }
+    dir = parent;
+  }
+  cached = dir;
+  return cached;
+}

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -1,5 +1,6 @@
 import { definePlugin } from "@oxlint/plugins";
 import commentCitesWhatExists from "./rules/comment-cites-what-exists.ts";
+import completeEnumerationRestatement from "./rules/complete-enumeration-restatement.ts";
 import noUncaughtVoidChain from "./rules/no-uncaught-void-chain.ts";
 import noUnsynchronisedReassert from "./rules/no-unsynchronised-reassert.ts";
 import preferIsHelpers from "./rules/prefer-is-helpers.ts";
@@ -29,7 +30,7 @@ import useTruncate from "./rules/use-truncate.ts";
  *       fix is not an import: the construct itself is defective wherever it
  *       appears, it shipped that way, and the diagnostic names the correction.
  *
- * Eleven of the fourteen clear (a). Three clear (b): `no-uncaught-void-chain`,
+ * Twelve of the fifteen clear (a). Three clear (b): `no-uncaught-void-chain`,
  * which bans a construct and names no import, and the two the third sweep
  * added, which name a correction instead of a ban. Say which arm a new rule is
  * on when you add one.
@@ -108,8 +109,11 @@ import useTruncate from "./rules/use-truncate.ts";
  * citation against the real tree and its message says which file DOES define
  * the symbol. Two message ids in one file on purpose — the arms share one repo
  * file index, one `getAllComments()` pass and one comment normalization, and
- * two files would walk the filesystem twice. It is the only house rule that
- * touches the filesystem; the walk is memoized once per lint process.
+ * two files would walk the filesystem twice. It is one of the two house rules
+ * that touch the filesystem, and the `pnpm-workspace.yaml` root walk both need
+ * is `tools/lint/repo-root.ts` — one shared function, memoized once per lint
+ * process, because a second copy of it would be the arm-(a) class this plugin
+ * exists to report.
  *
  * The 2026-09 structure sweep IV added two rules and widened two, all on arm
  * (a). `use-lookup-accessors` guards the sharpest defect of the set:
@@ -127,9 +131,10 @@ import useTruncate from "./rules/use-truncate.ts";
  * the simulator's `previewValue` was `fixSnippet`'s body with the budget as a
  * parameter, byte-identical and with the same two imports, living in a feature
  * slice while `value-preview.ts` declared itself the home). Two more literal
- * copies were still live and are converted by landing it. Both rules are
- * app-only, which removes their only false positives structurally rather than
- * by heuristic.
+ * copies were still live and are converted by landing it. Both rules LANDED
+ * app-only, which removed their only false positives structurally rather than
+ * by heuristic; `use-json-snippet` still is, and `use-lookup-accessors` stopped
+ * being one sweep later — see below.
  *
  * The two widenings sit on rules already here. `prefer-plural` grew from the
  * `{n} {pluralWord(n, word)}` adjacency arm to the hand-spelled
@@ -148,6 +153,42 @@ import useTruncate from "./rules/use-truncate.ts";
  * hunting this class. The backtick around the symbol is the whole precision
  * device — without it the possessive matches fifteen lines of ordinary prose,
  * with it five.
+ *
+ * The 2026-09 structure sweep V added one rule and widened three, all on arm
+ * (a). `complete-enumeration-restatement` is the only rule here that guards a
+ * COVERAGE LIE rather than a code defect: a test hand-copies part of an
+ * enumeration that has a home, and the copy silently stops covering the members
+ * added after it was written. `cli/src/main.test.ts` already records the class
+ * in its own words — a hand-written list is how `group` and `mcp` shipped
+ * untested — and sweep V's finding 29 is the same defect in the app, where
+ * "accepts every real tab id" looped six of the seven `RESULTS_TAB_IDS`
+ * (2613e96e); finding 50's own fix then made a second copy of the CLI's drifted
+ * six-of-twelve list in the built bin's only gate. Landing it removes both. It
+ * is the second house rule to touch the filesystem, reusing
+ * `comment-cites-what-exists`'s memoized root walk to scrape its two registries
+ * from the tree, and a scrape that matches nothing goes silent — it fails open.
+ *
+ * The three widenings. `use-lookup-accessors` made the arm-(b)-to-(a) move a
+ * second time by MOVING ITS HOME: the own-key read now lives beside the
+ * predicates as `ownValue(table, key)` in `packages/engine/src/is.ts`, so the
+ * import is `./is` from all three packages, five hand-spelled
+ * `Object.hasOwn(T, k) ? T[k] : undefined` copies collapse onto one function,
+ * and the engine's two caller-keyed tables (`resolvers` in
+ * `shims/presets/local.ts`, `managerExtractors` in `extract.ts`) join the
+ * registry — both of them defects fixed by hand in THIS sweep (40d7e954), the
+ * same class that shipped as sweep IV's finding 69. It is no longer app-only,
+ * and the two app path exemptions became call sites, leaving one exemption
+ * (`shims/repo-config.ts`, a total `Record<HostPlatform, …>` read).
+ * `comment-cites-what-exists` grew a third citation spelling, the EXTENSIONLESS
+ * possessive ``App's `keysLive`` `` — the hole that let findings 26 and 27(c)
+ * survive the sweep before it, since the shipped arm needs the extension. The
+ * module half must be CamelCase or kebab-with-a-hyphen and the symbol must stay
+ * backticked (a bare lowercase word takes 39 matches to 226), and it reports
+ * only when it can name a definite destination, which deliberately silences two
+ * real drifts whose symbols are bound by destructuring. `prefer-plural` grew
+ * `preferPluralNoun`, a hard-spelled plural noun immediately after
+ * `nf.format(n)`: three of the four sites were live "1 <plural>" renderings the
+ * sweep's own review walked past.
  *
  * WHAT IS DELIBERATELY NOT HERE. On arm (a), a rule is the right tool only when
  * the duplicate cannot be REMOVED. The review also found a message phrase the
@@ -169,6 +210,7 @@ export default definePlugin({
   },
   rules: {
     "comment-cites-what-exists": commentCitesWhatExists,
+    "complete-enumeration-restatement": completeEnumerationRestatement,
     "no-uncaught-void-chain": noUncaughtVoidChain,
     "no-unsynchronised-reassert": noUnsynchronisedReassert,
     "prefer-is-helpers": preferIsHelpers,

--- a/tools/lint/rules/comment-cites-what-exists.spec.ts
+++ b/tools/lint/rules/comment-cites-what-exists.spec.ts
@@ -67,6 +67,43 @@ ruleTester.run("comment-cites-what-exists", rule, {
     "// rule lives in App.tsx's `jumpDisplacedFocus`, which is module-private and has\nexport const t = 20;",
     // a possessive whose file is nowhere is arm A's business or nobody's
     "// no-such-module.ts's `nowhereSymbol`\nexport const u = 21;",
+    // ---- arm B, the extensionless spelling: escapes --------------------
+    // THE MODULE HALF IS NEVER A BARE LOWERCASE WORD. Allowing one takes the
+    // raw match count from 39 to 226 — ordinary prose that resolves by accident
+    // against `types/*.ts`.
+    "// the link's `node` is the row the reader clicked\nexport const v = 22;",
+    "// the engine's `digest` is what the header line prints\nexport const w = 23;",
+    // SAME PRECISION DEVICE AS THE ARM ABOVE: no backtick, no citation.
+    "// every page-level key is gated on App's keysLive while the sheet is up\nexport const x = 24;",
+    // the symbol is where the extensionless possessive says it is — and this is
+    // the trailing-apostrophe spelling, which the sweep's own fixes write
+    "// use-keyboard-landings' `keysLive` is the gate every page key reads\nexport const y = 25;",
+    // …and the same possessive spelled as lowercase-leading camelCase is NOT in
+    // the module half at all — the header says so, so this pins it: only
+    // CamelCase or kebab-with-a-hyphen is read, and a would-be lie in this
+    // spelling is silent rather than reported.
+    "// useKeyboardLandings' `nowhereSymbol` is not a spelling this arm reads\nexport const ae = 31;",
+    // AMBIGUOUS, checked before the symbol ever is: `rule-provenance.ts` is both
+    // the app hook and the CLI projection, so the arm declines.
+    "// rule-provenance's `nowhereSymbol` decides the row\nexport const z = 26;",
+    // a module name that resolves to no file at all
+    "// NoSuchModule's `keysLive` is the gate\nexport const aa = 27;",
+    // THE GATE, both live silences, verbatim. `packageRules` is prose naming a
+    // UI row: 151 files mention it and none is its unique home, so the message
+    // could only say "not here, and I cannot tell you where".
+    "/**\n * the `packageRules` array — EffectiveConfig's `packageRules` row is the\n * same list.\n */\nexport const ab = 28;",
+    // THE SAME PLAIN-TEXT RECALL LOSS AS `activeHide`, and it costs this arm
+    // one of the two findings it was built from: sweep V finding 26
+    // (`app/use-focus-landing.ts:55` verbatim, fixed BY HAND in 2613e96e) cited
+    // `App` for a function roadmap 086 had moved into `use-keyboard-landings`,
+    // but App.tsx destructures the moved binding out of the hook, and a mention
+    // counts as present.
+    "/**\n * Exported since the ninth 068 review for App's `gestureWantsResultsLanding`,\n * which asks the same question of the same DOM.\n */\nexport const ad = 30;",
+    // AND THE RECALL COST OF THE GATE, stated rather than hidden (RepoLoadForm.tsx:22,
+    // verbatim): a REAL drift the gate silences, because `inheritAutoEdit` is
+    // bound only by destructuring in `app/use-inherited-config-layer.ts` and no
+    // declaration site can be named.
+    "/**\n * 2026-07-26 — see App's `inheritAutoEdit`) plus the exact repo and file the\n */\nexport const ac = 29;",
     // ---- structurally out of reach: only comments are read ---------------
     'const p = "packages/app/src/nope.tsx";',
     'const q = ["fixtures/does-not-exist.test.ts"];',
@@ -155,6 +192,46 @@ ruleTester.run("comment-cites-what-exists", rule, {
     // both spellings in one comment, two reports
     {
       code: "// `noSuchExport` in App.tsx, and App.tsx's `alsoNoSuchExport`\nexport const o = 15;",
+      errors: [{ messageId: "symbolNotInFile" }, { messageId: "symbolNotInFile" }],
+    },
+    // ---- arm B extensionless, the shipped defect (2613e96e) -------------
+    // Sweep V finding 27(c), `lib/input-schemas.ts:329` verbatim — the kebab
+    // half of the matcher, and the zero-mention branch of the gate: the real
+    // function is `parseRepoReference` in `lib/repo-reference.ts`, so nothing in
+    // the shipped tree defines what this cites.
+    {
+      code: "// Repo-load input (use-repo-load's `parseRepoRef` result, before request building)\nexport const q = 17;",
+      errors: [{ messageId: "symbolNotInFile" }],
+    },
+    // ---- arm B extensionless, the live defects it was landed with -------
+    // `keysLive` is `use-keyboard-landings.ts`'s, and four comments in three
+    // trees said it was App's (ShortcutSheet.tsx:25 verbatim).
+    {
+      code: "/**\n * read), the same way every other page-level key is gated on App's `keysLive`.\n */\nexport const r = 18;",
+      errors: [{ messageId: "symbolNotInFile" }],
+    },
+    // StageRail.tsx:197 verbatim — and it named the right file in the very next
+    // clause, which is how a possessive drifts without anyone noticing.
+    {
+      code: "/** An uninterrupted walk is 1.28 s at this pace; App's `LANDING_WALK_CAP_MS`\n *  (use-landing-walk.ts) must stay comfortably above it. */\nexport const s = 19;",
+      errors: [{ messageId: "symbolNotInFile" }],
+    },
+    // THE TRAILING-APOSTROPHE POSSESSIVE, the spelling the sweep's own fixes
+    // introduced, resolved through the same index.
+    {
+      code: "// use-keyboard-landings' `LANDING_WALK_CAP_MS` paces the walk\nexport const t = 20;",
+      errors: [{ messageId: "symbolNotInFile" }],
+    },
+    // `.mjs` is in the extension list too — the app's build scripts are cited
+    // the same way the modules are.
+    {
+      code: "// build-manifest's `keysLive` decides what the manifest lists\nexport const u = 21;",
+      errors: [{ messageId: "symbolNotInFile" }],
+    },
+    // the extensionless and the extension-carrying spelling of two different
+    // claims in one comment, two reports from two arms
+    {
+      code: "// App's `keysLive`, and App.tsx's `alsoNoSuchExport`\nexport const v = 22;",
       errors: [{ messageId: "symbolNotInFile" }, { messageId: "symbolNotInFile" }],
     },
   ],

--- a/tools/lint/rules/comment-cites-what-exists.ts
+++ b/tools/lint/rules/comment-cites-what-exists.ts
@@ -1,6 +1,7 @@
 import { type Context, defineRule, type ESTree } from "@oxlint/plugins";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { repoRoot } from "../repo-root.ts";
 
 /**
  * Arm (b), and the one arm-(b) rule that names a destination rather than a ban:
@@ -40,15 +41,15 @@ import { dirname, join } from "node:path";
  * PLAIN TEXT, not by scope analysis — a symbol merely mentioned in a comment
  * inside the target counts as present, which trades recall for precision.
  *
- * ARM B READS TWO SPELLINGS of one claim. The first puts the backticked symbol
- * ahead of the file. The second is POSSESSIVE — a bare filename, an apostrophe
- * `s`, then the backticked member (`Thing.tsx`'s `member`) — and it was added
- * because the sweep hunting exactly this class walked past two of them: both
- * halves of `use-share-link`'s sign-in citation named a `signInRef` that has
- * never existed anywhere in the repo. Two of the sweep's own hand fixes are
- * where the spelling comes from (finding 37, e0a388b5, whose fix REWROTE a
- * possessive citation into the shape this rule could already see; finding 29,
- * 75684991).
+ * ARM B READS THREE SPELLINGS of one claim. The first puts the backticked
+ * symbol ahead of the file. The second is POSSESSIVE — a bare filename, an
+ * apostrophe `s`, then the backticked member (`Thing.tsx`'s `member`) — and it
+ * was added because the sweep hunting exactly this class walked past two of
+ * them: both halves of `use-share-link`'s sign-in citation named a `signInRef`
+ * that has never existed anywhere in the repo. Two of the sweep's own hand
+ * fixes are where the spelling comes from (finding 37, e0a388b5, whose fix
+ * REWROTE a possessive citation into the shape this rule could already see;
+ * finding 29, 75684991).
  *
  * The backtick around the symbol is the possessive arm's entire precision
  * device: without it the possessive matches fifteen lines of ordinary prose in
@@ -57,6 +58,47 @@ import { dirname, join } from "node:path";
  * the symbol stays a single identifier: widening it to a dotted member path
  * would have caught finding 29 as well, but no dotted possessive citation
  * exists in the tree, so that widening has no measured precision to stand on.
+ *
+ * THE THIRD SPELLING IS THE SAME POSSESSIVE WITH THE EXTENSION LEFT OFF —
+ * `App`'s `keysLive`, `use-repo-load`'s `parseRepoRef` — and it exists because
+ * sweep V found two of them by hand that the extension-carrying arm above could
+ * not see (finding 26, `use-focus-landing.ts`, citing `App` for a binding
+ * roadmap 086 had moved; finding 27(c), `input-schemas.ts`, citing a
+ * `parseRepoRef` that matches nothing in the repo — both fixed in 2613e96e, and
+ * both fixed by REWRITING the citation into the extension-carrying shape). That
+ * is the class surviving its second sweep in a row: the shipped possessive arm
+ * exists because `App.tsx`'s `signInRef` was walked past, and these are the
+ * identical claim with three characters missing. This arm catches 27(c); 26
+ * still falls to the plain-text trade, because App.tsx destructures the moved
+ * binding out of the hook and a mention counts as present. Widening to the
+ * declaration would report every re-export in the tree.
+ *
+ * THREE PRECISION DEVICES, ALL MEASURED. (i) The module half is CamelCase or
+ * kebab-WITH-a-hyphen, never a bare lowercase word: allowing lowercase words
+ * takes the raw match count from 39 to 226 — `link`'s `node`, `engine`'s
+ * `digest` — which resolve accidentally against `types/*.ts`. (ii) The backtick
+ * around the symbol stays, the same device the arm above calls its whole
+ * precision device. (iii) The name resolves through `<name>.ts` / `.tsx` /
+ * `.mjs` and must hit exactly ONE file, the same unique-target rule the arm
+ * above applies. Disjoint from that arm by construction: `App.tsx`'s `x` cannot
+ * match, since the lookbehind rejects the preceding `.` and `tsx` is neither
+ * CamelCase nor hyphenated.
+ *
+ * AND ONE GATE THIS ARM CARRIES ALONE: it reports only when the message can
+ * name something definite — a unique `definitionSite`, or a symbol no source
+ * file mentions at all. An extensionless name is a weaker claim than a path, so
+ * a report that can only say "not here, and I cannot tell you where" is not
+ * worth its false-positive risk. Measured over `packages/**`: 39 raw matches,
+ * 21 resolve to a unique file, 14 correctly silent because the symbol IS in the
+ * cited file, 5 reports, all true. THE RECALL COST IS TWO, both stated: the
+ * gate silences `EffectiveConfig`'s `packageRules` (`hooks/rule-provenance.ts`
+ * — prose naming a UI row, 151 files mention the symbol) and, deliberately,
+ * `App`'s `inheritAutoEdit` (`RepoLoadForm.tsx`), a REAL drift whose symbol is
+ * bound only by destructuring, so no declaration site can be named. The count
+ * is taken over `packages/**` only, for the same reason the SCOPE note below
+ * gives: a census entry in a `tools/**` header is not the tree still using the
+ * symbol, and counting one would silence the arm on the very citations the
+ * headers are a record of.
  *
  * Comments are the only thing read, so string literals and JSX are structurally
  * out of reach in both directions.
@@ -98,24 +140,25 @@ const SYMBOL_HOME_CITATION =
 /** The same claim possessed: the file, then the backticked symbol it owns. */
 const POSSESSIVE_HOME_CITATION = /([\w.@/-]+\.tsx?)'s\s+`([A-Za-z_$][\w$]*)`/g;
 
+/**
+ * The possessive with the extension left off. The module half is CamelCase or
+ * kebab-with-a-hyphen — a bare lowercase word matches ordinary prose — and
+ * `'s?` also reads the trailing-apostrophe possessive the sweep's own fixes
+ * write (`use-keyboard-landings' `member``: a lowercase-leading camelCase name
+ * is NOT in the module half, so `useKeyboardLandings' `member`` is silent).
+ */
+const MODULE_HOME_CITATION =
+  /(?<![\w./-])((?:[A-Z][A-Za-z0-9]*)|(?:[a-z][a-z0-9]*(?:-[a-z0-9]+)+))'s?\s+`([A-Za-z_$][\w$]*)`/g;
+
+/** The extensions an extensionless module name is tried with. */
+const MODULE_EXTENSIONS = [".ts", ".tsx", ".mjs"];
+
 /** Files a symbol could be DEFINED in — the destination search reads only these. */
 const SOURCE_FILE = /\.(?:tsx|jsx|mjs|ts|js)$/;
 
 interface FileIndex {
   readonly byBasename: ReadonlyMap<string, readonly string[]>;
   readonly paths: ReadonlySet<string>;
-}
-
-function findRepoRoot(): string {
-  let dir = import.meta.dirname;
-  while (!existsSync(join(dir, "pnpm-workspace.yaml"))) {
-    const parent = dirname(dir);
-    if (parent === dir) {
-      throw new Error("comment-cites-what-exists: no pnpm-workspace.yaml above the rule file");
-    }
-    dir = parent;
-  }
-  return dir;
 }
 
 function indexRepo(root: string): FileIndex {
@@ -148,11 +191,13 @@ function indexRepo(root: string): FileIndex {
 
 // Built once per lint process, on the first comment the rule actually looks at:
 // importing the plugin should not walk the tree in a run that never enables it.
+// The root walk itself is `../repo-root.ts`, shared with the one other rule
+// that reads the tree.
 let index: FileIndex | undefined;
 let root = "";
 function fileIndex(): FileIndex {
   if (index === undefined) {
-    root = findRepoRoot();
+    root = repoRoot();
     index = indexRepo(root);
   }
   return index;
@@ -195,6 +240,30 @@ function definitionSite(symbol: string): string | null {
   return only;
 }
 
+/**
+ * How many SHIPPED source files mention `symbol` at all — the gate on the
+ * extensionless arm reads this. Counted over the rule's own scope and not the
+ * whole index for the reason the scope note below gives: `tools/**` keeps a
+ * past-tense census of symbols the tree no longer has, and a census entry is
+ * not the tree still using the symbol.
+ */
+const mentions = new Map<string, number>();
+function mentionCount(symbol: string): number {
+  const cached = mentions.get(symbol);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const used = new RegExp(`\\b${symbol.replaceAll("$", "\\$")}\\b`);
+  let count = 0;
+  for (const path of fileIndex().paths) {
+    if (path.startsWith("packages/") && SOURCE_FILE.test(path) && used.test(textOf(path))) {
+      count += 1;
+    }
+  }
+  mentions.set(symbol, count);
+  return count;
+}
+
 /** A wrapped JSDoc citation is one token: strip the leading `*` of each line and join with a space. */
 function normalize(comment: ESTree.Comment): string {
   return comment.value
@@ -211,6 +280,22 @@ function isFragment(text: string, match: RegExpExecArray): boolean {
 
 function basenameOf(path: string): string {
   return path.slice(path.lastIndexOf("/") + 1);
+}
+
+function onlyFile(candidates: readonly string[]): string | undefined {
+  return candidates.length === 1 ? candidates[0] : undefined;
+}
+
+/** A citation that carries its own extension resolves by basename, so a colocation move is not a miss. */
+function citedFile(cited: string): string | undefined {
+  return onlyFile(fileIndex().byBasename.get(basenameOf(cited)) ?? []);
+}
+
+/** An extensionless name is tried as each module extension, and must still land on exactly one file. */
+function citedModule(name: string): string | undefined {
+  return onlyFile(
+    MODULE_EXTENSIONS.flatMap((extension) => fileIndex().byBasename.get(name + extension) ?? []),
+  );
 }
 
 export default defineRule({
@@ -265,16 +350,36 @@ function reportMissingFiles(context: Context, comment: ESTree.Comment, text: str
 }
 
 function reportMisplacedSymbols(context: Context, comment: ESTree.Comment, text: string): void {
-  // One body, two spellings: the groups only differ in which end of the claim
-  // they capture, so the arm is a pattern plus where its symbol sits.
+  // One body, three spellings: they differ only in which end of the claim they
+  // capture, how the cited half resolves to a file, and whether the message has
+  // to be able to name a destination.
   const spellings = [
-    { pattern: SYMBOL_HOME_CITATION, symbolGroup: 1, fileGroup: 2 },
-    { pattern: POSSESSIVE_HOME_CITATION, symbolGroup: 2, fileGroup: 1 },
+    {
+      pattern: SYMBOL_HOME_CITATION,
+      symbolGroup: 1,
+      fileGroup: 2,
+      resolve: citedFile,
+      gated: false,
+    },
+    {
+      pattern: POSSESSIVE_HOME_CITATION,
+      symbolGroup: 2,
+      fileGroup: 1,
+      resolve: citedFile,
+      gated: false,
+    },
+    {
+      pattern: MODULE_HOME_CITATION,
+      symbolGroup: 2,
+      fileGroup: 1,
+      resolve: citedModule,
+      gated: true,
+    },
   ];
-  for (const { pattern, symbolGroup, fileGroup } of spellings) {
+  for (const { pattern, symbolGroup, fileGroup, resolve, gated } of spellings) {
     pattern.lastIndex = 0;
     for (let match = pattern.exec(text); match !== null; match = pattern.exec(text)) {
-      reportIfMisplaced(context, comment, match[symbolGroup], match[fileGroup]);
+      reportIfMisplaced(context, comment, match[symbolGroup], match[fileGroup], resolve, gated);
     }
   }
 }
@@ -284,14 +389,15 @@ function reportIfMisplaced(
   comment: ESTree.Comment,
   symbol: string | undefined,
   cited: string | undefined,
+  resolve: (cited: string) => string | undefined,
+  gated: boolean,
 ): void {
   if (symbol === undefined || cited === undefined) {
     return;
   }
   // A missing or ambiguous target is arm A's business or nobody's: this arm
   // only ever checks a symbol against the ONE file the comment names.
-  const candidates = fileIndex().byBasename.get(basenameOf(cited)) ?? [];
-  const target = candidates.length === 1 ? candidates[0] : undefined;
+  const target = resolve(cited);
   if (target === undefined) {
     return;
   }
@@ -299,6 +405,11 @@ function reportIfMisplaced(
     return;
   }
   const home = definitionSite(symbol);
+  // The extensionless spelling reports only when the message can name something
+  // definite: a unique home, or a symbol the tree never mentions.
+  if (gated && home === null && mentionCount(symbol) !== 0) {
+    return;
+  }
   context.report({
     loc: comment.loc,
     messageId: "symbolNotInFile",

--- a/tools/lint/rules/comment-cites-what-exists.ts
+++ b/tools/lint/rules/comment-cites-what-exists.ts
@@ -61,7 +61,9 @@ import { dirname, join } from "node:path";
  * Comments are the only thing read, so string literals and JSX are structurally
  * out of reach in both directions.
  *
- * SCOPE IS PART OF THE PRECISION, and the override comment has to say so.
+ * SCOPE IS PART OF THE PRECISION, and the override comment has to say so. All
+ * of `packages/**` is in — src, every test tree, e2e and scripts alike, since
+ * an enumeration of trees is what let two test suites drift out of scope.
  * `tools/**` is deliberately out: a rule header here keeps a past-tense census
  * of WHAT WAS IN THE TREE, naming symbols and files the sweep deleted on
  * purpose (`prefer-is-helpers`' is the standing example). That is the one

--- a/tools/lint/rules/complete-enumeration-restatement.spec.ts
+++ b/tools/lint/rules/complete-enumeration-restatement.spec.ts
@@ -1,0 +1,88 @@
+import { ruleTester } from "../rule-tester.ts";
+import rule from "./complete-enumeration-restatement.ts";
+
+// The registries are scraped from the real tree, so these cases spell the real
+// members: twelve `rcd` commands, seven results-tab ids. A member added to
+// either enumeration turns the "complete" cases below into the very drift the
+// rule reports, which is the intended way for this spec to fail.
+const ALL_COMMANDS =
+  '["compare", "digest", "docs", "extract", "group", "mcp", "provenance", "resolved", "run", "simulate", "tree", "validate"]';
+const ALL_TABS = '["overview", "tests", "pipeline", "presets", "effective", "deps", "problems"]';
+
+ruleTester.run("complete-enumeration-restatement", rule, {
+  valid: [
+    // ---- COMPLETE is deliberately silent: a full list is a golden pin, and it
+    // starts reporting only once the enumeration grows past it.
+    `for (const name of ${ALL_COMMANDS}) { expect(run.stdout).toContain(name); }`,
+    `for (const tab of ${ALL_TABS}) { expect(resultsTabIdSchema.safeParse(tab).success).toBe(true); }`,
+    // `share.test.ts`'s pin — the admissible shape, and the correction the
+    // message names for a site that wants to keep a literal.
+    `expect(RESULTS_TAB_IDS).toEqual(${ALL_TABS});`,
+    // the definition itself, which is a complete list by construction
+    `export const RESULTS_TAB_IDS = ${ALL_TABS} as const;`,
+    // ---- the correction, once applied: neither shape is a literal list any more
+    "for (const name of COMMANDS.map((command) => command.name)) { expect(run.stdout).toContain(name); }",
+    "for (const tab of RESULTS_TAB_IDS) { check(tab); }",
+    // ---- one member is not a restatement of anything
+    'const only = ["validate"];',
+    // ---- a list that mixes in a name the registry does not have is some other
+    // list, not a partial copy of this one
+    'const mixed = ["validate", "digest", "publish"];',
+    'const tabs = ["overview", "tests", "settings"];',
+    // ---- nothing here is a member at all
+    'const files = ["clean.json", "invalid.json"];',
+    'const keys = ["labels", "extends"];',
+    // ---- not a plain list of string literals: spread, identifier, template,
+    // hole, non-string. Each would need to be evaluated to know what it names.
+    'const spread = ["validate", ...others];',
+    'const named = ["validate", digestName, "run", "simulate", "compare", "docs"];',
+    "const templated = [`validate`, `digest`, `run`, `simulate`, `compare`, `docs`];",
+    'const sparse = ["validate", , "digest", "run", "simulate", "compare", "docs"];',
+    'const mixedTypes = ["validate", 2, "run", "simulate", "compare", "docs"];',
+    'const nested = [["clean.json", "invalid.json"], ["stdin.json"]];',
+  ],
+  invalid: [
+    // `packages/cli/test/bin.test.ts:83` — six of the twelve commands, under the
+    // title "--help writes the command list to stdout and exits 0".
+    {
+      code: 'for (const name of ["validate", "digest", "run", "simulate", "compare", "docs"]) { expect(run.stdout).toContain(name); }',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // `packages/cli/test/bundle/cli-surface.test.ts:56` — the second copy of
+    // that same drifted list, looped twice in the built bin's only gate.
+    {
+      code: 'const COMMANDS = ["validate", "digest", "run", "simulate", "compare", "docs"];',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // THE ORIGINAL DEFECT, verbatim from before 2613e96e: "accepts every real
+    // tab id" looped six of the seven ids, and `deps` was silently unasserted.
+    {
+      code: 'for (const tab of ["overview", "tests", "pipeline", "presets", "effective", "problems"]) { expect(resultsTabIdSchema.safeParse(tab).success).toBe(true); }',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // a single missing member is the whole defect — the drift is always one id
+    // at a time, and the rule fires on the first one
+    {
+      code: 'const commands = ["compare", "digest", "docs", "extract", "group", "mcp", "provenance", "resolved", "run", "simulate", "tree"];',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // the smallest restatement the rule sees at all
+    {
+      code: 'const pair = ["validate", "digest"];',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // single quotes are the same list
+    {
+      code: "const tabs = ['overview', 'tests', 'pipeline'];",
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+    // THE RESIDUAL FALSE POSITIVE, pinned rather than left to be discovered: a
+    // subset chosen on purpose reads exactly like a drifted copy, and the rule
+    // says so. No such site exists today; when one does, it takes an inline
+    // disable naming the subset.
+    {
+      code: 'expect(visibleTabs).toEqual(["overview", "tests"]);',
+      errors: [{ messageId: "iterateTheEnumeration" }],
+    },
+  ],
+});

--- a/tools/lint/rules/complete-enumeration-restatement.ts
+++ b/tools/lint/rules/complete-enumeration-restatement.ts
@@ -1,0 +1,187 @@
+import { defineRule, type ESTree } from "@oxlint/plugins";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { repoRoot } from "../repo-root.ts";
+
+/**
+ * Arm (a), and the only rule of the set that guards a COVERAGE LIE rather than
+ * a code defect: a test hand-copies part of an enumeration that has a home, and
+ * the copy stops covering the members added after it was written.
+ *
+ * The class shipped, and the tree records it. `packages/cli/src/main.test.ts`
+ * says it in its own words — "a hand-written list is how `group` and `mcp` came
+ * to be shipped untested by this suite" — and converted that suite to iterate
+ * the registry. Sweep V's finding 29 is the other half in the app: a test
+ * titled "accepts every real tab id" looped SIX of the seven `RESULTS_TAB_IDS`,
+ * because the hand-copied list never gained the `deps` id roadmap 089 added
+ * (2613e96e adds the literal, and nothing stops the eighth id drifting the same
+ * way). Finding 50's own fix then created a second copy of the CLI's drifted
+ * list, in the file that is the built bin's only gate.
+ *
+ * Invisible in review is the whole point: every one of these lists is a correct
+ * list of real names, and only counting it against the registry shows it is six
+ * of twelve.
+ *
+ * A COMPLETE RESTATEMENT IS DELIBERATELY SILENT. That is the proper-subset
+ * condition, and it is what keeps the rule honest: a full list is a golden pin —
+ * `share.test.ts`'s `expect(RESULTS_TAB_IDS).toEqual([…])` is the admissible
+ * shape — and it starts reporting the moment the enumeration grows, which is
+ * exactly the moment the copy becomes a lie. Requiring EVERY element to be a
+ * plain string literal and a member excludes the rest: a list that mixes in one
+ * name the registry does not have is not a restatement of it, it is some other
+ * list.
+ *
+ * THE ONE RESIDUAL FALSE POSITIVE, named here rather than discovered later: a
+ * proper subset chosen ON PURPOSE is indistinguishable from a drifted copy, and
+ * the rule reports it. `expect(visibleTabs).toEqual(["overview", "tests"])` —
+ * a test about a FILTERED tab strip — reads as "names 2 of the 7 ids in
+ * `RESULTS_TAB_IDS`". Zero such sites exist today, so no exemption is carried;
+ * when one appears the answer is an inline disable saying which subset it is,
+ * because the alternative (guessing intent from the assertion around the list)
+ * is the heuristic this rule is built to avoid.
+ *
+ * THE REGISTRIES ARE READ FROM THE TREE, through the same root walk
+ * `comment-cites-what-exists` uses — `tools/lint/repo-root.ts`, shared rather
+ * than copied, and memoized there once per lint process for both. Two entries,
+ * two file reads, no type information and no cross-file AST. The command list is `readdirSync` of `packages/cli/src/commands/` minus
+ * the colocated tests, which is literally what `main.test.ts`'s own
+ * `commandModules` reads, so the rule and the suite agree on what "exists"
+ * means. A scrape that matches nothing yields an empty registry and the rule
+ * goes silent — it fails open, never toward a false positive — and adding an
+ * entry is the only way to widen it, so the blast radius stays a decision.
+ * (`ENGINE_STAGE_IDS` would be a one-line third and adds nothing today: all
+ * three of its restatements are complete, and one is already pinned by
+ * `satisfies`.)
+ *
+ * SCOPE IS TEST TREES ONLY, where a restatement stands in for coverage. The
+ * repo measures identically clean when the rule is pointed at everything, so
+ * the scope buys no precision today — it keeps the message TRUE of every site
+ * the rule can reach, and structurally excludes a future production subset that
+ * is deliberately partial. The registry definitions are complete lists and are
+ * therefore out of shape even inside the glob, so the rule needs no exemption
+ * anywhere.
+ */
+
+/** Where the enumerations live, and where a test should be reading them from. */
+interface Registry {
+  /** How the message names the set. */
+  readonly label: string;
+  /** The correction the message names: what to iterate instead of the copy. */
+  readonly source: string;
+  readonly members: readonly string[];
+}
+
+const COMMANDS_DIR = "packages/cli/src/commands";
+const RESULTS_TABS_FILE = "packages/app/src/data/results-tabs.ts";
+
+/** The `as const` block by name — anchored on the export, so the retired-id lists below it are not read. */
+const RESULTS_TAB_IDS_BLOCK = /export const RESULTS_TAB_IDS\s*=\s*\[([^\]]*)\]\s*as const/;
+const DOUBLE_QUOTED = /"([^"]*)"/g;
+
+/** One module per command, named after it — the convention `main.test.ts` reads as the list that EXISTS. */
+function commandMembers(root: string): readonly string[] {
+  try {
+    return readdirSync(join(root, COMMANDS_DIR))
+      .filter((file) => file.endsWith(".ts") && !file.endsWith(".test.ts"))
+      .map((file) => file.slice(0, -".ts".length));
+  } catch {
+    return [];
+  }
+}
+
+function resultsTabMembers(root: string): readonly string[] {
+  let text = "";
+  try {
+    text = readFileSync(join(root, RESULTS_TABS_FILE), "utf8");
+  } catch {
+    return [];
+  }
+  const block = RESULTS_TAB_IDS_BLOCK.exec(text);
+  const body = block?.[1];
+  if (body === undefined) {
+    return [];
+  }
+  return [...body.matchAll(DOUBLE_QUOTED)].map((match) => match[1] ?? "");
+}
+
+// Built once per lint process. An entry that scraped nothing is dropped rather
+// than kept empty, so a moved file silences that arm instead of misreporting.
+let registries: readonly Registry[] | undefined;
+function enumerations(): readonly Registry[] {
+  if (registries === undefined) {
+    const root = repoRoot();
+    registries = [
+      {
+        label: `\`rcd\` commands in \`${COMMANDS_DIR}/\``,
+        source:
+          "`COMMANDS` from `src/main`, or the `src/commands/` module listing where importing `src/` is not available",
+        members: commandMembers(root),
+      },
+      {
+        label: "ids in `RESULTS_TAB_IDS`",
+        source: "`RESULTS_TAB_IDS` from `@/data/results-tabs`",
+        members: resultsTabMembers(root),
+      },
+    ].filter((registry) => registry.members.length > 0);
+  }
+  return registries;
+}
+
+/** The array's values when it is a plain list of at least two string literals — no spread, no hole, no expression. */
+function stringLiterals(node: ESTree.ArrayExpression): readonly string[] | undefined {
+  const values: string[] = [];
+  for (const element of node.elements) {
+    if (element === null || element.type !== "Literal" || typeof element.value !== "string") {
+      return undefined;
+    }
+    values.push(element.value);
+  }
+  return values.length < 2 ? undefined : values;
+}
+
+function quoteAll(names: readonly string[]): string {
+  return names.map((name) => `\`${name}\``).join(", ");
+}
+
+export default defineRule({
+  meta: {
+    type: "suggestion",
+    messages: {
+      iterateTheEnumeration:
+        "This list names {{n}} of the {{total}} {{registry}} — missing {{missing}} — so it asserts nothing about the rest. Iterate {{source}}, or pin the whole list with `toEqual`, which fails on drift by construction.",
+    },
+  },
+  createOnce(context) {
+    const known = enumerations();
+    return {
+      ArrayExpression(node) {
+        const values = stringLiterals(node);
+        if (values === undefined) {
+          return;
+        }
+        const present = new Set(values);
+        for (const registry of known) {
+          if (!values.every((value) => registry.members.includes(value))) {
+            continue;
+          }
+          const missing = registry.members.filter((member) => !present.has(member));
+          if (missing.length === 0) {
+            return;
+          }
+          context.report({
+            node,
+            messageId: "iterateTheEnumeration",
+            data: {
+              n: String(present.size),
+              total: String(registry.members.length),
+              registry: registry.label,
+              missing: quoteAll(missing),
+              source: registry.source,
+            },
+          });
+          return;
+        }
+      },
+    };
+  },
+});

--- a/tools/lint/rules/prefer-plural.spec.ts
+++ b/tools/lint/rules/prefer-plural.spec.ts
@@ -115,6 +115,97 @@ ruleTester.run("prefer-plural", rule, {
     'const s = n === 1 ? "rules" : "rule";',
     // a suffix neither helper can append
     'const s = n === 1 ? "" : "es";',
+
+    // ---- Sweep V: the noun hard-spelled beside `nf.format(n)` --------------
+    // already the helper, in both of its spellings
+    'const line = `${plural(rules.length, "rule")} evaluated per test`;',
+    { code: 'const el = <p>Show all {plural(stat.total, "line")}</p>;', filename: tsx },
+
+    // A camelCase token after the count is a quoted Renovate config key, not
+    // prose — `LedgerFamilies`, the one false positive the lowercase class
+    // excludes structurally. `plural(n, "packageRule")` would rename the key.
+    {
+      code: "const el = <p>— {nf.format(totalRules)} packageRules in this expansion</p>;",
+      filename: tsx,
+    },
+    "const note = `${nf.format(totalRules)} packageRules in this expansion`;",
+    // the same guard where the token's lowercase head itself ends in "s"
+    "const note = `${nf.format(n)} statusChecks were considered`;",
+
+    // ---- a word BETWEEN the count and the noun: not a shape `plural` can
+    // express, which is why the other 48 `nf.format` sites are out of shape.
+    "const base = `${nf.format(builtIn)} of ${total} managers matched files`;",
+    "const more = `… ${nf.format(hidden.length)} more across ${named}`;",
+    "const s = `${nf.format(n)} matched rules`;",
+    "const s = `${nf.format(n)} skipped rules`;",
+    // `JsonDiff`'s own header line: the first word after the count is singular
+    "const s = `Showing the first ${nf.format(MAX)} of ${nf.format(total)} diff lines`;",
+    // two rendered spaces is not `plural`'s output either
+    "const s = `${nf.format(n)}  rules`;",
+    // and no space at all is not it
+    "const s = `${nf.format(n)}rules`;",
+
+    // ---- singulars that merely END in "s": `plural` would spell "acrosss".
+    "const s = `${nf.format(n)} across the tree`;",
+    "const s = `${nf.format(n)} status lines`;",
+    "const s = `${nf.format(n)} analysis passes`;",
+    "const s = `${nf.format(n)} less than before`;",
+    // ---- and the "-ies" stem splice, which `plural` cannot spell either:
+    // `plural(n, "dependencie")` is not advice. This is the likeliest plural in
+    // this tree — `countNoun`/`DataTableNoun` exists for exactly this class.
+    "const s = `${nf.format(n)} dependencies found`;",
+    "const s = `${nf.format(n)} properties`;",
+    { code: "const el = <p>{nf.format(n)} entries</p>;", filename: tsx },
+    // ---- and words shorter than four characters, which are not nouns here
+    "const s = `${nf.format(n)} was dropped`;",
+    "const s = `${nf.format(n)} has been pinned`;",
+    // ---- a word that is not a plural at all
+    "const s = `${nf.format(n)} rule`;",
+    "const s = `${nf.format(extract.deps.length)} dep`;",
+
+    // ---- NEITHER HOME SELF-REPORTS on this arm: `plural`'s body and
+    // `countNoun`'s both put an EXPRESSION after the space, not a word, so it
+    // asks for no exemption beyond the `lib/format.ts` one the config already
+    // carries for the suffix arm.
+    "const out = `${nf.format(n)} ${word}${suffix}`;",
+    "export function countNoun(n: number, noun: DataTableNoun) { return `${nf.format(n)} ${n === 1 ? noun.one : noun.many}`; }",
+
+    // ---- the subject is `nf.format` with exactly one argument, matched by
+    // source text: a different formatter, method or arity is not it.
+    "const s = `${pf.format(n)} rules`;",
+    "const s = `${nf.formatRange(a, b)} rules`;",
+    "const s = `${nf.format(n, opts)} rules`;",
+    "const s = `${format(n)} rules`;",
+
+    // ---- an ELEMENT between the count and the noun: the count is in its own
+    // element, which is chrome `plural` cannot produce — the same silence the
+    // `pluralWord` arm above keeps.
+    {
+      code: "const el = <p>{nf.format(n)} <strong>rules</strong> matched</p>;",
+      filename: tsx,
+    },
+    {
+      code: 'const el = <p><strong>{nf.format(n)}</strong>{" "}rules apply</p>;',
+      filename: tsx,
+    },
+    // ---- `{" "}` is ONE rendered space, so a space of its own after it is two,
+    // which is not what `plural` prints
+    {
+      code: 'const el = <p>expands to {nf.format(total)}{" "} presets.</p>;',
+      filename: tsx,
+    },
+    // ---- the noun on the next SOURCE line with no `{" "}`: the newline-indent
+    // renders as nothing, so this is `{count}presets`, not `plural`'s output
+    {
+      code: "const el = <p>expands to {nf.format(total)}\n        presets.</p>;",
+      filename: tsx,
+    },
+    // ---- the wrapped separator in front of the helper, which is the shape the
+    // four live sites already have — the next rendered child is a container
+    {
+      code: 'const el = <p>{nf.format(sources)}{" "}{pluralWord(sources, "source")}</p>;',
+      filename: tsx,
+    },
   ],
   invalid: [
     // ---- THE ORIGINAL. 27b81f43 swept `SimRulesBody`'s ad-hoc
@@ -260,6 +351,82 @@ ruleTester.run("prefer-plural", rule, {
     {
       code: 'const parts = [`${a} error${a === 1 ? "" : "s"}`, `${b} warning${b === 1 ? "" : "s"}`];',
       errors: [{ messageId: "preferPluralSuffix" }, { messageId: "preferPluralSuffix" }],
+    },
+
+    // ---- Sweep V. THE ORIGINAL: `PinsView`'s summary line before 2613e96e,
+    // which rendered "1 rules evaluated per test" for a one-rule config.
+    // The `{{word}}` slot makes the message quote the fix, so it is pinned.
+    {
+      code: "const note = ` · ${nf.format(ruleCount)} rules evaluated per test, in merge order`;",
+      errors: [{ messageId: "preferPluralNoun", data: { word: "rule" } }],
+    },
+    // `TreeRow`'s rollup badge, the same commit: "· 1 presets" / "· 1 rules"
+    // for a collapsed node with a single resolved descendant.
+    {
+      code: 'const el = <ExplainedText className="badge">{stats.descResolved > 0 ? `· ${nf.format(stats.descResolved)} presets ` : ""}{stats.descRules > 0 ? `· ${nf.format(stats.descRules)} rules` : ""}</ExplainedText>;',
+      filename: tsx,
+      errors: [
+        { messageId: "preferPluralNoun", data: { word: "preset" } },
+        { messageId: "preferPluralNoun", data: { word: "rule" } },
+      ],
+    },
+
+    // ---- the four sites still standing when this arm landed.
+    // `PhasePicker`: the extract phase's note rendered "+1 deps".
+    {
+      code: 'const note = { text: `+${nf.format(extract.deps.length)} deps`, tone: "ok" };',
+      errors: [{ messageId: "preferPluralNoun", data: { word: "dep" } }],
+    },
+    // `extract-phase`: "0 of 1 managers matched files" — the FIRST count is
+    // followed by " of ", so only the second one is in shape.
+    {
+      code: "const base = `${nf.format(builtIn)} of ${nf.format(view.managersConsidered)} managers matched files`;",
+      errors: [{ messageId: "preferPluralNoun", data: { word: "manager" } }],
+    },
+    // `EffectiveConfig`'s table note: "1 options in the config Renovate runs".
+    {
+      code: 'const el = <p className="data-table-note">{nf.format(entries.length)} options in the config Renovate runs · hover any key</p>;',
+      filename: tsx,
+      errors: [{ messageId: "preferPluralNoun", data: { word: "option" } }],
+    },
+    // `JsonDiff`'s "Show all" button — output-identical, since the footer only
+    // renders above the truncation threshold, but the same spelling.
+    {
+      code: 'const el = <button type="button">Show all {nf.format(stat.total)} lines</button>;',
+      filename: tsx,
+      errors: [{ messageId: "preferPluralNoun", data: { word: "line" } }],
+    },
+    // the noun as the direct text of a fragment
+    {
+      code: "const el = <>{nf.format(count)} rules</>;",
+      filename: tsx,
+      errors: [{ messageId: "preferPluralNoun", data: { word: "rule" } }],
+    },
+    // two counts in one sentence, each with its noun beside it
+    {
+      code: "const s = `${nf.format(n)} rules, ${nf.format(m)} presets.`;",
+      errors: [
+        { messageId: "preferPluralNoun", data: { word: "rule" } },
+        { messageId: "preferPluralNoun", data: { word: "preset" } },
+      ],
+    },
+    // THE WRAPPED SEPARATOR, which oxfmt writes the moment the line grows past
+    // the width: `{" "}` renders the same single space the `JSXText` one does,
+    // so the site is identical and the report has to be too — otherwise the arm
+    // is silenced by a formatting accident (`OriginFraming`'s spelling before
+    // 2613e96e put it on `plural`).
+    {
+      code: 'const el = <p>expands to {nf.format(total)}{" "}presets.</p>;',
+      filename: tsx,
+      errors: [{ messageId: "preferPluralNoun", data: { word: "preset" } }],
+    },
+    // …including with the noun on the line after it, which is what the wrap
+    // actually looks like: JSX strips the newline-indent, so it renders one
+    // space and nothing else.
+    {
+      code: 'const el = <p>evaluated {nf.format(ruleCount)}{" "}\n        rules per test</p>;',
+      filename: tsx,
+      errors: [{ messageId: "preferPluralNoun", data: { word: "rule" } }],
     },
   ],
 });

--- a/tools/lint/rules/prefer-plural.ts
+++ b/tools/lint/rules/prefer-plural.ts
@@ -86,6 +86,49 @@ import { defineRule, type ESTree } from "@oxlint/plugins";
  * it. The import differs per package and the messages say so: `@/lib/format` in
  * the app, `@renovate-config-debugger/app/headless` in the CLI, which re-exports
  * both from that same file.
+ *
+ * SWEEP V WIDENS IT ONCE MORE, to the noun that is hard-spelled beside a
+ * `nf.format(n)` with no ternary at all — the same divergence with the
+ * conditional deleted, so a count of one renders "1 rules". It reached users
+ * three times in one commit's findings (PinsView's "1 rules evaluated per
+ * test", TreeRow's "· 1 presets", OriginFraming's collapsed sentence, all
+ * fixed in 2613e96e onto `plural`), and it is invisible in review because every
+ * copy is correct at the counts a reviewer pictures.
+ *
+ * `nf` IS THE SUBJECT because there is exactly one of it: a single shared
+ * `Intl.NumberFormat` exported from `packages/app/src/lib/format.ts` and
+ * imported under that name in both packages, so matching the callee's source
+ * text needs no type information and cannot mean anything else.
+ *
+ * THREE NARROWINGS, each measured over all 53 `nf.format(` sites in the tree,
+ * of which exactly five are followed by a lowercase word ending in "s":
+ *
+ *   - ALL-LOWERCASE. A camelCase token after the count is a quoted Renovate
+ *     config key, not English prose, and this is what structurally excludes the
+ *     one false positive in the tree — `LedgerFamilies`' `{nf.format(totalRules)}
+ *     packageRules`, where `plural(n, "packageRule")` would rename the key to
+ *     make the sentence agree.
+ *   - FOUR CHARACTERS OR MORE, and never ending "ss", "us", "is" or "ies" —
+ *     across, less, status, focus, analysis, basis; dependencies, properties,
+ *     entries. The first three are singulars that merely end in "s"; the "-ies"
+ *     class is the likeliest plural in this tree and `plural` cannot spell it at
+ *     all (`plural(n, "dependencie")` is not advice), which is precisely why
+ *     `countNoun`/`DataTableNoun` exists and why the message names it. None is
+ *     live today and the four real hits end "ps", "rs", "ns", "es".
+ *   - FIRST AFTER EXACTLY ONE RENDERED SPACE, the adjacency requirement the arms
+ *     above already impose: a sentence with a word between (`} of `, `} more `,
+ *     `} matched`) is not a shape `plural` can express, and it is why the other
+ *     48 sites are out of shape. RENDERED is the load-bearing word — an oxfmt
+ *     wrap rewrites the separator as `{" "}` without changing a pixel of the
+ *     output, and four such shapes are live here, so the arm reads that spelling
+ *     too rather than falling silent on a line-width accident. An ELEMENT
+ *     between (`<strong>{nf.format(n)}</strong> rules`) is the one adjacency
+ *     escape left, and it stays silent for the arm above's reason: the count is
+ *     in its own element, which is chrome `plural` cannot produce.
+ *
+ * NEITHER HOME SELF-REPORTS, so this arm needs no exemption of its own:
+ * `plural`'s body and `countNoun`'s both put an EXPRESSION after the space, not
+ * a word.
  */
 
 const HELPER = "pluralWord";
@@ -142,6 +185,45 @@ function renderedChildren(children: readonly ESTree.JSXChild[]): Rendered[] {
   return rendered;
 }
 
+/** The one shared `Intl.NumberFormat`, matched by source text — there is a
+ *  single declaration of `nf` in the tree and every importer keeps the name. */
+const COUNT_CALLEE = "nf.format";
+
+/** `nf.format(<count>)` — the formatted count, one argument exactly. */
+function countCall(
+  node: ESTree.JSXExpression | ESTree.Expression,
+  textOf: TextOf,
+): ESTree.CallExpression | undefined {
+  if (node.type !== "CallExpression" || node.arguments.length !== 1) {
+    return undefined;
+  }
+  return textOf(node.callee) === COUNT_CALLEE ? node : undefined;
+}
+
+/** One space, then a word `plural` could have spelled: all-lowercase, four
+ *  characters or more, ending in a bare "s", and nothing before it. */
+const PLURAL_NOUN = /^ ([a-z]{3,}s)\b/;
+
+/** The same noun after a wrapped `{" "}`, which IS the space: the word opens the
+ *  text run, behind at most the newline-indent JSX strips to nothing. Any other
+ *  leading whitespace would render a second space, which `plural` never prints. */
+const WRAPPED_PLURAL_NOUN = /^(?:[^\S\n]*\n\s*)?([a-z]{3,}s)\b/;
+
+/** Words `plural` cannot spell from a singular: the ones that merely END in "s"
+ *  (it would write "acrosss") and the "-ies" stem splice, whose singular is not
+ *  the word minus its "s" — `dependencies`, `properties`, `entries`. That class
+ *  is what `countNoun` exists for, so guessing it here would be wrong advice. */
+const NOT_A_PLURAL = /(?:ss|us|is|ies)$/;
+
+/** The singular of the hard-spelled plural that opens `text`, if it is one. */
+function hardSpelledPlural(text: string, pattern: RegExp): string | undefined {
+  const word = pattern.exec(text)?.[1];
+  if (word === undefined || NOT_A_PLURAL.test(word)) {
+    return undefined;
+  }
+  return word.slice(0, -1);
+}
+
 /** The `1` in `n === 1` / `1 === n`. */
 function isOne(node: ESTree.Node): boolean {
   return node.type === "Literal" && node.value === 1;
@@ -171,6 +253,8 @@ export default defineRule({
         "Use `plural(n, word)` from `@/lib/format` instead of writing the count next to `pluralWord(n, word)` — `plural` runs the count through the shared `nf` and this pair interpolates it raw, so the two spellings diverge the moment the number reaches four figures.",
       preferPluralWord:
         'Use `pluralWord(n, "{{word}}")` — or `plural(n, "{{word}}")` where the count prints right beside the noun — from `@/lib/format` (`@renovate-config-debugger/app/headless` in the CLI) instead of hand-spelling the regular plural in a ternary: one argument feeds both the count and the word, so they cannot disagree the way `1 of 2 rule hidden` did.',
+      preferPluralNoun:
+        'Use `plural(n, "{{word}}")` from `@/lib/format` (`@renovate-config-debugger/app/headless` in the CLI) — or `countNoun(n, noun)` from `@/components/data-table` when the plural is irregular, which is app-only — instead of hard-spelling a plural noun beside `nf.format(n)`: one argument feeds the count and the noun together, so a count of one cannot render "1 {{word}}s".',
       preferPluralSuffix:
         'Use `plural(n, word)` from `@/lib/format` (`@renovate-config-debugger/app/headless` in the CLI) instead of appending a hand-spelled "s" from a ternary — `plural` prints the count and the noun from one argument, and runs the count through the shared `nf` rather than interpolating it raw.',
     },
@@ -205,12 +289,40 @@ export default defineRule({
       }
     };
 
+    // `{nf.format(n)} rules` — the noun opens the count's next rendered text,
+    // either behind the space that is part of that text or behind the `{" "}`
+    // the formatter leaves in its place when the line wraps. Both render the one
+    // space `plural` prints, so both are the same site.
+    const checkCountedNouns = (children: readonly ESTree.JSXChild[]): void => {
+      const kids = renderedChildren(children);
+      for (const [index, child] of kids.entries()) {
+        if (child === SPACE || child.type !== "JSXExpressionContainer") {
+          continue;
+        }
+        const call = countCall(child.expression, textOf);
+        const wrapped = kids[index + 1] === SPACE;
+        const next = kids[index + (wrapped ? 2 : 1)];
+        if (call === undefined || next === undefined || next === SPACE) {
+          continue;
+        }
+        const word =
+          next.type === "JSXText"
+            ? hardSpelledPlural(next.value, wrapped ? WRAPPED_PLURAL_NOUN : PLURAL_NOUN)
+            : undefined;
+        if (word !== undefined) {
+          context.report({ node: call, messageId: "preferPluralNoun", data: { word } });
+        }
+      }
+    };
+
     return {
       JSXElement(node) {
         checkChildren(node.children);
+        checkCountedNouns(node.children);
       },
       JSXFragment(node) {
         checkChildren(node.children);
+        checkCountedNouns(node.children);
       },
       // `n === 1 ? "rule" : "rules"` — a regular plural spelled out by hand.
       // Reported only when the two branches differ by exactly a trailing "s",
@@ -245,6 +357,19 @@ export default defineRule({
           }
           if (node.quasis[index]?.value.raw === " " && textOf(previous) === textOf(count)) {
             context.report({ node: call, messageId: "preferPlural" });
+          }
+        }
+        // `` `${nf.format(n)} rules` `` — the quasi that FOLLOWS the count is
+        // the one that would open with the hard-spelled noun.
+        for (const [index, expression] of node.expressions.entries()) {
+          const call = countCall(expression, textOf);
+          const following = node.quasis[index + 1];
+          if (call === undefined || following === undefined) {
+            continue;
+          }
+          const word = hardSpelledPlural(following.value.raw, PLURAL_NOUN);
+          if (word !== undefined) {
+            context.report({ node: call, messageId: "preferPluralNoun", data: { word } });
           }
         }
       },

--- a/tools/lint/rules/use-lookup-accessors.spec.ts
+++ b/tools/lint/rules/use-lookup-accessors.spec.ts
@@ -8,12 +8,31 @@ ruleTester.run("use-lookup-accessors", rule, {
     'const endpoint = defaultEndpointFor(platform) ?? "";',
     "const known = parsed.host ? platformForHost(parsed.host) : undefined;",
 
+    // ---- the shared home the five hand-spelled guards became ----------------
+    // `ownValue(table, key)` passes the table as an ARGUMENT, so no computed
+    // member expression is left for the visitor to see
+    `import { ownValue } from "@renovate-config-debugger/engine/is";`,
+    "const resolver = ownValue(resolvers, platform);",
+    "const loadExtractor = ownValue(managerExtractors, manager);",
+    "export function defaultEndpointFor(platform: string) { return ownValue(PLATFORM_ENDPOINTS, platform); }",
+    "export function platformForHost(host: string) { return ownValue(HOST_PLATFORM, host); }",
+    // `is.ts`'s own body needs no exemption: the parameter is not a table name
+    "export function ownValue<T>(table: Readonly<Record<string, T>>, key: string) { return Object.hasOwn(table, key) ? table[key] : undefined; }",
+
+    // ---- the `in` operator is deliberately NOT matched ----------------------
+    // `extract.ts:194`/`:334` test keys the engine produced itself, so an `in`
+    // arm would be two false positives for no gain
+    "if (!(manager in managerExtractors)) { return unsupported(manager); }",
+    "const manager = matched().find((m) => m in managerExtractors);",
+
     // ---- a string-literal key is provably an own key ------------------------
     // the table is written in the same file, so `"gitea"` cannot reach a
     // prototype member — no guard buys anything here
     `const gitea = PLATFORM_ENDPOINTS["gitea"];`,
     `const github = PLATFORM_ENDPOINTS["github"] || "";`,
     `const platform = HOST_PLATFORM["github.com"];`,
+    `const resolver = resolvers["github"];`,
+    `const load = managerExtractors["npm"];`,
 
     // ---- a dotted access is not computed and never reaches the visitor ------
     "export const Endpoint = PLATFORM_ENDPOINTS.github;",
@@ -27,6 +46,9 @@ ruleTester.run("use-lookup-accessors", rule, {
     "const entries = Object.entries(HOST_PLATFORM);",
     "const present = Object.hasOwn(PLATFORM_ENDPOINTS, platform);",
     "const table = PLATFORM_ENDPOINTS;",
+    // `extract.ts:72` — the key list, not a read
+    "export const EXTRACTABLE_MANAGERS = Object.keys(managerExtractors);",
+    "const platforms = Object.keys(resolvers);",
 
     // ---- a table this rule does not own ------------------------------------
     "const endpoint = ENDPOINTS[platform];",
@@ -49,6 +71,73 @@ ruleTester.run("use-lookup-accessors", rule, {
   PLATFORM_ENDPOINTS[platform] ??
   "";`,
       errors: [{ messageId: "useLookupAccessor" }],
+    },
+
+    // ---- THE TWO DEFECTS THIS WIDENING IS FOR ------------------------------
+    // `shims/presets/local.ts:41` before 40d7e954: `platform` comes out of
+    // `GlobalConfig`, and `Object.prototype.constructor` is TRUTHY, so the
+    // truthy branch called `.getPresetFromEndpoint` on a FUNCTION
+    {
+      code: "const resolver = resolvers[platform];",
+      errors: [
+        {
+          messageId: "useLookupAccessor",
+          data: {
+            table: "resolvers",
+            accessor: "ownValue(table, key)",
+            from: "@renovate-config-debugger/engine/is",
+          },
+        },
+      ],
+    },
+    // `extract.ts:352` before the same commit: `manager` arrives from
+    // `rcd extract --manager` and MCP `extract_deps.manager`, so the
+    // `loadExtractor === undefined` fall-through could never fire for a
+    // prototype key
+    {
+      code: "const loadExtractor = managerExtractors[manager];",
+      errors: [
+        {
+          messageId: "useLookupAccessor",
+          data: {
+            table: "managerExtractors",
+            accessor: "ownValue(table, key)",
+            from: "@renovate-config-debugger/engine/is",
+          },
+        },
+      ],
+    },
+    // the endpoint table names the SHARED helper: the name is declared in both
+    // packages, so `defaultEndpointFor` would be wrong advice inside the engine
+    {
+      code: "const endpoint = PLATFORM_ENDPOINTS[platform];",
+      errors: [
+        {
+          messageId: "useLookupAccessor",
+          data: {
+            table: "PLATFORM_ENDPOINTS",
+            accessor: "ownValue(table, key)",
+            from: "@renovate-config-debugger/engine/is",
+          },
+        },
+      ],
+    },
+    // …and the app-only table keeps its narrower domain name — and its own
+    // ARITY: the message carries each accessor's call shape, so a reader does
+    // not have to open `is.ts` to find out that one takes the table and the
+    // other does not.
+    {
+      code: "const platform = HOST_PLATFORM[parsed.host];",
+      errors: [
+        {
+          messageId: "useLookupAccessor",
+          data: {
+            table: "HOST_PLATFORM",
+            accessor: "platformForHost(key)",
+            from: "@/data/host-tokens",
+          },
+        },
+      ],
     },
 
     // ---- the nine siblings converted by the same commit ---------------------
@@ -119,15 +208,45 @@ const endpoint = PLATFORM_ENDPOINTS[platform];`,
       errors: [{ messageId: "useLookupAccessor" }, { messageId: "useLookupAccessor" }],
     },
 
-    // ---- the accessor bodies themselves ------------------------------------
-    // reported on shape, exempted BY PATH in `.oxlintrc.json`: the guard and the
-    // read need not be adjacent, so an AST rule must not try to recognise one
+    // ---- the hand-spelled guard is still reported, which is now the point ---
+    // all five of these were live; each is one `ownValue` call after this
+    // landing. The rule does NOT try to recognise the guarded shape — the guard
+    // and the read need not be adjacent — so a site that must keep it is
+    // exempted by PATH, and exactly one does.
     {
       code: "function defaultEndpointFor(platform: string) { return Object.hasOwn(PLATFORM_ENDPOINTS, platform) ? PLATFORM_ENDPOINTS[platform] : undefined; }",
       errors: [{ messageId: "useLookupAccessor" }],
     },
     {
       code: "function platformForHost(host: string) { return Object.hasOwn(HOST_PLATFORM, host) ? HOST_PLATFORM[host] : undefined; }",
+      errors: [{ messageId: "useLookupAccessor" }],
+    },
+    {
+      code: "const resolver = Object.hasOwn(resolvers, platform) ? resolvers[platform] : undefined;",
+      errors: [{ messageId: "useLookupAccessor" }],
+    },
+    {
+      code: `const loadExtractor = Object.hasOwn(managerExtractors, manager)
+  ? managerExtractors[manager]
+  : undefined;`,
+      errors: [{ messageId: "useLookupAccessor" }],
+    },
+    // the engine's twin carried a cast the shared helper makes unnecessary
+    {
+      code: `function defaultEndpointFor(platform: string): string | undefined {
+  return Object.hasOwn(PLATFORM_ENDPOINTS, platform)
+    ? PLATFORM_ENDPOINTS[platform as HostPlatform]
+    : undefined;
+}`,
+      errors: [{ messageId: "useLookupAccessor" }],
+    },
+
+    // ---- the one path exemption, reported here on shape ---------------------
+    // `shims/repo-config.ts:207`/`:245`: a `RepoPlatform` union key on a
+    // `Record<HostPlatform, string>` is total by construction, and the `||` arm
+    // would not typecheck against a `string | undefined`
+    {
+      code: "const endpoint = withTrailingSlash(req.endpoint || PLATFORM_ENDPOINTS[platform]);",
       errors: [{ messageId: "useLookupAccessor" }],
     },
   ],

--- a/tools/lint/rules/use-lookup-accessors.ts
+++ b/tools/lint/rules/use-lookup-accessors.ts
@@ -16,6 +16,23 @@ import { defineRule } from "@oxlint/plugins";
  * defect, and it was invisible in review precisely because it looked like the
  * other nine.
  *
+ * Sweep V found the same class twice more, in the tree the rule did not cover:
+ * `shims/presets/local.ts:41` dispatched on `resolvers[platform]` with the
+ * platform out of `GlobalConfig`, where `Object.prototype.constructor` is
+ * TRUTHY and `.getPresetFromEndpoint` is not a function; `extract.ts:352`
+ * looked up `managerExtractors[manager]` with a manager out of
+ * `rcd extract --manager` / MCP `extract_deps`, so the `undefined`
+ * fall-through below it could never fire for `constructor`. 40d7e954 fixed
+ * both by hand-spelling the guard, which made five hand-spelled copies in
+ * three packages.
+ *
+ * SO THE HOME MOVED, the way `rules.ts` asks: `ownValue(table, key)` in
+ * `packages/engine/src/is.ts` — the import-free module the app and the CLI
+ * already reach as `@renovate-config-debugger/engine/is`, the same route
+ * `prefer-is-helpers` uses. All five copies collapse onto it, the two app
+ * accessors keep their domain names with a one-call body, and the rule reaches
+ * the engine because its answer now does.
+ *
  * Arm (a): an import, not a ban. The message names the accessor AND the hazard,
  * because `HOST_PLATFORM[parsed.host]` on a host the user TYPES is the natural
  * thing to write and will be written again.
@@ -27,34 +44,59 @@ import { defineRule } from "@oxlint/plugins";
  * reach a prototype member, so neither is reported. Nor is anything that is not
  * a member expression on the bare table identifier: `lib/trusted-endpoint.ts`
  * iterates `Object.values(PLATFORM_ENDPOINTS)`, which is out of shape
- * structurally rather than by exception. Both tables are module-level `const`
- * maps that nothing in scope assigns into, so every computed access the rule
- * sees is a read.
+ * structurally rather than by exception. All four tables are module-level
+ * `const` maps that nothing in scope assigns into, so every computed access the
+ * rule sees is a read.
  *
  * TABLE-DRIVEN ON PURPOSE. A third lookup table with an own-key accessor is one
  * entry in `TABLES`, which is what keeps this from being a rule about one
  * symbol — the same shape as `use-rule-ref`, `use-truncate` and
  * `use-goto-app-helper`, each of which is about one named home.
  *
- * DELIBERATELY OUT OF SCOPE, so nobody re-derives it: the rule is enabled on
- * `packages/app/src/**` only. `engine/src/shims/repo-config.ts:207` and `:245`
- * index a `Record<HostPlatform, string>` with a `platform: RepoPlatform` union —
- * total by construction, and behind a `||` fallback — and
- * `engine/src/shims/presets/host-transport.ts:55` is the engine's OWN guarded
- * accessor, the twin the app's two were modelled on. Those three are the rule's
- * only false positives on the whole tree, and app-only scoping removes all three
- * structurally (the `comment-cites-what-exists` excludes-`tools/**` precedent).
- * The two app accessor bodies ARE the guarded access and take the standard
- * one-file `"off"` override in `.oxlintrc.json` — by path, not by shape: a
- * `Object.hasOwn(T, k) ? T[k] : undefined` arm is not something an AST rule
- * should try to recognise, since the guard and the read need not be adjacent.
+ * WHY `PLATFORM_ENDPOINTS` NAMES THE SHARED HELPER AND `HOST_PLATFORM` DOES
+ * NOT. `PLATFORM_ENDPOINTS` is declared TWICE — in the engine
+ * (`shims/presets/host-transport.ts:38`) and in the app
+ * (`data/platform-endpoints.ts`) — and this rule has no cross-file knowledge,
+ * so naming the app-only `defaultEndpointFor` would be wrong advice inside the
+ * engine. `ownValue` is right in both, and each file's own accessor is still
+ * there for the callers that want the domain name. `HOST_PLATFORM` is app-only
+ * (it occurs in `data/host-tokens.ts` and nowhere else), so it keeps
+ * `platformForHost`, the narrower answer.
+ *
+ * DELIBERATELY OUT OF SCOPE, so nobody re-derives it:
+ * - `packages/engine/src/shims/repo-config.ts` is the rule's ONE path
+ *   exemption. `:207` and `:245` index a `Record<HostPlatform, string>` with a
+ *   `platform: RepoPlatform` union — total by construction, and behind a
+ *   `req.endpoint || …` where a `string | undefined` would not typecheck.
+ * - The `in` operator has the same prototype hole and is NOT matched:
+ *   `manager in managerExtractors` at `extract.ts:194` and `:334` both test
+ *   keys this engine produced itself, so an `in` arm would be two false
+ *   positives for no gain.
+ * - `is.ts` itself needs no exemption — `ownValue` indexes a parameter named
+ *   `table`, which is not a registered table name.
+ * - `resolvers` is the one table name generic enough to collide: it also names
+ *   a local array in `tools/lint/rules/comment-cites-what-exists.ts`, which no
+ *   enabled glob covers. A collision inside an enabled `src`
+ *   tree would be a false positive, and the answer is to rename the table.
+ * A hand-spelled `Object.hasOwn(T, k) ? T[k] : undefined` IS still reported,
+ * on shape: that is the point now, since `ownValue` is where it goes. The rule
+ * does not try to recognise the guarded shape — the guard and the read need not
+ * be adjacent — which is why `repo-config.ts` is exempted by PATH.
  */
 
+/** Where `ownValue` lives, spelled as the app and the CLI import it. */
+const IS_HELPERS = "@renovate-config-debugger/engine/is";
+
 /** Lookup tables whose keys can be user-supplied, and the own-key accessor that
- *  owns each. One entry per table; the app-only scoping is in `.oxlintrc.json`. */
+ *  owns each. The accessor carries its CALL SHAPE, not just its name: the shared
+ *  `ownValue` takes the table too, the domain accessors do not, and a reader who
+ *  hits this message should not have to open `is.ts` to learn the arity. One
+ *  entry per table; the enabled trees are in `.oxlintrc.json`. */
 const TABLES = new Map<string, { accessor: string; from: string }>([
-  ["PLATFORM_ENDPOINTS", { accessor: "defaultEndpointFor", from: "@/data/platform-endpoints" }],
-  ["HOST_PLATFORM", { accessor: "platformForHost", from: "@/data/host-tokens" }],
+  ["PLATFORM_ENDPOINTS", { accessor: "ownValue(table, key)", from: IS_HELPERS }],
+  ["HOST_PLATFORM", { accessor: "platformForHost(key)", from: "@/data/host-tokens" }],
+  ["resolvers", { accessor: "ownValue(table, key)", from: IS_HELPERS }],
+  ["managerExtractors", { accessor: "ownValue(table, key)", from: IS_HELPERS }],
 ]);
 
 export default defineRule({
@@ -62,7 +104,7 @@ export default defineRule({
     type: "suggestion",
     messages: {
       useLookupAccessor:
-        "Read `{{table}}` through `{{accessor}}(key)` from `{{from}}`: an unvalidated key with no own-key guard resolves `constructor`, `toString` and `valueOf` to Object.prototype members, so the table answers a function where it should answer `undefined`.",
+        "Read `{{table}}` through `{{accessor}}` from `{{from}}`: an unvalidated key with no own-key guard resolves `constructor`, `toString` and `valueOf` to Object.prototype members, so the table answers a function where it should answer `undefined`.",
     },
   },
   createOnce(context) {

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -19,8 +19,8 @@
     "lint/**/*.ts",
     "docs/**/*.ts",
     "verify-deployment.ts",
-    // Lives at the repo root but configures tools/lint's specs, so no
-    // package project covers it.
+    // Lives at the repo root but configures the tools/ specs, so no package
+    // project covers it.
     "../vitest.tools.config.ts"
   ]
 }

--- a/vitest.tools.config.ts
+++ b/vitest.tools.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from "vitest/config";
 
 /**
- * The repo-level specs' vitest config: the house lint rules (`tools/lint`)
- * and the docs-claim guard (`tools/docs`).
+ * The repo-level specs' vitest config: every `.spec.ts` under `tools/`.
  *
  * NOT named `vitest.config.ts`: vitest walks UP from a package looking for one,
  * and `packages/oauth-worker` has none of its own — a root config by that name


### PR DESCRIPTION
Fifth and final refactor sweep, over the tree after #322 plus its lint lock-in (base: `e9339233`), stacked on #322 → #320 → #316 → #315.

**How it was produced.** 13 area scouts + 12 cross-cutting lens scouts reported 93 claims (the `cli` scout died on an API error and was re-run alone with the same verification); two adversarial refuters per claim left 60 confirmed, 22 refuted, 11 dropped as already on the ledger. All 60 went through 12 file-disjoint implement → review → fix chains (the wave was interrupted once by the account's session limit and resumed from its cache); the tree then passed the full gate (lint, format, typecheck, exports, all suites, dev-graph check, app and CLI builds, CLI bundle test) and 129/129 e2e against the production build.

**Findings the refuters agreed are high-impact, fixed with regression tests:**
- `fix(engine)` — the published `rcd` bundle's every `--help` path crashed: the shim plugin's `node:util` stub was also applied under commander in the `noExternal` build, which needs `stripVTControlCharacters`. A bundle-level test now exercises the built bin's help.
- `fix(app)` — loading a second repository left the Dependencies tab and the Pipeline Extract phase stuck on "Reading … package files" because discovery was keyed on a stable callback identity.

**Findings the scouts labelled high but the value refuter downgraded on survival** (fixed all the same): the `depTypes` "check the spelling" note contradicting the matcher table; the migrate card calling an unparseable config "current"; `signOut` never notifying its own tab; the Stop hook ignoring deletion-only branches; SECURITY.md's stale "cleared when the tab closes" promise.

**The rest** (53): docs-drift 18, error-handling 12, structure 9, duplication 6, test-quality 6, dead-code 5, simplification 3, perf 1 — one commit per package, each body listing its findings by file:line. One finding (`signInRef` citations) was already fixed by #322's lock-in and is recorded as skipped.

Commit types are what semantic-release reads: the `fix(...)` commits cut a patch release; `docs`/`ci`/`chore` do not.

**Lint lock-in (commit `677ad650`).** The 60 fixes were mined for lintable classes (12 candidates, 4 survived): `rcd/complete-enumeration-restatement` (test-tree only; a hand-copied proper subset of a registered enumeration — the class that once shipped `group` and `mcp` untested; 2 sites converted), `rcd/use-lookup-accessors` widened to the engine with a shared `ownValue` home in `engine/is` (5 guard copies collapsed), `rcd/prefer-plural` widened to hard-spelled plural nouns beside `nf.format` (3 live "1 <plural>" renderings fixed), `rcd/comment-cites-what-exists` widened to extensionless possessive citations (5 fixed). The house-rule set is now 15.