### PR TITLE
feat(app): pattern tests — match* patterns against the strings they should hit (roadmap 094)

### DIFF
--- a/packages/app/e2e/23-pattern-tests.spec.ts
+++ b/packages/app/e2e/23-pattern-tests.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { encodeShareFragment, PACKAGE_RULES_CONFIG } from "./fixtures";
+import { openTab, tabButton } from "./helpers";
+
+/**
+ * Roadmap 094 — the Tests tab's second group: pattern tests, a `match*`
+ * option's patterns tried against the strings they should and should not
+ * match, with Renovate's own matcher. What this pins down: a link carries
+ * them and they are evaluated on arrival, the badge counts both groups, and
+ * an edit re-evaluates without a Run.
+ */
+
+test("a share link carries pattern tests; edits re-evaluate in place", async ({ page }) => {
+  await page.goto(
+    await encodeShareFragment({
+      config: PACKAGE_RULES_CONFIG,
+      view: { tab: "tests" },
+      pins: [{ packageName: "lodash", currentValue: "4.17.20", newValue: "4.17.21" }],
+      patternTests: [
+        {
+          option: "matchDepNames",
+          patterns: ["/^react/", "!react-dom"],
+          inputs: [
+            { value: "react", expect: true },
+            { value: "react-dom", expect: false },
+            { value: "@types/react", expect: true },
+          ],
+        },
+      ],
+    }),
+  );
+  await openTab(page, "tests");
+
+  // Both groups count: one pin, one pattern test (the starters yield to a
+  // link's pins).
+  await expect(tabButton(page, "tests")).toContainText("2");
+  const card = page.locator(".pattern-card");
+  await expect(card).toHaveCount(1);
+  await expect(card.locator(".pattern-option")).toHaveValue("matchDepNames");
+  await expect(card.locator(".pin-summary")).toContainText("2 of 3 expected");
+
+  await card.getByRole("button", { name: /Expand the pattern test/ }).click();
+  await expect(card.getByText("blocked by !react-dom")).toBeVisible();
+
+  // Loosening the regex so `@types/react` matches too: no Run, the card
+  // re-evaluates on the keystroke.
+  await card.getByLabel("Pattern 1").fill("/react/");
+  await expect(card.locator(".pin-summary")).toContainText("3 of 3 expected");
+
+  // A new pattern test from the ghost row lands open, unpicked.
+  await page.getByRole("button", { name: /Test a pattern/ }).click();
+  await expect(page.locator(".pattern-card")).toHaveCount(2);
+  await expect(page.locator(".pattern-option-unset")).toBeVisible();
+  await expect(tabButton(page, "tests")).toContainText("3");
+});

--- a/packages/app/e2e/fixtures.ts
+++ b/packages/app/e2e/fixtures.ts
@@ -13,6 +13,7 @@
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+import type { SharePatternTest } from "../src/lib/input-schemas-zod";
 import { configChecksum, encodeShare, type ShareSimulator, type ShareView } from "../src/lib/share";
 // Relative, not `@tools/*`: the alias is the app's vitest/tsconfig mapping, and
 // the Playwright graph resolves this file on its own.
@@ -59,6 +60,8 @@ interface SharePayloadInput {
   /** Roadmap 075 (iteration 6): the pinned tests a link carries — descriptor
    *  field bags, the same shape `sim.form` has. */
   pins?: Record<string, string>[];
+  /** Roadmap 094: the pattern tests a link carries. */
+  patternTests?: SharePatternTest[];
 }
 
 /**
@@ -137,6 +140,7 @@ export async function encodeShareToken(
     view: input.view as ShareView | undefined,
     sim: input.sim,
     pins: input.pins,
+    patternTests: input.patternTests,
   });
 }
 

--- a/packages/app/src/app/App.tsx
+++ b/packages/app/src/app/App.tsx
@@ -51,6 +51,7 @@ import { usePanelStats } from "@/app/use-panel-stats";
 import { usePinnedRun } from "@/app/use-pinned-run";
 import { useResultsTab } from "@/app/use-results-tab";
 import { useStarterPins } from "@/app/use-starter-pins";
+import { usePatternTests } from "@/app/use-pattern-tests";
 import { useShareLink } from "@/hooks/use-share-link";
 import type { RunInputs } from "@/lib/run-inputs";
 import { createRunQueue, type RunQueue } from "@/lib/run-queue";
@@ -245,6 +246,16 @@ export function App() {
    */
   const { pins, addPin, removePin, seedStarterPins, setPinsFromShare, pinsAsShareFields } =
     usePinnedRun();
+  // Roadmap 094: the pattern tests — the Tests tab's second group, owned here
+  // for the same two reasons (the link, the badge).
+  const {
+    patternTests,
+    addPatternTest,
+    updatePatternTest,
+    removePatternTest,
+    setPatternTestsFromShare,
+    patternTestsAsShare,
+  } = usePatternTests();
   // Roadmap 028/069/083: the counts the results panels report back up (the
   // Effective tab's key tally, the Overview tab's behavior count) and the
   // ledger signal that goes the other way — as one hook, because a new run
@@ -323,6 +334,7 @@ export function App() {
       // Roadmap 075 (iteration 6): the link's pins, with ids minted by the
       // cluster that owns them.
       setPins: setPinsFromShare,
+      setPatternTests: setPatternTestsFromShare,
       // An arrow, not the bare method: this host object is built during render
       // and `repoProvenance` is declared further down. The arrow only runs on a
       // link arrival, which is the same deferred-capture rule this object's
@@ -1054,7 +1066,8 @@ export function App() {
   } = useRunSummary(
     result,
     effectiveStats,
-    pins.length,
+    // Roadmap 094: both test groups — every standing test the run re-checks.
+    pins.length + patternTests.length,
     overviewBehaviors,
     // Roadmap 089: only a discovery that actually REPORTED gives the
     // Dependencies tab a badge — before that (no repo, not opened yet, or a
@@ -1198,6 +1211,7 @@ export function App() {
       view,
       sim,
       pins: pinsAsShareFields(),
+      patternTests: patternTestsAsShare(),
       // Roadmap 087: where the config was loaded from, when it was — the
       // opener's connect panel offers to reload it. A suggestion this session
       // never confirmed by a load is not re-shared as provenance.
@@ -1263,6 +1277,10 @@ export function App() {
       pins,
       onAddPin: addPin,
       onRemovePin: removePin,
+      patternTests,
+      onAddPatternTest: addPatternTest,
+      onUpdatePatternTest: updatePatternTest,
+      onRemovePatternTest: removePatternTest,
       pendingRuleFocus,
       onRuleFocused,
       simRequest: activeSimRequest,
@@ -1315,6 +1333,10 @@ export function App() {
       pins,
       addPin,
       removePin,
+      patternTests,
+      addPatternTest,
+      updatePatternTest,
+      removePatternTest,
       pendingRuleFocus,
       onRuleFocused,
       activeSimRequest,

--- a/packages/app/src/app/ResultsColumn.tsx
+++ b/packages/app/src/app/ResultsColumn.tsx
@@ -117,6 +117,10 @@ export function ResultsColumn({
     pins,
     onAddPin,
     onRemovePin,
+    patternTests,
+    onAddPatternTest,
+    onUpdatePatternTest,
+    onRemovePatternTest,
     pendingRuleFocus,
     onRuleFocused,
     simRequest,
@@ -271,6 +275,10 @@ export function ResultsColumn({
           repoDeps={repoDeps}
           onLoadRepoDeps={onLoadRepoDeps}
           repoConnect={repoConnect}
+          patternTests={patternTests}
+          onAddPatternTest={onAddPatternTest}
+          onUpdatePatternTest={onUpdatePatternTest}
+          onRemovePatternTest={onRemovePatternTest}
         />
       ) : (
         <EmptyNote>Nothing to test — the pipeline produced no effective config.</EmptyNote>
@@ -401,6 +409,10 @@ export function ResultsColumn({
     pins,
     onAddPin,
     onRemovePin,
+    patternTests,
+    onAddPatternTest,
+    onUpdatePatternTest,
+    onRemovePatternTest,
     pendingRuleFocus,
     onRuleFocused,
     simRequest,

--- a/packages/app/src/app/run-view-context.ts
+++ b/packages/app/src/app/run-view-context.ts
@@ -34,7 +34,7 @@ import type { PipelinePhase } from "@/features/pipeline/phases";
 import type { ShareSimulator } from "@/lib/share";
 import type { ErrorTranslationLib } from "@/platform/run";
 import type { SimRequest } from "@/hooks/use-share-link";
-import type { FormState, PinnedTest } from "@/types/simulator";
+import type { FormState, PatternTest, PinnedTest } from "@/types/simulator";
 import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 
 export interface RunView {
@@ -97,6 +97,11 @@ export interface RunView {
   pins: PinnedTest[];
   onAddPin: (form: FormState) => void;
   onRemovePin: (id: string) => void;
+  /** Roadmap 094: the pattern tests and their three edits. */
+  patternTests: PatternTest[];
+  onAddPatternTest: () => string | null;
+  onUpdatePatternTest: (id: string, update: (test: PatternTest) => PatternTest) => void;
+  onRemovePatternTest: (id: string) => void;
   pendingRuleFocus: number | null;
   onRuleFocused: () => void;
   simRequest: SimRequest | null;

--- a/packages/app/src/app/use-pattern-tests.ts
+++ b/packages/app/src/app/use-pattern-tests.ts
@@ -1,0 +1,82 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  newPatternTest,
+  patternTestShareFields,
+  patternTestsFromShare,
+} from "@/features/simulator/pattern-tests";
+import { MAX_PATTERN_TESTS } from "@/lib/input-schemas";
+import type { SharePatternTest } from "@/lib/input-schemas-zod";
+import type { PatternTest } from "@/types/simulator";
+
+/**
+ * Roadmap 094 — the pattern tests as one hook, the shape `usePinnedRun` set:
+ * the list, the ids minted for it, the edits, and both halves of the share
+ * round trip. Owned by the shell for the two reasons pins are: a link carries
+ * them, and the Tests tab's badge counts them. What a test MEANS is the
+ * feature's (`features/simulator/pattern-tests.ts`); the evaluation is the
+ * card's, per render, since it is a handful of matcher calls.
+ */
+export interface PatternTestsState {
+  patternTests: PatternTest[];
+  /** Appends an empty test (no-op at the cap) and returns its id, so the
+   *  card that opens for it can be the one the reader just asked for. */
+  addPatternTest: () => string | null;
+  updatePatternTest: (id: string, update: (test: PatternTest) => PatternTest) => void;
+  removePatternTest: (id: string) => void;
+  /** The decode side: the link's tests, with ids minted here. Called with
+   *  `[]` when the link carries none — a link installs the screen it
+   *  describes. */
+  setPatternTestsFromShare: (shared: SharePatternTest[]) => void;
+  /** The encode side — a function, so nothing is serialized until a link is
+   *  built. */
+  patternTestsAsShare: () => SharePatternTest[];
+}
+
+export function usePatternTests(): PatternTestsState {
+  const [patternTests, setPatternTests] = useState<PatternTest[]>([]);
+  const seqRef = useRef(0);
+  const nextId = useCallback(() => `pattern-${++seqRef.current}`, []);
+
+  const addPatternTest = useCallback((): string | null => {
+    if (patternTests.length >= MAX_PATTERN_TESTS) {
+      return null;
+    }
+    const id = nextId();
+    setPatternTests((prev) =>
+      prev.length >= MAX_PATTERN_TESTS ? prev : [...prev, newPatternTest(id)],
+    );
+    return id;
+  }, [nextId, patternTests.length]);
+
+  const updatePatternTest = useCallback(
+    (id: string, update: (test: PatternTest) => PatternTest) => {
+      setPatternTests((prev) => prev.map((test) => (test.id === id ? update(test) : test)));
+    },
+    [],
+  );
+
+  const removePatternTest = useCallback((id: string) => {
+    setPatternTests((prev) => prev.filter((test) => test.id !== id));
+  }, []);
+
+  const setPatternTestsFromShare = useCallback(
+    (shared: SharePatternTest[]) => {
+      setPatternTests(patternTestsFromShare(shared, nextId));
+    },
+    [nextId],
+  );
+
+  const patternTestsAsShare = useCallback(
+    () => patternTests.map(patternTestShareFields),
+    [patternTests],
+  );
+
+  return {
+    patternTests,
+    addPatternTest,
+    updatePatternTest,
+    removePatternTest,
+    setPatternTestsFromShare,
+    patternTestsAsShare,
+  };
+}

--- a/packages/app/src/app/use-run-summary.ts
+++ b/packages/app/src/app/use-run-summary.ts
@@ -41,10 +41,10 @@ export interface RunSummary {
 export function useRunSummary(
   result: TraceResult | null,
   effectiveStats: EffectiveTally | null,
-  /** Roadmap 075 (iteration 6): how many dependency tests are pinned — the
-   *  Tests tab's badge. Owned by App (a share link carries the pins), passed in
-   *  for the same reason `effectiveStats` is: this hook counts, it does not
-   *  hold. */
+  /** Roadmap 075 (iteration 6): how many standing tests the run re-checks —
+   *  the Tests tab's badge; since 094 the pins AND the pattern tests. Owned by
+   *  App (a share link carries both), passed in for the same reason
+   *  `effectiveStats` is: this hook counts, it does not hold. */
   pinCount: number,
   /** Roadmap 083: how many author-written sentences the Overview lists — the
    *  Overview tab's badge. `null` until the description provenance has settled,

--- a/packages/app/src/features/simulator/PatternAddLine.tsx
+++ b/packages/app/src/features/simulator/PatternAddLine.tsx
@@ -1,0 +1,43 @@
+import { type KeyboardEvent, useState } from "react";
+
+/**
+ * Roadmap 094: the dashed "add pattern ⏎" / "add input ⏎" line at the foot of
+ * each column. Enter commits and clears; the field is otherwise inert, so a
+ * half-typed value is never a pattern. Bare Enter only — ⌘⏎ stays the Run
+ * chord (the `MultiValueInput` rule).
+ */
+export function PatternAddLine({
+  label,
+  placeholder,
+  onAdd,
+}: {
+  /** The accessible name; the placeholder is the visible one. */
+  label: string;
+  placeholder: string;
+  onAdd: (value: string) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  function keyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key !== "Enter" || e.metaKey || e.ctrlKey) {
+      return;
+    }
+    e.preventDefault();
+    const value = draft.trim();
+    if (value === "") {
+      return;
+    }
+    onAdd(value);
+    setDraft("");
+  }
+  return (
+    <input
+      type="text"
+      className="pattern-add-line"
+      aria-label={label}
+      placeholder={placeholder}
+      value={draft}
+      onChange={(e) => setDraft(e.target.value)}
+      onKeyDown={keyDown}
+    />
+  );
+}

--- a/packages/app/src/features/simulator/PatternTestBody.tsx
+++ b/packages/app/src/features/simulator/PatternTestBody.tsx
@@ -1,0 +1,155 @@
+import { PatternAddLine } from "./PatternAddLine";
+import { expectationFor, type PatternMatcher, type PatternTestEvaluation } from "./pattern-tests";
+import { InputRow, PatternRow } from "./PatternTestRows";
+import { MAX_PATTERN_INPUTS, MAX_PATTERNS_PER_TEST } from "@/lib/input-schemas";
+import { nf } from "@/lib/format";
+import type { PatternTest } from "@/types/simulator";
+
+/**
+ * Roadmap 094: the open card — patterns on the left, inputs with their
+ * expectations on the right, each column with its add line. Every edit goes
+ * through `onUpdate` as a pure transform of the test, so the shell owns the
+ * list and this file owns nothing.
+ */
+
+type Update = (update: (test: PatternTest) => PatternTest) => void;
+
+function PatternColumn({
+  test,
+  evaluation,
+  onUpdate,
+}: {
+  test: PatternTest;
+  evaluation: PatternTestEvaluation;
+  onUpdate: Update;
+}) {
+  const full = test.patterns.length >= MAX_PATTERNS_PER_TEST;
+  return (
+    <div className="pattern-col">
+      <p className="pin-evidence-title">Patterns</p>
+      {evaluation.patterns.map((verdict, i) => (
+        <PatternRow
+          // Patterns are editable in place, so the value is not an identity —
+          // the position is. Rows are only ever appended or removed.
+          // oxlint-disable-next-line react/no-array-index-key -- see above
+          key={i}
+          verdict={verdict}
+          index={i}
+          onChange={(value) =>
+            onUpdate((t) => ({ ...t, patterns: t.patterns.map((p, j) => (j === i ? value : p)) }))
+          }
+          onRemove={() =>
+            onUpdate((t) => ({ ...t, patterns: t.patterns.filter((_, j) => j !== i) }))
+          }
+        />
+      ))}
+      {full ? null : (
+        <PatternAddLine
+          label="Add a pattern"
+          placeholder="add pattern ⏎"
+          onAdd={(value) => onUpdate((t) => ({ ...t, patterns: [...t.patterns, value] }))}
+        />
+      )}
+      <p className="pattern-rule">
+        ≥1 positive must match · no <code>!negative</code> may match
+      </p>
+    </div>
+  );
+}
+
+function InputColumn({
+  test,
+  evaluation,
+  matcher,
+  seeds,
+  onUpdate,
+}: {
+  test: PatternTest;
+  evaluation: PatternTestEvaluation;
+  matcher: PatternMatcher;
+  seeds: readonly string[];
+  onUpdate: Update;
+}) {
+  const room = MAX_PATTERN_INPUTS - test.inputs.length;
+  const fresh = seeds.filter((value) => !test.inputs.some((input) => input.value === value));
+  const offered = fresh.slice(0, Math.max(room, 0));
+  function add(values: readonly string[]) {
+    onUpdate((t) => ({
+      ...t,
+      inputs: [
+        ...t.inputs,
+        ...values.map((value) => ({
+          value,
+          expect: expectationFor(matcher.explain, t.patterns, value),
+        })),
+      ],
+    }));
+  }
+  return (
+    <div className="pattern-col">
+      <p className="pin-evidence-title">Inputs · expectation</p>
+      {evaluation.inputs.map((verdict, i) => (
+        <InputRow
+          // oxlint-disable-next-line react/no-array-index-key -- editable in place; position is the identity
+          key={i}
+          verdict={verdict}
+          index={i}
+          onChange={(value) =>
+            onUpdate((t) => ({
+              ...t,
+              inputs: t.inputs.map((input, j) => (j === i ? { ...input, value } : input)),
+            }))
+          }
+          onFlip={() =>
+            onUpdate((t) => ({
+              ...t,
+              inputs: t.inputs.map((input, j) =>
+                j === i ? { ...input, expect: !input.expect } : input,
+              ),
+            }))
+          }
+          onRemove={() => onUpdate((t) => ({ ...t, inputs: t.inputs.filter((_, j) => j !== i) }))}
+        />
+      ))}
+      {room > 0 ? (
+        <PatternAddLine
+          label="Add an input"
+          placeholder="add input ⏎"
+          onAdd={(value) => add([value])}
+        />
+      ) : null}
+      {offered.length > 0 ? (
+        <button type="button" className="btn-quiet pattern-seed" onClick={() => add(offered)}>
+          + add the {nf.format(offered.length)} values from your last run
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function PatternTestBody({
+  test,
+  evaluation,
+  matcher,
+  seeds,
+  onUpdate,
+}: {
+  test: PatternTest;
+  evaluation: PatternTestEvaluation;
+  matcher: PatternMatcher;
+  seeds: readonly string[];
+  onUpdate: Update;
+}) {
+  return (
+    <div className="pattern-body">
+      <PatternColumn test={test} evaluation={evaluation} onUpdate={onUpdate} />
+      <InputColumn
+        test={test}
+        evaluation={evaluation}
+        matcher={matcher}
+        seeds={seeds}
+        onUpdate={onUpdate}
+      />
+    </div>
+  );
+}

--- a/packages/app/src/features/simulator/PatternTestCard.tsx
+++ b/packages/app/src/features/simulator/PatternTestCard.tsx
@@ -1,0 +1,164 @@
+import { useMemo } from "react";
+import { Caret } from "@/components/Caret";
+import {
+  evaluatePatternTest,
+  type PatternMatcher,
+  type PatternTestEvaluation,
+  type PatternTestTone,
+} from "./pattern-tests";
+import { PatternTestBody } from "./PatternTestBody";
+import type { PatternTest } from "@/types/simulator";
+
+/**
+ * Roadmap 094: one pattern test as a card in the pin grammar — a head row
+ * that answers at a glance (caret, dot, the option, the patterns while
+ * collapsed, the `N of M expected` sentence) and the two-column body when
+ * open. The option is a native `<select>` beside the toggle rather than the
+ * design's searchable popover: eleven names, and a real select is the more
+ * accessible control for a list that short.
+ */
+
+const DOT_TITLE: Record<PatternTestTone, string> = {
+  ok: "every input behaves as expected",
+  error: "an input does not behave as expected",
+  pending: "no inputs to check yet",
+};
+
+function OptionPicker({
+  value,
+  options,
+  onChange,
+}: {
+  value: string;
+  options: readonly string[];
+  onChange: (option: string) => void;
+}) {
+  // An option a newer app's link named, which this Renovate lacks, is still
+  // shown — the reader must see what the test is about to fix it.
+  const known = value === "" || options.includes(value) ? options : [value, ...options];
+  return (
+    <select
+      className={value === "" ? "pattern-option pattern-option-unset" : "pattern-option"}
+      aria-label="Option this test is for"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">pick option…</option>
+      {known.map((option) => (
+        <option key={option} value={option}>
+          {option}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function PatternTestHead({
+  test,
+  evaluation,
+  options,
+  open,
+  onToggle,
+  onOption,
+  onRemove,
+}: {
+  test: PatternTest;
+  evaluation: PatternTestEvaluation | null;
+  options: readonly string[];
+  open: boolean;
+  onToggle: () => void;
+  onOption: (option: string) => void;
+  onRemove: () => void;
+}) {
+  const tone = evaluation?.tone ?? "pending";
+  const name = test.option === "" ? "an unnamed option" : test.option;
+  return (
+    <div className="pin-head">
+      <button
+        type="button"
+        className="pin-head-toggle pattern-head-toggle"
+        aria-expanded={open}
+        aria-label={`${open ? "Collapse" : "Expand"} the pattern test for ${name}`}
+        onClick={onToggle}
+      >
+        <Caret open={open} />
+        <span className={`pin-dot ${tone}`} title={DOT_TITLE[tone]} />
+      </button>
+      <OptionPicker value={test.option} options={options} onChange={onOption} />
+      {/* The rest of the row is a pointer-only mirror of the toggle above — one
+          control for assistive tech, the whole row as a target for a mouse. */}
+      <span className="pattern-head-rest" aria-hidden="true" onClick={onToggle}>
+        {open
+          ? null
+          : test.patterns.map((pattern, i) => (
+              // oxlint-disable-next-line react/no-array-index-key -- a duplicate pattern is legal; position is the identity
+              <code key={i} className="pattern-head-pattern">
+                {pattern}
+              </code>
+            ))}
+        <span
+          className={
+            evaluation?.tone === "error" ? "pin-summary pattern-summary-fail" : "pin-summary"
+          }
+        >
+          {evaluation === null ? "checking…" : evaluation.summary}
+        </span>
+      </span>
+      <button
+        type="button"
+        className="pin-remove"
+        onClick={onRemove}
+        title="Remove this test"
+        aria-label={`Remove the pattern test for ${name}`}
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+export function PatternTestCard({
+  test,
+  matcher,
+  seeds,
+  open,
+  onToggle,
+  onUpdate,
+  onRemove,
+}: {
+  test: PatternTest;
+  matcher: PatternMatcher | null;
+  /** Values the last run offers as inputs for this test's option. */
+  seeds: readonly string[];
+  open: boolean;
+  onToggle: () => void;
+  onUpdate: (update: (test: PatternTest) => PatternTest) => void;
+  onRemove: () => void;
+}) {
+  const evaluation = useMemo(
+    () => (matcher ? evaluatePatternTest(matcher, test) : null),
+    [matcher, test],
+  );
+  return (
+    <div className="card pattern-card">
+      <PatternTestHead
+        test={test}
+        evaluation={evaluation}
+        options={matcher?.options ?? []}
+        open={open}
+        onToggle={onToggle}
+        onOption={(option) => onUpdate((t) => ({ ...t, option }))}
+        onRemove={onRemove}
+      />
+      {open && matcher && evaluation ? (
+        <PatternTestBody
+          test={test}
+          evaluation={evaluation}
+          matcher={matcher}
+          seeds={seeds}
+          onUpdate={onUpdate}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/app/src/features/simulator/PatternTestRows.tsx
+++ b/packages/app/src/features/simulator/PatternTestRows.tsx
@@ -1,0 +1,110 @@
+import type { InputVerdict, PatternVerdict } from "./pattern-tests";
+
+/**
+ * Roadmap 094: the two row shapes inside an open pattern-test card.
+ *
+ * A PATTERN row is the pattern itself (editable in place), its hit count over
+ * the inputs, and the chips saying how upstream reads it. An INPUT row is the
+ * mark upstream gave it, the value (editable), the expectation the reader
+ * holds about it, and — when the mark alone would leave a reader guessing —
+ * the one-line why.
+ */
+
+export function PatternRow({
+  verdict,
+  index,
+  onChange,
+  onRemove,
+}: {
+  verdict: PatternVerdict;
+  index: number;
+  onChange: (value: string) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className={verdict.dead ? "pattern-row pattern-row-dead" : "pattern-row"}>
+      <div className="pattern-row-main">
+        <input
+          type="text"
+          className="pattern-row-value"
+          aria-label={`Pattern ${index + 1}`}
+          value={verdict.pattern}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <span className="pattern-count" title="Inputs this pattern matches">
+          {verdict.count}
+        </span>
+        <button
+          type="button"
+          className="pin-remove"
+          aria-label={`Remove pattern ${verdict.pattern}`}
+          title="Remove"
+          onClick={onRemove}
+        >
+          ✕
+        </button>
+      </div>
+      <div className="pattern-chips">
+        {verdict.chips.map((chip) => (
+          <span key={chip} className="pill pill-count">
+            {chip}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function InputRow({
+  verdict,
+  index,
+  onChange,
+  onFlip,
+  onRemove,
+}: {
+  verdict: InputVerdict;
+  index: number;
+  onChange: (value: string) => void;
+  onFlip: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className={verdict.pass ? "pattern-input" : "pattern-input pattern-input-fail"}>
+      <div className="pattern-row-main">
+        <span
+          className={`pin-section-mark ${verdict.matches ? "mark-ok" : "mark-error"}`}
+          aria-hidden="true"
+        >
+          {verdict.matches ? "✓" : "✗"}
+        </span>
+        <span className="visually-hidden">{verdict.matches ? "matches" : "does not match"}</span>
+        <input
+          type="text"
+          className="pattern-row-value"
+          aria-label={`Input ${index + 1}`}
+          value={verdict.value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <button
+          type="button"
+          className="btn-chip pattern-expect"
+          title="Toggle expectation"
+          aria-pressed={verdict.expect}
+          onClick={onFlip}
+        >
+          {verdict.expect ? "should match" : "should not"}
+        </button>
+        <button
+          type="button"
+          className="pin-remove"
+          aria-label={`Remove input ${verdict.value}`}
+          title="Remove"
+          onClick={onRemove}
+        >
+          ✕
+        </button>
+      </div>
+      {verdict.why === null ? null : <span className="pattern-why">{verdict.why}</span>}
+    </div>
+  );
+}

--- a/packages/app/src/features/simulator/PatternTests.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/PatternTests.shimmed.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Roadmap 094: the cards over Renovate's OWN matcher — the two traps the
+ * design was drawn around, said in the card's own words: a `**quay.io/**`
+ * glob that never matches a registry URL (with the rewrite upstream accepts),
+ * and a negative entry blocking a positive hit.
+ */
+import { render, waitFor } from "@testing-library/react";
+import { expect, it } from "vitest";
+import type { TraceResult } from "@renovate-config-debugger/engine";
+import { EMPTY_REPO_DEPS } from "./repo-deps";
+import { PatternTests } from "./PatternTests";
+
+const RESULT = { finalConfig: {} } as unknown as TraceResult;
+
+it("explains a miss and a block in upstream's terms", async () => {
+  const view = render(
+    <PatternTests
+      tests={[
+        {
+          id: "pattern-1",
+          option: "matchRegistryUrls",
+          patterns: ["**quay.io/**"],
+          inputs: [
+            { value: "https://quay.io", expect: true },
+            { value: "https://index.docker.io", expect: false },
+          ],
+        },
+      ]}
+      seedSources={{ pins: [], repoDeps: EMPTY_REPO_DEPS, result: RESULT }}
+      onAdd={() => null}
+      onUpdate={() => undefined}
+      onRemove={() => undefined}
+    />,
+  );
+  // The engine chunk's first load under the shimmed graph takes seconds.
+  await waitFor(
+    () => expect(view.container.querySelector(".pin-summary")?.textContent).toBe("1 of 2 expected"),
+    { timeout: 120_000 },
+  );
+  view.getByRole("button", { name: /Expand the pattern test/ }).click();
+  await waitFor(() => expect(view.getByText("no match — try **/quay.io{/,}**")).toBeDefined());
+  expect(view.container.querySelector(".pattern-row-dead")).not.toBeNull();
+  expect(
+    [...view.container.querySelectorAll(".pattern-chips .pill")].map((el) => el.textContent),
+  ).toEqual(["glob", "Aa ignored"]);
+});

--- a/packages/app/src/features/simulator/PatternTests.test.tsx
+++ b/packages/app/src/features/simulator/PatternTests.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Roadmap 094: the pattern-test cards' interaction contract — a test is
+ * added open, an option picked, patterns and inputs typed in with Enter, an
+ * expectation flipped, the seed offer taken — over a STUB engine. What
+ * Renovate's own matcher says is the shimmed suite's business.
+ */
+import { useState } from "react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { expect, it, vi } from "vitest";
+import type { PatternListMatch, TraceResult } from "@renovate-config-debugger/engine";
+import { EMPTY_REPO_DEPS } from "./repo-deps";
+import { EMPTY_FORM } from "./form";
+import { newPatternTest } from "./pattern-tests";
+import { PatternTests } from "./PatternTests";
+import type { PatternTest } from "@/types/simulator";
+
+/** Exact-match-or-`!`-negate: enough matcher to drive the card. */
+function explain(patterns: readonly string[], input: string): PatternListMatch {
+  const entries = patterns.map((pattern) => {
+    const negative = pattern.startsWith("!");
+    const hit = (negative ? pattern.slice(1) : pattern) === input;
+    return { pattern, kind: "glob" as const, negative, caseInsensitive: true, invalid: false, hit };
+  });
+  const positives = entries.filter((entry) => !entry.negative);
+  const blocked = entries.some((entry) => entry.negative && entry.hit);
+  const matches =
+    entries.length > 0 && (positives.length === 0 || positives.some((e) => e.hit)) && !blocked;
+  return { matches, entries, reason: matches ? null : blocked ? "blocked" : "no-positive" };
+}
+
+vi.mock("@/platform/engine-chunk", () => ({
+  loadEngine: () =>
+    Promise.resolve({
+      explainPatternMatch: explain,
+      parsePattern: (pattern: string) => ({
+        kind: "glob",
+        negative: pattern.startsWith("!"),
+        caseInsensitive: true,
+        invalid: false,
+      }),
+      patternListOptionNames: () => ["matchDepNames", "matchPackageNames"],
+    }),
+}));
+
+const RESULT = { finalConfig: {} } as unknown as TraceResult;
+
+function Harness({ initial = [] }: { initial?: PatternTest[] }) {
+  const [tests, setTests] = useState<PatternTest[]>(initial);
+  let seq = initial.length;
+  return (
+    <PatternTests
+      tests={tests}
+      seedSources={{
+        pins: [{ id: "pin-1", form: { ...EMPTY_FORM, packageName: "react" } }],
+        repoDeps: EMPTY_REPO_DEPS,
+        result: RESULT,
+      }}
+      onAdd={() => {
+        const id = `pattern-${++seq}`;
+        setTests((prev) => [...prev, newPatternTest(id)]);
+        return id;
+      }}
+      onUpdate={(id, update) =>
+        setTests((prev) => prev.map((test) => (test.id === id ? update(test) : test)))
+      }
+      onRemove={(id) => setTests((prev) => prev.filter((test) => test.id !== id))}
+    />
+  );
+}
+
+function enter(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+  fireEvent.keyDown(input, { key: "Enter" });
+}
+
+it("builds a test from the ghost row: option, patterns, inputs, expectations", async () => {
+  const view = render(<Harness />);
+  expect(view.container.querySelector(".pattern-empty")).not.toBeNull();
+
+  fireEvent.click(view.getByRole("button", { name: /Test a pattern/ }));
+  // Added OPEN, with the option unpicked.
+  const select = await view.findByLabelText("Option this test is for");
+  expect(select).toHaveProperty("value", "");
+  fireEvent.change(select, { target: { value: "matchPackageNames" } });
+
+  enter(view.getByLabelText("Add a pattern"), "react");
+  enter(view.getByLabelText("Add a pattern"), "!react-dom");
+  await waitFor(() => expect(view.getAllByLabelText(/^Pattern \d/)).toHaveLength(2));
+
+  // A typed input starts as an assertion of the CURRENT verdict.
+  enter(view.getByLabelText("Add an input"), "react");
+  enter(view.getByLabelText("Add an input"), "lodash");
+  await waitFor(() =>
+    expect(view.container.querySelector(".pin-summary")?.textContent).toBe("2 of 2 expected"),
+  );
+  const expectations = view.getAllByRole("button", { name: /^should/ });
+  expect(expectations.map((button) => button.textContent)).toEqual(["should match", "should not"]);
+
+  // Flipping the expectation is what makes it a failing test.
+  fireEvent.click(expectations[1] as HTMLElement);
+  await waitFor(() =>
+    expect(view.container.querySelector(".pin-summary")?.textContent).toBe("1 of 2 expected"),
+  );
+  expect(view.container.querySelector(".pin-dot.error")).not.toBeNull();
+  expect(view.container.querySelectorAll(".pattern-input-fail")).toHaveLength(1);
+
+  // The pattern counts: `react` hit one of two; `!react-dom` blocks none.
+  const counts = [...view.container.querySelectorAll(".pattern-count")].map((el) => el.textContent);
+  expect(counts).toEqual(["1/2", "blocks 0"]);
+});
+
+it("offers the last run's values for the picked option, and removes a test", async () => {
+  const view = render(
+    <Harness
+      initial={[{ id: "pattern-1", option: "matchPackageNames", patterns: ["react"], inputs: [] }]}
+    />,
+  );
+  // Collapsed: the head shows the patterns and the pending sentence.
+  await waitFor(() =>
+    expect(view.container.querySelector(".pin-summary")?.textContent).toBe("no inputs yet"),
+  );
+  expect(view.container.querySelector(".pattern-head-pattern")?.textContent).toBe("react");
+
+  fireEvent.click(view.getByRole("button", { name: /Expand the pattern test/ }));
+  fireEvent.click(
+    await view.findByRole("button", { name: "+ add the 1 values from your last run" }),
+  );
+  await waitFor(() => expect(view.getByLabelText("Input 1")).toHaveProperty("value", "react"));
+  // Taken, the offer is gone.
+  expect(view.queryByRole("button", { name: /values from your last run/ })).toBeNull();
+
+  fireEvent.click(
+    view.getByRole("button", { name: "Remove the pattern test for matchPackageNames" }),
+  );
+  await waitFor(() => expect(view.container.querySelector(".pattern-card")).toBeNull());
+});

--- a/packages/app/src/features/simulator/PatternTests.tsx
+++ b/packages/app/src/features/simulator/PatternTests.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { nf } from "@/lib/format";
+import { MAX_PATTERN_TESTS } from "@/lib/input-schemas";
+import { seedValuesFor, type SeedSources } from "./pattern-tests";
+import { PatternTestCard } from "./PatternTestCard";
+import { usePatternMatcher } from "./use-pattern-matcher";
+import type { PatternTest } from "@/types/simulator";
+
+/**
+ * Roadmap 094 — the Tests tab's second group, as the design's `Pattern Tests`
+ * artboard draws it: a strip, one card per test, the empty note, and the
+ * ghost row that starts a new one. A pattern test is re-evaluated on every
+ * render against Renovate's own list matcher, which makes "re-tested against
+ * your config on every Run" true by construction rather than by a hook.
+ *
+ * One card is open at a time (the design's accordion): the one the reader
+ * just added, or the one they last opened. The shell owns the list; this
+ * component owns only which card is open.
+ */
+export function PatternTests({
+  tests,
+  seedSources,
+  onAdd,
+  onUpdate,
+  onRemove,
+}: {
+  tests: readonly PatternTest[];
+  seedSources: SeedSources;
+  onAdd: () => string | null;
+  onUpdate: (id: string, update: (test: PatternTest) => PatternTest) => void;
+  onRemove: (id: string) => void;
+}) {
+  const matcher = usePatternMatcher();
+  const [openId, setOpenId] = useState<string | null>(null);
+  const atCap = tests.length >= MAX_PATTERN_TESTS;
+  function add() {
+    const id = onAdd();
+    if (id !== null) {
+      setOpenId(id);
+    }
+  }
+  return (
+    <section className="pattern-tests" aria-labelledby="pattern-tests-title">
+      <div className="summary-strip">
+        <span id="pattern-tests-title">
+          <strong>{nf.format(tests.length)}</strong> pattern {tests.length === 1 ? "test" : "tests"}
+        </span>
+        <span className="pins-strip-note">re-tested against your config on every Run</span>
+      </div>
+      {tests.map((test) => (
+        <PatternTestCard
+          key={test.id}
+          test={test}
+          matcher={matcher}
+          seeds={seedValuesFor(test.option, seedSources)}
+          open={openId === test.id}
+          onToggle={() => setOpenId((current) => (current === test.id ? null : test.id))}
+          onUpdate={(update) => onUpdate(test.id, update)}
+          onRemove={() => onRemove(test.id)}
+        />
+      ))}
+      {tests.length === 0 ? (
+        <p className="pattern-empty">
+          No pattern tests yet — try a <code>match*</code> pattern against the strings it should and
+          should not match, before it goes into a rule.
+        </p>
+      ) : null}
+      <button
+        type="button"
+        className="pattern-add-ghost"
+        onClick={add}
+        disabled={atCap}
+        title={atCap ? `At most ${MAX_PATTERN_TESTS} pattern tests` : undefined}
+      >
+        + Test a pattern…{" "}
+        <span className="pin-add-ghost-hint">
+          pick an option, add patterns and the inputs they should (not) match
+        </span>
+      </button>
+    </section>
+  );
+}

--- a/packages/app/src/features/simulator/PinsView.tsx
+++ b/packages/app/src/features/simulator/PinsView.tsx
@@ -9,9 +9,10 @@ import { nf } from "@/lib/format";
 import { AddTestBox } from "./AddTestBox";
 import { EmptyTestsCard } from "./EmptyTestsCard";
 import { PinCard } from "./PinCard";
+import { PatternTests } from "./PatternTests";
 import type { RuleDescriptionNote } from "./rule-descriptions";
 import type { PinEvaluation } from "./use-pinned-tests";
-import type { FormState, PinnedTest } from "@/types/simulator";
+import type { FormState, PatternTest, PinnedTest } from "@/types/simulator";
 import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 
 /**
@@ -29,10 +30,11 @@ import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
  * descriptor-less door.
  */
 
-/** Roadmap 077 (Proposal F): pins ride in the share link, said where pins are
- *  made. "Share" is live — the same build-and-copy as the header's button —
- *  with its own inline receipt, since the header's popover is a screen away
- *  from this click. */
+/** Roadmap 077 (Proposal F): the tests ride in the share link, said where
+ *  they are made — since 094 under BOTH groups, which is why it is the view's
+ *  last line rather than the Add-a-test card's footnote. "Share" is live — the
+ *  same build-and-copy as the header's button — with its own inline receipt,
+ *  since the header's popover is a screen away from this click. */
 function ShareNote({ onShare }: { onShare: () => Promise<void> }) {
   const [copied, flashCopied] = useTransientFlag(1500);
   async function share() {
@@ -45,7 +47,7 @@ function ShareNote({ onShare }: { onShare: () => Promise<void> }) {
   }
   return (
     <p className="pins-share-note">
-      Pins are saved with the share link —{" "}
+      Both test groups are saved with the share link —{" "}
       <button type="button" className="digest-link" onClick={() => void share()}>
         Share
       </button>{" "}
@@ -103,6 +105,10 @@ export function PinsView({
   repoDeps,
   onLoadRepoDeps,
   repoConnect,
+  patternTests,
+  onAddPatternTest,
+  onUpdatePatternTest,
+  onRemovePatternTest,
 }: {
   result: TraceResult;
   pins: PinnedTest[];
@@ -125,6 +131,11 @@ export function PinsView({
   repoDeps: RepoDepsView;
   onLoadRepoDeps: () => void;
   repoConnect: RepoConnectOffer;
+  /** Roadmap 094: the second test group and its edits — the shell's list. */
+  patternTests: readonly PatternTest[];
+  onAddPatternTest: () => string | null;
+  onUpdatePatternTest: (id: string, update: (test: PatternTest) => PatternTest) => void;
+  onRemovePatternTest: (id: string) => void;
 }) {
   // A quick-start chip seeds the Add-a-test form below — nonce-versioned so
   // the same chip works twice in a row.
@@ -171,8 +182,15 @@ export function PinsView({
         repoConnect={repoConnect}
         onAddPin={onAddPin}
         onOpenInSimulator={onOpenInSimulator}
-        footnote={onShare ? <ShareNote onShare={onShare} /> : undefined}
       />
+      <PatternTests
+        tests={patternTests}
+        seedSources={{ pins, repoDeps, result }}
+        onAdd={onAddPatternTest}
+        onUpdate={onUpdatePatternTest}
+        onRemove={onRemovePatternTest}
+      />
+      {onShare ? <ShareNote onShare={onShare} /> : null}
     </div>
   );
 }

--- a/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.shimmed.test.tsx
@@ -79,6 +79,10 @@ function Harness({
       repoDeps={repoDeps}
       onLoadRepoDeps={() => undefined}
       repoConnect={repoConnect}
+      patternTests={[]}
+      onAddPatternTest={() => null}
+      onUpdatePatternTest={() => undefined}
+      onRemovePatternTest={() => undefined}
     />
   );
 }

--- a/packages/app/src/features/simulator/TestsPanel.tsx
+++ b/packages/app/src/features/simulator/TestsPanel.tsx
@@ -12,7 +12,7 @@ import { RuleSimulator } from "./RuleSimulator";
 import type { SimRequest } from "./use-share-link-request";
 import { usePinnedTests } from "./use-pinned-tests";
 import { useSyncedReset } from "@/hooks/use-synced-reset";
-import type { FormState, PinnedTest } from "@/types/simulator";
+import type { FormState, PatternTest, PinnedTest } from "@/types/simulator";
 import type { RepoConnectOffer, RepoDepsView } from "@/types/repo";
 
 /**
@@ -68,6 +68,10 @@ export const TestsPanel = memo(function TestsPanel({
   repoDeps,
   onLoadRepoDeps,
   repoConnect,
+  patternTests,
+  onAddPatternTest,
+  onUpdatePatternTest,
+  onRemovePatternTest,
 }: {
   result: TraceResult;
   pins: PinnedTest[];
@@ -91,6 +95,11 @@ export const TestsPanel = memo(function TestsPanel({
   repoDeps: RepoDepsView;
   onLoadRepoDeps: () => void;
   repoConnect: RepoConnectOffer;
+  /** Roadmap 094: the pattern tests — the pins view's second group. */
+  patternTests: readonly PatternTest[];
+  onAddPatternTest: () => string | null;
+  onUpdatePatternTest: (id: string, update: (test: PatternTest) => PatternTest) => void;
+  onRemovePatternTest: (id: string) => void;
 }) {
   // A link carrying a simulation, or a cross-link naming a rule, is a request
   // for the simulator — including on the very first render, since App applies
@@ -183,6 +192,10 @@ export const TestsPanel = memo(function TestsPanel({
       repoDeps={repoDeps}
       onLoadRepoDeps={onLoadRepoDeps}
       repoConnect={repoConnect}
+      patternTests={patternTests}
+      onAddPatternTest={onAddPatternTest}
+      onUpdatePatternTest={onUpdatePatternTest}
+      onRemovePatternTest={onRemovePatternTest}
     />
   );
 });

--- a/packages/app/src/features/simulator/pattern-tests.test.ts
+++ b/packages/app/src/features/simulator/pattern-tests.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Roadmap 094: the pattern tests' pure half — the share round trip, the
+ * evaluation's sentences given a matcher, and where the seed offer looks.
+ * The matcher is a STUB (regex-only, `!` negates): what Renovate's own one
+ * says is the engine's test; what the card says about an answer is this one.
+ */
+import { describe, expect, test } from "vitest";
+import type { PatternListMatch, TraceResult } from "@renovate-config-debugger/engine";
+import { EMPTY_REPO_DEPS } from "./repo-deps";
+import { EMPTY_FORM } from "./form";
+import {
+  evaluatePatternTest,
+  expectationFor,
+  newPatternTest,
+  patternChips,
+  type PatternMatcher,
+  patternTestShareFields,
+  patternTestsFromShare,
+  seedValuesFor,
+} from "./pattern-tests";
+import { repoDep } from "@tools/test/repo-deps";
+
+function parse(pattern: string) {
+  const negative = pattern.startsWith("!");
+  const body = negative ? pattern.slice(1) : pattern;
+  const regex = /^\/(.*)\/(i?)$/.exec(body);
+  return {
+    kind: pattern === "*" ? ("any" as const) : regex ? ("regex" as const) : ("glob" as const),
+    negative,
+    caseInsensitive: !regex || regex[2] === "i",
+    invalid: regex?.[1] === "[",
+    body:
+      regex?.[1] === "["
+        ? /$^/
+        : regex
+          ? new RegExp(regex[1] ?? "", regex[2])
+          : new RegExp(`^${body.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")}$`, "i"),
+  };
+}
+
+/** Positive-OR / negative-AND, the upstream rule, over the stub's regexes. */
+function explain(patterns: readonly string[], input: string): PatternListMatch {
+  const entries = patterns.map((pattern) => {
+    const { body, ...parsed } = parse(pattern);
+    const hit = parsed.kind === "any" || body.test(input);
+    return {
+      ...parsed,
+      pattern,
+      hit,
+      ...(pattern === "**quay.io/**" && input === "https://quay.io"
+        ? { suggestion: "**/quay.io{/,}**" }
+        : {}),
+    };
+  });
+  const positives = entries.filter((entry) => !entry.negative);
+  const blocked = entries.some((entry) => entry.negative && entry.hit);
+  const matches =
+    entries.length > 0 && (positives.length === 0 || positives.some((e) => e.hit)) && !blocked;
+  return {
+    matches,
+    entries,
+    reason: matches ? null : entries.length === 0 ? "empty" : blocked ? "blocked" : "no-positive",
+  };
+}
+
+const matcher: PatternMatcher = {
+  explain,
+  parse: (pattern) => {
+    const { body: _body, ...parsed } = parse(pattern);
+    return parsed;
+  },
+  options: ["matchDepNames", "matchPackageNames"],
+};
+
+function ids(): () => string {
+  let n = 0;
+  return () => `pattern-${++n}`;
+}
+
+describe("share round trip", () => {
+  test("the share fields are the test minus its id, and come back with a fresh id", () => {
+    const test1 = {
+      ...newPatternTest("pattern-9"),
+      option: "matchDepNames",
+      patterns: ["/^react/", "!react-dom"],
+      inputs: [
+        { value: "react", expect: true },
+        { value: "react-dom", expect: false },
+      ],
+    };
+    const shared = patternTestShareFields(test1);
+    expect(shared).toEqual({
+      option: "matchDepNames",
+      patterns: ["/^react/", "!react-dom"],
+      inputs: [
+        { value: "react", expect: true },
+        { value: "react-dom", expect: false },
+      ],
+    });
+    expect(patternTestsFromShare([shared], ids())).toEqual([{ ...test1, id: "pattern-1" }]);
+  });
+
+  test("the decode side caps the list like the pins' cap", () => {
+    const many = Array.from({ length: 30 }, () => ({
+      option: "matchDepNames",
+      patterns: ["react"],
+      inputs: [],
+    }));
+    expect(patternTestsFromShare(many, ids())).toHaveLength(20);
+  });
+});
+
+describe("evaluatePatternTest", () => {
+  test("the header sentence counts inputs whose verdict met the expectation", () => {
+    const evaluation = evaluatePatternTest(matcher, {
+      patterns: ["/^react/", "!react-dom"],
+      inputs: [
+        { value: "react", expect: true },
+        { value: "react-dom", expect: false },
+        { value: "@types/react", expect: true },
+      ],
+    });
+    expect(evaluation.summary).toBe("2 of 3 expected");
+    expect(evaluation.tone).toBe("error");
+    expect(evaluation.inputs.map((input) => input.pass)).toEqual([true, true, false]);
+    // The negative that blocked react-dom is named on its row; the plain miss
+    // for @types/react has no why — its mark says it.
+    expect(evaluation.inputs[1]?.why).toBe("blocked by !react-dom");
+    expect(evaluation.inputs[2]?.why).toBeNull();
+  });
+
+  test("a pattern's count is its hits over the inputs, or the inputs it blocks", () => {
+    const evaluation = evaluatePatternTest(matcher, {
+      patterns: ["/^react/", "!react-dom", "lodash"],
+      inputs: [
+        { value: "react", expect: true },
+        { value: "react-dom", expect: false },
+      ],
+    });
+    expect(evaluation.patterns.map((pattern) => pattern.count)).toEqual(["2/2", "blocks 1", "0/2"]);
+    // A positive pattern no input satisfies is flagged; a negative never is.
+    expect(evaluation.patterns.map((pattern) => pattern.dead)).toEqual([false, false, true]);
+  });
+
+  test("no inputs is pending, all-pass is ok", () => {
+    expect(evaluatePatternTest(matcher, { patterns: ["react"], inputs: [] })).toMatchObject({
+      tone: "pending",
+      summary: "no inputs yet",
+    });
+    expect(
+      evaluatePatternTest(matcher, {
+        patterns: ["react"],
+        inputs: [{ value: "react", expect: true }],
+      }).tone,
+    ).toBe("ok");
+  });
+
+  test("the upstream-verified rewrite and an invalid regex each become the row's why", () => {
+    const trap = evaluatePatternTest(matcher, {
+      patterns: ["**quay.io/**"],
+      inputs: [{ value: "https://quay.io", expect: true }],
+    });
+    expect(trap.inputs[0]?.why).toBe("no match — try **/quay.io{/,}**");
+    const invalid = evaluatePatternTest(matcher, {
+      patterns: ["/[/"],
+      inputs: [{ value: "x", expect: true }],
+    });
+    expect(invalid.inputs[0]?.why).toContain("/[/ is not a valid regex");
+  });
+
+  test("a new input's expectation defaults to the current verdict", () => {
+    expect(expectationFor(explain, ["/^react/"], "react")).toBe(true);
+    expect(expectationFor(explain, ["/^react/"], "lodash")).toBe(false);
+  });
+});
+
+test("patternChips say how upstream will read the entry", () => {
+  expect(
+    patternChips({ kind: "glob", negative: false, caseInsensitive: true, invalid: false }),
+  ).toEqual(["glob", "Aa ignored"]);
+  expect(
+    patternChips({ kind: "regex", negative: true, caseInsensitive: false, invalid: false }),
+  ).toEqual(["regex", "Aa exact", "! negative"]);
+  expect(
+    patternChips({ kind: "regex", negative: false, caseInsensitive: false, invalid: true }),
+  ).toEqual(["regex", "Aa exact", "invalid regex"]);
+  expect(
+    patternChips({ kind: "any", negative: false, caseInsensitive: true, invalid: false }),
+  ).toEqual(["matches everything"]);
+});
+
+describe("seedValuesFor", () => {
+  const result = { finalConfig: { baseBranches: ["main", "release/*"] } } as unknown as TraceResult;
+  const pins = [
+    {
+      id: "pin-1",
+      form: {
+        ...EMPTY_FORM,
+        packageName: "react",
+        manager: "npm",
+        registryUrls: "https://registry.npmjs.org, https://npm.pkg.github.com",
+      },
+    },
+  ];
+  const repoDeps = {
+    ...EMPTY_REPO_DEPS,
+    repo: "acme/webapp",
+    deps: [
+      repoDep("react", "package.json", "npm"),
+      repoDep("nginx", "Dockerfile", "dockerfile", { fill: { datasource: "docker" } }),
+    ],
+    files: [
+      {
+        path: "package.json",
+        managers: ["npm"],
+        extractedBy: "npm",
+        depCount: 1,
+        outcome: "extracted" as const,
+      },
+    ],
+  };
+
+  test("draws on the pins and the loaded repository, deduplicated", () => {
+    const sources = { pins, repoDeps, result };
+    expect(seedValuesFor("matchPackageNames", sources)).toEqual(["react", "nginx"]);
+    expect(seedValuesFor("matchManagers", sources)).toEqual(["npm"]);
+    expect(seedValuesFor("matchFileNames", sources)).toEqual(["package.json", "Dockerfile"]);
+    expect(seedValuesFor("matchRegistryUrls", sources)).toEqual([
+      "https://registry.npmjs.org",
+      "https://npm.pkg.github.com",
+    ]);
+    expect(seedValuesFor("matchDatasources", sources)).toEqual(["docker"]);
+    expect(seedValuesFor("matchRepositories", sources)).toEqual(["acme/webapp"]);
+    expect(seedValuesFor("matchBaseBranches", sources)).toEqual(["main", "release/*"]);
+  });
+
+  test("an unpicked or unknown option seeds nothing", () => {
+    const sources = { pins, repoDeps, result };
+    expect(seedValuesFor("", sources)).toEqual([]);
+    expect(seedValuesFor("matchSomethingElse", sources)).toEqual([]);
+  });
+});

--- a/packages/app/src/features/simulator/pattern-tests.ts
+++ b/packages/app/src/features/simulator/pattern-tests.ts
@@ -1,0 +1,223 @@
+import type {
+  ParsedPattern,
+  PatternListMatch,
+  TraceResult,
+} from "@renovate-config-debugger/engine";
+import { splitValues } from "./form";
+import { MAX_PATTERN_TESTS } from "@/lib/input-schemas";
+import type { SharePatternTest } from "@/lib/input-schemas-zod";
+import type { PatternInput, PatternTest, PinnedTest } from "@/types/simulator";
+import type { RepoDepsView } from "@/types/repo";
+
+/**
+ * Roadmap 094 — the pattern tests' pure half: what a test is on the wire, how
+ * one is evaluated (given the engine's matcher), and the sentences the card
+ * prints about it. DOM-free, engine-free — the matcher is INJECTED, so the
+ * unit tests hand in a stub and the component hands in Renovate's own.
+ */
+
+/** The engine's `explainPatternMatch`, as the functions here take it. */
+export type ExplainPatterns = (patterns: readonly string[], input: string) => PatternListMatch;
+
+/** The engine's matcher surface, as the card and the evaluation take it —
+ *  `null` while the engine chunk is still loading. */
+export interface PatternMatcher {
+  explain: ExplainPatterns;
+  parse: (pattern: string) => ParsedPattern;
+  /** The `match*` list options the pinned Renovate has. */
+  options: string[];
+}
+
+export function newPatternTest(id: string): PatternTest {
+  return { id, option: "", patterns: [], inputs: [] };
+}
+
+/** The encode side: everything but the session id. */
+export function patternTestShareFields(test: PatternTest): SharePatternTest {
+  return {
+    option: test.option,
+    patterns: [...test.patterns],
+    inputs: test.inputs.map((input) => ({ value: input.value, expect: input.expect })),
+  };
+}
+
+/** The decode side: the link's tests with ids minted here, capped like pins. */
+export function patternTestsFromShare(
+  shared: readonly SharePatternTest[],
+  nextId: () => string,
+): PatternTest[] {
+  return shared.slice(0, MAX_PATTERN_TESTS).map((test) => ({
+    id: nextId(),
+    option: test.option,
+    patterns: [...test.patterns],
+    inputs: test.inputs.map((input) => ({ value: input.value, expect: input.expect })),
+  }));
+}
+
+/** The chips under a pattern — how upstream will read it, said before the
+ *  reader finds out the hard way. */
+export function patternChips(parsed: ParsedPattern): string[] {
+  if (parsed.kind === "any") {
+    return ["matches everything"];
+  }
+  const chips = [parsed.kind === "regex" ? "regex" : "glob"];
+  chips.push(parsed.caseInsensitive ? "Aa ignored" : "Aa exact");
+  if (parsed.negative) {
+    chips.push("! negative");
+  }
+  if (parsed.invalid) {
+    chips.push("invalid regex");
+  }
+  return chips;
+}
+
+export interface InputVerdict extends PatternInput {
+  /** Upstream's answer for this input. */
+  matches: boolean;
+  /** `matches` agrees with what the reader expected. */
+  pass: boolean;
+  /** The one-line reason under the row, or null when the mark says it all. */
+  why: string | null;
+}
+
+export interface PatternVerdict {
+  pattern: string;
+  parsed: ParsedPattern;
+  chips: string[];
+  /** Positive: inputs it matched. Negative: inputs it blocks. */
+  hits: number;
+  /** The count as the card prints it — `3/5`, or `blocks 1`. */
+  count: string;
+  /** A positive pattern that matched nothing while there were inputs to match. */
+  dead: boolean;
+}
+
+export type PatternTestTone = "ok" | "error" | "pending";
+
+export interface PatternTestEvaluation {
+  inputs: InputVerdict[];
+  patterns: PatternVerdict[];
+  passCount: number;
+  tone: PatternTestTone;
+  /** The header's sentence: `3 of 4 expected`, or `no inputs yet`. */
+  summary: string;
+}
+
+function whyFor(match: PatternListMatch): string | null {
+  const invalid = match.entries.find((entry) => entry.invalid);
+  if (invalid) {
+    return `${invalid.pattern} is not a valid regex — Renovate would reject this config`;
+  }
+  if (match.reason === "blocked") {
+    const blocker = match.entries.find((entry) => entry.negative && entry.hit);
+    return blocker ? `blocked by ${blocker.pattern}` : null;
+  }
+  const suggestion = match.entries.find((entry) => entry.suggestion !== undefined)?.suggestion;
+  return suggestion === undefined ? null : `no match — try ${suggestion}`;
+}
+
+export function evaluatePatternTest(
+  matcher: Pick<PatternMatcher, "explain" | "parse">,
+  test: Pick<PatternTest, "patterns" | "inputs">,
+): PatternTestEvaluation {
+  const inputs = test.inputs.map((input) => {
+    const match = matcher.explain(test.patterns, input.value);
+    return {
+      value: input.value,
+      expect: input.expect,
+      matches: match.matches,
+      pass: match.matches === input.expect,
+      why: whyFor(match),
+      entries: match.entries,
+    };
+  });
+  const patterns = test.patterns.map((pattern, j) => {
+    const parsed = matcher.parse(pattern);
+    const hits = inputs.filter((input) => input.entries[j]?.hit === true).length;
+    return {
+      pattern,
+      parsed,
+      chips: patternChips(parsed),
+      hits,
+      count: parsed.negative ? `blocks ${hits}` : `${hits}/${test.inputs.length}`,
+      dead: !parsed.negative && parsed.kind !== "any" && hits === 0 && test.inputs.length > 0,
+    };
+  });
+  const passCount = inputs.filter((input) => input.pass).length;
+  const tone: PatternTestTone =
+    inputs.length === 0 ? "pending" : passCount === inputs.length ? "ok" : "error";
+  return {
+    inputs: inputs.map(({ entries: _entries, ...verdict }) => verdict),
+    patterns,
+    passCount,
+    tone,
+    summary: inputs.length === 0 ? "no inputs yet" : `${passCount} of ${inputs.length} expected`,
+  };
+}
+
+/** What the card offers to seed a new input's expectation with: upstream's
+ *  current answer, so a freshly typed input starts as a passing assertion the
+ *  reader then flips if that is not what they meant. */
+export function expectationFor(
+  explain: ExplainPatterns,
+  patterns: string[],
+  value: string,
+): boolean {
+  return explain(patterns, value).matches;
+}
+
+/**
+ * Where the "add the N values from your last run" offer looks, per option:
+ * the pinned descriptors (every field a pin can carry) and the loaded
+ * repository's extraction. Deduplicated, in first-seen order. Every option
+ * the engine lists has a row here so the offer can never be silently absent
+ * for one of them; an option with nothing to draw on simply seeds nothing.
+ */
+export interface SeedSources {
+  pins: readonly PinnedTest[];
+  repoDeps: RepoDepsView;
+  result: TraceResult;
+}
+
+function pinField(pins: readonly PinnedTest[], key: keyof PinnedTest["form"]): string[] {
+  return pins.flatMap((pin) => splitValues(pin.form[key]));
+}
+
+function repoFill(
+  repoDeps: RepoDepsView,
+  key: "datasource" | "depType" | "registryUrls",
+): string[] {
+  return repoDeps.deps.flatMap((dep) => splitValues(dep.fill[key] ?? ""));
+}
+
+export function seedValuesFor(option: string, { pins, repoDeps, result }: SeedSources): string[] {
+  const baseBranches = result.finalConfig?.baseBranches;
+  const byOption: Record<string, string[]> = {
+    matchBaseBranches: [
+      ...pinField(pins, "baseBranch"),
+      ...(Array.isArray(baseBranches)
+        ? baseBranches.filter((branch): branch is string => typeof branch === "string")
+        : []),
+    ],
+    matchCategories: pinField(pins, "categories"),
+    matchDatasources: [...pinField(pins, "datasource"), ...repoFill(repoDeps, "datasource")],
+    matchDepNames: [...pinField(pins, "depName"), ...repoDeps.deps.map((dep) => dep.depName)],
+    matchDepTypes: [...pinField(pins, "depType"), ...repoFill(repoDeps, "depType")],
+    matchFileNames: [
+      ...pinField(pins, "packageFile"),
+      ...repoDeps.deps.map((dep) => dep.packageFile),
+    ],
+    matchManagers: [
+      ...pinField(pins, "manager"),
+      ...repoDeps.files.flatMap((file) => file.managers),
+    ],
+    matchPackageNames: [
+      ...pinField(pins, "packageName"),
+      ...repoDeps.deps.map((dep) => dep.fill.packageName ?? dep.depName),
+    ],
+    matchRegistryUrls: [...pinField(pins, "registryUrls"), ...repoFill(repoDeps, "registryUrls")],
+    matchRepositories: [...pinField(pins, "repository"), repoDeps.repo],
+    matchSourceUrls: pinField(pins, "sourceUrl"),
+  };
+  return [...new Set((byOption[option] ?? []).map((v) => v.trim()).filter((v) => v !== ""))];
+}

--- a/packages/app/src/features/simulator/use-pattern-matcher.ts
+++ b/packages/app/src/features/simulator/use-pattern-matcher.ts
@@ -1,0 +1,21 @@
+import { useEngineDerivation } from "@/hooks/use-engine-derivation";
+import type { PatternMatcher } from "./pattern-tests";
+
+/** Keyed on nothing — the matcher is the engine's, the same for the life of
+ *  the page (the `useEngineModule` idiom). */
+const NO_INPUTS: readonly unknown[] = [];
+
+/**
+ * Roadmap 094: Renovate's own list matcher, as the pattern-test cards need it.
+ * A cache hit in practice — the Tests tab only renders after a run, which has
+ * already pulled the engine chunk in. `null` until then.
+ */
+export function usePatternMatcher(): PatternMatcher | null {
+  return (
+    useEngineDerivation(NO_INPUTS, (engine) => ({
+      explain: engine.explainPatternMatch,
+      parse: engine.parsePattern,
+      options: engine.patternListOptionNames(),
+    })) ?? null
+  );
+}

--- a/packages/app/src/hooks/use-share-link.test.tsx
+++ b/packages/app/src/hooks/use-share-link.test.tsx
@@ -91,6 +91,7 @@ function makeHost(onRun: ShareLinkHost["onRun"]): ShareLinkHost {
     setAuthUser: noop,
     applyUntrustedGuard: noop,
     setPins: noop,
+    setPatternTests: noop,
     applyShareRepo: noop,
     setPendingView: noop,
     // Equal, so a hashchange never has unsaved edits to confirm away.

--- a/packages/app/src/hooks/use-share-link.ts
+++ b/packages/app/src/hooks/use-share-link.ts
@@ -42,6 +42,7 @@ import {
   type UntrustedEndpointGuard,
   untrustedGuardForPolicy,
 } from "@/lib/share";
+import type { SharePatternTest } from "@/lib/input-schemas-zod";
 import { errorMessage } from "@/lib/errors";
 
 /** Roadmap 018: a share link's simulator inputs, applied once by nonce. */
@@ -123,6 +124,9 @@ export interface ShareLinkHost {
    *  unconditional: a link installs the screen it describes, and pins from a
    *  previous one are not part of it. */
   setPins: (pins: Record<string, string>[]) => void;
+  /** Roadmap 094: the link's pattern tests — the same contract as `setPins`,
+   *  `[]` when the link carries none. */
+  setPatternTests: (tests: SharePatternTest[]) => void;
   /** Roadmap 087: the link's repo provenance — the slug the config was loaded
    *  from, or null. Called unconditionally in the populate block for the same
    *  reason `setPins` is: a link installs the screen it describes, and the
@@ -302,6 +306,7 @@ export function useShareLink(oauthConfig: OAuthConfig | null, host: ShareLinkHos
     // result that run commits is the first thing they are checked against —
     // which is the whole promise of the tab that lists them.
     host.setPins(payload.pins ?? []);
+    host.setPatternTests(payload.patternTests ?? []);
     host.applyShareRepo(payload.repo ?? null);
     // Roadmap 068 review — half one of the attribution rule stated below: a
     // decode that replaces the screen replaces the simulator request with it,

--- a/packages/app/src/lib/input-schemas-zod.ts
+++ b/packages/app/src/lib/input-schemas-zod.ts
@@ -28,6 +28,10 @@ import {
   isValidPlatform,
   isValidShareConfigLayer,
   isValidToken,
+  MAX_PATTERN_INPUTS,
+  MAX_PATTERN_LENGTH,
+  MAX_PATTERN_TESTS,
+  MAX_PATTERNS_PER_TEST,
   MAX_PINNED_TESTS,
   STAGE_IDS,
 } from "./input-schemas";
@@ -220,6 +224,61 @@ export function sanitizeSharePins(raw: unknown): Record<string, string>[] | unde
     }
   }
   return pins.length > 0 ? pins : undefined;
+}
+
+/** Roadmap 094: a pattern test as the link carries it — no id (the opener
+ *  mints its own), the option name, the patterns, the inputs with their
+ *  expectations. */
+export interface SharePatternTest {
+  option: string;
+  patterns: string[];
+  inputs: { value: string; expect: boolean }[];
+}
+
+const patternTextSchema = z.string().check(z.minLength(1), z.maxLength(MAX_PATTERN_LENGTH));
+
+/** An option NAME: the engine decides whether it is a matcher it knows; the
+ *  link only has to hand over something that is safely printable. */
+const patternOptionSchema = z.string().check(z.maxLength(64), z.regex(/^[A-Za-z]*$/));
+
+const sharePatternTestSchema = z.object({
+  option: patternOptionSchema,
+  patterns: z.array(patternTextSchema).check(z.maxLength(MAX_PATTERNS_PER_TEST)),
+  inputs: z
+    .array(z.object({ value: patternTextSchema, expect: z.boolean() }))
+    .check(z.maxLength(MAX_PATTERN_INPUTS)),
+});
+
+/**
+ * Roadmap 094: a decoded payload's `patternTests`. Additive within v2 like
+ * `pins`, and tolerant per ENTRY for the same reason: a pattern test is
+ * cosmetic state — the app re-evaluates it against the config it would
+ * evaluate anyway — so a malformed one is dropped alone rather than failing a
+ * link that also carries a config. Bounded on every axis (count, patterns,
+ * inputs, text length) so a hand-edited link cannot hand the reader's browser
+ * thousands of matcher calls per render. An entry with nothing in it (no
+ * option, no patterns, no inputs) is dropped: it would render an empty card.
+ */
+export function sanitizeSharePatternTests(raw: unknown): SharePatternTest[] | undefined {
+  if (!Array.isArray(raw)) {
+    return undefined;
+  }
+  const tests: SharePatternTest[] = [];
+  for (const entry of raw) {
+    if (tests.length >= MAX_PATTERN_TESTS) {
+      break;
+    }
+    const parsed = sharePatternTestSchema.safeParse(entry);
+    if (!parsed.success) {
+      continue;
+    }
+    const { option, patterns, inputs } = parsed.data;
+    if (option === "" && patterns.length === 0 && inputs.length === 0) {
+      continue;
+    }
+    tests.push({ option, patterns, inputs });
+  }
+  return tests.length > 0 ? tests : undefined;
 }
 
 /**

--- a/packages/app/src/lib/input-schemas.ts
+++ b/packages/app/src/lib/input-schemas.ts
@@ -255,6 +255,19 @@ export const STAGE_IDS = [
  */
 export const MAX_PINNED_TESTS = 20;
 
+/**
+ * Roadmap 094: the pattern tests' bounds — the list cap for the same two
+ * reasons pins have one (the link's length, the per-run re-check), and the
+ * per-test caps because every pattern × input is one minimatch/regex call on
+ * every render of the card. Here, zod-free, so the "+ Test a pattern…" row and
+ * the payload sanitizer read one number.
+ */
+export const MAX_PATTERN_TESTS = 20;
+export const MAX_PATTERNS_PER_TEST = 20;
+export const MAX_PATTERN_INPUTS = 50;
+/** One pattern or one input value — a matcher's argument, never a document. */
+export const MAX_PATTERN_LENGTH = 256;
+
 // ---------------------------------------------------------------------------
 // Storage reads (OAuth stored user — sync at boot, so zod-free)
 // ---------------------------------------------------------------------------

--- a/packages/app/src/lib/share.test.ts
+++ b/packages/app/src/lib/share.test.ts
@@ -6,7 +6,7 @@ import {
   resultsTabForShareTab,
   shareTabWantsMigrateStage,
 } from "@/data/results-tabs";
-import { MAX_PINNED_TESTS } from "./input-schemas";
+import { MAX_PATTERN_TESTS, MAX_PINNED_TESTS } from "./input-schemas";
 import {
   configChecksum,
   decideShareRunPolicy,
@@ -975,5 +975,76 @@ describe("087: the provenance repo round-trips and stays additive", () => {
       return;
     }
     expect(result.payload.repo).toBeUndefined();
+  });
+});
+
+/**
+ * Roadmap 094: `patternTests` — the pattern tests a link carries. Additive
+ * within v2 exactly like `pins`, sanitized per entry, bounded on every axis.
+ */
+describe("094: pattern tests round-trip and stay additive", () => {
+  const TEST = {
+    option: "matchDepNames",
+    patterns: ["/^react/", "!react-dom"],
+    inputs: [
+      { value: "react", expect: true },
+      { value: "react-dom", expect: false },
+    ],
+  };
+
+  test("encode → decode preserves the tests", async () => {
+    const result = await decodeShareResult(
+      await encodeShare(minimalState({ patternTests: [structuredClone(TEST)] })),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.payload.patternTests).toEqual([TEST]);
+  });
+
+  test("no tests (or an empty list) writes no field at all", async () => {
+    const absent = await decodeShareResult(await encodeShare(minimalState()));
+    const empty = await decodeShareResult(await encodeShare(minimalState({ patternTests: [] })));
+    expect(absent.ok && absent.payload.patternTests).toBeUndefined();
+    expect(empty.ok && empty.payload.patternTests).toBeUndefined();
+  });
+
+  test("a malformed field never fails the link; bad entries are dropped alone", async () => {
+    const mixed = await decodeShareResult(
+      await rawEncodeToken(
+        taggedPayload({
+          patternTests: [
+            TEST,
+            "nope",
+            { option: "matchDepNames", patterns: "react", inputs: [] },
+            { option: "match Names", patterns: [], inputs: [] },
+            { option: "", patterns: [], inputs: [] },
+            { option: "matchDepNames", patterns: [], inputs: [{ value: "x", expect: "yes" }] },
+          ],
+        }),
+      ),
+    );
+    expect(mixed.ok).toBe(true);
+    if (!mixed.ok) {
+      return;
+    }
+    expect(mixed.payload.patternTests).toEqual([TEST]);
+  });
+
+  test("a hand-edited link cannot exceed the caps", async () => {
+    const many = Array.from({ length: MAX_PATTERN_TESTS + 5 }, () => TEST);
+    const result = await decodeShareResult(
+      await rawEncodeToken(taggedPayload({ patternTests: many })),
+    );
+    expect(result.ok && result.payload.patternTests).toHaveLength(MAX_PATTERN_TESTS);
+    const oversized = await decodeShareResult(
+      await rawEncodeToken(
+        taggedPayload({
+          patternTests: [{ ...TEST, patterns: ["x".repeat(300)] }],
+        }),
+      ),
+    );
+    expect(oversized.ok && oversized.payload.patternTests).toBeUndefined();
   });
 });

--- a/packages/app/src/lib/share.ts
+++ b/packages/app/src/lib/share.ts
@@ -13,6 +13,7 @@
 import type { StageId } from "@renovate-config-debugger/engine";
 import type { ShareResultsTabId } from "@/data/results-tabs";
 import { isValidRepoRefPart } from "@/lib/input-schemas";
+import type { SharePatternTest } from "@/lib/input-schemas-zod";
 import { DEFAULT_ENDPOINT, DEFAULT_PLATFORM, PLATFORM_ENDPOINTS } from "@/data/platform-endpoints";
 import { isTrustedEndpoint } from "@/lib/trusted-endpoint";
 
@@ -97,6 +98,10 @@ export interface ShareState {
    *  Same content class as `sim.form` — dependency descriptors, never tokens
    *  and never an injected preset — and omitted entirely when there are none. */
   pins?: Record<string, string>[];
+  /** Roadmap 094: the pattern tests — a `match*` option, its patterns and
+   *  the inputs they should (not) match. Config-shaped text only, never a
+   *  token; omitted entirely when there are none. */
+  patternTests?: SharePatternTest[];
   /** Roadmap 087: the repository the config was LOADED from, when it was — a
    *  provenance hint the From-repository tab's connect panel offers to reload.
    *  A slug, never credentials; nothing is fetched without a click. */
@@ -129,6 +134,12 @@ export interface SharePayload {
    * the version stays 2. Sanitized per entry (`sanitizeSharePins`).
    */
   pins?: Record<string, string>[];
+  /**
+   * Roadmap 094: the pattern tests. Additive within v2 exactly like `pins`:
+   * absent on old links, ignored by old readers, sanitized per entry
+   * (`sanitizeSharePatternTests`).
+   */
+  patternTests?: SharePatternTest[];
   /**
    * Roadmap 087: the repository the config was loaded from. Additive within
    * v2 exactly like `sim` and `pins`: absent on old links, ignored by old
@@ -224,7 +235,8 @@ export async function encodeShare(state: ShareState): Promise<string> {
   if (state.platformOverride) {
     payload.platformOverride = true;
   }
-  const { sanitizeShareView, sanitizeShareSim, sanitizeSharePins } = await loadSchemas();
+  const { sanitizeShareView, sanitizeShareSim, sanitizeSharePins, sanitizeSharePatternTests } =
+    await loadSchemas();
   // Roadmap 033: the encode side runs the SAME sanitizers the decoder runs
   // (input-schemas-zod.ts), so what goes onto the wire and what is accepted off
   // it can never disagree again. This reconciles the one live divergence the
@@ -247,6 +259,10 @@ export async function encodeShare(state: ShareState): Promise<string> {
   const pins = sanitizeSharePins(state.pins);
   if (pins) {
     payload.pins = pins;
+  }
+  const patternTests = sanitizeSharePatternTests(state.patternTests);
+  if (patternTests) {
+    payload.patternTests = patternTests;
   }
   // Roadmap 087: the same validator the decoder runs (and the repo-load form
   // runs on what the user types) — what goes onto the wire is what comes off.
@@ -312,8 +328,13 @@ export async function decodeShareResult(token: string): Promise<DecodeResult> {
   if (typeof p.c === "string" && p.c !== configChecksum(p.config)) {
     return { ok: false, reason: "cutOff" };
   }
-  const { sanitizeShareView, sanitizeShareSim, sanitizeSharePins, sharePayloadStrictFieldsSchema } =
-    await loadSchemas();
+  const {
+    sanitizeShareView,
+    sanitizeShareSim,
+    sanitizeSharePins,
+    sanitizeSharePatternTests,
+    sharePayloadStrictFieldsSchema,
+  } = await loadSchemas();
   // Roadmap 030: the security-relevant fields (platform/endpoint/the two
   // config layers/platformOverride) are schema-validated as a unit — a
   // hostile or corrupted value here (a polluted globalConfig, a
@@ -346,6 +367,8 @@ export async function decodeShareResult(token: string): Promise<DecodeResult> {
   // re-simulates, which it would do for a hand-typed pin just the same — so a
   // malformed entry is dropped, never a reason to refuse the config.
   p.pins = sanitizeSharePins(p.pins);
+  // Roadmap 094: same tier, same rule — evaluated, never fetched or merged.
+  p.patternTests = sanitizeSharePatternTests(p.patternTests);
   // Roadmap 087: the provenance slug is cosmetic-tier in the pins sense — a
   // malformed value is dropped, never a reason to refuse the config. What it
   // must not be is arbitrary text: the connect panel prints it on a button

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -31,6 +31,7 @@ import "./styles/16-tabs.css";
 import "./styles/17-build-info.css";
 import "./styles/18-data-table.css";
 import "./styles/19-pipeline-extract.css";
+import "./styles/20-pattern-tests.css";
 
 // Roadmap 033: one-time storage migrations run before the App's `useState`
 // initializers read storage — and, unlike their old module-scope home, they

--- a/packages/app/src/styles/15-pins.css
+++ b/packages/app/src/styles/15-pins.css
@@ -598,8 +598,11 @@
 }
 
 /* The design's ghost row: a dashed, muted "+ Pin a dependency…" that expands
-   into the New-pin card. Accent on hover — it is a door, not a card. */
-.pin-add-ghost {
+   into the New-pin card. Accent on hover — it is a door, not a card. Roadmap
+   094's "+ Test a pattern…" row is the same door with its own name, so the
+   e2e selectors on this one keep resolving to one element. */
+.pin-add-ghost,
+.pattern-add-ghost {
   background: transparent;
   border: 1px dashed var(--border);
   border-radius: var(--radius-lg);
@@ -613,7 +616,8 @@
   width: 100%;
 }
 
-.pin-add-ghost:hover {
+.pin-add-ghost:hover,
+.pattern-add-ghost:hover {
   border-color: var(--accent);
   color: var(--accent);
 }

--- a/packages/app/src/styles/20-pattern-tests.css
+++ b/packages/app/src/styles/20-pattern-tests.css
@@ -1,0 +1,246 @@
+/* Appended after 19 (main.tsx's rule for new files). This file: the pattern
+   tests (roadmap 094 / the `Pattern Tests` artboard).
+
+   Nothing here is a new shape: the cards are `.card` wearing the pin head
+   (`.pin-head`, `.pin-dot`, `.pin-summary`, `.pin-remove`), the chips are
+   `.pill pill-count`, the column titles are `.pin-evidence-title`, the marks
+   are `.pin-section-mark`, the ghost row is `.pin-add-ghost`. What the block
+   adds is the card's two-column body and the in-place editable rows. */
+
+.pattern-tests {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-top: 0.9rem;
+}
+
+.pattern-card {
+  margin-bottom: 0;
+  overflow: visible;
+}
+
+/* The design's red dot: the test's OWN assertion failed — a claim the reader
+   made, not a claim about the run, which is why it is not the pin's amber. */
+.pin-dot.error {
+  background: var(--error);
+}
+
+.pattern-head-toggle {
+  flex: none;
+}
+
+/* The option, in the design's mono button. A native select: the browser's
+   own picker, so only the closed state is styled. */
+.pattern-option {
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  cursor: pointer;
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  font-weight: 600;
+  max-width: 14rem;
+  padding: 0.1rem 0.4rem;
+}
+
+/* Unset reads as the call to action it is — accent, not a value. */
+.pattern-option-unset {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+/* The pointer-only remainder of the head (see PatternTestHead). */
+.pattern-head-rest {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  flex: 1;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.pattern-head-pattern {
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  overflow: hidden;
+  padding: 0 0.3rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pattern-summary-fail {
+  color: var(--error);
+  font-weight: 600;
+}
+
+/* ----- the open card ----- */
+
+.pattern-body {
+  border-top: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+}
+
+.pattern-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.5rem 0.7rem;
+}
+
+.pattern-col + .pattern-col {
+  border-top: 1px solid var(--border);
+}
+
+/* Side by side once the grid has room for both columns — the rule between
+   them turns from a top edge into a left one. */
+@container (min-width: 34rem) {
+  .pattern-col + .pattern-col {
+    border-left: 1px solid var(--border);
+    border-top: none;
+  }
+}
+
+.pattern-body {
+  container-type: inline-size;
+}
+
+.pattern-row,
+.pattern-input {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.3rem 0.5rem;
+}
+
+/* The design's red row: this input's expectation does not hold. */
+.pattern-input-fail {
+  background: var(--error-bg);
+  border-color: var(--error-border);
+}
+
+.pattern-row-main {
+  align-items: center;
+  display: flex;
+  gap: 0.4rem;
+}
+
+/* In-place editing: a bare mono field with a dashed underline on focus, the
+   design's grammar for "this text IS the value". */
+.pattern-row-value {
+  background: none;
+  border: none;
+  border-bottom: 1px dashed transparent;
+  color: var(--ink);
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  min-width: 4rem;
+  padding: 0.05rem 0.1rem;
+}
+
+.pattern-row .pattern-row-value {
+  font-weight: 600;
+}
+
+.pattern-row-value:focus {
+  border-bottom-color: var(--accent);
+  outline: none;
+}
+
+.pattern-count {
+  color: var(--faint);
+  flex: none;
+  font-size: 0.66rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/* A positive pattern no input satisfies: the count goes red, so a pattern
+   that would match nothing in the reader's world says so before the rule
+   does. */
+.pattern-row-dead .pattern-count {
+  color: var(--error);
+}
+
+.pattern-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+
+.pattern-chips .pill {
+  font-size: 0.62rem;
+}
+
+.pattern-expect {
+  flex: none;
+  font-size: 0.64rem;
+  line-height: 1.6;
+  padding: 0 0.45rem;
+  white-space: nowrap;
+}
+
+.pattern-why {
+  color: var(--muted);
+  display: block;
+  font-size: 0.68rem;
+  padding-left: 1.4rem;
+}
+
+.pattern-add-line {
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.pattern-add-line:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+
+.pattern-rule {
+  color: var(--faint);
+  font-size: 0.66rem;
+  margin: 0.15rem 0 0;
+}
+
+.pattern-rule code {
+  font-family: var(--font-mono);
+}
+
+.pattern-seed {
+  align-self: flex-start;
+  font-size: 0.7rem;
+  text-decoration: none;
+}
+
+.pattern-seed:hover {
+  text-decoration: underline;
+}
+
+.pattern-empty {
+  color: var(--faint);
+  font-size: 0.76rem;
+  margin: 0;
+  text-align: center;
+}
+
+.pattern-empty code {
+  font-family: var(--font-mono);
+}
+
+.pattern-add-ghost:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}

--- a/packages/app/src/types/simulator.ts
+++ b/packages/app/src/types/simulator.ts
@@ -58,3 +58,29 @@ export interface PinnedTest {
    */
   starter?: boolean;
 }
+
+/**
+ * Roadmap 094 — one input of a pattern test: the string a `match*` list is
+ * tried against, and whether the reader expects it to match.
+ */
+export interface PatternInput {
+  value: string;
+  expect: boolean;
+}
+
+/**
+ * Roadmap 094 — a PATTERN TEST: one `packageRules` list option, the patterns
+ * a reader is writing for it, and the inputs those patterns should (not)
+ * match. Evaluated with Renovate's own list matcher, re-checked on every run
+ * exactly like a pin; carried by the share link like a pin.
+ */
+export interface PatternTest {
+  /** Session identity, minted by App — never shared, for the reason a pin's
+   *  is not. */
+  id: string;
+  /** A `match*` list option name (`matchPackageNames`, …), or `""` while the
+   *  reader has not picked one yet. */
+  option: string;
+  patterns: string[];
+  inputs: PatternInput[];
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -66,6 +66,16 @@ export {
 } from "./option-docs";
 export { listDatasourceNames, listManagerNames } from "./registries";
 export {
+  explainPatternMatch,
+  parsePattern,
+  type ParsedPattern,
+  type PatternEntryMatch,
+  type PatternKind,
+  type PatternListMatch,
+  patternListOptionNames,
+  type PatternMissReason,
+} from "./pattern-match";
+export {
   type ErrorFixResult,
   type ErrorTranslation,
   findMentionedOption,

--- a/packages/engine/src/pattern-match.test.ts
+++ b/packages/engine/src/pattern-match.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Roadmap 094 — the explanation never disagrees with the verdict: for every
+ * case, `matches` equals a direct `matchRegexOrGlobList` call, and the
+ * per-entry breakdown says why in upstream's own terms.
+ */
+import { describe, expect, it } from "vitest";
+import { explainPatternMatch, parsePattern, patternListOptionNames } from "./pattern-match";
+import { matchRegexOrGlobList } from "./renovate-adapter";
+
+const CASES: [patterns: string[], input: string][] = [
+  [["**quay.io/**"], "https://quay.io"],
+  [["**quay.io/**"], "https://quay.io/org/image"],
+  [["**/quay.io{/,}**"], "https://quay.io"],
+  [["/^react/", "!react-dom"], "react"],
+  [["/^react/", "!react-dom"], "react-dom"],
+  [["/^react/", "!react-dom"], "@types/react"],
+  [["/^REACT/"], "react"],
+  [["/^REACT/i"], "react"],
+  [["React"], "react"],
+  [["!lodash"], "lodash"],
+  [["!lodash"], "react"],
+  [["*"], "anything"],
+  [[], "anything"],
+  [["/[/"], "["],
+  [["{npm,docker}"], "docker"],
+  [["@types/*"], "@types/react"],
+  [["@types/*"], "@types/react/sub"],
+];
+
+describe("explainPatternMatch", () => {
+  it.each(CASES)("%j against %s reports upstream's verdict", (patterns, input) => {
+    const explained = explainPatternMatch(patterns, input);
+    expect(explained.matches).toBe(matchRegexOrGlobList(input, patterns));
+    expect(explained.entries.map((entry) => entry.pattern)).toEqual(patterns);
+  });
+
+  it("names the negative entry that blocked the list", () => {
+    const explained = explainPatternMatch(["/^react/", "!react-dom"], "react-dom");
+    expect(explained.matches).toBe(false);
+    expect(explained.reason).toBe("blocked");
+    expect(explained.entries.map((entry) => entry.hit)).toEqual([true, true]);
+  });
+
+  it("says when no positive matched, and when the list was empty", () => {
+    expect(explainPatternMatch(["/^react/"], "lodash").reason).toBe("no-positive");
+    expect(explainPatternMatch([], "lodash").reason).toBe("empty");
+    expect(explainPatternMatch(["/^react/"], "react").reason).toBeNull();
+  });
+
+  it("suggests a rewrite only when upstream's matcher accepts it", () => {
+    const [entry] = explainPatternMatch(["**quay.io/**"], "https://quay.io").entries;
+    expect(entry?.hit).toBe(false);
+    expect(entry?.suggestion).toBe("**/quay.io{/,}**");
+    const [path] = explainPatternMatch(["**/quay.io/**"], "https://quay.io").entries;
+    expect(path?.suggestion).toBe("**/quay.io{/,}**");
+    const [hopeless] = explainPatternMatch(["**quay.io/**"], "https://ghcr.io").entries;
+    expect(hopeless?.suggestion).toBeUndefined();
+  });
+
+  it("parses each entry the way upstream reads it", () => {
+    expect(parsePattern("*")).toMatchObject({ kind: "any", negative: false });
+    expect(parsePattern("/^react/")).toMatchObject({ kind: "regex", caseInsensitive: false });
+    expect(parsePattern("!/^react/i")).toMatchObject({
+      kind: "regex",
+      negative: true,
+      caseInsensitive: true,
+    });
+    expect(parsePattern("React")).toMatchObject({ kind: "glob", caseInsensitive: true });
+    expect(parsePattern("/[/")).toMatchObject({ kind: "regex", invalid: true });
+  });
+});
+
+describe("patternListOptionNames", () => {
+  it("is exactly the packageRules list matchers of the pinned Renovate", () => {
+    expect(patternListOptionNames()).toEqual([
+      "matchBaseBranches",
+      "matchCategories",
+      "matchDatasources",
+      "matchDepNames",
+      "matchDepTypes",
+      "matchFileNames",
+      "matchManagers",
+      "matchPackageNames",
+      "matchRegistryUrls",
+      "matchRepositories",
+      "matchSourceUrls",
+    ]);
+  });
+});

--- a/packages/engine/src/pattern-match.ts
+++ b/packages/engine/src/pattern-match.ts
@@ -1,0 +1,151 @@
+/**
+ * Roadmap 094 — one pattern list, one input, explained.
+ *
+ * Every `match*` list option (`matchPackageNames`, `matchFileNames`, …) goes
+ * through upstream's `matchRegexOrGlobList`, and that function is what the
+ * verdict here IS: `matches` is its return value, never a re-derivation. What
+ * this module adds is the per-entry breakdown a reader needs to see WHY — which
+ * positive hit, which negative blocked — and it gets that by asking the same
+ * upstream predicate one entry at a time (`matchRegexOrGlob`), so the two
+ * views cannot disagree. The proof is `pattern-match.test.ts`, which checks
+ * `matches` against a direct call for every case.
+ */
+import { getOptionIndex } from "./option-docs";
+import {
+  getRegexPredicate,
+  isRegexMatch,
+  matchRegexOrGlob,
+  matchRegexOrGlobList,
+} from "./renovate-adapter";
+
+/** How upstream reads one entry: `*` short-circuits, `/…/` is a regex,
+ *  anything else is a minimatch glob. */
+export type PatternKind = "any" | "regex" | "glob";
+
+export interface ParsedPattern {
+  kind: PatternKind;
+  /** A leading `!` — the entry must NOT match for the list to match. */
+  negative: boolean;
+  /** Regexes are case-sensitive unless written `/…/i`; globs never are
+   *  (`nocase: true` upstream). */
+  caseInsensitive: boolean;
+  /** Written as a regex that does not compile. Upstream's validator rejects
+   *  the config; its matcher silently falls back to treating the text as a
+   *  glob, which is what `hit` then reports. */
+  invalid: boolean;
+}
+
+export interface PatternEntryMatch extends ParsedPattern {
+  pattern: string;
+  /**
+   * Whether the entry's BODY matched the input. For a positive entry this is
+   * the match; for a negative one it means the entry BLOCKS the list (upstream
+   * inverts negatives, so this is the inverse of its predicate's answer).
+   */
+  hit: boolean;
+  /** For a positive glob that missed: a rewrite upstream's matcher DOES
+   *  accept for this input, when one of the two URL-shaped traps explains the
+   *  miss (see `globRewrites`). */
+  suggestion?: string;
+}
+
+/** Why the list did not match, when it did not. */
+export type PatternMissReason = "empty" | "no-positive" | "blocked";
+
+export interface PatternListMatch {
+  /** Upstream's own answer — `matchRegexOrGlobList(input, patterns)`. */
+  matches: boolean;
+  entries: PatternEntryMatch[];
+  reason: PatternMissReason | null;
+}
+
+const REGEX_FLAGS = /\/(i?)$/;
+
+export function parsePattern(pattern: string): ParsedPattern {
+  if (pattern === "*") {
+    return { kind: "any", negative: false, caseInsensitive: true, invalid: false };
+  }
+  const negative = pattern.startsWith("!");
+  if (isRegexMatch(pattern)) {
+    return {
+      kind: "regex",
+      negative,
+      caseInsensitive: REGEX_FLAGS.exec(pattern)?.[1] === "i",
+      invalid: getRegexPredicate(pattern) === null,
+    };
+  }
+  return { kind: "glob", negative, caseInsensitive: true, invalid: false };
+}
+
+/**
+ * The rewrites a missed positive glob is tried against, in order — the two
+ * minimatch traps a URL-shaped input falls into: `**` glued to text is a
+ * single-SEGMENT wildcard (so `**quay.io` never crosses the `https://`
+ * slashes; `**\/quay.io` does), and a trailing `/**` demands a path (so
+ * `quay.io/**` misses the bare host; `quay.io{/,}**` takes both). Only a
+ * candidate upstream's own matcher accepts is ever suggested.
+ */
+function globRewrites(pattern: string): string[] {
+  const optionalPath = pattern.endsWith("/**") ? `${pattern.slice(0, -3)}{/,}**` : pattern;
+  const segmented =
+    optionalPath.startsWith("**") && !optionalPath.startsWith("**/")
+      ? `**/${optionalPath.slice(2)}`
+      : optionalPath;
+  return [...new Set([optionalPath, segmented])].filter((candidate) => candidate !== pattern);
+}
+
+function explainEntry(pattern: string, input: string): PatternEntryMatch {
+  const parsed = parsePattern(pattern);
+  const predicate = matchRegexOrGlob(input, pattern);
+  const hit = parsed.negative ? !predicate : predicate;
+  const entry: PatternEntryMatch = { ...parsed, pattern, hit };
+  if (parsed.kind === "glob" && !parsed.negative && !hit) {
+    const suggestion = globRewrites(pattern).find((candidate) =>
+      matchRegexOrGlob(input, candidate),
+    );
+    if (suggestion !== undefined) {
+      entry.suggestion = suggestion;
+    }
+  }
+  return entry;
+}
+
+export function explainPatternMatch(patterns: readonly string[], input: string): PatternListMatch {
+  const matches = matchRegexOrGlobList(input, [...patterns]);
+  const entries = patterns.map((pattern) => explainEntry(pattern, input));
+  let reason: PatternMissReason | null = null;
+  if (!matches) {
+    if (entries.length === 0) {
+      reason = "empty";
+    } else if (entries.some((entry) => entry.negative && entry.hit)) {
+      reason = "blocked";
+    } else {
+      reason = "no-positive";
+    }
+  }
+  return { matches, entries, reason };
+}
+
+/**
+ * The `packageRules` options whose value is a LIST of these patterns — read
+ * from the pinned option table (`patternMatch` + `parents: ["packageRules"]`
+ * + array-typed), so a matcher upstream adds shows up here without an edit.
+ * `matchCurrentValue`/`matchNewValue` are single patterns, not lists, and
+ * `matchUpdateTypes` is an enum the table only flags as pattern-matched —
+ * neither is what the list matcher evaluates.
+ */
+export function patternListOptionNames(): string[] {
+  const names: string[] = [];
+  for (const option of getOptionIndex().options.values()) {
+    if (
+      option.patternMatch &&
+      option.type === "array" &&
+      option.placement.kind === "restricted" &&
+      option.placement.parents.includes("packageRules") &&
+      option.allowedValues === undefined
+    ) {
+      names.push(option.name);
+    }
+  }
+  return names.toSorted();
+}

--- a/packages/engine/src/renovate-adapter.ts
+++ b/packages/engine/src/renovate-adapter.ts
@@ -50,6 +50,14 @@ export {
   type VersioningApi,
 } from "renovate/dist/modules/versioning/index.js";
 export { getUpdateType } from "renovate/dist/workers/repository/process/lookup/update-type.js";
+// Roadmap 094: the pattern tests re-run upstream's own glob-or-regex matcher
+// (the one every `match*` list matcher calls) against the reader's inputs.
+export {
+  getRegexPredicate,
+  isRegexMatch,
+  matchRegexOrGlob,
+  matchRegexOrGlobList,
+} from "renovate/dist/util/string-match.js";
 // ---- Manager extraction (roadmap 078) --------------------------------------
 // Filename → manager detection: the generated per-manager file patterns are
 // already in the bundle transitively (loadManagerOptions), and getMatchingFiles

--- a/roadmap/094-pattern-tests.md
+++ b/roadmap/094-pattern-tests.md
@@ -1,0 +1,95 @@
+# 094 — Pattern tests: does this `match*` pattern match what I think it matches?
+
+- Milestone: M21 · Status: done
+- Design: Claude Design project "Renovate Config Debugger", artboards
+  `Pattern Tests.dc.html` (the component), `Pattern Tester Options.dc.html`
+  (the variations it was settled from) and `Proposal F - Integrated Shell.dc.html`
+  (the Tests tab it sits in, under the pins).
+
+## The ask
+
+Every `matchPackageNames`, `matchFileNames`, `matchRegistryUrls` entry is a
+glob — or a regex when written `/…/` — and the two traps are well known: a
+`**quay.io/**` that never matches `https://quay.io` (minimatch's `**` glued to
+text is a single-segment wildcard, and a trailing `/**` demands a path), and a
+`!react-dom` whose reader forgets that a negative entry must ALSO hold. Until
+now the only way to find out was to write the rule, run, and read the
+simulator's clause grid.
+
+The design's answer is a second test group on the Tests tab, next to the
+pins: a **pattern test** is one `match*` list option, the patterns the reader
+is writing for it, and the inputs those patterns should (and should not)
+match. Each input wears the mark Renovate's own matcher gives it and the
+expectation the reader holds; the card's sentence is `N of M expected`; the dot
+is red the moment an assertion fails. Like a pin, a pattern test is standing:
+it rides in the share link and is re-evaluated whenever anything changes.
+
+## What was built
+
+### Engine: `pattern-match.ts`
+
+`explainPatternMatch(patterns, input)` — `matches` IS upstream's
+`matchRegexOrGlobList`; the per-entry breakdown asks the same predicate
+(`matchRegexOrGlob`) one entry at a time, so the explanation cannot disagree
+with the verdict (`pattern-match.test.ts` proves it case by case). Each entry
+says how upstream reads it (`any` / `regex` / `glob`, negative, case
+sensitivity, an invalid regex that upstream's validator would reject) and
+whether its body hit; a miss carries a `reason` (`no-positive`, `blocked`,
+`empty`).
+
+A missed positive glob is tried against two rewrites — `/**` → `{/,}**`, and a
+leading `**` → `**/` — and only a rewrite upstream's matcher ACCEPTS for that
+input is ever suggested. The design's `{/,}**` hint on its own was a mockup
+approximation: for `**quay.io/**` against `https://quay.io` the rewrite that
+works under minimatch is `**/quay.io{/,}**`, and the suggestion says that.
+
+`patternListOptionNames()` reads the option table (`patternMatch`, array-typed,
+`parents: ["packageRules"]`, no enum) rather than hand-listing the eleven
+matchers, so an upstream addition shows up on a version bump; the test pins
+the list for the pinned Renovate.
+
+### App
+
+- **`types/simulator.ts`** — `PatternTest` / `PatternInput`, beside `PinnedTest`
+  for the same layering reason.
+- **`features/simulator/pattern-tests.ts`** — the pure half: the share
+  round trip, `evaluatePatternTest` (the sentences, the counts, the row's why,
+  given an injected matcher), and `seedValuesFor` — where "+ add the N values
+  from your last run" looks per option: the pins' descriptors and the loaded
+  repository's extraction.
+- **`PatternTests.tsx`, `PatternTestCard.tsx`, `PatternTestBody.tsx`,
+  `PatternTestRows.tsx`, `PatternAddLine.tsx`** — the strip, the accordion of
+  cards, the two-column body, the in-place editable rows, the dashed add lines.
+  The option is a native `<select>` rather than the design's searchable
+  popover: eleven names, and the browser's own picker is the more accessible
+  control at that size. The head row's toggle is ONE control (caret + dot) with
+  a pointer-only mirror over the rest of the row, so assistive tech sees a
+  single expand/collapse.
+- **`app/use-pattern-tests.ts`** — the shell's list, in `usePinnedRun`'s shape;
+  the Tests badge counts both groups; `ShareState`/`SharePayload` carry
+  `patternTests`, sanitized per entry and bounded on every axis
+  (`MAX_PATTERN_TESTS`, `MAX_PATTERNS_PER_TEST`, `MAX_PATTERN_INPUTS`,
+  `MAX_PATTERN_LENGTH`), additive within v2 exactly like `pins`.
+- The share note under the tab now says "Both test groups are saved with the
+  share link" and moved from the Add-a-test card's footnote to the view's last
+  line, under both groups.
+
+### Deliberately not built
+
+- **The editor popover** (`Pattern Popover.dc.html`, Proposal F's inline
+  "Test this pattern" on a config line) is a separate artboard and was not in
+  this scope. The empty state's copy was adjusted accordingly — it does not
+  promise "pin one from the editor".
+- **A CLI subcommand.** `rcd` could answer the same question headlessly
+  (`explainPatternMatch` is on the engine barrel); nothing in the design asked
+  for it.
+
+## Tests
+
+- engine `src/pattern-match.test.ts` (golden): verdict parity with upstream,
+  the reasons, the verified suggestion, the option list.
+- app `pattern-tests.test.ts` (unit, stub matcher), `PatternTests.test.tsx`
+  (components, stub engine), `PatternTests.shimmed.test.tsx` (Renovate's own
+  matcher through the card), `share.test.ts` (round trip, tolerance, caps),
+  e2e `23-pattern-tests.spec.ts` (a link carries them, the badge counts both
+  groups, an edit re-evaluates without a Run).

--- a/roadmap/README.md
+++ b/roadmap/README.md
@@ -93,6 +93,7 @@ Full context and architecture: [docs/Architecture.md](../docs/Architecture.md).
 | [086](086-app-state-sharing.md)                         | The App.tsx state-sharing ruling: context, hooks, no store           | M21                  | done                                                                                                                                                 |
 | [087](087-ghost-row-and-repo-deps.md)                   | The ghost row, and dependencies from the loaded repo                 | M21                  | done                                                                                                                                                 |
 | [088](088-build-provenance.md)                          | Build provenance: "verify this build"                                | M21                  | done                                                                                                                                                 |
+| [094](094-pattern-tests.md)                             | Pattern tests: `match*` patterns against the strings they should hit | M21                  | done                                                                                                                                                 |
 
 M5/M6 items derive from the [2026-07 persona UX study](2026-07-persona-ux-study.md):
 three real discussion-board configuration problems, each replayed against the live


### PR DESCRIPTION
Implements the `Pattern Tests` artboard (settled from `Pattern Tester Options`, placed by `Proposal F - Integrated Shell`) as the Tests tab's second test group — roadmap 094.

## What
A **pattern test** is one `match*` list option, the patterns being written for it, and the inputs those patterns should (and should not) match. Each input wears the verdict Renovate's own matcher gives it and the expectation the reader holds; the card's sentence is `N of M expected`, the dot goes red on a failed assertion. Tests ride in the share link and re-evaluate on every keystroke.

- **Engine** `pattern-match.ts`: `explainPatternMatch` — `matches` IS upstream's `matchRegexOrGlobList`; the per-entry breakdown calls the same predicate per entry, so verdict and explanation cannot disagree (golden test checks parity case by case). `patternListOptionNames` reads the option table rather than hand-listing the eleven matchers.
- **App**: `PatternTests*` components under the pins, `pattern-tests.ts` (pure evaluation, share round trip, seed values from pins + repo extraction), `use-pattern-tests` shell hook, `patternTests` on the share payload (additive within v2, sanitized per entry, capped on every axis), Tests badge counts both groups, share note now covers both.

## Deviations from the artboard
- The design's `{/,}**` hint was a mockup approximation: under real minimatch `**quay.io/**` never matches `https://quay.io`; the working rewrite is `**/quay.io{/,}**`. A suggestion is only shown when upstream's matcher accepts it.
- Option picker is a native `<select>` (eleven names; better a11y than a custom popover).
- `Pattern Popover` (editor inline tester) is a separate artboard and out of scope; the empty-state copy no longer promises it.

## Tests
Engine golden+shimmed, app unit/components/shimmed, `share.test.ts` round trip + tolerance + caps, e2e `23-pattern-tests.spec.ts` (link carries them, badge counts both groups, edits re-evaluate without a Run). Lint, typecheck, format, knip and the dev-graph guard are green.
