### PR TITLE
chore(renovate): exclude the migration-drift tripwire from snapshot regeneration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
         "commands": [
           "pnpm install --frozen-lockfile",
           "pnpm --filter @renovate-config-debugger/engine generate:registries",
-          "pnpm --filter @renovate-config-debugger/engine exec vitest run --project golden --update"
+          "pnpm --filter @renovate-config-debugger/engine exec vitest run --project golden --update --exclude test/migration-drift.node.test.ts"
         ],
         "executionMode": "update",
         "fileFilters": [


### PR DESCRIPTION
The drift test in `test/migration-drift.node.test.ts` needs a human to re-diff the forked `migrateConfig` against upstream, so it can never be fixed by the post-upgrade command. Running it inside the `--update` step made every renovate bump that touches `config/migration.js` fail as an artifact-update error (see #286), which hides the snapshot refresh behind a scary comment and blocks automerge for the wrong reason.

Exclude it from the post-upgrade command. The drift is still caught by CI on the bump PR itself.