### PR TITLE
chore(renovate): automerge everything except major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>secustor/renovate-config"],
   "postUpdateOptions": ["pnpmDedupe"],
+  "automerge": true,
   "packageRules": [
+    {
+      "description": [
+        "Major updates need a human review; everything else automerges once ci-result is green."
+      ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
     {
       "description": ["Regnerate shims and snapshots"],
       "matchPackageNames": ["renovate"],


### PR DESCRIPTION
Enables `automerge: true` repo-wide and adds a last-position packageRule that turns it off for `major` updates.

Proven with `rcd compare` (Renovate 44.42.1) against the org preset `local>secustor/renovate-config`:

| update | before | after |
|---|---|---|
| react 19.1 → 19.2 (prod, minor) | no automerge | automerge |
| renovate 44.42 → 44.43 (prod, minor) | no automerge | automerge |
| react 19 → 20 (prod, major) | no automerge | no automerge |
| vitest 3 → 4 (devDep, major) | automerge (preset rule) | no automerge |
| actions/checkout v4 → v5 (major) | automerge (preset rule) | no automerge |

The `main` ruleset requires the `ci-result` check, so platform automerge waits on CI. `renovate-config-validator --strict` on the pinned 44.42.1 passes.